### PR TITLE
Implement CSRF protection

### DIFF
--- a/api-server/app.js
+++ b/api-server/app.js
@@ -2,6 +2,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import express from "express";
 import cookieParser from "cookie-parser";
+import csurf from "csurf";
 import dotenv from "dotenv";
 import { testConnection } from "../db/index.js";
 import { errorHandler } from "./middlewares/errorHandler.js";
@@ -23,6 +24,11 @@ const __dirname = path.dirname(__filename);
 const app = express();
 app.use(express.json());
 app.use(cookieParser());
+
+// Setup CSRF protection using cookies
+const csrfProtection = csurf({ cookie: true });
+app.use(csrfProtection);
+
 app.use(logger);
 
 // Health-check: also verify DB connection
@@ -34,6 +40,11 @@ app.get("/api/auth/health", async (req, res, next) => {
   } catch (err) {
     next(err);
   }
+});
+
+// Provide CSRF token for frontend
+app.get("/api/csrf-token", (req, res) => {
+  res.json({ csrfToken: req.csrfToken() });
 });
 
 // API routes

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "mysql2": "^3.9.0",
     "dotenv": "^16.4.6",
     "cookie-parser": "^1.4.6",
+    "csurf": "^1.11.0",
     "react-mosaic-component": "^6.0.0",
     "jsonwebtoken": "^9.0.0"
   },

--- a/src/erp.mgt.mn/main.jsx
+++ b/src/erp.mgt.mn/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
+import './utils/csrfFetch.js';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/src/erp.mgt.mn/utils/csrfFetch.js
+++ b/src/erp.mgt.mn/utils/csrfFetch.js
@@ -1,0 +1,22 @@
+let tokenPromise;
+
+async function getToken() {
+  if (!tokenPromise) {
+    tokenPromise = fetch('/api/csrf-token', { credentials: 'include' })
+      .then(res => res.json())
+      .then(data => data.csrfToken)
+      .catch(() => undefined);
+  }
+  return tokenPromise;
+}
+
+const originalFetch = window.fetch.bind(window);
+window.fetch = async (url, options = {}) => {
+  const method = (options.method || 'GET').toUpperCase();
+  if (['POST', 'PUT', 'DELETE', 'PATCH'].includes(method)) {
+    const token = await getToken();
+    options.headers = { ...(options.headers || {}), 'X-CSRF-Token': token };
+    options.credentials = options.credentials || 'include';
+  }
+  return originalFetch(url, options);
+};


### PR DESCRIPTION
## Summary
- add `csurf` package
- wire CSRF middleware into `api-server/app.js`
- expose `/api/csrf-token` endpoint
- send token automatically in POST/PUT/DELETE via a fetch wrapper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843ebc0f99083319103a6fcaac0b9bb