### PR TITLE
Fix module permissions in sidebar

### DIFF
--- a/config/modules.js
+++ b/config/modules.js
@@ -1,0 +1,10 @@
+export const modules = [
+  { key: 'dashboard', name: 'Blue Link Demo', path: '/' },
+  { key: 'forms', name: 'Forms', path: '/forms' },
+  { key: 'reports', name: 'Reports', path: '/reports' },
+  { key: 'settings', name: 'Settings', path: '/settings' },
+  { key: 'users', name: 'Users', path: '/settings/users', parent: 'settings' },
+  { key: 'user_companies', name: 'User Companies', path: '/settings/user-companies', parent: 'settings' },
+  { key: 'role_permissions', name: 'Role Permissions', path: '/settings/role-permissions', parent: 'settings' },
+  { key: 'change_password', name: 'Change Password', path: '/settings/change-password', parent: 'settings' },
+];

--- a/db/index.js
+++ b/db/index.js
@@ -1,6 +1,7 @@
 import mysql from 'mysql2/promise';
 import dotenv from 'dotenv';
 import bcrypt from 'bcryptjs';
+import { modules } from '../config/modules.js';
 
 dotenv.config();
 
@@ -248,7 +249,18 @@ export async function listRoleModulePermissions(roleId) {
      ${roleId ? 'WHERE rmp.role_id = ?' : ''}`,
     roleId ? [roleId] : []
   );
-  return rows;
+  if (!roleId) return rows;
+  const map = {};
+  rows.forEach(r => {
+    map[r.module_key] = r.allowed;
+  });
+  const roleName = rows[0] ? rows[0].role : '';
+  return modules.map(m => ({
+    role_id: roleId,
+    role: roleName,
+    module_key: m.key,
+    allowed: map[m.key] ?? 0,
+  }));
 }
 
 /**

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -6,6 +6,7 @@ import { Outlet, NavLink, useNavigate, useLocation } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { logout } from '../hooks/useAuth.jsx';
 import { useRolePermissions } from '../hooks/useRolePermissions.js';
+import { modules } from '../../config/modules.js';
 
 /**
  * A desktop‐style “ERPLayout” with:
@@ -89,17 +90,17 @@ function Sidebar() {
       <nav>
         <div style={styles.menuGroup}>
           <div style={styles.groupTitle}>📌 Pinned</div>
-          {perms.dashboard !== false && (
+          {perms.dashboard && (
             <NavLink to="/" style={styles.menuItem}>
               Blue Link Demo
             </NavLink>
           )}
-          {perms.forms !== false && (
+          {perms.forms && (
             <NavLink to="/forms" style={styles.menuItem}>
               Forms
             </NavLink>
           )}
-          {perms.reports !== false && (
+          {perms.reports && (
             <NavLink to="/reports" style={styles.menuItem}>
               Reports
             </NavLink>
@@ -122,22 +123,26 @@ function Sidebar() {
                   General
                 </NavLink>
               )}
-              {user?.role === 'admin' && (
-                <>
-                  <NavLink to="/settings/users" style={styles.menuItem}>
-                    Users
-                  </NavLink>
-                  <NavLink to="/settings/user-companies" style={styles.menuItem}>
-                    User Companies
-                  </NavLink>
-                  <NavLink to="/settings/role-permissions" style={styles.menuItem}>
-                    Role Permissions
-                  </NavLink>
-                </>
+              {perms.users && (
+                <NavLink to="/settings/users" style={styles.menuItem}>
+                  Users
+                </NavLink>
               )}
-              <NavLink to="/settings/change-password" style={styles.menuItem}>
-                Change Password
-              </NavLink>
+              {perms.user_companies && (
+                <NavLink to="/settings/user-companies" style={styles.menuItem}>
+                  User Companies
+                </NavLink>
+              )}
+              {perms.role_permissions && (
+                <NavLink to="/settings/role-permissions" style={styles.menuItem}>
+                  Role Permissions
+                </NavLink>
+              )}
+              {perms.change_password && (
+                <NavLink to="/settings/change-password" style={styles.menuItem}>
+                  Change Password
+                </NavLink>
+              )}
             </>
           )}
         </div>

--- a/src/erp.mgt.mn/pages/RolePermissions.jsx
+++ b/src/erp.mgt.mn/pages/RolePermissions.jsx
@@ -1,5 +1,6 @@
 // src/erp.mgt.mn/pages/RolePermissions.jsx
 import React, { useEffect, useState } from 'react';
+import { modules } from '../../config/modules.js';
 
 export default function RolePermissions() {
   const [perms, setPerms] = useState([]);
@@ -69,7 +70,9 @@ export default function RolePermissions() {
             {perms.map(p => (
               <tr key={p.role_id + '-' + p.module_key}>
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{p.role}</td>
-                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{p.module_key}</td>
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
+                  {modules.find(m => m.key === p.module_key)?.name || p.module_key}
+                </td>
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{p.allowed ? 'Yes' : 'No'}</td>
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
                   <button onClick={() => handleToggle(p)}>


### PR DESCRIPTION
## Summary
- add central module list for assigning permissions
- show/hide sidebar items based on module permissions
- ensure API always returns all modules for a role
- display friendly names in Role Permissions page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842ab1285bc83318b6bd288e34c224b