### PR TITLE
Update sidebar menu and routes

### DIFF
--- a/api-server/server.js
+++ b/api-server/server.js
@@ -11,6 +11,7 @@ import userRoutes from './routes/users.js';
 import companyRoutes from './routes/companies.js';
 import settingsRoutes from './routes/settings.js';
 import userCompanyRoutes from './routes/user_companies.js';
+import rolePermissionRoutes from './routes/role_permissions.js';
 import { requireAuth } from './middlewares/auth.js';
 
 dotenv.config();
@@ -41,6 +42,7 @@ app.use('/api/users', requireAuth, userRoutes);
 app.use('/api/companies', requireAuth, companyRoutes);
 app.use('/api/settings', requireAuth, settingsRoutes);
 app.use('/api/user_companies', requireAuth, userCompanyRoutes);
+app.use('/api/role_permissions', requireAuth, rolePermissionRoutes);
 
 
 // Serve static React build and fallback to index.html

--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -29,18 +29,15 @@ export default function App() {
               <Route index element={<BlueLinkPage />} />
               <Route path="forms" element={<FormsPage />} />
               <Route path="reports" element={<ReportsPage />} />
-              <Route element={<RequireAdmin />}>
-                <Route path="users" element={<UsersPage />} />
-                <Route path="user-companies" element={<UserCompaniesPage />} />
-                <Route path="role-permissions" element={<RolePermissionsPage />} />
-              </Route>
-              <Route path="settings" element={<SettingsPage />}> 
+              <Route path="settings" element={<SettingsPage />}>
                 <Route index element={<GeneralSettings />} />
-                <Route element={<RequireAdmin />}> 
+                <Route element={<RequireAdmin />}>
+                  <Route path="users" element={<UsersPage />} />
+                  <Route path="user-companies" element={<UserCompaniesPage />} />
                   <Route path="role-permissions" element={<RolePermissionsPage />} />
                 </Route>
+                <Route path="change-password" element={<ChangePasswordPage />} />
               </Route>
-              <Route path="change-password" element={<ChangePasswordPage />} />
             </Route>
           </Route>
         </Routes>

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -21,11 +21,11 @@ export default function ERPLayout() {
     '/': 'Blue Link Demo',
     '/forms': 'Forms',
     '/reports': 'Reports',
-    '/users': 'Users',
-    '/user-companies': 'User Companies',
-    '/role-permissions': 'Role Permissions',
     '/settings': 'Settings',
+    '/settings/users': 'Users',
+    '/settings/user-companies': 'User Companies',
     '/settings/role-permissions': 'Role Permissions',
+    '/settings/change-password': 'Change Password',
   };
   const windowTitle = titleMap[location.pathname] || 'ERP';
 
@@ -81,52 +81,48 @@ function Header({ user, onLogout }) {
 function Sidebar() {
   const { user } = useContext(AuthContext);
 
-  // You can expand/collapse these groups if you like; this is a static example
+  // Simple static menu with groups
   return (
     <aside style={styles.sidebar}>
-      <div style={styles.menuGroup}>
-        <div style={styles.groupTitle}>📌 Pinned</div>
-        <NavLink to="/" style={styles.menuItem}>
-          Blue Link Demo
-        </NavLink>
-        <NavLink to="/forms" style={styles.menuItem}>
-          Forms
-        </NavLink>
-        <NavLink to="/reports" style={styles.menuItem}>
-          Reports
-        </NavLink>
-      </div>
-
-      <hr style={styles.divider} />
-
-      <div style={styles.menuGroup}>
-        <div style={styles.groupTitle}>📁 Modules</div>
-        {user?.role === 'admin' && (
-          <>
-            <NavLink to="/users" style={styles.menuItem}>
-              Users
-            </NavLink>
-            <NavLink to="/user-companies" style={styles.menuItem}>
-              User Companies
-            </NavLink>
-            <NavLink to="/role-permissions" style={styles.menuItem}>
-              Role Permissions
-            </NavLink>
-          </>
-        )}
-      </div>
-
-      <div style={styles.menuGroup}>
-        <div style={styles.groupTitle}>⚙ Settings</div>
-        <NavLink to="/settings" style={styles.menuItem}>
-          General
-        </NavLink>
-        {user?.role === 'admin' && (
-          <NavLink to="/settings/role-permissions" style={styles.menuItem}>
-            Role Permissions
+      <nav>
+        <div style={styles.menuGroup}>
+          <div style={styles.groupTitle}>📌 Pinned</div>
+          <NavLink to="/" style={styles.menuItem}>
+            Blue Link Demo
           </NavLink>
-        )}
-      </div>
+          <NavLink to="/forms" style={styles.menuItem}>
+            Forms
+          </NavLink>
+          <NavLink to="/reports" style={styles.menuItem}>
+            Reports
+          </NavLink>
+        </div>
+
+        <hr style={styles.divider} />
+
+        <div style={styles.menuGroup}>
+          <div style={styles.groupTitle}>⚙ Settings</div>
+          <NavLink to="/settings" style={styles.menuItem} end>
+            General
+          </NavLink>
+          {user?.role === 'admin' && (
+            <>
+              <NavLink to="/settings/users" style={styles.menuItem}>
+                Users
+              </NavLink>
+              <NavLink to="/settings/user-companies" style={styles.menuItem}>
+                User Companies
+              </NavLink>
+              <NavLink to="/settings/role-permissions" style={styles.menuItem}>
+                Role Permissions
+              </NavLink>
+            </>
+          )}
+          <NavLink to="/settings/change-password" style={styles.menuItem}>
+            Change Password
+          </NavLink>
+        </div>
+      </nav>
     </aside>
   );
 }

--- a/src/erp.mgt.mn/components/Layout.jsx
+++ b/src/erp.mgt.mn/components/Layout.jsx
@@ -19,8 +19,11 @@ export default function ERPLayout() {
     '/': 'Dashboard',
     '/forms': 'Forms',
     '/reports': 'Reports',
-    '/users': 'Users',
     '/settings': 'Settings',
+    '/settings/users': 'Users',
+    '/settings/user-companies': 'User Companies',
+    '/settings/role-permissions': 'Role Permissions',
+    '/settings/change-password': 'Change Password',
   };
   const windowTitle = titleMap[location.pathname] || 'ERP';
 
@@ -97,14 +100,25 @@ function Sidebar() {
       <hr style={styles.divider} />
 
       <div style={styles.menuGroup}>
-        <div style={styles.groupTitle}>📁 Modules</div>
+        <div style={styles.groupTitle}>⚙ Settings</div>
+        <NavLink to="/settings" style={styles.menuItem} end>
+          General
+        </NavLink>
         {user?.role === 'admin' && (
-          <NavLink to="/users" style={styles.menuItem}>
-            Users
-          </NavLink>
+          <>
+            <NavLink to="/settings/users" style={styles.menuItem}>
+              Users
+            </NavLink>
+            <NavLink to="/settings/user-companies" style={styles.menuItem}>
+              User Companies
+            </NavLink>
+            <NavLink to="/settings/role-permissions" style={styles.menuItem}>
+              Role Permissions
+            </NavLink>
+          </>
         )}
-        <NavLink to="/settings" style={styles.menuItem}>
-          Settings
+        <NavLink to="/settings/change-password" style={styles.menuItem}>
+          Change Password
         </NavLink>
       </div>
     </aside>

--- a/src/erp.mgt.mn/components/UserMenu.jsx
+++ b/src/erp.mgt.mn/components/UserMenu.jsx
@@ -13,7 +13,7 @@ export default function UserMenu({ user, onLogout }) {
 
   function handleChangePassword() {
     setOpen(false);
-    navigate('/change-password');
+    navigate('/settings/change-password');
   }
 
   function handleLogout() {

--- a/src/erp.mgt.mn/pages/Settings.jsx
+++ b/src/erp.mgt.mn/pages/Settings.jsx
@@ -1,6 +1,6 @@
 // src/erp.mgt.mn/pages/Settings.jsx
 import React, { useEffect, useState } from 'react';
-import { NavLink, Outlet } from 'react-router-dom';
+import { NavLink, Outlet, Link } from 'react-router-dom';
 
 export default function SettingsLayout() {
   return (
@@ -9,8 +9,17 @@ export default function SettingsLayout() {
         <NavLink end to="/settings" style={styles.menuItem}>
           General
         </NavLink>
+        <NavLink to="/settings/users" style={styles.menuItem}>
+          Users
+        </NavLink>
+        <NavLink to="/settings/user-companies" style={styles.menuItem}>
+          User Companies
+        </NavLink>
         <NavLink to="/settings/role-permissions" style={styles.menuItem}>
           Role Permissions
+        </NavLink>
+        <NavLink to="/settings/change-password" style={styles.menuItem}>
+          Change Password
         </NavLink>
       </aside>
       <div style={styles.content}>
@@ -42,7 +51,7 @@ export function GeneralSettings() {
         <p>Loading settings…</p>
       )}
       <p style={{ marginTop: '1rem' }}>
-        <Link to="/role-permissions">Edit Role Permissions</Link>
+        <Link to="/settings/role-permissions">Edit Role Permissions</Link>
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
- hook up role permission routes on server
- move admin pages under the settings section
- update sidebar menus accordingly
- adjust user menu path

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68429e4fe3d483318415ef33afe9e1c4