### PR TITLE
Show user name in dropdown

### DIFF
--- a/api-server/controllers/authController.js
+++ b/api-server/controllers/authController.js
@@ -15,6 +15,7 @@ export async function login(req, res, next) {
         email: user.email,
         empid: user.empid,
         role: user.role,
+        name: user.name,
       },
       process.env.JWT_SECRET,
       {
@@ -32,6 +33,7 @@ export async function login(req, res, next) {
       email: user.email,
       empid: user.empid,
       role: user.role,
+      name: user.name,
     });
   } catch (err) {
     next(err);
@@ -49,6 +51,7 @@ export async function getProfile(req, res) {
     email: req.user.email,
     empid: req.user.empid,
     role: req.user.role,
+    name: req.user.name,
   });
 }
 

--- a/src/erp.mgt.mn/components/UserMenu.jsx
+++ b/src/erp.mgt.mn/components/UserMenu.jsx
@@ -24,7 +24,7 @@ export default function UserMenu({ user, onLogout }) {
   return (
     <div style={styles.wrapper}>
       <button style={styles.userBtn} onClick={toggle}>
-        {user.email || user.empid} ▾
+        {user.name || user.email || user.empid} ▾
       </button>
       {open && (
         <div style={styles.menu}>


### PR DESCRIPTION
## Summary
- display the logged in user's name in the menu
- expose user `name` from auth login and profile endpoints

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68427cea4354833189259a7d82ba7584