### PR TITLE
Limit user management menus to admins

### DIFF
--- a/api-server/controllers/authController.js
+++ b/api-server/controllers/authController.js
@@ -9,7 +9,12 @@ export async function login(req, res, next) {
       return res.status(401).json({ message: 'Invalid credentials' });
     }
     const token = jwt.sign(
-      { id: user.id, email: user.email, empid: user.empid },
+      {
+        id: user.id,
+        email: user.email,
+        empid: user.empid,
+        role: user.role,
+      },
       process.env.JWT_SECRET,
       {
         expiresIn: '2h'
@@ -21,7 +26,12 @@ export async function login(req, res, next) {
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax'
     });
-    res.json({ id: user.id, email: user.email, empid: user.empid });
+    res.json({
+      id: user.id,
+      email: user.email,
+      empid: user.empid,
+      role: user.role,
+    });
   } catch (err) {
     next(err);
   }
@@ -33,5 +43,10 @@ export async function logout(req, res) {
 }
 
 export async function getProfile(req, res) {
-  res.json({ id: req.user.id, email: req.user.email, empid: req.user.empid });
+  res.json({
+    id: req.user.id,
+    email: req.user.email,
+    empid: req.user.empid,
+    role: req.user.role,
+  });
 }

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -83,6 +83,8 @@ function Header({ user, onLogout }) {
 
 /** Left sidebar with “menu groups” and “pinned items” **/
 function Sidebar() {
+  const { user } = useContext(AuthContext);
+
   // You can expand/collapse these groups if you like; this is a static example
   return (
     <aside style={styles.sidebar}>
@@ -103,12 +105,16 @@ function Sidebar() {
 
       <div style={styles.menuGroup}>
         <div style={styles.groupTitle}>📁 Modules</div>
-        <NavLink to="/users" style={styles.menuItem}>
-          Users
-        </NavLink>
-        <NavLink to="/user-companies" style={styles.menuItem}>
-          User Companies
-        </NavLink>
+        {user?.role === 'admin' && (
+          <>
+            <NavLink to="/users" style={styles.menuItem}>
+              Users
+            </NavLink>
+            <NavLink to="/user-companies" style={styles.menuItem}>
+              User Companies
+            </NavLink>
+          </>
+        )}
         <NavLink to="/settings" style={styles.menuItem}>
           Settings
         </NavLink>

--- a/src/erp.mgt.mn/components/Layout.jsx
+++ b/src/erp.mgt.mn/components/Layout.jsx
@@ -76,6 +76,8 @@ function Header({ user, onLogout }) {
 
 /** Left sidebar with “menu groups” and “pinned items” **/
 function Sidebar() {
+  const { user } = useContext(AuthContext);
+
   // You can expand/collapse these groups if you like; this is a static example
   return (
     <aside style={styles.sidebar}>
@@ -96,9 +98,11 @@ function Sidebar() {
 
       <div style={styles.menuGroup}>
         <div style={styles.groupTitle}>📁 Modules</div>
-        <NavLink to="/users" style={styles.menuItem}>
-          Users
-        </NavLink>
+        {user?.role === 'admin' && (
+          <NavLink to="/users" style={styles.menuItem}>
+            Users
+          </NavLink>
+        )}
         <NavLink to="/settings" style={styles.menuItem}>
           Settings
         </NavLink>

--- a/src/erp.mgt.mn/hooks/useAuth.jsx
+++ b/src/erp.mgt.mn/hooks/useAuth.jsx
@@ -5,8 +5,9 @@ import { AuthContext } from '../context/AuthContext.jsx';
 // src/erp.mgt.mn/hooks/useAuth.jsx
 
 /**
- * Performs a login request, sets HttpOnly cookie on success.
+ * Performs a login request and sets an HttpOnly cookie on success.
  * @param {{empid: string, password: string}} credentials - empid refers to the employee login ID
+ * @returns {Promise<{id: number, email: string, empid: string, role: string}>}
  */
 export async function login({ empid, password }) {
   const res = await fetch('/api/auth/login', {
@@ -35,8 +36,8 @@ export async function logout() {
 
 /**
  * Fetches current user profile if authenticated.
- * @returns {Promise<{id: number, email: string, empid: string}>}
- */
+ * @returns {Promise<{id: number, email: string, empid: string, role: string}>}
+*/
 export async function fetchProfile() {
   const res = await fetch('/api/auth/me', { credentials: 'include' });
   if (!res.ok) throw new Error('Not authenticated');


### PR DESCRIPTION
## Summary
- include `role` in JWT payload and `/auth/me` response
- expose role information in frontend auth helpers
- hide *Users* and *User Companies* sidebar links for non-admins

## Testing
- `npm run build:erp` *(fails: vite not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841982c4af88331b395850c6563c100