### PR TITLE
Add Blue Link demo ERP page

### DIFF
--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -9,6 +9,7 @@ import FormsPage from './pages/Forms.jsx';
 import ReportsPage from './pages/Reports.jsx';
 import UsersPage from './pages/Users.jsx';
 import SettingsPage from './pages/Settings.jsx';
+import BlueLinkPage from './pages/BlueLinkPage.jsx';
 
 export default function App() {
   return (
@@ -26,6 +27,7 @@ export default function App() {
               <Route path="reports" element={<ReportsPage />} />
               <Route path="users" element={<UsersPage />} />
               <Route path="settings" element={<SettingsPage />} />
+              <Route path="bluelink" element={<BlueLinkPage />} />
             </Route>
           </Route>
         </Routes>

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -22,6 +22,7 @@ export default function ERPLayout() {
     '/reports': 'Reports',
     '/users': 'Users',
     '/settings': 'Settings',
+    '/bluelink': 'Blue Link Demo',
   };
   const windowTitle = titleMap[location.pathname] || 'ERP';
 
@@ -95,6 +96,9 @@ function Sidebar() {
         </NavLink>
         <NavLink to="/reports" style={styles.menuItem}>
           Reports
+        </NavLink>
+        <NavLink to="/bluelink" style={styles.menuItem}>
+          Blue Link Demo
         </NavLink>
       </div>
 

--- a/src/erp.mgt.mn/components/MosaicLayout.jsx
+++ b/src/erp.mgt.mn/components/MosaicLayout.jsx
@@ -4,14 +4,19 @@ import 'react-mosaic-component/react-mosaic-component.css';
 import GLInquiry from '../windows/GLInquiry.jsx';
 import PurchaseOrders from '../windows/PurchaseOrders.jsx';
 import TabbedWindows from './TabbedWindows.jsx';
+import Inventory from '../windows/Inventory.jsx';
+import OrderEntry from '../windows/OrderEntry.jsx';
+import Accounting from '../windows/Accounting.jsx';
 
-export default function MosaicLayout() {
-  const [layout, setLayout] = useState({
-    direction: 'row',
-    first: 'gl',
-    second: 'po',
-    splitPercentage: 70,
-  });
+export default function MosaicLayout({ initialLayout }) {
+  const [layout, setLayout] = useState(
+    initialLayout || {
+      direction: 'row',
+      first: 'gl',
+      second: 'po',
+      splitPercentage: 70,
+    },
+  );
 
   return (
     <Mosaic
@@ -33,6 +38,18 @@ export default function MosaicLayout() {
           case 'sales':
             title = 'Sales Dashboard';
             Component = TabbedWindows;
+            break;
+          case 'inventory':
+            title = 'Inventory';
+            Component = Inventory;
+            break;
+          case 'orders':
+            title = 'Order Entry';
+            Component = OrderEntry;
+            break;
+          case 'acct':
+            title = 'Accounting';
+            Component = Accounting;
             break;
           default:
             return null;

--- a/src/erp.mgt.mn/pages/BlueLinkPage.jsx
+++ b/src/erp.mgt.mn/pages/BlueLinkPage.jsx
@@ -1,0 +1,22 @@
+import MosaicLayout from '../components/MosaicLayout.jsx';
+
+export default function BlueLinkPage() {
+  const initial = {
+    direction: 'row',
+    first: 'inventory',
+    second: {
+      direction: 'column',
+      first: 'orders',
+      second: 'acct',
+      splitPercentage: 60,
+    },
+    splitPercentage: 40,
+  };
+  return (
+    <div>
+      <h2>Blue Link ERP Demo</h2>
+      <p>This page demonstrates a Blue Link style ERP dashboard using Mosaic.</p>
+      <MosaicLayout initialLayout={initial} />
+    </div>
+  );
+}

--- a/src/erp.mgt.mn/windows/Accounting.jsx
+++ b/src/erp.mgt.mn/windows/Accounting.jsx
@@ -1,0 +1,3 @@
+export default function Accounting() {
+  return <div>Accounting Module</div>;
+}

--- a/src/erp.mgt.mn/windows/Inventory.jsx
+++ b/src/erp.mgt.mn/windows/Inventory.jsx
@@ -1,0 +1,3 @@
+export default function Inventory() {
+  return <div>Inventory Management Module</div>;
+}

--- a/src/erp.mgt.mn/windows/OrderEntry.jsx
+++ b/src/erp.mgt.mn/windows/OrderEntry.jsx
@@ -1,0 +1,3 @@
+export default function OrderEntry() {
+  return <div>Order Entry Module</div>;
+}


### PR DESCRIPTION
## Summary
- add MosaicLayout initialLayout prop and support extra windows
- create Inventory, Order Entry, and Accounting window components
- create Blue Link demo page using MosaicLayout
- register the route in `App.jsx` and sidebar link in `ERPLayout`

## Testing
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f0e69c6b88331ae7bc912c845698c