### PR TITLE
Fix user management forms and API queries

### DIFF
--- a/api-server/controllers/userCompanyController.js
+++ b/api-server/controllers/userCompanyController.js
@@ -9,9 +9,9 @@ import { requireAuth } from '../middlewares/auth.js';
 
 export async function listAssignments(req, res, next) {
   try {
-    const userId = req.query.userId;
-    const assignments = userId
-      ? await listUserCompanies(userId)
+    const empid = req.query.empid;
+    const assignments = empid
+      ? await listUserCompanies(empid)
       : await listAllUserCompanies();
     res.json(assignments);
   } catch (err) {
@@ -21,8 +21,8 @@ export async function listAssignments(req, res, next) {
 
 export async function assignCompany(req, res, next) {
   try {
-    const { userId, companyId, empid, role } = req.body;
-    await assignCompanyToUser(userId, companyId, empid, role);
+    const { empid, companyId, role } = req.body;
+    await assignCompanyToUser(empid, companyId, role);
     res.sendStatus(201);
   } catch (err) {
     next(err);
@@ -31,8 +31,8 @@ export async function assignCompany(req, res, next) {
 
 export async function updateAssignment(req, res, next) {
   try {
-    const { userId, companyId, role } = req.body;
-    await updateCompanyAssignment(userId, companyId, role);
+    const { empid, companyId, role } = req.body;
+    await updateCompanyAssignment(empid, companyId, role);
     res.sendStatus(200);
   } catch (err) {
     next(err);
@@ -41,8 +41,8 @@ export async function updateAssignment(req, res, next) {
 
 export async function removeAssignment(req, res, next) {
   try {
-    const { userId, companyId } = req.body;
-    await removeCompanyAssignment(userId, companyId);
+    const { empid, companyId } = req.body;
+    await removeCompanyAssignment(empid, companyId);
     res.sendStatus(204);
   } catch (err) {
     next(err);

--- a/db/index.js
+++ b/db/index.js
@@ -128,7 +128,7 @@ export async function removeCompanyAssignment(userId, companyId) {
  */
 export async function updateCompanyAssignment(userId, companyId, role) {
   const [result] = await pool.query(
-    'UPDATE user_companies SET role = ? WHERE empid = ? AND company_id = ?',
+    'UPDATE user_companies SET role = ? WHERE user_id = ? AND company_id = ?',
     [role, userId, companyId]
   );
   return result;
@@ -139,7 +139,7 @@ export async function updateCompanyAssignment(userId, companyId, role) {
  */
 export async function listAllUserCompanies() {
   const [rows] = await pool.query(
-    'SELECT uc.empid, uc.company_id, c.name AS company_name, uc.role FROM user_companies uc JOIN companies c ON uc.company_id = c.id'
+    'SELECT uc.user_id, uc.empid, uc.company_id, c.name AS company_name, uc.role FROM user_companies uc JOIN companies c ON uc.company_id = c.id'
   );
   return rows;
 }

--- a/db/index.js
+++ b/db/index.js
@@ -93,10 +93,10 @@ export async function deleteUserById(id) {
 /**
  * Assign a user to a company with a specific role
  */
-export async function assignCompanyToUser(userId, companyId, empid, role) {
+export async function assignCompanyToUser(empid, companyId, role) {
   const [result] = await pool.query(
-    'INSERT INTO user_companies (user_id, company_id, empid, role) VALUES (?, ?, ?, ?)',
-    [userId, companyId, empid, role]
+    'INSERT INTO user_companies (empid, company_id, role) VALUES (?, ?, ?)',
+    [empid, companyId, role]
   );
   return { id: result.insertId };
 }
@@ -104,10 +104,10 @@ export async function assignCompanyToUser(userId, companyId, empid, role) {
 /**
  * List company assignments for a given user
  */
-export async function listUserCompanies(userId) {
+export async function listUserCompanies(empid) {
   const [rows] = await pool.query(
-    'SELECT uc.company_id, c.name AS company_name, uc.role, uc.empid FROM user_companies uc JOIN companies c ON uc.company_id = c.id WHERE uc.user_id = ?',
-    [userId]
+    'SELECT uc.company_id, c.name AS company_name, uc.role, uc.empid FROM user_companies uc JOIN companies c ON uc.company_id = c.id WHERE uc.empid = ?',
+    [empid]
   );
   return rows;
 }
@@ -115,10 +115,10 @@ export async function listUserCompanies(userId) {
 /**
  * Remove a user-company assignment
  */
-export async function removeCompanyAssignment(userId, companyId) {
+export async function removeCompanyAssignment(empid, companyId) {
   const [result] = await pool.query(
-    'DELETE FROM user_companies WHERE user_id = ? AND company_id = ?',
-    [userId, companyId]
+    'DELETE FROM user_companies WHERE empid = ? AND company_id = ?',
+    [empid, companyId]
   );
   return result;
 }
@@ -126,10 +126,10 @@ export async function removeCompanyAssignment(userId, companyId) {
 /**
  * Update a user's company assignment role
  */
-export async function updateCompanyAssignment(userId, companyId, role) {
+export async function updateCompanyAssignment(empid, companyId, role) {
   const [result] = await pool.query(
-    'UPDATE user_companies SET role = ? WHERE user_id = ? AND company_id = ?',
-    [role, userId, companyId]
+    'UPDATE user_companies SET role = ? WHERE empid = ? AND company_id = ?',
+    [role, empid, companyId]
   );
   return result;
 }
@@ -139,7 +139,7 @@ export async function updateCompanyAssignment(userId, companyId, role) {
  */
 export async function listAllUserCompanies() {
   const [rows] = await pool.query(
-    'SELECT uc.user_id, uc.empid, uc.company_id, c.name AS company_name, uc.role FROM user_companies uc JOIN companies c ON uc.company_id = c.id'
+    'SELECT uc.empid, uc.company_id, c.name AS company_name, uc.role FROM user_companies uc JOIN companies c ON uc.company_id = c.id'
   );
   return rows;
 }

--- a/src/erp.mgt.mn/pages/UserCompanies.jsx
+++ b/src/erp.mgt.mn/pages/UserCompanies.jsx
@@ -19,8 +19,6 @@ export default function UserCompanies() {
   }, []);
 
   async function handleAdd() {
-    const userId = prompt('User ID?');
-    if (!userId) return;
     const empid = prompt('EmpID?');
     if (!empid) return;
     const companyId = prompt('Company ID?');
@@ -30,7 +28,7 @@ export default function UserCompanies() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ userId, companyId, empid, role })
+      body: JSON.stringify({ empid, companyId, role })
     });
     if (!res.ok) {
       alert('Failed to add assignment');
@@ -46,7 +44,7 @@ export default function UserCompanies() {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ userId: a.user_id, companyId: a.company_id, role })
+      body: JSON.stringify({ empid: a.empid, companyId: a.company_id, role })
     });
     if (!res.ok) {
       alert('Failed to update assignment');
@@ -61,7 +59,7 @@ export default function UserCompanies() {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ userId: a.user_id, companyId: a.company_id })
+      body: JSON.stringify({ empid: a.empid, companyId: a.company_id })
     });
     if (!res.ok) {
       alert('Failed to delete assignment');

--- a/src/erp.mgt.mn/pages/UserCompanies.jsx
+++ b/src/erp.mgt.mn/pages/UserCompanies.jsx
@@ -19,6 +19,8 @@ export default function UserCompanies() {
   }, []);
 
   async function handleAdd() {
+    const userId = prompt('User ID?');
+    if (!userId) return;
     const empid = prompt('EmpID?');
     if (!empid) return;
     const companyId = prompt('Company ID?');
@@ -28,7 +30,7 @@ export default function UserCompanies() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ userId, empid, companyId, role })
+      body: JSON.stringify({ userId, companyId, empid, role })
     });
     if (!res.ok) {
       alert('Failed to add assignment');
@@ -44,7 +46,7 @@ export default function UserCompanies() {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ empId: a.empid, companyId: a.company_id, role })
+      body: JSON.stringify({ userId: a.user_id, companyId: a.company_id, role })
     });
     if (!res.ok) {
       alert('Failed to update assignment');
@@ -59,7 +61,7 @@ export default function UserCompanies() {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ empId: a.empid, companyId: a.company_id })
+      body: JSON.stringify({ userId: a.user_id, companyId: a.company_id })
     });
     if (!res.ok) {
       alert('Failed to delete assignment');

--- a/src/erp.mgt.mn/pages/Users.jsx
+++ b/src/erp.mgt.mn/pages/Users.jsx
@@ -21,6 +21,8 @@ export default function Users() {
   async function handleAdd() {
     const empid = prompt('EmpID?');
     if (!empid) return;
+    const email = prompt('Email?');
+    if (!email) return;
     const name = prompt('Name?');
     const password = prompt('Password?');
     const role = prompt('Role (user|admin)?', 'user');
@@ -45,7 +47,7 @@ export default function Users() {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ name, role })
+      body: JSON.stringify({ email, name, role })
     });
     if (!res.ok) {
       alert('Failed to update user');


### PR DESCRIPTION
## Summary
- fix DB query for updating user-company assignment
- return `user_id` when listing assignments
- prompt for email when creating users
- include email in edit payload
- collect user id in assignment UI and send to backend

## Testing
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841830f75248331be99177bd1bb059c