### PR TITLE
Add user dropdown menu with password change

### DIFF
--- a/api-server/controllers/authController.js
+++ b/api-server/controllers/authController.js
@@ -1,4 +1,5 @@
-import { getUserByEmail } from '../../db/index.js'; // adjust path to your db folder
+import { getUserByEmail, updateUserPassword } from '../../db/index.js'; // adjust path to your db folder
+import { hash } from '../services/passwordService.js';
 import jwt from 'jsonwebtoken';
 
 export async function login(req, res, next) {
@@ -11,6 +12,7 @@ export async function login(req, res, next) {
     const token = jwt.sign(
       {
         id: user.id,
+        name: user.name,
         email: user.email,
         empid: user.empid,
         role: user.role,
@@ -28,6 +30,7 @@ export async function login(req, res, next) {
     });
     res.json({
       id: user.id,
+      name: user.name,
       email: user.email,
       empid: user.empid,
       role: user.role,
@@ -45,8 +48,23 @@ export async function logout(req, res) {
 export async function getProfile(req, res) {
   res.json({
     id: req.user.id,
+    name: req.user.name,
     email: req.user.email,
     empid: req.user.empid,
     role: req.user.role,
   });
+}
+
+export async function changePassword(req, res, next) {
+  try {
+    const { password } = req.body;
+    if (!password) {
+      return res.status(400).json({ message: 'Password required' });
+    }
+    const hashed = await hash(password);
+    await updateUserPassword(req.user.id, hashed);
+    res.sendStatus(204);
+  } catch (err) {
+    next(err);
+  }
 }

--- a/api-server/middlewares/auth.js
+++ b/api-server/middlewares/auth.js
@@ -11,7 +11,7 @@ export function requireAuth(req, res, next) {
   try {
     // Verify the JWT
     const payload = jwt.verify(token, process.env.JWT_SECRET);
-    req.user = payload; // { id, email, iat, exp }
+    req.user = payload; // { id, name, email, empid, role, iat, exp }
     next();
   } catch (err) {
     console.error('JWT verification failed:', err);

--- a/api-server/routes/auth.js
+++ b/api-server/routes/auth.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { login, logout, getProfile } from '../controllers/authController.js';
+import { login, logout, getProfile, changePassword } from '../controllers/authController.js';
 import { requireAuth } from '../middlewares/auth.js';
 const router = express.Router();
 router.post('/login', login);
@@ -7,4 +7,5 @@ router.post('/logout', logout);
 router.get('/health', (req, res) => res.json({ status: 'ok' }));
 // comment out the middleware
 router.get('/me', requireAuth, getProfile);
+router.post('/change-password', requireAuth, changePassword);
 export default router;

--- a/db/index.js
+++ b/db/index.js
@@ -94,6 +94,11 @@ export async function updateUser(id, { name, email, role_id }) {
   return { id };
 }
 
+export async function updateUserPassword(id, hashedPassword) {
+  await pool.query('UPDATE users SET password = ? WHERE id = ?', [hashedPassword, id]);
+  return { id };
+}
+
 /**
  * Delete a user by ID
  */

--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -9,6 +9,7 @@ import ReportsPage from './pages/Reports.jsx';
 import UsersPage from './pages/Users.jsx';
 import UserCompaniesPage from './pages/UserCompanies.jsx';
 import SettingsPage from './pages/Settings.jsx';
+import ChangePasswordPage from './pages/ChangePassword.jsx';
 import Dashboard from './pages/Dashboard.jsx';
 import BlueLinkPage from './pages/BlueLinkPage.jsx';
 
@@ -29,6 +30,7 @@ export default function App() {
               <Route path="users" element={<UsersPage />} />
               <Route path="user-companies" element={<UserCompaniesPage />} />
               <Route path="settings" element={<SettingsPage />} />
+              <Route path="change-password" element={<ChangePasswordPage />} />
             </Route>
           </Route>
         </Routes>

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -1,6 +1,7 @@
 // src/erp.mgt.mn/components/ERPLayout.jsx
 import React, { useContext } from 'react';
 import HeaderMenu from './HeaderMenu.jsx';
+import UserMenu from './UserMenu.jsx';
 import { Outlet, NavLink, useNavigate, useLocation } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { logout } from '../hooks/useAuth.jsx';
@@ -68,14 +69,7 @@ function Header({ user, onLogout }) {
       </nav>
       <HeaderMenu onOpen={handleOpen} />
       <div style={styles.userSection}>
-        <span style={{ marginRight: '0.5rem' }}>
-          {user ? `Welcome, ${user.email || user.empid}` : ''}
-        </span>
-        {user && (
-          <button style={styles.logoutBtn} onClick={onLogout}>
-            Logout
-          </button>
-        )}
+        <UserMenu user={user} onLogout={onLogout} />
       </div>
     </header>
   );

--- a/src/erp.mgt.mn/components/Layout.jsx
+++ b/src/erp.mgt.mn/components/Layout.jsx
@@ -62,7 +62,7 @@ function Header({ user, onLogout }) {
       </nav>
       <div style={styles.userSection}>
         <span style={{ marginRight: '0.5rem' }}>
-          {user ? `Welcome, ${user.email || user.empid}` : ''}
+          {user ? `Welcome, ${user.name || user.empid}` : ''}
         </span>
         {user && (
           <button style={styles.logoutBtn} onClick={onLogout}>

--- a/src/erp.mgt.mn/components/UserMenu.jsx
+++ b/src/erp.mgt.mn/components/UserMenu.jsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function UserMenu({ user, onLogout }) {
+  const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
+
+  if (!user) return null;
+
+  function toggle() {
+    setOpen((o) => !o);
+  }
+
+  function handleChangePassword() {
+    setOpen(false);
+    navigate('/change-password');
+  }
+
+  function handleLogout() {
+    setOpen(false);
+    onLogout();
+  }
+
+  return (
+    <div style={styles.wrapper}>
+      <button style={styles.userBtn} onClick={toggle}>
+        {user.name || user.empid} ▾
+      </button>
+      {open && (
+        <div style={styles.menu}>
+          <button style={styles.menuItem} onClick={handleChangePassword}>
+            Change Password
+          </button>
+          <button style={styles.menuItem} onClick={handleLogout}>Logout</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const styles = {
+  wrapper: { position: 'relative', display: 'inline-block' },
+  userBtn: {
+    background: 'transparent',
+    border: 'none',
+    color: '#fff',
+    cursor: 'pointer',
+    fontSize: '0.9rem',
+  },
+  menu: {
+    position: 'absolute',
+    right: 0,
+    top: '100%',
+    background: '#ffffff',
+    border: '1px solid #d1d5db',
+    borderRadius: '3px',
+    minWidth: '150px',
+    padding: '0.25rem 0',
+    zIndex: 10,
+  },
+  menuItem: {
+    display: 'block',
+    width: '100%',
+    background: 'transparent',
+    border: 'none',
+    textAlign: 'left',
+    padding: '0.5rem',
+    cursor: 'pointer',
+    fontSize: '0.9rem',
+  },
+};

--- a/src/erp.mgt.mn/components/UserProfile.jsx
+++ b/src/erp.mgt.mn/components/UserProfile.jsx
@@ -3,5 +3,5 @@ import { AuthContext } from '../context/AuthContext.jsx';
 
 export default function UserProfile() {
   const { user } = useContext(AuthContext);
-  return <div>Logged in as: {user.email || user.empid}</div>;
+  return <div>Logged in as: {user.name || user.empid}</div>;
 }

--- a/src/erp.mgt.mn/hooks/useAuth.jsx
+++ b/src/erp.mgt.mn/hooks/useAuth.jsx
@@ -7,7 +7,7 @@ import { AuthContext } from '../context/AuthContext.jsx';
 /**
  * Performs a login request and sets an HttpOnly cookie on success.
  * @param {{empid: string, password: string}} credentials - empid refers to the employee login ID
- * @returns {Promise<{id: number, email: string, empid: string, role: string}>}
+ * @returns {Promise<{id: number, name: string, email: string, empid: string, role: string}>}
  */
 export async function login({ empid, password }) {
   const res = await fetch('/api/auth/login', {
@@ -36,7 +36,7 @@ export async function logout() {
 
 /**
  * Fetches current user profile if authenticated.
- * @returns {Promise<{id: number, email: string, empid: string, role: string}>}
+ * @returns {Promise<{id: number, name: string, email: string, empid: string, role: string}>}
 */
 export async function fetchProfile() {
   const res = await fetch('/api/auth/me', { credentials: 'include' });

--- a/src/erp.mgt.mn/pages/ChangePassword.jsx
+++ b/src/erp.mgt.mn/pages/ChangePassword.jsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+
+export default function ChangePasswordPage() {
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(false);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError(null);
+    if (password !== confirm) {
+      setError('Passwords do not match');
+      return;
+    }
+    try {
+      const res = await fetch('/api/auth/change-password', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.message || 'Failed to update password');
+      }
+      setSuccess(true);
+      setPassword('');
+      setConfirm('');
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2>Change Password</h2>
+      {success && <p style={{ color: 'green' }}>Password updated</p>}
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <form onSubmit={handleSubmit} style={{ maxWidth: '320px' }}>
+        <div style={{ marginBottom: '0.75rem' }}>
+          <label htmlFor="newpwd" style={{ display: 'block', marginBottom: '0.25rem' }}>
+            New Password
+          </label>
+          <input
+            id="newpwd"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            style={{ width: '100%', padding: '0.5rem', borderRadius: '3px' }}
+          />
+        </div>
+        <div style={{ marginBottom: '0.75rem' }}>
+          <label htmlFor="confirm" style={{ display: 'block', marginBottom: '0.25rem' }}>
+            Confirm Password
+          </label>
+          <input
+            id="confirm"
+            type="password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            required
+            style={{ width: '100%', padding: '0.5rem', borderRadius: '3px' }}
+          />
+        </div>
+        <button
+          type="submit"
+          style={{
+            backgroundColor: '#2563eb',
+            color: '#fff',
+            padding: '0.5rem 1rem',
+            border: 'none',
+            borderRadius: '3px',
+            cursor: 'pointer',
+          }}
+        >
+          Update Password
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `UserMenu` dropdown component
- hook menu into layout header
- create change password page
- allow server to update password via `/api/auth/change-password`
- show user name instead of email

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684199c6d4948331bbaa657429dd0fc4