### PR TITLE
Fix auth loading & add refresh button

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -66,7 +66,12 @@ function Header({ user, onLogout }) {
         <span style={styles.logoText}>MyERP</span>
       </div>
       <nav style={styles.headerNav}>
-        <button style={styles.iconBtn}>🗔 Home</button>
+        <button
+          style={styles.iconBtn}
+          onClick={() => window.location.reload()}
+        >
+          🗔 Home
+        </button>
         <button style={styles.iconBtn}>🗗 Windows</button>
         <button style={styles.iconBtn}>❔ Help</button>
       </nav>

--- a/src/erp.mgt.mn/components/Layout.jsx
+++ b/src/erp.mgt.mn/components/Layout.jsx
@@ -59,7 +59,12 @@ function Header({ user, onLogout }) {
         <span style={styles.logoText}>MyERP</span>
       </div>
       <nav style={styles.headerNav}>
-        <button style={styles.iconBtn}>🗔 Home</button>
+        <button
+          style={styles.iconBtn}
+          onClick={() => window.location.reload()}
+        >
+          🗔 Home
+        </button>
         <button style={styles.iconBtn}>🗗 Windows</button>
         <button style={styles.iconBtn}>❔ Help</button>
       </nav>

--- a/src/erp.mgt.mn/components/RequireAuth.jsx
+++ b/src/erp.mgt.mn/components/RequireAuth.jsx
@@ -3,6 +3,9 @@ import { AuthContext } from '../context/AuthContext.jsx';
 import { Navigate, Outlet } from 'react-router-dom';
 
 export default function RequireAuth() {
-  const { user } = useContext(AuthContext);
+  const { user, loading } = useContext(AuthContext);
+  if (loading) {
+    return <p>Loading…</p>;
+  }
   return user ? <Outlet /> : <Navigate to="/login" replace />;
 }

--- a/src/erp.mgt.mn/context/AuthContext.jsx
+++ b/src/erp.mgt.mn/context/AuthContext.jsx
@@ -5,10 +5,12 @@ import React, { createContext, useState, useEffect, useContext } from 'react';
 export const AuthContext = createContext({
   user: null,
   setUser: () => {},
+  loading: true,
 });
 
 export default function AuthContextProvider({ children }) {
   const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
 
   // On mount, attempt to load the current profile (if a cookie is present)
   useEffect(() => {
@@ -26,6 +28,8 @@ export default function AuthContextProvider({ children }) {
         }
       } catch (err) {
         console.error('Unable to fetch profile:', err);
+      } finally {
+        setLoading(false);
       }
     }
 
@@ -33,7 +37,7 @@ export default function AuthContextProvider({ children }) {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, setUser }}>
+    <AuthContext.Provider value={{ user, setUser, loading }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- avoid redirect loop by waiting for auth profile to load
- show loading screen while checking authentication
- allow refreshing the app via Home button

## Testing
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842baa752cc8331b4f7e16a872e5bcf