### PR TITLE
Fix duplicate user-company assignment error

### DIFF
--- a/api-server/controllers/userCompanyController.js
+++ b/api-server/controllers/userCompanyController.js
@@ -22,9 +22,12 @@ export async function listAssignments(req, res, next) {
 export async function assignCompany(req, res, next) {
   try {
     const { empid, companyId, role } = req.body;
-    await assignCompanyToUser(empid, companyId, role);
+    await assignCompanyToUser(empid, companyId, role, req.user.empid);
     res.sendStatus(201);
   } catch (err) {
+    if (err.code === 'ER_NO_REFERENCED_ROW_2') {
+      return res.status(400).json({ message: 'Invalid empid or companyId' });
+    }
     next(err);
   }
 }

--- a/db/index.js
+++ b/db/index.js
@@ -93,12 +93,14 @@ export async function deleteUserById(id) {
 /**
  * Assign a user to a company with a specific role
  */
-export async function assignCompanyToUser(empid, companyId, role) {
+export async function assignCompanyToUser(empid, companyId, role, createdBy) {
   const [result] = await pool.query(
-    'INSERT INTO user_companies (empid, company_id, role) VALUES (?, ?, ?)',
-    [empid, companyId, role]
+    `INSERT INTO user_companies (empid, company_id, role, created_by)
+     VALUES (?, ?, ?, ?)
+     ON DUPLICATE KEY UPDATE role = VALUES(role)`,
+    [empid, companyId, role, createdBy]
   );
-  return { id: result.insertId };
+  return { affectedRows: result.affectedRows };
 }
 
 /**

--- a/db/migrations/2025-06-05_companies.sql
+++ b/db/migrations/2025-06-05_companies.sql
@@ -10,8 +10,11 @@ CREATE TABLE IF NOT EXISTS user_companies (
   empid      VARCHAR(50) NOT NULL,
   company_id INT NOT NULL,
   role       ENUM('user','admin') NOT NULL DEFAULT 'user',
+  created_by VARCHAR(50) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (empid, company_id),
   FOREIGN KEY (empid)     REFERENCES users(empid),
-  FOREIGN KEY (company_id) REFERENCES companies(id)
+  FOREIGN KEY (company_id) REFERENCES companies(id),
+  FOREIGN KEY (created_by) REFERENCES users(empid)
 );
 

--- a/db/schema_v4.sql
+++ b/db/schema_v4.sql
@@ -253,9 +253,12 @@ CREATE TABLE user_companies (
   empid       VARCHAR(50)               NOT NULL,
   company_id  INT                       NOT NULL,
   role        ENUM('user','admin')      NOT NULL DEFAULT 'user',
+  created_by  VARCHAR(50)               NOT NULL,
+  created_at  TIMESTAMP                 DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (empid, company_id),
   FOREIGN KEY (empid)     REFERENCES users(empid),
-  FOREIGN KEY (company_id) REFERENCES companies(id)
+  FOREIGN KEY (company_id) REFERENCES companies(id),
+  FOREIGN KEY (created_by) REFERENCES users(empid)
 ) ENGINE=InnoDB;
 
 ALTER TABLE users

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -48,7 +48,7 @@ This document outlines the roadmap, scope, architecture, milestones, and deliver
 - **DB Schema**  
   - `users(empid PK, email, name, password, role, created_by, created_at)`  
   - `companies(id PK, name, created_at)`  
-  - `user_companies(empid FK→users.empid, company_id FK→companies.id, role, created_at)`
+  - `user_companies(empid FK→users.empid, company_id FK→companies.id, role, created_by, created_at)`
   - Single-database multi-tenant (company_id discriminator)
 
 ## 5. Milestones & Timeline

--- a/src/erp.mgt.mn/pages/UserCompanies.jsx
+++ b/src/erp.mgt.mn/pages/UserCompanies.jsx
@@ -31,7 +31,8 @@ export default function UserCompanies() {
       body: JSON.stringify({ empid, companyId, role })
     });
     if (!res.ok) {
-      alert('Failed to add assignment');
+      const { message } = await res.json().catch(() => ({ message: 'Failed to add assignment' }));
+      alert(message || 'Failed to add assignment');
       return;
     }
     loadAssignments();
@@ -47,7 +48,8 @@ export default function UserCompanies() {
       body: JSON.stringify({ empid: a.empid, companyId: a.company_id, role })
     });
     if (!res.ok) {
-      alert('Failed to update assignment');
+      const { message } = await res.json().catch(() => ({ message: 'Failed to update assignment' }));
+      alert(message || 'Failed to update assignment');
       return;
     }
     loadAssignments();
@@ -62,7 +64,8 @@ export default function UserCompanies() {
       body: JSON.stringify({ empid: a.empid, companyId: a.company_id })
     });
     if (!res.ok) {
-      alert('Failed to delete assignment');
+      const { message } = await res.json().catch(() => ({ message: 'Failed to delete assignment' }));
+      alert(message || 'Failed to delete assignment');
       return;
     }
     loadAssignments();


### PR DESCRIPTION
## Summary
- allow assigning the same company again by using `ON DUPLICATE KEY UPDATE`
- return a useful message when empid/companyId are invalid
- surface server error messages in the UserCompanies page
- include `created_by` when creating user-company assignments

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68418f6a6aa8833180b83f2425fa83e7