### PR TITLE
Fix company licenses page not loading data

### DIFF
--- a/src/erp.mgt.mn/pages/CompanyLicenses.jsx
+++ b/src/erp.mgt.mn/pages/CompanyLicenses.jsx
@@ -1,9 +1,13 @@
 // src/erp.mgt.mn/pages/CompanyLicenses.jsx
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 export default function CompanyLicenses() {
   const [licenses, setLicenses] = useState([]);
   const [filterCompanyId, setFilterCompanyId] = useState('');
+
+  useEffect(() => {
+    loadLicenses('');
+  }, []);
 
   function loadLicenses(companyId) {
     const url = companyId ? `/api/company_modules?companyId=${encodeURIComponent(companyId)}` : '/api/company_modules';
@@ -80,3 +84,4 @@ export default function CompanyLicenses() {
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- load company module licenses when the page mounts so the table isn't empty

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842d890d6d88331ab48c965e80f0f99