### PR TITLE
Add modules page link

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -27,6 +27,7 @@ export default function ERPLayout() {
     "/settings/users": "Хэрэглэгчид",
     "/settings/user-companies": "Хэрэглэгчийн компаниуд",
     "/settings/role-permissions": "Эрхийн тохиргоо",
+    "/settings/modules": "Модуль",
     "/settings/company-licenses": "Лиценз",
     "/settings/tables-management": "Хүснэгтийн удирдлага",
     "/settings/forms-management": "Маягтын удирдлага",
@@ -206,6 +207,12 @@ function Sidebar() {
               )}
               {user?.role === "admin" && (
                 <>
+                  <NavLink
+                    to="/settings/modules"
+                    style={styles.menuItem}
+                  >
+                    Модуль
+                  </NavLink>
                   {licensed.tables_management && (
                     <NavLink
                       to="/settings/tables-management"


### PR DESCRIPTION
## Summary
- show the Modules page in the settings sidebar
- include Modules in the window title map

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844101cd4288331be1afb8c2a50c3df