### PR TITLE
Add useAuth hook for AuthContext

### DIFF
--- a/src/erp.mgt.mn/hooks/useAuth.jsx
+++ b/src/erp.mgt.mn/hooks/useAuth.jsx
@@ -41,3 +41,7 @@ export async function fetchProfile() {
   if (!res.ok) throw new Error('Not authenticated');
   return res.json();
 }
+
+export function useAuth() {
+  return useContext(AuthContext);
+}


### PR DESCRIPTION
## Summary
- expose `useAuth` hook from `src/erp.mgt.mn/hooks/useAuth.jsx`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683eaf76da948331947d2740a3b6eb6e