### PR TITLE
Fix duplicate user-company assignment error

### DIFF
--- a/api-server/controllers/userCompanyController.js
+++ b/api-server/controllers/userCompanyController.js
@@ -25,6 +25,9 @@ export async function assignCompany(req, res, next) {
     await assignCompanyToUser(empid, companyId, role);
     res.sendStatus(201);
   } catch (err) {
+    if (err.code === 'ER_NO_REFERENCED_ROW_2') {
+      return res.status(400).json({ message: 'Invalid empid or companyId' });
+    }
     next(err);
   }
 }

--- a/db/index.js
+++ b/db/index.js
@@ -95,10 +95,12 @@ export async function deleteUserById(id) {
  */
 export async function assignCompanyToUser(empid, companyId, role) {
   const [result] = await pool.query(
-    'INSERT INTO user_companies (empid, company_id, role) VALUES (?, ?, ?)',
+    `INSERT INTO user_companies (empid, company_id, role)
+     VALUES (?, ?, ?)
+     ON DUPLICATE KEY UPDATE role = VALUES(role)`,
     [empid, companyId, role]
   );
-  return { id: result.insertId };
+  return { affectedRows: result.affectedRows };
 }
 
 /**

--- a/src/erp.mgt.mn/pages/UserCompanies.jsx
+++ b/src/erp.mgt.mn/pages/UserCompanies.jsx
@@ -31,7 +31,8 @@ export default function UserCompanies() {
       body: JSON.stringify({ empid, companyId, role })
     });
     if (!res.ok) {
-      alert('Failed to add assignment');
+      const { message } = await res.json().catch(() => ({ message: 'Failed to add assignment' }));
+      alert(message || 'Failed to add assignment');
       return;
     }
     loadAssignments();
@@ -47,7 +48,8 @@ export default function UserCompanies() {
       body: JSON.stringify({ empid: a.empid, companyId: a.company_id, role })
     });
     if (!res.ok) {
-      alert('Failed to update assignment');
+      const { message } = await res.json().catch(() => ({ message: 'Failed to update assignment' }));
+      alert(message || 'Failed to update assignment');
       return;
     }
     loadAssignments();
@@ -62,7 +64,8 @@ export default function UserCompanies() {
       body: JSON.stringify({ empid: a.empid, companyId: a.company_id })
     });
     if (!res.ok) {
-      alert('Failed to delete assignment');
+      const { message } = await res.json().catch(() => ({ message: 'Failed to delete assignment' }));
+      alert(message || 'Failed to delete assignment');
       return;
     }
     loadAssignments();


### PR DESCRIPTION
## Summary
- allow assigning the same company again by using `ON DUPLICATE KEY UPDATE`
- return a useful message when empid/companyId are invalid
- surface server error messages in the UserCompanies page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68418f6a6aa8833180b83f2425fa83e7