### PR TITLE
Display Mosaic layout on dashboard

### DIFF
--- a/src/erp.mgt.mn/pages/Dashboard.jsx
+++ b/src/erp.mgt.mn/pages/Dashboard.jsx
@@ -1,6 +1,7 @@
 // src/erp.mgt.mn/pages/Dashboard.jsx
 import React, { useContext } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
+import MosaicLayout from '../components/MosaicLayout.jsx';
 
 export default function Dashboard() {
   const { user } = useContext(AuthContext);
@@ -15,7 +16,9 @@ export default function Dashboard() {
         Select a module from the sidebar on the left, or use the top header
         buttons to navigate.
       </p>
-      {/* You can add charts, grids, etc. here */}
+      <div style={{ marginTop: '1rem' }}>
+        <MosaicLayout />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `MosaicLayout` component into dashboard page

## Testing
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683eb6054da883319424d8cdc2a27914