### PR TITLE
Implement role module permission management

### DIFF
--- a/api-server/app.js
+++ b/api-server/app.js
@@ -11,6 +11,7 @@ import userRoutes from './routes/users.js';
 import companyRoutes from './routes/companies.js';
 import settingsRoutes from './routes/settings.js';
 import userCompanyRoutes from './routes/user_companies.js';
+import rolePermissionRoutes from './routes/role_permissions.js';
 
 dotenv.config();
 
@@ -40,6 +41,7 @@ app.use('/api/users', userRoutes);
 app.use('/api/companies', companyRoutes);
 app.use('/api/settings', settingsRoutes);
 app.use('/api/user_companies', userCompanyRoutes);
+app.use('/api/role_permissions', rolePermissionRoutes);
 
 // Serve static React build and fallback to index.html
 // NOTE: adjust this path to where your SPA build actually lives.

--- a/api-server/controllers/rolePermissionController.js
+++ b/api-server/controllers/rolePermissionController.js
@@ -1,0 +1,27 @@
+import {
+  listRoleModulePermissions,
+  setRoleModulePermission
+} from '../../db/index.js';
+
+export async function listPermissions(req, res, next) {
+  try {
+    const roleId = req.query.roleId;
+    const perms = await listRoleModulePermissions(roleId);
+    res.json(perms);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function updatePermission(req, res, next) {
+  try {
+    if (req.user.role !== 'admin') {
+      return res.sendStatus(403);
+    }
+    const { roleId, moduleKey, allowed } = req.body;
+    await setRoleModulePermission(roleId, moduleKey, allowed);
+    res.sendStatus(200);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/api-server/routes/role_permissions.js
+++ b/api-server/routes/role_permissions.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import { listPermissions, updatePermission } from '../controllers/rolePermissionController.js';
+import { requireAuth } from '../middlewares/auth.js';
+
+const router = express.Router();
+router.get('/', requireAuth, listPermissions);
+router.put('/', requireAuth, updatePermission);
+export default router;

--- a/db/index.js
+++ b/db/index.js
@@ -236,3 +236,30 @@ export async function setTenantFlags(companyId, flags) {
   }
   return getTenantFlags(companyId);
 }
+
+/**
+ * List module permissions for roles
+ */
+export async function listRoleModulePermissions(roleId) {
+  const [rows] = await pool.query(
+    `SELECT rmp.role_id, ur.name AS role, rmp.module_key, rmp.allowed
+     FROM role_module_permissions rmp
+     JOIN user_roles ur ON rmp.role_id = ur.id
+     ${roleId ? 'WHERE rmp.role_id = ?' : ''}`,
+    roleId ? [roleId] : []
+  );
+  return rows;
+}
+
+/**
+ * Set a role's module permission
+ */
+export async function setRoleModulePermission(roleId, moduleKey, allowed) {
+  await pool.query(
+    `INSERT INTO role_module_permissions (role_id, module_key, allowed)
+     VALUES (?, ?, ?)
+     ON DUPLICATE KEY UPDATE allowed = VALUES(allowed)`,
+    [roleId, moduleKey, allowed]
+  );
+  return { roleId, moduleKey, allowed };
+}

--- a/db/migrations/2025-06-07_role_module_permissions.sql
+++ b/db/migrations/2025-06-07_role_module_permissions.sql
@@ -1,0 +1,17 @@
+-- Manage module access per role
+CREATE TABLE role_module_permissions (
+  role_id INT NOT NULL,
+  module_key VARCHAR(50) NOT NULL,
+  allowed TINYINT(1) DEFAULT 1,
+  PRIMARY KEY (role_id, module_key),
+  FOREIGN KEY (role_id) REFERENCES user_roles(id)
+);
+
+-- Seed example permissions for initial roles
+INSERT INTO role_module_permissions (role_id, module_key, allowed) VALUES
+  (1, 'users', 1),
+  (1, 'user_companies', 1),
+  (1, 'settings', 1),
+  (2, 'users', 0),
+  (2, 'user_companies', 0),
+  (2, 'settings', 0);

--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -9,6 +9,7 @@ import FormsPage from './pages/Forms.jsx';
 import ReportsPage from './pages/Reports.jsx';
 import UsersPage from './pages/Users.jsx';
 import UserCompaniesPage from './pages/UserCompanies.jsx';
+import RolePermissionsPage from './pages/RolePermissions.jsx';
 import SettingsPage from './pages/Settings.jsx';
 import ChangePasswordPage from './pages/ChangePassword.jsx';
 import Dashboard from './pages/Dashboard.jsx';
@@ -31,6 +32,7 @@ export default function App() {
               <Route element={<RequireAdmin />}>
                 <Route path="users" element={<UsersPage />} />
                 <Route path="user-companies" element={<UserCompaniesPage />} />
+                <Route path="role-permissions" element={<RolePermissionsPage />} />
               </Route>
               <Route path="settings" element={<SettingsPage />} />
               <Route path="change-password" element={<ChangePasswordPage />} />

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -23,6 +23,7 @@ export default function ERPLayout() {
     '/reports': 'Reports',
     '/users': 'Users',
     '/user-companies': 'User Companies',
+    '/role-permissions': 'Role Permissions',
     '/settings': 'Settings',
   };
   const windowTitle = titleMap[location.pathname] || 'ERP';
@@ -106,6 +107,9 @@ function Sidebar() {
             </NavLink>
             <NavLink to="/user-companies" style={styles.menuItem}>
               User Companies
+            </NavLink>
+            <NavLink to="/role-permissions" style={styles.menuItem}>
+              Role Permissions
             </NavLink>
           </>
         )}

--- a/src/erp.mgt.mn/pages/RolePermissions.jsx
+++ b/src/erp.mgt.mn/pages/RolePermissions.jsx
@@ -1,0 +1,86 @@
+// src/erp.mgt.mn/pages/RolePermissions.jsx
+import React, { useEffect, useState } from 'react';
+
+export default function RolePermissions() {
+  const [perms, setPerms] = useState([]);
+  const [filterRoleId, setFilterRoleId] = useState('');
+
+  function loadPerms(roleId) {
+    const url = roleId ? `/api/role_permissions?roleId=${encodeURIComponent(roleId)}` : '/api/role_permissions';
+    fetch(url, { credentials: 'include' })
+      .then(res => {
+        if (!res.ok) throw new Error('Failed to fetch role permissions');
+        return res.json();
+      })
+      .then(setPerms)
+      .catch(err => console.error('Error fetching role permissions:', err));
+  }
+
+  useEffect(() => {
+    loadPerms();
+  }, []);
+
+  function handleFilter() {
+    loadPerms(filterRoleId);
+  }
+
+  async function handleToggle(p) {
+    const res = await fetch('/api/role_permissions', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({
+        roleId: p.role_id,
+        moduleKey: p.module_key,
+        allowed: p.allowed ? 0 : 1
+      })
+    });
+    if (!res.ok) {
+      alert('Failed to update permission');
+      return;
+    }
+    loadPerms(filterRoleId);
+  }
+
+  return (
+    <div>
+      <h2>Role Permissions</h2>
+      <input
+        type="text"
+        placeholder="Filter by Role ID"
+        value={filterRoleId}
+        onChange={(e) => setFilterRoleId(e.target.value)}
+        style={{ marginRight: '0.5rem' }}
+      />
+      <button onClick={handleFilter}>Apply</button>
+      {perms.length === 0 ? (
+        <p>No permissions.</p>
+      ) : (
+        <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '0.5rem' }}>
+          <thead>
+            <tr style={{ backgroundColor: '#e5e7eb' }}>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Role</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Module</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Allowed</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {perms.map(p => (
+              <tr key={p.role_id + '-' + p.module_key}>
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{p.role}</td>
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{p.module_key}</td>
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{p.allowed ? 'Yes' : 'No'}</td>
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
+                  <button onClick={() => handleToggle(p)}>
+                    {p.allowed ? 'Revoke' : 'Allow'}
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/src/erp.mgt.mn/pages/Settings.jsx
+++ b/src/erp.mgt.mn/pages/Settings.jsx
@@ -1,5 +1,6 @@
 // src/erp.mgt.mn/pages/Settings.jsx
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 export default function Settings() {
   const [settings, setSettings] = useState(null);
@@ -22,6 +23,9 @@ export default function Settings() {
       ) : (
         <p>Loading settings…</p>
       )}
+      <p style={{ marginTop: '1rem' }}>
+        <Link to="/role-permissions">Edit Role Permissions</Link>
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `role_module_permissions` migration and seed example records
- expose DB helpers `listRoleModulePermissions` and `setRoleModulePermission`
- implement role permission API routes
- add React page for managing role permissions and link from Settings
- register new page in router and sidebar

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684298df88bc8331bec2ef1e4eb5c8f3