### PR TITLE
Ensure permission changes affect current user

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -15,7 +15,7 @@ import { useCompanyModules } from "../hooks/useCompanyModules.js";
  *  - Main content area (faux window container)
  */
 export default function ERPLayout() {
-  const { user, setUser } = useContext(AuthContext);
+  const { user, setUser, company } = useContext(AuthContext);
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -43,7 +43,8 @@ export default function ERPLayout() {
 
   function handleHome() {
     const roleId = user?.role_id || (user?.role === 'admin' ? 1 : 2);
-    refreshRolePermissions(roleId);
+    const companyId = user?.company_id || company?.company_id;
+    refreshRolePermissions(roleId, companyId);
     navigate('/');
   }
 

--- a/src/erp.mgt.mn/pages/RolePermissions.jsx
+++ b/src/erp.mgt.mn/pages/RolePermissions.jsx
@@ -47,7 +47,7 @@ export default function RolePermissions() {
       return;
     }
     loadPerms(filterRoleId);
-    refreshRolePermissions(p.role_id);
+    refreshRolePermissions(p.role_id, company?.company_id);
   }
 
   return (


### PR DESCRIPTION
## Summary
- update permission hook to support company-scoped caching
- refresh cached permissions with company ID
- propagate company ID in layout and role permission page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843fcef4f208331a1417486abff976a