### PR TITLE
Add filtering to user lists

### DIFF
--- a/src/erp.mgt.mn/pages/UserCompanies.jsx
+++ b/src/erp.mgt.mn/pages/UserCompanies.jsx
@@ -3,9 +3,13 @@ import React, { useEffect, useState } from 'react';
 
 export default function UserCompanies() {
   const [assignments, setAssignments] = useState([]);
+  const [filterEmpId, setFilterEmpId] = useState('');
 
-  function loadAssignments() {
-    fetch('/api/user_companies', { credentials: 'include' })
+  function loadAssignments(empid) {
+    const url = empid
+      ? `/api/user_companies?empid=${encodeURIComponent(empid)}`
+      : '/api/user_companies';
+    fetch(url, { credentials: 'include' })
       .then(res => {
         if (!res.ok) throw new Error('Failed to fetch user_companies');
         return res.json();
@@ -17,6 +21,10 @@ export default function UserCompanies() {
   useEffect(() => {
     loadAssignments();
   }, []);
+
+  function handleFilter() {
+    loadAssignments(filterEmpId);
+  }
 
   async function handleAdd() {
     const empid = prompt('EmpID?');
@@ -74,6 +82,16 @@ export default function UserCompanies() {
   return (
     <div>
       <h2>User Companies</h2>
+      <input
+        type="text"
+        placeholder="Filter by EmpID"
+        value={filterEmpId}
+        onChange={(e) => setFilterEmpId(e.target.value)}
+        style={{ marginRight: '0.5rem' }}
+      />
+      <button onClick={handleFilter} style={{ marginRight: '0.5rem' }}>
+        Apply
+      </button>
       <button onClick={handleAdd}>Add Assignment</button>
       {assignments.length === 0 ? (
         <p>No assignments.</p>

--- a/src/erp.mgt.mn/pages/Users.jsx
+++ b/src/erp.mgt.mn/pages/Users.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 
 export default function Users() {
   const [usersList, setUsersList] = useState([]);
+  const [filter, setFilter] = useState('');
 
   function loadUsers() {
     fetch('/api/users', { credentials: 'include' })
@@ -72,6 +73,13 @@ export default function Users() {
   return (
     <div>
       <h2>Users</h2>
+      <input
+        type="text"
+        placeholder="Filter users"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        style={{ marginRight: '0.5rem' }}
+      />
       <button onClick={handleAdd}>Add User</button>
       {usersList.length === 0 ? (
         <p>No users returned.</p>
@@ -100,7 +108,14 @@ export default function Users() {
             </tr>
           </thead>
           <tbody>
-            {usersList.map((u) => (
+            {usersList
+              .filter(
+                (u) =>
+                  u.empid.toLowerCase().includes(filter.toLowerCase()) ||
+                  u.name.toLowerCase().includes(filter.toLowerCase()) ||
+                  (u.email || '').toLowerCase().includes(filter.toLowerCase())
+              )
+              .map((u) => (
               <tr key={u.id}>
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
                   {u.empid}


### PR DESCRIPTION
## Summary
- add simple text filter on Users list
- add EmpID filter for UserCompanies list

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build:erp` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841969008908331a1d806f43eed31a8