### PR TITLE
Fix permission refresh via home button

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -5,7 +5,7 @@ import UserMenu from "./UserMenu.jsx";
 import { Outlet, NavLink, useNavigate, useLocation } from "react-router-dom";
 import { AuthContext } from "../context/AuthContext.jsx";
 import { logout } from "../hooks/useAuth.jsx";
-import { useRolePermissions } from "../hooks/useRolePermissions.js";
+import { useRolePermissions, refreshRolePermissions } from "../hooks/useRolePermissions.js";
 
 /**
  * A desktop‐style “ERPLayout” with:
@@ -36,9 +36,15 @@ export default function ERPLayout() {
     navigate("/login");
   }
 
+  function handleHome() {
+    const roleId = user?.role_id || (user?.role === 'admin' ? 1 : 2);
+    refreshRolePermissions(roleId);
+    navigate('/');
+  }
+
   return (
     <div style={styles.container}>
-      <Header user={user} onLogout={handleLogout} />
+      <Header user={user} onLogout={handleLogout} onHome={handleHome} />
       <div style={styles.body}>
         <Sidebar />
         <MainWindow title={windowTitle}>
@@ -50,7 +56,7 @@ export default function ERPLayout() {
 }
 
 /** Top header bar **/
-function Header({ user, onLogout }) {
+function Header({ user, onLogout, onHome }) {
   function handleOpen(id) {
     console.log("open module", id);
   }
@@ -66,7 +72,7 @@ function Header({ user, onLogout }) {
         <span style={styles.logoText}>MyERP</span>
       </div>
       <nav style={styles.headerNav}>
-        <button style={styles.iconBtn}>🗔 Home</button>
+        <button style={styles.iconBtn} onClick={onHome}>🗔 Home</button>
         <button style={styles.iconBtn}>🗗 Windows</button>
         <button style={styles.iconBtn}>❔ Help</button>
       </nav>

--- a/src/erp.mgt.mn/hooks/useRolePermissions.js
+++ b/src/erp.mgt.mn/hooks/useRolePermissions.js
@@ -4,9 +4,35 @@ import { AuthContext } from '../context/AuthContext.jsx';
 // Cache permissions by role so switching users does not refetch unnecessarily
 const cache = {};
 
+// Simple event emitter for permission refresh events
+const emitter = new EventTarget();
+
+export function refreshRolePermissions(roleId) {
+  if (roleId) delete cache[roleId];
+  emitter.dispatchEvent(new Event('refresh'));
+}
+
 export function useRolePermissions() {
   const { user } = useContext(AuthContext);
   const [perms, setPerms] = useState(null);
+
+  async function fetchPerms(roleId) {
+    try {
+      const res = await fetch(`/api/role_permissions?roleId=${roleId}`, {
+        credentials: 'include',
+      });
+      const rows = res.ok ? await res.json() : [];
+      const map = {};
+      rows.forEach((r) => {
+        map[r.module_key] = !!r.allowed;
+      });
+      cache[roleId] = map;
+      setPerms(map);
+    } catch (err) {
+      console.error('Failed to load permissions', err);
+      setPerms({});
+    }
+  }
 
   useEffect(() => {
     if (!user) {
@@ -17,23 +43,18 @@ export function useRolePermissions() {
 
     if (cache[roleId]) {
       setPerms(cache[roleId]);
-      return;
+    } else {
+      fetchPerms(roleId);
     }
+  }, [user]);
 
-    fetch(`/api/role_permissions?roleId=${roleId}`, { credentials: 'include' })
-      .then((res) => (res.ok ? res.json() : []))
-      .then((rows) => {
-        const map = {};
-        rows.forEach((r) => {
-          map[r.module_key] = !!r.allowed;
-        });
-        cache[roleId] = map;
-        setPerms(map);
-      })
-      .catch((err) => {
-        console.error('Failed to load permissions', err);
-        setPerms({});
-      });
+  // Listen for refresh events
+  useEffect(() => {
+    if (!user) return;
+    const roleId = user.role_id || (user.role === 'admin' ? 1 : 2);
+    const handler = () => fetchPerms(roleId);
+    emitter.addEventListener('refresh', handler);
+    return () => emitter.removeEventListener('refresh', handler);
   }, [user]);
 
   return perms;

--- a/src/erp.mgt.mn/pages/RolePermissions.jsx
+++ b/src/erp.mgt.mn/pages/RolePermissions.jsx
@@ -1,5 +1,6 @@
 // src/erp.mgt.mn/pages/RolePermissions.jsx
 import React, { useEffect, useState } from "react";
+import { refreshRolePermissions } from "../hooks/useRolePermissions.js";
 
 export default function RolePermissions() {
   const [perms, setPerms] = useState([]);
@@ -42,6 +43,7 @@ export default function RolePermissions() {
       return;
     }
     loadPerms(filterRoleId);
+    refreshRolePermissions(p.role_id);
   }
 
   return (


### PR DESCRIPTION
## Summary
- add an event-based permission cache refresh
- refresh permissions after updates
- make the Home button reload permissions and navigate to dashboard

## Testing
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bde49e0c8331b6c9580569d0fb5b