### PR TITLE
Update permission population scripts

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -290,13 +290,32 @@ export async function upsertModule(moduleKey, label) {
   return { moduleKey, label };
 }
 
-export async function populateRoleModulePermissions() {
+export async function populateRoleDefaultModules() {
   await pool.query(
-    `INSERT INTO role_module_permissions (company_id, role_id, module_key, allowed)
+    `INSERT INTO role_default_modules (role_id, module_key, allowed)
+     SELECT ur.id, m.module_key,
+            CASE
+              WHEN ur.name = 'admin' THEN 1
+              WHEN m.module_key IN (
+                'settings', 'users', 'user_companies', 'role_permissions',
+                'company_licenses', 'tables_management', 'forms_management',
+                'report_management'
+              ) THEN 0
+              ELSE 1
+            END AS allowed
+       FROM user_roles ur
+       CROSS JOIN modules m
+     ON DUPLICATE KEY UPDATE allowed = VALUES(allowed)`,
+  );
+}
+
+export async function populateRoleModulePermissions() {
+  await populateRoleDefaultModules();
+  await pool.query(
+    `INSERT IGNORE INTO role_module_permissions (company_id, role_id, module_key, allowed)
      SELECT c.id, rdm.role_id, rdm.module_key, rdm.allowed
        FROM companies c
-       CROSS JOIN role_default_modules rdm
-     ON DUPLICATE KEY UPDATE allowed = VALUES(allowed)`,
+       CROSS JOIN role_default_modules rdm`,
   );
 }
 

--- a/db/scripts/populate_role_module_permissions.sql
+++ b/db/scripts/populate_role_module_permissions.sql
@@ -1,6 +1,21 @@
--- Populate role_module_permissions from role_default_modules
-INSERT INTO role_module_permissions (company_id, role_id, module_key, allowed)
+-- Populate role_default_modules with any new modules
+INSERT INTO role_default_modules (role_id, module_key, allowed)
+SELECT ur.id, m.module_key,
+       CASE
+         WHEN ur.name = 'admin' THEN 1
+         WHEN m.module_key IN (
+           'settings', 'users', 'user_companies', 'role_permissions',
+           'company_licenses', 'tables_management', 'forms_management',
+           'report_management'
+         ) THEN 0
+         ELSE 1
+       END AS allowed
+FROM user_roles ur
+CROSS JOIN modules m
+ON DUPLICATE KEY UPDATE allowed = VALUES(allowed);
+
+-- Populate role_module_permissions using the defaults, but keep existing rows
+INSERT IGNORE INTO role_module_permissions (company_id, role_id, module_key, allowed)
 SELECT c.id, rdm.role_id, rdm.module_key, rdm.allowed
 FROM companies c
-CROSS JOIN role_default_modules rdm
-ON DUPLICATE KEY UPDATE allowed = VALUES(allowed);
+CROSS JOIN role_default_modules rdm;


### PR DESCRIPTION
## Summary
- enhance SQL script for role permissions
- populate role default modules with all modules
- keep existing role permissions intact when populating

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684407b5857c8331aaccf4ce7fb7b1f6