### PR TITLE
Fix role permission update with company scoping

### DIFF
--- a/api-server/controllers/rolePermissionController.js
+++ b/api-server/controllers/rolePermissionController.js
@@ -19,8 +19,8 @@ export async function updatePermission(req, res, next) {
     if (req.user.role !== 'admin') {
       return res.sendStatus(403);
     }
-    const { roleId, moduleKey, allowed } = req.body;
-    await setRoleModulePermission(roleId, moduleKey, allowed);
+    const { companyId, roleId, moduleKey, allowed } = req.body;
+    await setRoleModulePermission(companyId, roleId, moduleKey, allowed);
     res.sendStatus(200);
   } catch (err) {
     next(err);

--- a/db/index.js
+++ b/db/index.js
@@ -312,14 +312,14 @@ export async function listRoleModulePermissions(roleId, companyId) {
 /**
  * Set a role's module permission
  */
-export async function setRoleModulePermission(roleId, moduleKey, allowed) {
+export async function setRoleModulePermission(companyId, roleId, moduleKey, allowed) {
   await pool.query(
-    `INSERT INTO role_module_permissions (role_id, module_key, allowed)
-     VALUES (?, ?, ?)
+    `INSERT INTO role_module_permissions (company_id, role_id, module_key, allowed)
+     VALUES (?, ?, ?, ?)
      ON DUPLICATE KEY UPDATE allowed = VALUES(allowed)`,
-    [roleId, moduleKey, allowed],
+    [companyId, roleId, moduleKey, allowed],
   );
-  return { roleId, moduleKey, allowed };
+  return { companyId, roleId, moduleKey, allowed };
 }
 
 /**

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -15,7 +15,7 @@ import { useCompanyModules } from "../hooks/useCompanyModules.js";
  *  - Main content area (faux window container)
  */
 export default function ERPLayout() {
-  const { user, setUser } = useContext(AuthContext);
+  const { user, setUser, company } = useContext(AuthContext);
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -43,7 +43,7 @@ export default function ERPLayout() {
 
   function handleHome() {
     const roleId = user?.role_id || (user?.role === 'admin' ? 1 : 2);
-    refreshRolePermissions(roleId);
+    refreshRolePermissions(roleId, company?.company_id);
     navigate('/');
   }
 

--- a/src/erp.mgt.mn/hooks/useRolePermissions.js
+++ b/src/erp.mgt.mn/hooks/useRolePermissions.js
@@ -1,14 +1,14 @@
 import { useContext, useEffect, useState } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
 
-// Cache permissions by role so switching users does not refetch unnecessarily
+// Cache permissions by role/company so switching users does not refetch unnecessarily
 const cache = {};
 
 // Simple event emitter for permission refresh events
 const emitter = new EventTarget();
 
-export function refreshRolePermissions(roleId) {
-  if (roleId) delete cache[roleId];
+export function refreshRolePermissions(roleId, companyId) {
+  if (roleId && companyId) delete cache[`${companyId}-${roleId}`];
   emitter.dispatchEvent(new Event('refresh'));
 }
 
@@ -16,9 +16,12 @@ export function useRolePermissions() {
   const { user, company } = useContext(AuthContext);
   const [perms, setPerms] = useState(null);
 
-  async function fetchPerms(roleId) {
+  async function fetchPerms(roleId, companyId) {
     try {
-      const res = await fetch(`/api/role_permissions?roleId=${roleId}`, {
+      const params = new URLSearchParams();
+      if (roleId) params.append('roleId', roleId);
+      if (companyId) params.append('companyId', companyId);
+      const res = await fetch(`/api/role_permissions?${params.toString()}`, {
         credentials: 'include',
       });
       const rows = res.ok ? await res.json() : [];
@@ -26,7 +29,7 @@ export function useRolePermissions() {
       rows.forEach((r) => {
         map[r.module_key] = !!r.allowed;
       });
-      cache[roleId] = map;
+      cache[`${companyId}-${roleId}`] = map;
       setPerms(map);
     } catch (err) {
       console.error('Failed to load permissions', err);
@@ -39,22 +42,23 @@ export function useRolePermissions() {
       setPerms(null);
       return;
     }
-    const roleId =
-      company?.role_id || user.role_id || (user.role === 'admin' ? 1 : 2);
+    const roleId = company?.role_id || user.role_id || (user.role === 'admin' ? 1 : 2);
+    const companyId = company?.company_id;
 
-    if (cache[roleId]) {
-      setPerms(cache[roleId]);
+    const key = `${companyId}-${roleId}`;
+    if (cache[key]) {
+      setPerms(cache[key]);
     } else {
-      fetchPerms(roleId);
+      fetchPerms(roleId, companyId);
     }
   }, [user, company]);
 
   // Listen for refresh events
   useEffect(() => {
     if (!user) return;
-    const roleId =
-      company?.role_id || user.role_id || (user.role === 'admin' ? 1 : 2);
-    const handler = () => fetchPerms(roleId);
+    const roleId = company?.role_id || user.role_id || (user.role === 'admin' ? 1 : 2);
+    const companyId = company?.company_id;
+    const handler = () => fetchPerms(roleId, companyId);
     emitter.addEventListener('refresh', handler);
     return () => emitter.removeEventListener('refresh', handler);
   }, [user, company]);

--- a/src/erp.mgt.mn/pages/RolePermissions.jsx
+++ b/src/erp.mgt.mn/pages/RolePermissions.jsx
@@ -36,6 +36,7 @@ export default function RolePermissions() {
       headers: { "Content-Type": "application/json" },
       credentials: "include",
       body: JSON.stringify({
+        companyId: company?.company_id,
         roleId: p.role_id,
         moduleKey: p.module_key,
         allowed: p.allowed ? 0 : 1,
@@ -46,7 +47,7 @@ export default function RolePermissions() {
       return;
     }
     loadPerms(filterRoleId);
-    refreshRolePermissions(p.role_id);
+    refreshRolePermissions(p.role_id, company?.company_id);
   }
 
   return (


### PR DESCRIPTION
## Summary
- include company_id when updating role permissions
- pass company context to permission caching and refresh logic
- update ERP layout to refresh permissions with company context

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843f34974a48331bf04472054cbd72c