### PR TITLE
Fix duplicate comment in server.js

### DIFF
--- a/api-server/server.js
+++ b/api-server/server.js
@@ -42,7 +42,6 @@ app.use('/api/settings', requireAuth, settingsRoutes);
 
 
 // Serve static React build and fallback to index.html
-// Serve static React build and fallback to index.html
 // NOTE: adjust this path to where your SPA build actually lives.
 // If your build outputs to /home/mgtmn/erp.mgt.mn, update to:
 const buildDir = path.resolve(__dirname, '../../../erp.mgt.mn');


### PR DESCRIPTION
## Summary
- remove redundant comment about serving the React build

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683eaf89e6708331816eb39571523574