### PR TITLE
Add modules management page

### DIFF
--- a/api-server/controllers/moduleController.js
+++ b/api-server/controllers/moduleController.js
@@ -1,9 +1,36 @@
-import { listModules as dbListModules } from "../../db/index.js";
+import {
+  listModules as dbListModules,
+  upsertModule,
+  populateRoleModulePermissions,
+} from "../../db/index.js";
 
 export async function listModules(req, res, next) {
   try {
     const modules = await dbListModules();
     res.json(modules);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function saveModule(req, res, next) {
+  try {
+    if (req.user.role !== 'admin') return res.sendStatus(403);
+    const moduleKey = req.params.moduleKey || req.body.moduleKey;
+    const label = req.body.label;
+    if (!moduleKey || !label) return res.status(400).json({ message: 'Missing fields' });
+    const result = await upsertModule(moduleKey, label);
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function populatePermissions(req, res, next) {
+  try {
+    if (req.user.role !== 'admin') return res.sendStatus(403);
+    await populateRoleModulePermissions();
+    res.sendStatus(204);
   } catch (err) {
     next(err);
   }

--- a/api-server/routes/modules.js
+++ b/api-server/routes/modules.js
@@ -1,7 +1,14 @@
 import express from "express";
-import { listModules } from "../controllers/moduleController.js";
+import {
+  listModules,
+  saveModule,
+  populatePermissions,
+} from "../controllers/moduleController.js";
 import { requireAuth } from "../middlewares/auth.js";
 
 const router = express.Router();
 router.get("/", requireAuth, listModules);
+router.post("/", requireAuth, saveModule);
+router.put("/:moduleKey", requireAuth, saveModule);
+router.post("/populate", requireAuth, populatePermissions);
 export default router;

--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -14,6 +14,7 @@ import CompanyLicensesPage from './pages/CompanyLicenses.jsx';
 import TablesManagementPage from './pages/TablesManagement.jsx';
 import FormsManagementPage from './pages/FormsManagement.jsx';
 import ReportManagementPage from './pages/ReportManagement.jsx';
+import ModulesPage from './pages/Modules.jsx';
 import SettingsPage, { GeneralSettings } from './pages/Settings.jsx';
 import ChangePasswordPage from './pages/ChangePassword.jsx';
 import Dashboard from './pages/Dashboard.jsx';
@@ -39,6 +40,7 @@ export default function App() {
                   <Route path="users" element={<UsersPage />} />
                   <Route path="user-companies" element={<UserCompaniesPage />} />
                   <Route path="role-permissions" element={<RolePermissionsPage />} />
+                  <Route path="modules" element={<ModulesPage />} />
                   <Route path="company-licenses" element={<CompanyLicensesPage />} />
                   <Route path="tables-management" element={<TablesManagementPage />} />
                   <Route path="forms-management" element={<FormsManagementPage />} />

--- a/src/erp.mgt.mn/components/Layout.jsx
+++ b/src/erp.mgt.mn/components/Layout.jsx
@@ -115,6 +115,9 @@ function Sidebar() {
             <NavLink to="/settings/role-permissions" style={styles.menuItem}>
               Role Permissions
             </NavLink>
+            <NavLink to="/settings/modules" style={styles.menuItem}>
+              Modules
+            </NavLink>
           </>
         )}
         <NavLink to="/settings/change-password" style={styles.menuItem}>

--- a/src/erp.mgt.mn/pages/Modules.jsx
+++ b/src/erp.mgt.mn/pages/Modules.jsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useState } from 'react';
+
+export default function ModulesPage() {
+  const [modules, setModules] = useState([]);
+
+  function loadModules() {
+    fetch('/api/modules', { credentials: 'include' })
+      .then(res => {
+        if (!res.ok) throw new Error('Failed to fetch modules');
+        return res.json();
+      })
+      .then(setModules)
+      .catch(err => console.error('Error fetching modules:', err));
+  }
+
+  useEffect(() => {
+    loadModules();
+  }, []);
+
+  async function handleAdd() {
+    const moduleKey = prompt('Module key?');
+    if (!moduleKey) return;
+    const label = prompt('Label?');
+    if (!label) return;
+    const res = await fetch('/api/modules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ moduleKey, label })
+    });
+    if (!res.ok) {
+      alert('Failed to save module');
+      return;
+    }
+    loadModules();
+  }
+
+  async function handleEdit(m) {
+    const label = prompt('Label?', m.label);
+    if (!label) return;
+    const res = await fetch(`/api/modules/${m.module_key}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ label })
+    });
+    if (!res.ok) {
+      alert('Failed to update module');
+      return;
+    }
+    loadModules();
+  }
+
+  async function handlePopulate() {
+    const res = await fetch('/api/modules/populate', {
+      method: 'POST',
+      credentials: 'include'
+    });
+    if (!res.ok) {
+      alert('Failed to populate permissions');
+      return;
+    }
+    alert('Permissions populated');
+  }
+
+  return (
+    <div>
+      <h2>Modules</h2>
+      <button onClick={handleAdd}>Add Module</button>
+      <button onClick={handlePopulate} style={{ marginLeft: '0.5rem' }}>
+        Populate Permissions
+      </button>
+      {modules.length === 0 ? (
+        <p>No modules.</p>
+      ) : (
+        <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '0.5rem' }}>
+          <thead>
+            <tr style={{ backgroundColor: '#e5e7eb' }}>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Key</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Label</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {modules.map(m => (
+              <tr key={m.module_key}>
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{m.module_key}</td>
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{m.label}</td>
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
+                  <button onClick={() => handleEdit(m)}>Edit</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Modules admin page under Settings
- allow editing and creating modules
- populate role permissions table from role defaults
- wire modules routes and controller logic
- ensure populate button fills missing defaults before assigning permissions

## Testing
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ff52991483319e132c7e3433c483