### PR TITLE
Add Blue Link demo ERP page

### DIFF
--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -3,12 +3,12 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import AuthContextProvider from './context/AuthContext.jsx';
 import RequireAuth from './components/RequireAuth.jsx';
 import ERPLayout from './components/ERPLayout.jsx';
-import Dashboard from './pages/Dashboard.jsx';
 import LoginPage from './pages/Login.jsx';
 import FormsPage from './pages/Forms.jsx';
 import ReportsPage from './pages/Reports.jsx';
 import UsersPage from './pages/Users.jsx';
 import SettingsPage from './pages/Settings.jsx';
+import BlueLinkPage from './pages/BlueLinkPage.jsx';
 
 export default function App() {
   return (
@@ -21,7 +21,7 @@ export default function App() {
           {/* Protected app routes */}
           <Route element={<RequireAuth />}>
             <Route path="/" element={<ERPLayout />}>
-              <Route index element={<Dashboard />} />
+              <Route index element={<BlueLinkPage />} />
               <Route path="forms" element={<FormsPage />} />
               <Route path="reports" element={<ReportsPage />} />
               <Route path="users" element={<UsersPage />} />

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -17,7 +17,7 @@ export default function ERPLayout() {
   const location = useLocation();
 
   const titleMap = {
-    '/': 'Dashboard',
+    '/': 'Blue Link Demo',
     '/forms': 'Forms',
     '/reports': 'Reports',
     '/users': 'Users',
@@ -88,7 +88,7 @@ function Sidebar() {
       <div style={styles.menuGroup}>
         <div style={styles.groupTitle}>📌 Pinned</div>
         <NavLink to="/" style={styles.menuItem}>
-          Dashboard
+          Blue Link Demo
         </NavLink>
         <NavLink to="/forms" style={styles.menuItem}>
           Forms

--- a/src/erp.mgt.mn/components/MosaicLayout.jsx
+++ b/src/erp.mgt.mn/components/MosaicLayout.jsx
@@ -1,17 +1,27 @@
 import { Mosaic, MosaicWindow } from 'react-mosaic-component';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import 'react-mosaic-component/react-mosaic-component.css';
 import GLInquiry from '../windows/GLInquiry.jsx';
 import PurchaseOrders from '../windows/PurchaseOrders.jsx';
 import TabbedWindows from './TabbedWindows.jsx';
+import Inventory from '../windows/Inventory.jsx';
+import OrderEntry from '../windows/OrderEntry.jsx';
+import Accounting from '../windows/Accounting.jsx';
 
-export default function MosaicLayout() {
-  const [layout, setLayout] = useState({
+export default function MosaicLayout({ initialLayout }) {
+  const defaultLayout = {
     direction: 'row',
     first: 'gl',
     second: 'po',
     splitPercentage: 70,
-  });
+  };
+  const [layout, setLayout] = useState(initialLayout || defaultLayout);
+
+  useEffect(() => {
+    if (initialLayout) {
+      setLayout(initialLayout);
+    }
+  }, [initialLayout]);
 
   return (
     <Mosaic
@@ -33,6 +43,18 @@ export default function MosaicLayout() {
           case 'sales':
             title = 'Sales Dashboard';
             Component = TabbedWindows;
+            break;
+          case 'inventory':
+            title = 'Inventory';
+            Component = Inventory;
+            break;
+          case 'orders':
+            title = 'Order Entry';
+            Component = OrderEntry;
+            break;
+          case 'acct':
+            title = 'Accounting';
+            Component = Accounting;
             break;
           default:
             return null;

--- a/src/erp.mgt.mn/pages/BlueLinkPage.jsx
+++ b/src/erp.mgt.mn/pages/BlueLinkPage.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import MosaicLayout from '../components/MosaicLayout.jsx';
+
+const initialLayout = {
+    direction: 'row',
+    first: 'inventory',
+    second: {
+      direction: 'column',
+      first: 'orders',
+      second: 'acct',
+      splitPercentage: 60,
+    },
+    splitPercentage: 40,
+};
+
+export default function BlueLinkPage() {
+  return (
+    <div>
+      <h2>Blue Link ERP Demo</h2>
+      <p>This page demonstrates a Blue Link style ERP dashboard using Mosaic.</p>
+      <MosaicLayout initialLayout={initialLayout} />
+    </div>
+  );
+}
+

--- a/src/erp.mgt.mn/windows/Accounting.jsx
+++ b/src/erp.mgt.mn/windows/Accounting.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+export default function Accounting() {
+  return <div>Accounting Module</div>;
+}
+

--- a/src/erp.mgt.mn/windows/Inventory.jsx
+++ b/src/erp.mgt.mn/windows/Inventory.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+export default function Inventory() {
+  return <div>Inventory Management Module</div>;
+}
+

--- a/src/erp.mgt.mn/windows/OrderEntry.jsx
+++ b/src/erp.mgt.mn/windows/OrderEntry.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+export default function OrderEntry() {
+  return <div>Order Entry Module</div>;
+}
+


### PR DESCRIPTION
## Summary
- add MosaicLayout initialLayout prop and support extra windows
- create Inventory, Order Entry, and Accounting window components
- create Blue Link demo page using MosaicLayout
- register the route in `App.jsx` and sidebar link in `ERPLayout`
- set Blue Link page as default dashboard

## Testing
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f0e69c6b88331ae7bc912c845698c