### PR TITLE
Hide modules by permission

### DIFF
--- a/db/migrations/2025-06-08_seed_module_permissions.sql
+++ b/db/migrations/2025-06-08_seed_module_permissions.sql
@@ -8,6 +8,9 @@ INSERT INTO role_module_permissions (role_id, module_key, allowed) VALUES
   (1, 'user_companies', 1),
   (1, 'role_permissions', 1),
   (1, 'change_password', 1),
+  (1, 'gl', 1),
+  (1, 'po', 1),
+  (1, 'sales', 1),
   (2, 'dashboard', 1),
   (2, 'forms', 1),
   (2, 'reports', 1),
@@ -15,5 +18,8 @@ INSERT INTO role_module_permissions (role_id, module_key, allowed) VALUES
   (2, 'users', 0),
   (2, 'user_companies', 0),
   (2, 'role_permissions', 0),
-  (2, 'change_password', 1)
+  (2, 'change_password', 1),
+  (2, 'gl', 1),
+  (2, 'po', 1),
+  (2, 'sales', 1)
 ON DUPLICATE KEY UPDATE allowed = VALUES(allowed);

--- a/db/migrations/2025-06-09_modules.sql
+++ b/db/migrations/2025-06-09_modules.sql
@@ -13,7 +13,10 @@ INSERT INTO modules (module_key, label) VALUES
   ('users', 'Users'),
   ('user_companies', 'User Companies'),
   ('role_permissions', 'Role Permissions'),
-  ('change_password', 'Change Password')
+  ('change_password', 'Change Password'),
+  ('gl', 'General Ledger'),
+  ('po', 'Purchase Orders'),
+  ('sales', 'Sales Dashboard')
 ON DUPLICATE KEY UPDATE label = VALUES(label);
 
 ALTER TABLE role_module_permissions

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -89,33 +89,30 @@ function Sidebar() {
       <nav>
         <div style={styles.menuGroup}>
           <div style={styles.groupTitle}>📌 Pinned</div>
-          <NavLink
-            to="/"
-            onClick={(e) => perms.dashboard === false && e.preventDefault()}
-            style={({ isActive }) =>
-              styles.menuItem({ isActive, disabled: perms.dashboard === false })
-            }
-          >
-            Blue Link Demo
-          </NavLink>
-          <NavLink
-            to="/forms"
-            onClick={(e) => perms.forms === false && e.preventDefault()}
-            style={({ isActive }) =>
-              styles.menuItem({ isActive, disabled: perms.forms === false })
-            }
-          >
-            Forms
-          </NavLink>
-          <NavLink
-            to="/reports"
-            onClick={(e) => perms.reports === false && e.preventDefault()}
-            style={({ isActive }) =>
-              styles.menuItem({ isActive, disabled: perms.reports === false })
-            }
-          >
-            Reports
-          </NavLink>
+          {perms.dashboard !== false && (
+            <NavLink
+              to="/"
+              style={({ isActive }) => styles.menuItem({ isActive })}
+            >
+              Blue Link Demo
+            </NavLink>
+          )}
+          {perms.forms !== false && (
+            <NavLink
+              to="/forms"
+              style={({ isActive }) => styles.menuItem({ isActive })}
+            >
+              Forms
+            </NavLink>
+          )}
+          {perms.reports !== false && (
+            <NavLink
+              to="/reports"
+              style={({ isActive }) => styles.menuItem({ isActive })}
+            >
+              Reports
+            </NavLink>
+          )}
         </div>
 
         <hr style={styles.divider} />

--- a/src/erp.mgt.mn/components/HeaderMenu.jsx
+++ b/src/erp.mgt.mn/components/HeaderMenu.jsx
@@ -1,17 +1,23 @@
 import React from 'react';
+import { useRolePermissions } from '../hooks/useRolePermissions.js';
 
 export default function HeaderMenu({ onOpen }) {
+  const perms = useRolePermissions();
+  const items = [
+    { id: 'gl', label: 'General Ledger' },
+    { id: 'po', label: 'Purchase Orders' },
+    { id: 'sales', label: 'Sales Dashboard' },
+  ];
   return (
     <nav style={styles.menu}>
-      <button style={styles.btn} onClick={() => onOpen('gl')}>
-        General Ledger
-      </button>
-      <button style={styles.btn} onClick={() => onOpen('po')}>
-        Purchase Orders
-      </button>
-      <button style={styles.btn} onClick={() => onOpen('sales')}>
-        Sales Dashboard
-      </button>
+      {items.map(
+        (m) =>
+          perms[m.id] !== false && (
+            <button key={m.id} style={styles.btn} onClick={() => onOpen(m.id)}>
+              {m.label}
+            </button>
+          ),
+      )}
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- hide unauthorized modules in the sidebar and header
- add General Ledger, Purchase Orders and Sales Dashboard to the modules list
- seed default permissions for the new modules

## Testing
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b3d581108331ac47c667aa1431c3