### PR TITLE
Add company module license management

### DIFF
--- a/api-server/controllers/companyModuleController.js
+++ b/api-server/controllers/companyModuleController.js
@@ -1,0 +1,24 @@
+import { listCompanyModuleLicenses, setCompanyModuleLicense } from '../../db/index.js';
+
+export async function listLicenses(req, res, next) {
+  try {
+    const companyId = req.query.companyId;
+    const licenses = await listCompanyModuleLicenses(companyId);
+    res.json(licenses);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function updateLicense(req, res, next) {
+  try {
+    if (req.user.role !== 'admin') {
+      return res.sendStatus(403);
+    }
+    const { companyId, moduleKey, licensed } = req.body;
+    await setCompanyModuleLicense(companyId, moduleKey, licensed);
+    res.sendStatus(200);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/api-server/routes/company_modules.js
+++ b/api-server/routes/company_modules.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import { listLicenses, updateLicense } from '../controllers/companyModuleController.js';
+import { requireAuth } from '../middlewares/auth.js';
+
+const router = express.Router();
+router.get('/', requireAuth, listLicenses);
+router.put('/', requireAuth, updateLicense);
+export default router;

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -13,6 +13,7 @@ import settingsRoutes from "./routes/settings.js";
 import userCompanyRoutes from "./routes/user_companies.js";
 import rolePermissionRoutes from "./routes/role_permissions.js";
 import moduleRoutes from "./routes/modules.js";
+import companyModuleRoutes from "./routes/company_modules.js";
 import { requireAuth } from "./middlewares/auth.js";
 
 dotenv.config();
@@ -45,6 +46,7 @@ app.use("/api/settings", requireAuth, settingsRoutes);
 app.use("/api/user_companies", requireAuth, userCompanyRoutes);
 app.use("/api/role_permissions", requireAuth, rolePermissionRoutes);
 app.use("/api/modules", requireAuth, moduleRoutes);
+app.use("/api/company_modules", requireAuth, companyModuleRoutes);
 
 // Serve static React build and fallback to index.html
 // NOTE: adjust this path to where your SPA build actually lives.

--- a/db/migrations/2025-06-10_company_module_licenses.sql
+++ b/db/migrations/2025-06-10_company_module_licenses.sql
@@ -1,0 +1,7 @@
+CREATE TABLE company_module_licenses (
+  company_id INT NOT NULL,
+  module_key VARCHAR(50) NOT NULL,
+  licensed TINYINT(1) DEFAULT 0,
+  PRIMARY KEY (company_id, module_key),
+  FOREIGN KEY (company_id) REFERENCES companies(id)
+);

--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -10,6 +10,7 @@ import ReportsPage from './pages/Reports.jsx';
 import UsersPage from './pages/Users.jsx';
 import UserCompaniesPage from './pages/UserCompanies.jsx';
 import RolePermissionsPage from './pages/RolePermissions.jsx';
+import CompanyLicensesPage from './pages/CompanyLicenses.jsx';
 import SettingsPage, { GeneralSettings } from './pages/Settings.jsx';
 import ChangePasswordPage from './pages/ChangePassword.jsx';
 import Dashboard from './pages/Dashboard.jsx';
@@ -35,6 +36,7 @@ export default function App() {
                   <Route path="users" element={<UsersPage />} />
                   <Route path="user-companies" element={<UserCompaniesPage />} />
                   <Route path="role-permissions" element={<RolePermissionsPage />} />
+                  <Route path="company-licenses" element={<CompanyLicensesPage />} />
                 </Route>
                 <Route path="change-password" element={<ChangePasswordPage />} />
               </Route>

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -26,6 +26,7 @@ export default function ERPLayout() {
     "/settings/users": "Users",
     "/settings/user-companies": "User Companies",
     "/settings/role-permissions": "Role Permissions",
+    "/settings/company-licenses": "Company Licenses",
     "/settings/change-password": "Change Password",
   };
   const windowTitle = titleMap[location.pathname] || "ERP";
@@ -157,6 +158,12 @@ function Sidebar() {
                     style={styles.menuItem}
                   >
                     Role Permissions
+                  </NavLink>
+                  <NavLink
+                    to="/settings/company-licenses"
+                    style={styles.menuItem}
+                  >
+                    Company Licenses
                   </NavLink>
                 </>
               )}

--- a/src/erp.mgt.mn/pages/CompanyLicenses.jsx
+++ b/src/erp.mgt.mn/pages/CompanyLicenses.jsx
@@ -1,0 +1,82 @@
+// src/erp.mgt.mn/pages/CompanyLicenses.jsx
+import React, { useState } from 'react';
+
+export default function CompanyLicenses() {
+  const [licenses, setLicenses] = useState([]);
+  const [filterCompanyId, setFilterCompanyId] = useState('');
+
+  function loadLicenses(companyId) {
+    const url = companyId ? `/api/company_modules?companyId=${encodeURIComponent(companyId)}` : '/api/company_modules';
+    fetch(url, { credentials: 'include' })
+      .then(res => {
+        if (!res.ok) throw new Error('Failed to fetch licenses');
+        return res.json();
+      })
+      .then(setLicenses)
+      .catch(err => console.error('Error fetching licenses:', err));
+  }
+
+  function handleFilter() {
+    loadLicenses(filterCompanyId);
+  }
+
+  async function handleToggle(l) {
+    const res = await fetch('/api/company_modules', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({
+        companyId: l.company_id || filterCompanyId,
+        moduleKey: l.module_key,
+        licensed: l.licensed ? 0 : 1,
+      }),
+    });
+    if (!res.ok) {
+      alert('Failed to update license');
+      return;
+    }
+    loadLicenses(filterCompanyId);
+  }
+
+  return (
+    <div>
+      <h2>Company Licenses</h2>
+      <input
+        type="text"
+        placeholder="Filter by Company ID"
+        value={filterCompanyId}
+        onChange={(e) => setFilterCompanyId(e.target.value)}
+        style={{ marginRight: '0.5rem' }}
+      />
+      <button onClick={handleFilter}>Apply</button>
+      {licenses.length === 0 ? (
+        <p>No licenses.</p>
+      ) : (
+        <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '0.5rem' }}>
+          <thead>
+            <tr style={{ backgroundColor: '#e5e7eb' }}>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Company</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Module</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Licensed</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {licenses.map((l) => (
+              <tr key={l.company_id + '-' + l.module_key}>
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{l.company_name}</td>
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{l.label}</td>
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{l.licensed ? 'Yes' : 'No'}</td>
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
+                  <button onClick={() => handleToggle(l)}>
+                    {l.licensed ? 'Disable' : 'Enable'}
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add migration for `company_module_licenses`
- implement DB helpers for listing and setting module licenses
- expose new routes `/api/company_modules`
- allow admins to view and edit company module licenses in new settings page
- update layout and routing to include Company Licenses page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842c0592c788331b2dea4017c3ee5ac