### PR TITLE
Add role default module helpers

### DIFF
--- a/README_MIGRATION.md
+++ b/README_MIGRATION.md
@@ -27,3 +27,12 @@ Apply as follows:
 node server.js
 # Open http://localhost:3000/erp
 ```
+
+### Database helpers
+
+Two SQL utilities assist with default module permissions:
+
+* `db/migrations/2025-06-12_role_default_modules.sql` – defines `role_default_modules` and seeds defaults.
+* `db/scripts/populate_role_module_permissions.sql` – copies those defaults into `role_module_permissions` for admin review.
+
+Run the script after applying the migration to initialize permissions for all roles.

--- a/db/migrations/2025-06-12_role_default_modules.sql
+++ b/db/migrations/2025-06-12_role_default_modules.sql
@@ -1,0 +1,35 @@
+-- Define default modules per role used for initialization
+CREATE TABLE role_default_modules (
+  role_id INT NOT NULL,
+  module_key VARCHAR(50) NOT NULL,
+  allowed TINYINT(1) DEFAULT 1,
+  PRIMARY KEY (role_id, module_key),
+  FOREIGN KEY (role_id) REFERENCES user_roles(id),
+  FOREIGN KEY (module_key) REFERENCES modules(module_key)
+);
+
+-- Seed defaults mirroring initial permissions
+INSERT INTO role_default_modules (role_id, module_key, allowed) VALUES
+  (1, 'dashboard', 1),
+  (1, 'forms', 1),
+  (1, 'reports', 1),
+  (1, 'settings', 1),
+  (1, 'users', 1),
+  (1, 'user_companies', 1),
+  (1, 'role_permissions', 1),
+  (1, 'change_password', 1),
+  (1, 'gl', 1),
+  (1, 'po', 1),
+  (1, 'sales', 1),
+  (2, 'dashboard', 1),
+  (2, 'forms', 1),
+  (2, 'reports', 1),
+  (2, 'settings', 0),
+  (2, 'users', 0),
+  (2, 'user_companies', 0),
+  (2, 'role_permissions', 0),
+  (2, 'change_password', 1),
+  (2, 'gl', 1),
+  (2, 'po', 1),
+  (2, 'sales', 1)
+ON DUPLICATE KEY UPDATE allowed = VALUES(allowed);

--- a/db/scripts/populate_role_module_permissions.sql
+++ b/db/scripts/populate_role_module_permissions.sql
@@ -1,0 +1,5 @@
+-- Populate role_module_permissions from role_default_modules
+INSERT INTO role_module_permissions (role_id, module_key, allowed)
+SELECT rdm.role_id, rdm.module_key, rdm.allowed
+FROM role_default_modules rdm
+ON DUPLICATE KEY UPDATE allowed = VALUES(allowed);


### PR DESCRIPTION
## Summary
- create `role_default_modules` table with defaults
- add script to populate role permissions from defaults
- document the new migration and script

## Testing
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fb2dd2bc833197cbe5109df3ef52