### PR TITLE
Fix login flow to display ERP layout

### DIFF
--- a/src/erp.mgt.mn/components/LoginForm.jsx
+++ b/src/erp.mgt.mn/components/LoginForm.jsx
@@ -17,17 +17,10 @@ export default function LoginForm() {
 
     try {
       // Send POST /api/auth/login with credentials: 'include'
-      await login({ email, password });
+      const loggedIn = await login({ email, password });
 
-      // Immediately fetch the profile so we know who logged in:
-      const profileRes = await fetch('/api/auth/me', {
-        credentials: 'include',
-      });
-      if (!profileRes.ok) {
-        throw new Error('Failed to fetch profile');
-      }
-      const profile = await profileRes.json();
-      setUser(profile);
+      // The login response already returns the user profile
+      setUser(loggedIn);
 
       // Redirect to the ERP root (Dashboard)
       navigate('/');


### PR DESCRIPTION
## Summary
- fix login flow to use the profile returned by the `/api/auth/login` endpoint

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683eb435d6848331b8d3f9673fbf32d7