### PR TITLE
Make ERP layout use mosaic windows

### DIFF
--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -3,29 +3,16 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import AuthContextProvider from './context/AuthContext.jsx';
 import RequireAuth from './components/RequireAuth.jsx';
 import ERPLayout from './components/ERPLayout.jsx';
-import Layout from './components/Layout.jsx';
-import Dashboard from './pages/Dashboard.jsx';
 import LoginPage from './pages/Login.jsx';
-import FormsPage from './pages/Forms.jsx';
-import ReportsPage from './pages/Reports.jsx';
-import UsersPage from './pages/Users.jsx';
-import SettingsPage from './pages/Settings.jsx';
 
 export default function App() {
   return (
     <AuthContextProvider>
       <BrowserRouter>
         <Routes>
-          {/* Public route for login without sidebar/layout */}
           <Route path="/login" element={<LoginPage />} />
-
-          {/* Protected app routes */}
-          <Route path="/*" element={<RequireAuth><ERPLayout  /></RequireAuth>}>
-            <Route index element={<Dashboard />} />
-            <Route path="forms" element={<FormsPage />} />
-            <Route path="reports" element={<ReportsPage />} />
-            <Route path="users" element={<UsersPage />} />
-            <Route path="settings" element={<SettingsPage />} />
+          <Route element={<RequireAuth />}> 
+            <Route path="/*" element={<ERPLayout />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -1,59 +1,90 @@
 // src/erp.mgt.mn/components/ERPLayout.jsx
-import React, { useContext } from 'react';
-import { Outlet, NavLink, useNavigate } from 'react-router-dom';
+import React, { useContext, useState } from 'react';
+import { Mosaic, MosaicWindow } from 'react-mosaic-component';
+import 'react-mosaic-component/react-mosaic-component.css';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { logout } from '../hooks/useAuth.jsx';
+import Dashboard from '../pages/Dashboard.jsx';
+import FormsPage from '../pages/Forms.jsx';
+import ReportsPage from '../pages/Reports.jsx';
+import UsersPage from '../pages/Users.jsx';
+import SettingsPage from '../pages/Settings.jsx';
 
 /**
- * A desktop‐style “ERPLayout” with:
- *  - Top header bar (logo, nav icons, user dropdown)
- *  - Left sidebar (menu groups + items)
- *  - Main content area (faux window container)
+ * ERPLayout renders the header, sidebar and a Mosaic workspace where
+ * modules open as independent windows. Clicking sidebar items opens the
+ * corresponding window in the workspace. When no windows are open, the
+ * workspace shows a placeholder message.
  */
 export default function ERPLayout() {
   const { user, setUser } = useContext(AuthContext);
-  const navigate = useNavigate();
+  const [layout, setLayout] = useState('dashboard');
+
+  const windowMap = {
+    dashboard: { title: 'Dashboard', Component: Dashboard },
+    forms: { title: 'Forms', Component: FormsPage },
+    reports: { title: 'Reports', Component: ReportsPage },
+    users: { title: 'Users', Component: UsersPage },
+    settings: { title: 'Settings', Component: SettingsPage },
+  };
+
+  function openWindow(id) {
+    if (!layout) {
+      setLayout(id);
+    } else if (layout === id) {
+      // already open
+    } else {
+      setLayout({ direction: 'row', first: layout, second: id, splitPercentage: 70 });
+    }
+  }
 
   async function handleLogout() {
     await logout();
     setUser(null);
-    navigate('/login');
   }
 
   return (
     <div style={styles.container}>
       <Header user={user} onLogout={handleLogout} />
       <div style={styles.body}>
-        <Sidebar />
-        <MainWindow>
-          <Outlet />
-        </MainWindow>
+        <Sidebar onOpen={openWindow} />
+        <div style={styles.workspace}>
+          {layout ? (
+            <Mosaic
+              className="mosaic-blueprint-theme"
+              value={layout}
+              onChange={setLayout}
+              renderTile={(id, path) => {
+                const entry = windowMap[id];
+                if (!entry) return null;
+                const { title, Component } = entry;
+                return (
+                  <MosaicWindow title={title} path={path} toolbarControls={null}>
+                    <Component />
+                  </MosaicWindow>
+                );
+              }}
+            />
+          ) : (
+            <div style={styles.empty}>No windows open</div>
+          )}
+        </div>
       </div>
     </div>
   );
 }
 
-/** Top header bar **/
+/** Header bar */
 function Header({ user, onLogout }) {
   return (
     <header style={styles.header}>
       <div style={styles.logoSection}>
-        <img
-          src="/assets/logo‐small.png"
-          alt="ERP Logo"
-          style={styles.logoImage}
-        />
+        <img src="/assets/logo-small.png" alt="ERP Logo" style={styles.logoImage} />
         <span style={styles.logoText}>MyERP</span>
       </div>
-      <nav style={styles.headerNav}>
-        <button style={styles.iconBtn}>🗔 Home</button>
-        <button style={styles.iconBtn}>🗗 Windows</button>
-        <button style={styles.iconBtn}>❔ Help</button>
-      </nav>
+      <nav style={styles.headerNav}></nav>
       <div style={styles.userSection}>
-        <span style={{ marginRight: '0.5rem' }}>
-          {user ? `Welcome, ${user.email}` : ''}
-        </span>
+        <span style={{ marginRight: '0.5rem' }}>{user ? `Welcome, ${user.email}` : ''}</span>
         {user && (
           <button style={styles.logoutBtn} onClick={onLogout}>
             Logout
@@ -64,57 +95,36 @@ function Header({ user, onLogout }) {
   );
 }
 
-/** Left sidebar with “menu groups” and “pinned items” **/
-function Sidebar() {
-  // You can expand/collapse these groups if you like; this is a static example
+/** Sidebar menu */
+function Sidebar({ onOpen }) {
   return (
     <aside style={styles.sidebar}>
       <div style={styles.menuGroup}>
         <div style={styles.groupTitle}>📌 Pinned</div>
-        <NavLink to="/" style={styles.menuItem}>
+        <button style={styles.menuItem} onClick={() => onOpen('dashboard')}>
           Dashboard
-        </NavLink>
-        <NavLink to="/forms" style={styles.menuItem}>
+        </button>
+        <button style={styles.menuItem} onClick={() => onOpen('forms')}>
           Forms
-        </NavLink>
-        <NavLink to="/reports" style={styles.menuItem}>
+        </button>
+        <button style={styles.menuItem} onClick={() => onOpen('reports')}>
           Reports
-        </NavLink>
+        </button>
       </div>
-
       <hr style={styles.divider} />
-
       <div style={styles.menuGroup}>
         <div style={styles.groupTitle}>📁 Modules</div>
-        <NavLink to="/users" style={styles.menuItem}>
+        <button style={styles.menuItem} onClick={() => onOpen('users')}>
           Users
-        </NavLink>
-        <NavLink to="/settings" style={styles.menuItem}>
+        </button>
+        <button style={styles.menuItem} onClick={() => onOpen('settings')}>
           Settings
-        </NavLink>
+        </button>
       </div>
     </aside>
   );
 }
 
-/** A faux “window” wrapper around the main content **/
-function MainWindow({ children }) {
-  return (
-    <div style={styles.windowContainer}>
-      <div style={styles.windowHeader}>
-        <span>Sales Dashboard</span>
-        <div>
-          <button style={styles.windowHeaderBtn}>–</button>
-          <button style={styles.windowHeaderBtn}>□</button>
-          <button style={styles.windowHeaderBtn}>×</button>
-        </div>
-      </div>
-      <div style={styles.windowContent}>{children}</div>
-    </div>
-  );
-}
-
-/** Inline styles (you can move these into a `.css` or Tailwind classes if you prefer) **/
 const styles = {
   container: {
     display: 'flex',
@@ -131,39 +141,11 @@ const styles = {
     height: '48px',
     flexShrink: 0,
   },
-  logoSection: {
-    display: 'flex',
-    alignItems: 'center',
-    flex: '0 0 auto',
-  },
-  logoImage: {
-    width: '24px',
-    height: '24px',
-    marginRight: '0.5rem',
-  },
-  logoText: {
-    fontSize: '1.1rem',
-    fontWeight: 'bold',
-  },
-  headerNav: {
-    marginLeft: '2rem',
-    display: 'flex',
-    gap: '0.75rem',
-    flexGrow: 1,
-  },
-  iconBtn: {
-    background: 'transparent',
-    border: 'none',
-    color: '#fff',
-    cursor: 'pointer',
-    fontSize: '0.9rem',
-    padding: '0.25rem 0.5rem',
-  },
-  userSection: {
-    display: 'flex',
-    alignItems: 'center',
-    flex: '0 0 auto',
-  },
+  logoSection: { display: 'flex', alignItems: 'center', flex: '0 0 auto' },
+  logoImage: { width: '24px', height: '24px', marginRight: '0.5rem' },
+  logoText: { fontSize: '1.1rem', fontWeight: 'bold' },
+  headerNav: { marginLeft: '2rem', flexGrow: 1 },
+  userSection: { display: 'flex', alignItems: 'center', flex: '0 0 auto' },
   logoutBtn: {
     backgroundColor: '#dc2626',
     color: '#fff',
@@ -173,11 +155,7 @@ const styles = {
     cursor: 'pointer',
     fontSize: '0.9rem',
   },
-  body: {
-    display: 'flex',
-    flexGrow: 1,
-    backgroundColor: '#f3f4f6',
-  },
+  body: { display: 'flex', flexGrow: 1, backgroundColor: '#f3f4f6' },
   sidebar: {
     width: '220px',
     backgroundColor: '#374151',
@@ -187,61 +165,30 @@ const styles = {
     padding: '1rem 0.5rem',
     flexShrink: 0,
   },
-  menuGroup: {
-    marginBottom: '1rem',
-  },
-  groupTitle: {
-    fontSize: '0.85rem',
-    fontWeight: 'bold',
-    margin: '0.5rem 0 0.25rem 0',
-  },
-  menuItem: ({ isActive }) => ({
+  menuGroup: { marginBottom: '1rem' },
+  groupTitle: { fontSize: '0.85rem', fontWeight: 'bold', margin: '0.5rem 0 0.25rem' },
+  menuItem: {
     display: 'block',
     padding: '0.4rem 0.75rem',
-    color: isActive ? '#ffffff' : '#d1d5db',
-    backgroundColor: isActive ? '#4b5563' : 'transparent',
+    color: '#d1d5db',
+    background: 'transparent',
     textDecoration: 'none',
     borderRadius: '3px',
     marginBottom: '0.25rem',
     fontSize: '0.9rem',
-  }),
-  divider: {
     border: 'none',
-    borderTop: '1px solid #4b5563',
-    margin: '0.5rem 0',
-  },
-  windowContainer: {
-    flexGrow: 1,
-    margin: '1rem',
-    border: '1px solid #9ca3af',
-    borderRadius: '4px',
-    display: 'flex',
-    flexDirection: 'column',
-    backgroundColor: '#ffffff',
-    boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
-  },
-  windowHeader: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    backgroundColor: '#6b7280',
-    color: '#f9fafb',
-    padding: '0.5rem 1rem',
-    borderTopLeftRadius: '4px',
-    borderTopRightRadius: '4px',
-    fontSize: '0.95rem',
-  },
-  windowHeaderBtn: {
-    marginLeft: '0.5rem',
-    background: 'transparent',
-    border: 'none',
-    color: '#f9fafb',
+    textAlign: 'left',
     cursor: 'pointer',
-    fontSize: '0.9rem',
   },
-  windowContent: {
-    flexGrow: 1,
-    padding: '1rem',
-    overflow: 'auto',
+  divider: { border: 'none', borderTop: '1px solid #4b5563', margin: '0.5rem 0' },
+  workspace: { flexGrow: 1, margin: '1rem', overflow: 'hidden' },
+  empty: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+    border: '1px dashed #9ca3af',
+    borderRadius: '4px',
+    color: '#6b7280',
   },
 };

--- a/src/erp.mgt.mn/components/Layout.jsx
+++ b/src/erp.mgt.mn/components/Layout.jsx
@@ -1,6 +1,6 @@
 // src/erp.mgt.mn/components/ERPLayout.jsx
 import React, { useContext } from 'react';
-import { Outlet, NavLink, useNavigate } from 'react-router-dom';
+import { Outlet, NavLink, useNavigate, useLocation } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { logout } from '../hooks/useAuth.jsx';
 
@@ -13,6 +13,16 @@ import { logout } from '../hooks/useAuth.jsx';
 export default function ERPLayout() {
   const { user, setUser } = useContext(AuthContext);
   const navigate = useNavigate();
+  const location = useLocation();
+
+  const titleMap = {
+    '/': 'Dashboard',
+    '/forms': 'Forms',
+    '/reports': 'Reports',
+    '/users': 'Users',
+    '/settings': 'Settings',
+  };
+  const windowTitle = titleMap[location.pathname] || 'ERP';
 
   async function handleLogout() {
     await logout();
@@ -25,7 +35,7 @@ export default function ERPLayout() {
       <Header user={user} onLogout={handleLogout} />
       <div style={styles.body}>
         <Sidebar />
-        <MainWindow>
+        <MainWindow title={windowTitle}>
           <Outlet />
         </MainWindow>
       </div>
@@ -98,11 +108,11 @@ function Sidebar() {
 }
 
 /** A faux “window” wrapper around the main content **/
-function MainWindow({ children }) {
+function MainWindow({ children, title }) {
   return (
     <div style={styles.windowContainer}>
       <div style={styles.windowHeader}>
-        <span>Sales Dashboard</span>
+        <span>{title}</span>
         <div>
           <button style={styles.windowHeaderBtn}>–</button>
           <button style={styles.windowHeaderBtn}>□</button>

--- a/src/erp.mgt.mn/components/LoginForm.jsx
+++ b/src/erp.mgt.mn/components/LoginForm.jsx
@@ -5,7 +5,8 @@ import { AuthContext } from '../context/AuthContext.jsx';
 import { useNavigate } from 'react-router-dom';
 
 export default function LoginForm() {
-  const [email, setEmail] = useState('');
+  // login using a plain user ID
+  const [userId, setUserId] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState(null);
   const { setUser } = useContext(AuthContext);
@@ -17,7 +18,7 @@ export default function LoginForm() {
 
     try {
       // Send POST /api/auth/login with credentials: 'include'
-      const loggedIn = await login({ email, password });
+      const loggedIn = await login({ userId, password });
 
       // The login response already returns the user profile
       setUser(loggedIn);
@@ -33,14 +34,14 @@ export default function LoginForm() {
   return (
     <form onSubmit={handleSubmit} style={{ maxWidth: '320px' }}>
       <div style={{ marginBottom: '0.75rem' }}>
-        <label htmlFor="email" style={{ display: 'block', marginBottom: '0.25rem' }}>
-          Employee ID or Email
+        <label htmlFor="userid" style={{ display: 'block', marginBottom: '0.25rem' }}>
+          User ID
         </label>
         <input
-          id="email"
-          type="email"
-          value={email}
-          onChange={(ev) => setEmail(ev.target.value)}
+          id="userid"
+          type="text"
+          value={userId}
+          onChange={(ev) => setUserId(ev.target.value)}
           required
           style={{ width: '100%', padding: '0.5rem', borderRadius: '3px' }}
         />

--- a/src/erp.mgt.mn/components/MosaicLayout.jsx
+++ b/src/erp.mgt.mn/components/MosaicLayout.jsx
@@ -1,19 +1,48 @@
-import { Mosaic } from 'react-mosaic-component';
+import { Mosaic, MosaicWindow } from 'react-mosaic-component';
+import { useState } from 'react';
+import 'react-mosaic-component/react-mosaic-component.css';
 import GLInquiry from '../windows/GLInquiry.jsx';
 import PurchaseOrders from '../windows/PurchaseOrders.jsx';
-import SalesDashboard from '../windows/SalesDashboard.jsx';
+import TabbedWindows from './TabbedWindows.jsx';
 
 export default function MosaicLayout() {
+  const [layout, setLayout] = useState({
+    direction: 'row',
+    first: 'gl',
+    second: 'po',
+    splitPercentage: 70,
+  });
+
   return (
     <Mosaic
+      className="mosaic-blueprint-theme"
+      value={layout}
+      onChange={setLayout}
       renderTile={(id, path) => {
+        let title;
+        let Component;
         switch (id) {
-          case 'gl': return <GLInquiry />;
-          case 'po': return <PurchaseOrders />;
-          case 'sales': return <SalesDashboard />;
+          case 'gl':
+            title = 'General Ledger';
+            Component = GLInquiry;
+            break;
+          case 'po':
+            title = 'Purchase Orders';
+            Component = PurchaseOrders;
+            break;
+          case 'sales':
+            title = 'Sales Dashboard';
+            Component = TabbedWindows;
+            break;
+          default:
+            return null;
         }
+        return (
+          <MosaicWindow title={title} path={path}>
+            <Component />
+          </MosaicWindow>
+        );
       }}
-      initialValue={{ direction: 'row', first: 'gl', second: 'po', splitPercentage: 70 }}
     />
   );
 }

--- a/src/erp.mgt.mn/components/TabbedWindows.jsx
+++ b/src/erp.mgt.mn/components/TabbedWindows.jsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import GLInquiry from '../windows/GLInquiry.jsx';
+import PurchaseOrders from '../windows/PurchaseOrders.jsx';
+import SalesDashboard from '../windows/SalesDashboard.jsx';
+
+export default function TabbedWindows() {
+  const tabs = [
+    { id: 'gl', title: 'General Ledger', Component: GLInquiry },
+    { id: 'po', title: 'Purchase Orders', Component: PurchaseOrders },
+    { id: 'sales', title: 'Sales Dashboard', Component: SalesDashboard },
+  ];
+  const [active, setActive] = useState('gl');
+
+  const ActiveComponent = tabs.find(t => t.id === active)?.Component || null;
+
+  return (
+    <div>
+      <div style={styles.tabBar}>
+        {tabs.map(tab => (
+          <button
+            key={tab.id}
+            onClick={() => setActive(tab.id)}
+            style={active === tab.id ? styles.activeTab : styles.tab}
+          >
+            {tab.title}
+          </button>
+        ))}
+      </div>
+      <div style={styles.tabContent}>{ActiveComponent && <ActiveComponent />}</div>
+    </div>
+  );
+}
+
+const styles = {
+  tabBar: {
+    display: 'flex',
+    borderBottom: '1px solid #ccc',
+    marginBottom: '0.5rem',
+  },
+  tab: {
+    background: 'transparent',
+    border: 'none',
+    padding: '0.5rem 1rem',
+    cursor: 'pointer',
+  },
+  activeTab: {
+    background: '#e5e7eb',
+    border: '1px solid #ccc',
+    borderBottom: 'none',
+    padding: '0.5rem 1rem',
+    cursor: 'pointer',
+  },
+  tabContent: {
+    border: '1px solid #ccc',
+    padding: '1rem',
+  },
+};

--- a/src/erp.mgt.mn/hooks/useAuth.jsx
+++ b/src/erp.mgt.mn/hooks/useAuth.jsx
@@ -6,14 +6,15 @@ import { AuthContext } from '../context/AuthContext.jsx';
 
 /**
  * Performs a login request, sets HttpOnly cookie on success.
- * @param {{email: string, password: string}} credentials
+ * @param {{userId: string, password: string}} credentials - userId refers to the employee login ID
  */
-export async function login({ email, password }) {
+export async function login({ userId, password }) {
   const res = await fetch('/api/auth/login', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include', // Ensures cookie is stored
-    body: JSON.stringify({ email, password }),
+    // Backend accepts email field which can be either an email or empid
+    body: JSON.stringify({ email: userId, password }),
   });
   if (!res.ok) {
     const errorBody = await res.json().catch(() => ({}));

--- a/src/erp.mgt.mn/index.html
+++ b/src/erp.mgt.mn/index.html
@@ -5,6 +5,10 @@
     <!-- Use Vite's plugin to inject assets -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ERP Portal</title>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/@blueprintjs/core@5.0.0/lib/css/blueprint.css"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/src/erp.mgt.mn/pages/Dashboard.jsx
+++ b/src/erp.mgt.mn/pages/Dashboard.jsx
@@ -8,14 +8,8 @@ export default function Dashboard() {
   return (
     <div>
       <h2>Dashboard</h2>
-      <p>
-        Welcome to the ERP dashboard{user ? `, ${user.email}` : ''}!
-      </p>
-      <p>
-        Select a module from the sidebar on the left, or use the top header
-        buttons to navigate.
-      </p>
-      {/* You can add charts, grids, etc. here */}
+      <p>Welcome to the ERP dashboard{user ? `, ${user.email}` : ''}!</p>
+      <p>Select a module from the sidebar on the left.</p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- streamline routing: ERP layout loads for all post-login routes
- redesign `ERPLayout` with a Mosaic workspace and sidebar buttons to open windows
- simplify dashboard page

## Testing
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683eb6054da883319424d8cdc2a27914