### PR TITLE
Fix health-check route response

### DIFF
--- a/api-server/app.js
+++ b/api-server/app.js
@@ -28,9 +28,8 @@ app.get('/api/auth/health', async (req, res, next) => {
     const dbResult = await testConnection();
     if (!dbResult.ok) throw dbResult.error;
     res.json({ status: 'ok' });
-  return res.json({ status: 'ok' });
   } catch (err) {
-    return next(err);
+    next(err);
   }
 });
 


### PR DESCRIPTION
## Summary
- remove duplicate `res.json` call in `/api/auth/health` route
- allow error handler middleware to run via `next(err)`

## Testing
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683eaf85f8c88331acc9c5b4d51f38ee