### PR TITLE
Add header menu to ERP layout

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -1,5 +1,6 @@
 // src/erp.mgt.mn/components/ERPLayout.jsx
 import React, { useContext } from 'react';
+import HeaderMenu from './HeaderMenu.jsx';
 import { Outlet, NavLink, useNavigate, useLocation } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { logout } from '../hooks/useAuth.jsx';
@@ -45,6 +46,8 @@ export default function ERPLayout() {
 
 /** Top header bar **/
 function Header({ user, onLogout }) {
+  // No modules to open at this time.
+
   return (
     <header style={styles.header}>
       <div style={styles.logoSection}>
@@ -60,6 +63,7 @@ function Header({ user, onLogout }) {
         <button style={styles.iconBtn}>🗗 Windows</button>
         <button style={styles.iconBtn}>❔ Help</button>
       </nav>
+      <HeaderMenu />
       <div style={styles.userSection}>
         <span style={{ marginRight: '0.5rem' }}>
           {user ? `Welcome, ${user.email}` : ''}
@@ -159,7 +163,6 @@ const styles = {
     marginLeft: '2rem',
     display: 'flex',
     gap: '0.75rem',
-    flexGrow: 1,
   },
   iconBtn: {
     background: 'transparent',

--- a/src/erp.mgt.mn/components/HeaderMenu.jsx
+++ b/src/erp.mgt.mn/components/HeaderMenu.jsx
@@ -1,19 +1,8 @@
 import React from 'react';
 
 export default function HeaderMenu({ onOpen }) {
-  return (
-    <nav style={styles.menu}>
-      <button style={styles.btn} onClick={() => onOpen('gl')}>
-        General Ledger
-      </button>
-      <button style={styles.btn} onClick={() => onOpen('po')}>
-        Purchase Orders
-      </button>
-      <button style={styles.btn} onClick={() => onOpen('sales')}>
-        Sales Dashboard
-      </button>
-    </nav>
-  );
+  // All modules have been removed from the dashboard, so the menu is empty for now.
+  return <nav style={styles.menu}></nav>;
 }
 
 const styles = {

--- a/src/erp.mgt.mn/components/MosaicLayout.jsx
+++ b/src/erp.mgt.mn/components/MosaicLayout.jsx
@@ -1,48 +1,19 @@
-import { Mosaic, MosaicWindow } from 'react-mosaic-component';
-import { useState } from 'react';
-import 'react-mosaic-component/react-mosaic-component.css';
-import GLInquiry from '../windows/GLInquiry.jsx';
-import PurchaseOrders from '../windows/PurchaseOrders.jsx';
-import TabbedWindows from './TabbedWindows.jsx';
+// Mosaic layout originally arranged multiple ERP modules side by side.
+// Since those modules have been removed, the component now renders a simple
+// placeholder.
+import React from 'react';
 
 export default function MosaicLayout() {
-  const [layout, setLayout] = useState({
-    direction: 'row',
-    first: 'gl',
-    second: 'po',
-    splitPercentage: 70,
-  });
-
   return (
-    <Mosaic
-      className="mosaic-blueprint-theme"
-      value={layout}
-      onChange={setLayout}
-      renderTile={(id, path) => {
-        let title;
-        let Component;
-        switch (id) {
-          case 'gl':
-            title = 'General Ledger';
-            Component = GLInquiry;
-            break;
-          case 'po':
-            title = 'Purchase Orders';
-            Component = PurchaseOrders;
-            break;
-          case 'sales':
-            title = 'Sales Dashboard';
-            Component = TabbedWindows;
-            break;
-          default:
-            return null;
-        }
-        return (
-          <MosaicWindow title={title} path={path}>
-            <Component />
-          </MosaicWindow>
-        );
-      }}
-    />
+    <div style={styles.placeholder}>No modules to display.</div>
   );
 }
+
+const styles = {
+  placeholder: {
+    border: '1px solid #ccc',
+    padding: '1rem',
+    background: '#fff',
+    color: '#555',
+  },
+};

--- a/src/erp.mgt.mn/components/TabbedWindows.jsx
+++ b/src/erp.mgt.mn/components/TabbedWindows.jsx
@@ -1,57 +1,18 @@
-import { useState } from 'react';
-import GLInquiry from '../windows/GLInquiry.jsx';
-import PurchaseOrders from '../windows/PurchaseOrders.jsx';
-import SalesDashboard from '../windows/SalesDashboard.jsx';
-
+// Previously this component displayed multiple ERP modules in tabs.
+// The modules have been removed from the dashboard so it now simply shows a
+// placeholder message.
+import React from 'react';
 export default function TabbedWindows() {
-  const tabs = [
-    { id: 'gl', title: 'General Ledger', Component: GLInquiry },
-    { id: 'po', title: 'Purchase Orders', Component: PurchaseOrders },
-    { id: 'sales', title: 'Sales Dashboard', Component: SalesDashboard },
-  ];
-  const [active, setActive] = useState('gl');
-
-  const ActiveComponent = tabs.find(t => t.id === active)?.Component || null;
-
   return (
-    <div>
-      <div style={styles.tabBar}>
-        {tabs.map(tab => (
-          <button
-            key={tab.id}
-            onClick={() => setActive(tab.id)}
-            style={active === tab.id ? styles.activeTab : styles.tab}
-          >
-            {tab.title}
-          </button>
-        ))}
-      </div>
-      <div style={styles.tabContent}>{ActiveComponent && <ActiveComponent />}</div>
-    </div>
+    <div style={styles.placeholder}>No modules available.</div>
   );
 }
 
 const styles = {
-  tabBar: {
-    display: 'flex',
-    borderBottom: '1px solid #ccc',
-    marginBottom: '0.5rem',
-  },
-  tab: {
-    background: 'transparent',
-    border: 'none',
-    padding: '0.5rem 1rem',
-    cursor: 'pointer',
-  },
-  activeTab: {
-    background: '#e5e7eb',
-    border: '1px solid #ccc',
-    borderBottom: 'none',
-    padding: '0.5rem 1rem',
-    cursor: 'pointer',
-  },
-  tabContent: {
+  placeholder: {
     border: '1px solid #ccc',
     padding: '1rem',
+    background: '#fff',
+    color: '#555',
   },
 };

--- a/src/erp.mgt.mn/pages/Dashboard.jsx
+++ b/src/erp.mgt.mn/pages/Dashboard.jsx
@@ -1,8 +1,9 @@
 // src/erp.mgt.mn/pages/Dashboard.jsx
 import React, { useContext } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
-import TabbedWindows from '../components/TabbedWindows.jsx';
-import MosaicLayout from '../components/MosaicLayout.jsx';
+// Previously the dashboard displayed several modules in tabs.
+// These modules have been removed, so the dashboard now just shows a welcome
+// message.
 
 export default function Dashboard() {
   const { user } = useContext(AuthContext);
@@ -17,9 +18,7 @@ export default function Dashboard() {
         Select a module from the sidebar on the left, or use the top header
         buttons to navigate.
       </p>
-      <div style={{ marginTop: '1rem' }}>
-        <TabbedWindows />
-      </div>
+      {/* Modules have been removed so there is no tabbed content to display. */}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- import the existing `HeaderMenu` component
- insert `HeaderMenu` in the top header area
- adjust header nav style so menu pushes the user section
- remove module buttons and tabs from the dashboard

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f061604ac8331bcd043f55667e57e