### PR TITLE
Add Mongolian localization and settings pages

### DIFF
--- a/db/migrations/2025-06-13_mn_labels.sql
+++ b/db/migrations/2025-06-13_mn_labels.sql
@@ -1,0 +1,18 @@
+-- Translate module labels to Mongolian and add new modules
+UPDATE modules SET label='Самбар' WHERE module_key='dashboard';
+UPDATE modules SET label='Маягтууд' WHERE module_key='forms';
+UPDATE modules SET label='Тайлан' WHERE module_key='reports';
+UPDATE modules SET label='Тохиргоо' WHERE module_key='settings';
+UPDATE modules SET label='Хэрэглэгчид' WHERE module_key='users';
+UPDATE modules SET label='Хэрэглэгчийн компаниуд' WHERE module_key='user_companies';
+UPDATE modules SET label='Эрхийн тохиргоо' WHERE module_key='role_permissions';
+UPDATE modules SET label='Нууц үг солих' WHERE module_key='change_password';
+UPDATE modules SET label='Ерөнхий журнал' WHERE module_key='gl';
+UPDATE modules SET label='Худалдан авалтын захиалга' WHERE module_key='po';
+UPDATE modules SET label='Борлуулалтын самбар' WHERE module_key='sales';
+INSERT INTO modules (module_key, label) VALUES
+  ('company_licenses','Лиценз'),
+  ('tables_management','Хүснэгтийн удирдлага'),
+  ('forms_management','Маягтын удирдлага'),
+  ('report_management','Тайлангийн удирдлага')
+ON DUPLICATE KEY UPDATE label=VALUES(label);

--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -11,6 +11,9 @@ import UsersPage from './pages/Users.jsx';
 import UserCompaniesPage from './pages/UserCompanies.jsx';
 import RolePermissionsPage from './pages/RolePermissions.jsx';
 import CompanyLicensesPage from './pages/CompanyLicenses.jsx';
+import TablesManagementPage from './pages/TablesManagement.jsx';
+import FormsManagementPage from './pages/FormsManagement.jsx';
+import ReportManagementPage from './pages/ReportManagement.jsx';
 import SettingsPage, { GeneralSettings } from './pages/Settings.jsx';
 import ChangePasswordPage from './pages/ChangePassword.jsx';
 import Dashboard from './pages/Dashboard.jsx';
@@ -37,6 +40,9 @@ export default function App() {
                   <Route path="user-companies" element={<UserCompaniesPage />} />
                   <Route path="role-permissions" element={<RolePermissionsPage />} />
                   <Route path="company-licenses" element={<CompanyLicensesPage />} />
+                  <Route path="tables-management" element={<TablesManagementPage />} />
+                  <Route path="forms-management" element={<FormsManagementPage />} />
+                  <Route path="report-management" element={<ReportManagementPage />} />
                 </Route>
                 <Route path="change-password" element={<ChangePasswordPage />} />
               </Route>

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -20,15 +20,18 @@ export default function ERPLayout() {
   const location = useLocation();
 
   const titleMap = {
-    "/": "Blue Link Demo",
-    "/forms": "Forms",
-    "/reports": "Reports",
-    "/settings": "Settings",
-    "/settings/users": "Users",
-    "/settings/user-companies": "User Companies",
-    "/settings/role-permissions": "Role Permissions",
-    "/settings/company-licenses": "Company Licenses",
-    "/settings/change-password": "Change Password",
+    "/": "Blue Link демо",
+    "/forms": "Маягтууд",
+    "/reports": "Тайлан",
+    "/settings": "Тохиргоо",
+    "/settings/users": "Хэрэглэгчид",
+    "/settings/user-companies": "Хэрэглэгчийн компаниуд",
+    "/settings/role-permissions": "Эрхийн тохиргоо",
+    "/settings/company-licenses": "Лиценз",
+    "/settings/tables-management": "Хүснэгтийн удирдлага",
+    "/settings/forms-management": "Маягтын удирдлага",
+    "/settings/report-management": "Тайлангийн удирдлага",
+    "/settings/change-password": "Нууц үг солих",
   };
   const windowTitle = titleMap[location.pathname] || "ERP";
 
@@ -78,9 +81,9 @@ function Header({ user, onLogout, onHome }) {
         )}
       </div>
       <nav style={styles.headerNav}>
-        <button style={styles.iconBtn} onClick={onHome}>🗔 Home</button>
-        <button style={styles.iconBtn}>🗗 Windows</button>
-        <button style={styles.iconBtn}>❔ Help</button>
+        <button style={styles.iconBtn} onClick={onHome}>🗔 Нүүр</button>
+        <button style={styles.iconBtn}>🗗 Цонхнууд</button>
+        <button style={styles.iconBtn}>❔ Тусламж</button>
       </nav>
       <HeaderMenu onOpen={handleOpen} />
       <div style={styles.userSection}>
@@ -96,6 +99,7 @@ function Sidebar() {
   const perms = useRolePermissions();
   const licensed = useCompanyModules(company?.company_id);
   const [openSettings, setOpenSettings] = useState(false);
+  const [openUserSettings, setOpenUserSettings] = useState(false);
 
   if (!perms || !licensed) {
     return null;
@@ -105,13 +109,13 @@ function Sidebar() {
     <aside style={styles.sidebar}>
       <nav>
         <div style={styles.menuGroup}>
-          <div style={styles.groupTitle}>📌 Pinned</div>
+          <div style={styles.groupTitle}>📌 Түгээмэл</div>
           {perms.dashboard && licensed.dashboard && (
             <NavLink
               to="/"
               style={({ isActive }) => styles.menuItem({ isActive })}
             >
-              Blue Link Demo
+              Blue Link демо
             </NavLink>
           )}
           {perms.forms && licensed.forms && (
@@ -119,7 +123,7 @@ function Sidebar() {
               to="/forms"
               style={({ isActive }) => styles.menuItem({ isActive })}
             >
-              Forms
+              Маягтууд
             </NavLink>
           )}
           {perms.reports && licensed.reports && (
@@ -127,7 +131,7 @@ function Sidebar() {
               to="/reports"
               style={({ isActive }) => styles.menuItem({ isActive })}
             >
-              Reports
+              Тайлан
             </NavLink>
           )}
         </div>
@@ -139,52 +143,93 @@ function Sidebar() {
             style={styles.groupBtn}
             onClick={() => setOpenSettings((o) => !o)}
           >
-            ⚙ Settings {openSettings ? "▾" : "▸"}
+            ⚙ Тохиргоо {openSettings ? "▾" : "▸"}
           </button>
           {openSettings && (
             <>
               {perms.settings && licensed.settings && (
                 <NavLink to="/settings" style={styles.menuItem} end>
-                  General
+                  Ерөнхий
                 </NavLink>
               )}
-              {user?.role === "admin" && (
+              {licensed.company_licenses && (
+                <NavLink
+                  to="/settings/company-licenses"
+                  style={styles.menuItem}
+                >
+                  Лиценз
+                </NavLink>
+              )}
+              <button
+                style={styles.groupBtn}
+                onClick={() => setOpenUserSettings((o) => !o)}
+              >
+                👤 Хэрэглэгчийн тохиргоо {openUserSettings ? "▾" : "▸"}
+              </button>
+              {openUserSettings && (
                 <>
-                  {licensed.users && (
-                    <NavLink to="/settings/users" style={styles.menuItem}>
-                      Users
-                    </NavLink>
+                  {user?.role === "admin" && (
+                    <>
+                      {licensed.users && (
+                        <NavLink to="/settings/users" style={styles.menuItem}>
+                          Хэрэглэгчид
+                        </NavLink>
+                      )}
+                      {licensed.user_companies && (
+                        <NavLink
+                          to="/settings/user-companies"
+                          style={styles.menuItem}
+                        >
+                          Хэрэглэгчийн компаниуд
+                        </NavLink>
+                      )}
+                      {licensed.role_permissions && (
+                        <NavLink
+                          to="/settings/role-permissions"
+                          style={styles.menuItem}
+                        >
+                          Эрхийн тохиргоо
+                        </NavLink>
+                      )}
+                    </>
                   )}
-                  {licensed.user_companies && (
+                  {licensed.change_password && (
                     <NavLink
-                      to="/settings/user-companies"
+                      to="/settings/change-password"
                       style={styles.menuItem}
                     >
-                      User Companies
-                    </NavLink>
-                  )}
-                  {licensed.role_permissions && (
-                    <NavLink
-                      to="/settings/role-permissions"
-                      style={styles.menuItem}
-                    >
-                      Role Permissions
-                    </NavLink>
-                  )}
-                  {licensed.company_licenses && (
-                    <NavLink
-                      to="/settings/company-licenses"
-                      style={styles.menuItem}
-                    >
-                      Company Licenses
+                      Нууц үг солих
                     </NavLink>
                   )}
                 </>
               )}
-              {licensed.change_password && (
-                <NavLink to="/settings/change-password" style={styles.menuItem}>
-                  Change Password
-                </NavLink>
+              {user?.role === "admin" && (
+                <>
+                  {licensed.tables_management && (
+                    <NavLink
+                      to="/settings/tables-management"
+                      style={styles.menuItem}
+                    >
+                      Хүснэгтийн удирдлага
+                    </NavLink>
+                  )}
+                  {licensed.forms_management && (
+                    <NavLink
+                      to="/settings/forms-management"
+                      style={styles.menuItem}
+                    >
+                      Маягтын удирдлага
+                    </NavLink>
+                  )}
+                  {licensed.report_management && (
+                    <NavLink
+                      to="/settings/report-management"
+                      style={styles.menuItem}
+                    >
+                      Тайлангийн удирдлага
+                    </NavLink>
+                  )}
+                </>
               )}
             </>
           )}

--- a/src/erp.mgt.mn/components/HeaderMenu.jsx
+++ b/src/erp.mgt.mn/components/HeaderMenu.jsx
@@ -4,9 +4,9 @@ import { useRolePermissions } from '../hooks/useRolePermissions.js';
 export default function HeaderMenu({ onOpen }) {
   const perms = useRolePermissions();
   const items = [
-    { id: 'gl', label: 'General Ledger' },
-    { id: 'po', label: 'Purchase Orders' },
-    { id: 'sales', label: 'Sales Dashboard' },
+    { id: 'gl', label: 'Ерөнхий журнал' },
+    { id: 'po', label: 'Худалдан авалтын захиалга' },
+    { id: 'sales', label: 'Борлуулалтын самбар' },
   ];
 
   if (!perms) return null;

--- a/src/erp.mgt.mn/components/LoginForm.jsx
+++ b/src/erp.mgt.mn/components/LoginForm.jsx
@@ -64,7 +64,7 @@ export default function LoginForm() {
       >
         <div style={{ marginBottom: '0.75rem' }}>
           <label htmlFor="company" style={{ display: 'block', marginBottom: '0.25rem' }}>
-            Select Company
+            Компани сонгох
           </label>
           <select
             id="company"
@@ -74,7 +74,7 @@ export default function LoginForm() {
             style={{ width: '100%', padding: '0.5rem', borderRadius: '3px' }}
           >
             <option value="" disabled>
-              Choose...
+              Сонгоно уу...
             </option>
             {companyChoices.map((c) => (
               <option key={c.company_id} value={c.company_id}>
@@ -94,7 +94,7 @@ export default function LoginForm() {
             cursor: 'pointer',
           }}
         >
-          Continue
+          Үргэлжлүүлэх
         </button>
       </form>
     );
@@ -104,7 +104,7 @@ export default function LoginForm() {
     <form onSubmit={handleSubmit} style={{ maxWidth: '320px' }}>
       <div style={{ marginBottom: '0.75rem' }}>
         <label htmlFor="empid" style={{ display: 'block', marginBottom: '0.25rem' }}>
-          EmpID
+          Ажилтны ID
         </label>
         <input
           id="empid"
@@ -121,7 +121,7 @@ export default function LoginForm() {
           htmlFor="password"
           style={{ display: 'block', marginBottom: '0.25rem' }}
         >
-          Password
+          Нууц үг
         </label>
         <input
           id="password"
@@ -148,7 +148,7 @@ export default function LoginForm() {
           cursor: 'pointer',
         }}
       >
-        Login
+        Нэвтрэх
       </button>
     </form>
   );

--- a/src/erp.mgt.mn/components/UserMenu.jsx
+++ b/src/erp.mgt.mn/components/UserMenu.jsx
@@ -29,9 +29,9 @@ export default function UserMenu({ user, onLogout }) {
       {open && (
         <div style={styles.menu}>
           <button style={styles.menuItem} onClick={handleChangePassword}>
-            Change Password
+            Нууц үг солих
           </button>
-          <button style={styles.menuItem} onClick={handleLogout}>Logout</button>
+          <button style={styles.menuItem} onClick={handleLogout}>Гарах</button>
         </div>
       )}
     </div>

--- a/src/erp.mgt.mn/pages/BlueLinkPage.jsx
+++ b/src/erp.mgt.mn/pages/BlueLinkPage.jsx
@@ -16,7 +16,7 @@ const initialLayout = {
 export default function BlueLinkPage() {
   return (
     <div>
-      <h2>Blue Link Demo</h2>
+      <h2>Blue Link демо</h2>
       <MosaicLayout initialLayout={initialLayout} />
     </div>
   );

--- a/src/erp.mgt.mn/pages/ChangePassword.jsx
+++ b/src/erp.mgt.mn/pages/ChangePassword.jsx
@@ -34,13 +34,13 @@ export default function ChangePasswordPage() {
 
   return (
     <div style={{ padding: '1rem' }}>
-      <h2>Change Password</h2>
-      {success && <p style={{ color: 'green' }}>Password updated</p>}
+      <h2>Нууц үг солих</h2>
+      {success && <p style={{ color: 'green' }}>Нууц үг шинэчлэгдлээ</p>}
       {error && <p style={{ color: 'red' }}>{error}</p>}
       <form onSubmit={handleSubmit} style={{ maxWidth: '320px' }}>
         <div style={{ marginBottom: '0.75rem' }}>
           <label htmlFor="newpwd" style={{ display: 'block', marginBottom: '0.25rem' }}>
-            New Password
+            Шинэ нууц үг
           </label>
           <input
             id="newpwd"
@@ -53,7 +53,7 @@ export default function ChangePasswordPage() {
         </div>
         <div style={{ marginBottom: '0.75rem' }}>
           <label htmlFor="confirm" style={{ display: 'block', marginBottom: '0.25rem' }}>
-            Confirm Password
+            Нууц үг батлах
           </label>
           <input
             id="confirm"
@@ -75,7 +75,7 @@ export default function ChangePasswordPage() {
             cursor: 'pointer',
           }}
         >
-          Update Password
+          Шинэчлэх
         </button>
       </form>
     </div>

--- a/src/erp.mgt.mn/pages/CompanyLicenses.jsx
+++ b/src/erp.mgt.mn/pages/CompanyLicenses.jsx
@@ -46,25 +46,25 @@ export default function CompanyLicenses() {
 
   return (
     <div>
-      <h2>Company Licenses</h2>
+      <h2>Лиценз</h2>
       <input
         type="text"
-        placeholder="Filter by Company ID"
+        placeholder="Компанийн ID-р шүүх"
         value={filterCompanyId}
         onChange={(e) => setFilterCompanyId(e.target.value)}
         style={{ marginRight: '0.5rem' }}
       />
-      <button onClick={handleFilter}>Apply</button>
+      <button onClick={handleFilter}>Шүүх</button>
       {licenses.length === 0 ? (
-        <p>No licenses.</p>
+        <p>Лиценз алга.</p>
       ) : (
         <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '0.5rem' }}>
           <thead>
             <tr style={{ backgroundColor: '#e5e7eb' }}>
-              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Company</th>
-              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Module</th>
-              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Licensed</th>
-              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Actions</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Компани</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Модуль</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Идэвхтэй эсэх</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Үйлдэл</th>
             </tr>
           </thead>
           <tbody>
@@ -72,10 +72,10 @@ export default function CompanyLicenses() {
               <tr key={l.company_id + '-' + l.module_key}>
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{l.company_name}</td>
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{l.label}</td>
-                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{l.licensed ? 'Yes' : 'No'}</td>
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{l.licensed ? 'Тийм' : 'Үгүй'}</td>
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
                   <button onClick={() => handleToggle(l)}>
-                    {l.licensed ? 'Disable' : 'Enable'}
+                    {l.licensed ? 'Идэвхгүй болгох' : 'Идэвхжүүлэх'}
                   </button>
                 </td>
               </tr>

--- a/src/erp.mgt.mn/pages/Dashboard.jsx
+++ b/src/erp.mgt.mn/pages/Dashboard.jsx
@@ -21,7 +21,7 @@ const initialLayout = {
 export default function Dashboard() {
   return (
     <div>
-      <h2>Dashboard</h2>
+      <h2>Самбар</h2>
       <MosaicLayout initialLayout={initialLayout} />
     </div>
   );

--- a/src/erp.mgt.mn/pages/Forms.jsx
+++ b/src/erp.mgt.mn/pages/Forms.jsx
@@ -16,9 +16,9 @@ export default function Forms() {
 
   return (
     <div>
-      <h2>Forms</h2>
+      <h2>Маягтууд</h2>
       {formsList.length === 0 ? (
-        <p>No forms found.</p>
+        <p>Маягт олдсонгүй.</p>
       ) : (
         <ul>
           {formsList.map((f) => (

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function FormsManagement() {
+  return (
+    <div>
+      <h2>Маягтын удирдлага</h2>
+      <p>Энд маягтын тохиргоо хийнэ.</p>
+    </div>
+  );
+}

--- a/src/erp.mgt.mn/pages/Login.jsx
+++ b/src/erp.mgt.mn/pages/Login.jsx
@@ -5,7 +5,7 @@ import LoginForm from '../components/LoginForm.jsx';
 export default function LoginPage() {
   return (
     <div style={{ padding: '2rem' }}>
-      <h1>Login</h1>
+      <h1>Нэвтрэх</h1>
       <LoginForm />
     </div>
   );

--- a/src/erp.mgt.mn/pages/ReportManagement.jsx
+++ b/src/erp.mgt.mn/pages/ReportManagement.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function ReportManagement() {
+  return (
+    <div>
+      <h2>Тайлангийн удирдлага</h2>
+      <p>Энд тайлангийн тохиргоо хийнэ.</p>
+    </div>
+  );
+}

--- a/src/erp.mgt.mn/pages/Reports.jsx
+++ b/src/erp.mgt.mn/pages/Reports.jsx
@@ -16,11 +16,11 @@ export default function Reports() {
 
   return (
     <div>
-      <h2>Reports</h2>
+      <h2>Тайлан</h2>
       {data ? (
         <pre>{JSON.stringify(data, null, 2)}</pre>
       ) : (
-        <p>Loading report data…</p>
+        <p>Тайлангийн мэдээлэл ачааллаж байна…</p>
       )}
     </div>
   );

--- a/src/erp.mgt.mn/pages/RolePermissions.jsx
+++ b/src/erp.mgt.mn/pages/RolePermissions.jsx
@@ -51,17 +51,17 @@ export default function RolePermissions() {
 
   return (
     <div>
-      <h2>Role Permissions</h2>
+      <h2>Эрхийн тохиргоо</h2>
       <input
         type="text"
-        placeholder="Filter by Role ID"
+        placeholder="Role ID-р шүүх"
         value={filterRoleId}
         onChange={(e) => setFilterRoleId(e.target.value)}
         style={{ marginRight: "0.5rem" }}
       />
-      <button onClick={handleFilter}>Apply</button>
+      <button onClick={handleFilter}>Шүүх</button>
       {perms.length === 0 ? (
-        <p>No permissions.</p>
+        <p>Эрх олдсонгүй.</p>
       ) : (
         <table
           style={{
@@ -73,16 +73,16 @@ export default function RolePermissions() {
           <thead>
             <tr style={{ backgroundColor: "#e5e7eb" }}>
               <th style={{ padding: "0.5rem", border: "1px solid #d1d5db" }}>
-                Role
+                Үүрэг
               </th>
               <th style={{ padding: "0.5rem", border: "1px solid #d1d5db" }}>
-                Module
+                Модуль
               </th>
               <th style={{ padding: "0.5rem", border: "1px solid #d1d5db" }}>
-                Allowed
+                Зөвшөөрсөн эсэх
               </th>
               <th style={{ padding: "0.5rem", border: "1px solid #d1d5db" }}>
-                Actions
+                Үйлдэл
               </th>
             </tr>
           </thead>
@@ -100,7 +100,7 @@ export default function RolePermissions() {
                 </td>
                 <td style={{ padding: "0.5rem", border: "1px solid #d1d5db" }}>
                   <button onClick={() => handleToggle(p)}>
-                    {p.allowed ? "Revoke" : "Allow"}
+                    {p.allowed ? "Цуцлах" : "Зөвшөөрөх"}
                   </button>
                 </td>
               </tr>

--- a/src/erp.mgt.mn/pages/Settings.jsx
+++ b/src/erp.mgt.mn/pages/Settings.jsx
@@ -12,10 +12,10 @@ export default function SettingsPage() {
 export function GeneralSettings() {
   const perms = useRolePermissions();
   if (!perms) {
-    return <p>Loading…</p>;
+    return <p>Уншиж байна…</p>;
   }
   if (!perms.settings) {
-    return <p>Access denied.</p>;
+    return <p>Хандалт хориглолоо.</p>;
   }
   const [settings, setSettings] = useState(null);
 
@@ -31,14 +31,14 @@ export function GeneralSettings() {
 
   return (
     <div>
-      <h2>Settings</h2>
+      <h2>Тохиргоо</h2>
       {settings ? (
         <pre>{JSON.stringify(settings, null, 2)}</pre>
       ) : (
-        <p>Loading settings…</p>
+        <p>Тохиргоо ачааллаж байна…</p>
       )}
       <p style={{ marginTop: '1rem' }}>
-        <Link to="/settings/role-permissions">Edit Role Permissions</Link>
+        <Link to="/settings/role-permissions">Эрхийн тохиргоо засах</Link>
       </p>
     </div>
   );

--- a/src/erp.mgt.mn/pages/TablesManagement.jsx
+++ b/src/erp.mgt.mn/pages/TablesManagement.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function TablesManagement() {
+  return (
+    <div>
+      <h2>Хүснэгтийн удирдлага</h2>
+      <p>Энд хүснэгтийн тохиргоо хийнэ.</p>
+    </div>
+  );
+}

--- a/src/erp.mgt.mn/pages/UserCompanies.jsx
+++ b/src/erp.mgt.mn/pages/UserCompanies.jsx
@@ -99,30 +99,30 @@ export default function UserCompanies() {
 
   return (
     <div>
-      <h2>User Companies</h2>
+      <h2>Хэрэглэгчийн компаниуд</h2>
       <input
         type="text"
-        placeholder="Filter by EmpID"
+        placeholder="EmpID-р шүүх"
         value={filterEmpId}
         onChange={(e) => setFilterEmpId(e.target.value)}
         style={{ marginRight: '0.5rem' }}
       />
       <button onClick={handleFilter} style={{ marginRight: '0.5rem' }}>
-        Apply
+        Шүүх
       </button>
-      <button onClick={handleAdd}>Add Assignment</button>
+      <button onClick={handleAdd}>Хуваарилалт нэмэх</button>
       {assignments.length === 0 ? (
-        <p>No assignments.</p>
+        <p>Хуваарилалт алга.</p>
       ) : (
         <table
           style={{ width: '100%', borderCollapse: 'collapse', marginTop: '0.5rem' }}
         >
           <thead>
             <tr style={{ backgroundColor: '#e5e7eb' }}>
-              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>User</th>
-              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Company</th>
-              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Role</th>
-              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Actions</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Хэрэглэгч</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Компани</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Үүрэг</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Үйлдэл</th>
             </tr>
           </thead>
           <tbody>
@@ -132,9 +132,9 @@ export default function UserCompanies() {
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{a.company_name}</td>
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{a.role}</td>
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
-                  <button onClick={() => handleEdit(a)}>Edit</button>
+                  <button onClick={() => handleEdit(a)}>Засах</button>
                   <button onClick={() => handleDelete(a)} style={{ marginLeft: '0.5rem' }}>
-                    Delete
+                    Устгах
                   </button>
                 </td>
               </tr>
@@ -194,7 +194,7 @@ function AssignmentFormModal({ visible, onCancel, onSubmit, assignment, users, c
   return (
     <div style={overlay}>
       <div style={modal}>
-        <h3 style={{ marginTop: 0 }}>{isEdit ? 'Edit Assignment' : 'Add Assignment'}</h3>
+        <h3 style={{ marginTop: 0 }}>{isEdit ? 'Хуваарилалт засах' : 'Хуваарилалт нэмэх'}</h3>
         <form
           onSubmit={(e) => {
             e.preventDefault();
@@ -211,7 +211,7 @@ function AssignmentFormModal({ visible, onCancel, onSubmit, assignment, users, c
               style={{ width: '100%', padding: '0.5rem' }}
             >
               <option value="" disabled>
-                Choose...
+                Сонгоно уу...
               </option>
               {users.map((u) => (
                 <option key={u.empid} value={u.empid}>
@@ -222,7 +222,7 @@ function AssignmentFormModal({ visible, onCancel, onSubmit, assignment, users, c
           </div>
 
           <div style={{ marginBottom: '0.75rem' }}>
-            <label style={{ display: 'block', marginBottom: '0.25rem' }}>Company</label>
+            <label style={{ display: 'block', marginBottom: '0.25rem' }}>Компани</label>
             <select
               value={companyId}
               onChange={(e) => setCompanyId(e.target.value)}
@@ -231,7 +231,7 @@ function AssignmentFormModal({ visible, onCancel, onSubmit, assignment, users, c
               style={{ width: '100%', padding: '0.5rem' }}
             >
               <option value="" disabled>
-                Choose...
+                Сонгоно уу...
               </option>
               {companies.map((c) => (
                 <option key={c.id} value={c.id}>
@@ -242,7 +242,7 @@ function AssignmentFormModal({ visible, onCancel, onSubmit, assignment, users, c
           </div>
 
           <div style={{ marginBottom: '0.75rem' }}>
-            <label style={{ display: 'block', marginBottom: '0.25rem' }}>Role</label>
+            <label style={{ display: 'block', marginBottom: '0.25rem' }}>Үүрэг</label>
             <select
               value={roleId}
               onChange={(e) => setRoleId(e.target.value)}
@@ -256,9 +256,9 @@ function AssignmentFormModal({ visible, onCancel, onSubmit, assignment, users, c
 
           <div style={{ textAlign: 'right' }}>
             <button type="button" onClick={onCancel} style={{ marginRight: '0.5rem' }}>
-              Cancel
+              Болих
             </button>
-            <button type="submit">Save</button>
+            <button type="submit">Хадгалах</button>
           </div>
         </form>
       </div>

--- a/src/erp.mgt.mn/pages/Users.jsx
+++ b/src/erp.mgt.mn/pages/Users.jsx
@@ -75,17 +75,17 @@ export default function Users() {
 
   return (
     <div>
-      <h2>Users</h2>
+      <h2>Хэрэглэгчид</h2>
       <input
         type="text"
-        placeholder="Filter users"
+        placeholder="Хэрэглэгч шүүх"
         value={filter}
         onChange={(e) => setFilter(e.target.value)}
         style={{ marginRight: '0.5rem' }}
       />
-      <button onClick={handleAdd}>Add User</button>
+      <button onClick={handleAdd}>Хэрэглэгч нэмэх</button>
       {usersList.length === 0 ? (
-        <p>No users returned.</p>
+        <p>Хэрэглэгч олдсонгүй.</p>
       ) : (
         <table
           style={{
@@ -97,16 +97,16 @@ export default function Users() {
           <thead>
             <tr style={{ backgroundColor: '#e5e7eb' }}>
               <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
-                EmpID
+                ID
               </th>
               <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
-                Name
+                Нэр
               </th>
               <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
-                Role
+                Үүрэг
               </th>
               <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
-                Actions
+                Үйлдэл
               </th>
             </tr>
           </thead>
@@ -130,9 +130,9 @@ export default function Users() {
                   {u.role}
                 </td>
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
-                  <button onClick={() => handleEdit(u)}>Edit</button>
+                  <button onClick={() => handleEdit(u)}>Засах</button>
                   <button onClick={() => handleDelete(u)} style={{ marginLeft: '0.5rem' }}>
-                    Delete
+                    Устгах
                   </button>
                 </td>
               </tr>


### PR DESCRIPTION
## Summary
- add Mongolian labels to Settings navigation
- translate UI text into Mongolian
- create placeholders for new settings pages
- provide SQL migration to translate module names

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843f08587a88331a8d40460fe5046dc