### PR TITLE
Add header menu to ERP layout

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -1,5 +1,6 @@
 // src/erp.mgt.mn/components/ERPLayout.jsx
 import React, { useContext } from 'react';
+import HeaderMenu from './HeaderMenu.jsx';
 import { Outlet, NavLink, useNavigate, useLocation } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { logout } from '../hooks/useAuth.jsx';
@@ -45,6 +46,10 @@ export default function ERPLayout() {
 
 /** Top header bar **/
 function Header({ user, onLogout }) {
+  function handleOpen(id) {
+    console.log('open module', id);
+  }
+
   return (
     <header style={styles.header}>
       <div style={styles.logoSection}>
@@ -60,6 +65,7 @@ function Header({ user, onLogout }) {
         <button style={styles.iconBtn}>🗗 Windows</button>
         <button style={styles.iconBtn}>❔ Help</button>
       </nav>
+      <HeaderMenu onOpen={handleOpen} />
       <div style={styles.userSection}>
         <span style={{ marginRight: '0.5rem' }}>
           {user ? `Welcome, ${user.email}` : ''}
@@ -159,7 +165,6 @@ const styles = {
     marginLeft: '2rem',
     display: 'flex',
     gap: '0.75rem',
-    flexGrow: 1,
   },
   iconBtn: {
     background: 'transparent',


### PR DESCRIPTION
## Summary
- import the existing `HeaderMenu` component
- insert `HeaderMenu` in the top header area
- adjust header nav style so menu pushes the user section

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f061604ac8331bcd043f55667e57e