### PR TITLE
Implement role-based sidebar visibility

### DIFF
--- a/db/migrations/2025-06-08_seed_module_permissions.sql
+++ b/db/migrations/2025-06-08_seed_module_permissions.sql
@@ -1,0 +1,19 @@
+-- Seed permissions for all current modules
+INSERT INTO role_module_permissions (role_id, module_key, allowed) VALUES
+  (1, 'dashboard', 1),
+  (1, 'forms', 1),
+  (1, 'reports', 1),
+  (1, 'settings', 1),
+  (1, 'users', 1),
+  (1, 'user_companies', 1),
+  (1, 'role_permissions', 1),
+  (1, 'change_password', 1),
+  (2, 'dashboard', 1),
+  (2, 'forms', 1),
+  (2, 'reports', 1),
+  (2, 'settings', 0),
+  (2, 'users', 0),
+  (2, 'user_companies', 0),
+  (2, 'role_permissions', 0),
+  (2, 'change_password', 1)
+ON DUPLICATE KEY UPDATE allowed = VALUES(allowed);

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -1,10 +1,11 @@
 // src/erp.mgt.mn/components/ERPLayout.jsx
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import HeaderMenu from './HeaderMenu.jsx';
 import UserMenu from './UserMenu.jsx';
 import { Outlet, NavLink, useNavigate, useLocation } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { logout } from '../hooks/useAuth.jsx';
+import { useRolePermissions } from '../hooks/useRolePermissions.js';
 
 /**
  * A desktop‐style “ERPLayout” with:
@@ -80,47 +81,65 @@ function Header({ user, onLogout }) {
 /** Left sidebar with “menu groups” and “pinned items” **/
 function Sidebar() {
   const { user } = useContext(AuthContext);
+  const perms = useRolePermissions();
+  const [openSettings, setOpenSettings] = useState(false);
 
-  // Simple static menu with groups
   return (
     <aside style={styles.sidebar}>
       <nav>
         <div style={styles.menuGroup}>
           <div style={styles.groupTitle}>📌 Pinned</div>
-          <NavLink to="/" style={styles.menuItem}>
-            Blue Link Demo
-          </NavLink>
-          <NavLink to="/forms" style={styles.menuItem}>
-            Forms
-          </NavLink>
-          <NavLink to="/reports" style={styles.menuItem}>
-            Reports
-          </NavLink>
+          {perms.dashboard !== false && (
+            <NavLink to="/" style={styles.menuItem}>
+              Blue Link Demo
+            </NavLink>
+          )}
+          {perms.forms !== false && (
+            <NavLink to="/forms" style={styles.menuItem}>
+              Forms
+            </NavLink>
+          )}
+          {perms.reports !== false && (
+            <NavLink to="/reports" style={styles.menuItem}>
+              Reports
+            </NavLink>
+          )}
         </div>
 
         <hr style={styles.divider} />
 
         <div style={styles.menuGroup}>
-          <div style={styles.groupTitle}>⚙ Settings</div>
-          <NavLink to="/settings" style={styles.menuItem} end>
-            General
-          </NavLink>
-          {user?.role === 'admin' && (
+          <button
+            style={styles.groupBtn}
+            onClick={() => setOpenSettings((o) => !o)}
+          >
+            ⚙ Settings {openSettings ? '▾' : '▸'}
+          </button>
+          {openSettings && (
             <>
-              <NavLink to="/settings/users" style={styles.menuItem}>
-                Users
-              </NavLink>
-              <NavLink to="/settings/user-companies" style={styles.menuItem}>
-                User Companies
-              </NavLink>
-              <NavLink to="/settings/role-permissions" style={styles.menuItem}>
-                Role Permissions
+              {perms.settings && (
+                <NavLink to="/settings" style={styles.menuItem} end>
+                  General
+                </NavLink>
+              )}
+              {user?.role === 'admin' && (
+                <>
+                  <NavLink to="/settings/users" style={styles.menuItem}>
+                    Users
+                  </NavLink>
+                  <NavLink to="/settings/user-companies" style={styles.menuItem}>
+                    User Companies
+                  </NavLink>
+                  <NavLink to="/settings/role-permissions" style={styles.menuItem}>
+                    Role Permissions
+                  </NavLink>
+                </>
+              )}
+              <NavLink to="/settings/change-password" style={styles.menuItem}>
+                Change Password
               </NavLink>
             </>
           )}
-          <NavLink to="/settings/change-password" style={styles.menuItem}>
-            Change Password
-          </NavLink>
         </div>
       </nav>
     </aside>
@@ -223,6 +242,17 @@ const styles = {
     fontSize: '0.85rem',
     fontWeight: 'bold',
     margin: '0.5rem 0 0.25rem 0',
+  },
+  groupBtn: {
+    display: 'block',
+    width: '100%',
+    background: 'transparent',
+    border: 'none',
+    color: '#e5e7eb',
+    textAlign: 'left',
+    padding: '0.4rem 0.75rem',
+    cursor: 'pointer',
+    fontSize: '0.9rem',
   },
   menuItem: ({ isActive }) => ({
     display: 'block',

--- a/src/erp.mgt.mn/hooks/useRolePermissions.js
+++ b/src/erp.mgt.mn/hooks/useRolePermissions.js
@@ -1,0 +1,26 @@
+import { useContext, useEffect, useState } from 'react';
+import { AuthContext } from '../context/AuthContext.jsx';
+
+let cached = null;
+
+export function useRolePermissions() {
+  const { user } = useContext(AuthContext);
+  const [perms, setPerms] = useState(cached || {});
+
+  useEffect(() => {
+    if (!user) return;
+    if (cached) return;
+    const roleId = user.role_id || (user.role === 'admin' ? 1 : 2);
+    fetch(`/api/role_permissions?roleId=${roleId}`, { credentials: 'include' })
+      .then(res => (res.ok ? res.json() : []))
+      .then(rows => {
+        const map = {};
+        rows.forEach(r => { map[r.module_key] = !!r.allowed; });
+        cached = map;
+        setPerms(map);
+      })
+      .catch(err => console.error('Failed to load permissions', err));
+  }, [user]);
+
+  return perms;
+}

--- a/src/erp.mgt.mn/pages/Settings.jsx
+++ b/src/erp.mgt.mn/pages/Settings.jsx
@@ -1,14 +1,18 @@
 // src/erp.mgt.mn/pages/Settings.jsx
 import React, { useEffect, useState } from 'react';
+import { useRolePermissions } from '../hooks/useRolePermissions.js';
 import { NavLink, Outlet, Link } from 'react-router-dom';
 
 export default function SettingsLayout() {
+  const perms = useRolePermissions();
   return (
     <div style={styles.container}>
       <aside style={styles.menu}>
-        <NavLink end to="/settings" style={styles.menuItem}>
-          General
-        </NavLink>
+        {perms.settings && (
+          <NavLink end to="/settings" style={styles.menuItem}>
+            General
+          </NavLink>
+        )}
         <NavLink to="/settings/users" style={styles.menuItem}>
           Users
         </NavLink>
@@ -30,6 +34,10 @@ export default function SettingsLayout() {
 }
 
 export function GeneralSettings() {
+  const perms = useRolePermissions();
+  if (!perms.settings) {
+    return <p>Access denied.</p>;
+  }
   const [settings, setSettings] = useState(null);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add hook to fetch role permissions
- collapse sidebar settings and hide menu items based on permissions
- gate settings page from non-permitted roles
- seed permissions for all modules

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842a198856c8331bb6a1766b330f34f