### PR TITLE
Remove duplicate settings submenu

### DIFF
--- a/src/erp.mgt.mn/pages/Settings.jsx
+++ b/src/erp.mgt.mn/pages/Settings.jsx
@@ -1,36 +1,12 @@
 // src/erp.mgt.mn/pages/Settings.jsx
 import React, { useEffect, useState } from 'react';
 import { useRolePermissions } from '../hooks/useRolePermissions.js';
-import { NavLink, Outlet, Link } from 'react-router-dom';
+import { Outlet, Link } from 'react-router-dom';
 
-export default function SettingsLayout() {
-  const perms = useRolePermissions();
-  return (
-    <div style={styles.container}>
-      <aside style={styles.menu}>
-        {perms.settings && (
-          <NavLink end to="/settings" style={styles.menuItem}>
-            General
-          </NavLink>
-        )}
-        <NavLink to="/settings/users" style={styles.menuItem}>
-          Users
-        </NavLink>
-        <NavLink to="/settings/user-companies" style={styles.menuItem}>
-          User Companies
-        </NavLink>
-        <NavLink to="/settings/role-permissions" style={styles.menuItem}>
-          Role Permissions
-        </NavLink>
-        <NavLink to="/settings/change-password" style={styles.menuItem}>
-          Change Password
-        </NavLink>
-      </aside>
-      <div style={styles.content}>
-        <Outlet />
-      </div>
-    </div>
-  );
+export default function SettingsPage() {
+  // Just render the nested route content. The left sidebar already
+  // exposes settings links, so we do not repeat them here.
+  return <Outlet />;
 }
 
 export function GeneralSettings() {
@@ -65,28 +41,3 @@ export function GeneralSettings() {
   );
 }
 
-const styles = {
-  container: {
-    display: 'flex',
-    height: '100%'
-  },
-  menu: {
-    width: '200px',
-    padding: '0.5rem',
-    borderRight: '1px solid #d1d5db'
-  },
-  menuItem: ({ isActive }) => ({
-    display: 'block',
-    padding: '0.4rem 0.5rem',
-    color: isActive ? '#000' : '#374151',
-    textDecoration: 'none',
-    backgroundColor: isActive ? '#e5e7eb' : 'transparent',
-    borderRadius: '3px',
-    marginBottom: '0.25rem',
-    fontSize: '0.9rem'
-  }),
-  content: {
-    flexGrow: 1,
-    padding: '1rem'
-  }
-};


### PR DESCRIPTION
## Summary
- simplify `Settings` page so it only renders nested routes
- drop unused menu sidebar

## Testing
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a6c463288331a8c33a20b453468f