### PR TITLE
Add hierarchical modules and dynamic menus

### DIFF
--- a/api-server/controllers/moduleController.js
+++ b/api-server/controllers/moduleController.js
@@ -18,8 +18,18 @@ export async function saveModule(req, res, next) {
     if (req.user.role !== 'admin') return res.sendStatus(403);
     const moduleKey = req.params.moduleKey || req.body.moduleKey;
     const label = req.body.label;
-    if (!moduleKey || !label) return res.status(400).json({ message: 'Missing fields' });
-    const result = await upsertModule(moduleKey, label);
+    const parentKey = req.body.parentKey || null;
+    const showInSidebar = req.body.showInSidebar ?? true;
+    const showInHeader = req.body.showInHeader ?? false;
+    if (!moduleKey || !label)
+      return res.status(400).json({ message: 'Missing fields' });
+    const result = await upsertModule(
+      moduleKey,
+      label,
+      parentKey,
+      showInSidebar,
+      showInHeader,
+    );
     res.json(result);
   } catch (err) {
     next(err);

--- a/db/index.js
+++ b/db/index.js
@@ -275,19 +275,31 @@ export async function setTenantFlags(companyId, flags) {
  */
 export async function listModules() {
   const [rows] = await pool.query(
-    "SELECT module_key, label FROM modules ORDER BY module_key",
+    `SELECT module_key, label, parent_key, show_in_sidebar, show_in_header
+       FROM modules
+      ORDER BY module_key`,
   );
   return rows;
 }
 
-export async function upsertModule(moduleKey, label) {
+export async function upsertModule(
+  moduleKey,
+  label,
+  parentKey = null,
+  showInSidebar = true,
+  showInHeader = false,
+) {
   await pool.query(
-    `INSERT INTO modules (module_key, label)
-     VALUES (?, ?)
-     ON DUPLICATE KEY UPDATE label = VALUES(label)`,
-    [moduleKey, label],
+    `INSERT INTO modules (module_key, label, parent_key, show_in_sidebar, show_in_header)
+     VALUES (?, ?, ?, ?, ?)
+     ON DUPLICATE KEY UPDATE
+       label = VALUES(label),
+       parent_key = VALUES(parent_key),
+       show_in_sidebar = VALUES(show_in_sidebar),
+       show_in_header = VALUES(show_in_header)`,
+    [moduleKey, label, parentKey, showInSidebar ? 1 : 0, showInHeader ? 1 : 0],
   );
-  return { moduleKey, label };
+  return { moduleKey, label, parentKey, showInSidebar, showInHeader };
 }
 
 export async function populateRoleDefaultModules() {

--- a/db/migrations/2025-06-15_modules_hierarchy.sql
+++ b/db/migrations/2025-06-15_modules_hierarchy.sql
@@ -1,0 +1,7 @@
+-- Add parent_key and display flags for modules hierarchy
+ALTER TABLE modules
+  ADD COLUMN parent_key VARCHAR(50) NULL,
+  ADD COLUMN show_in_sidebar TINYINT(1) DEFAULT 1,
+  ADD COLUMN show_in_header TINYINT(1) DEFAULT 0,
+  ADD CONSTRAINT fk_modules_parent FOREIGN KEY (parent_key)
+    REFERENCES modules(module_key);

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -1,5 +1,5 @@
 // src/erp.mgt.mn/components/ERPLayout.jsx
-import React, { useContext, useState } from "react";
+import React, { useContext, useState, useEffect } from "react";
 import HeaderMenu from "./HeaderMenu.jsx";
 import UserMenu from "./UserMenu.jsx";
 import { Outlet, NavLink, useNavigate, useLocation } from "react-router-dom";
@@ -97,154 +97,81 @@ function Header({ user, onLogout, onHome }) {
 
 /** Left sidebar with “menu groups” and “pinned items” **/
 function Sidebar() {
-  const { user, company } = useContext(AuthContext);
+  const { company } = useContext(AuthContext);
   const perms = useRolePermissions();
   const licensed = useCompanyModules(company?.company_id);
-  const [openSettings, setOpenSettings] = useState(false);
-  const [openUserSettings, setOpenUserSettings] = useState(false);
+  const [modules, setModules] = useState([]);
 
-  if (!perms || !licensed) {
-    return null;
-  }
+  useEffect(() => {
+    fetch('/api/modules', { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : []))
+      .then(setModules)
+      .catch(() => setModules([]));
+  }, []);
+
+  if (!perms || !licensed) return null;
+
+  const map = {};
+  modules.forEach((m) => {
+    if (perms[m.module_key] && licensed[m.module_key] && m.show_in_sidebar) {
+      map[m.module_key] = { ...m, children: [] };
+    }
+  });
+
+  const roots = [];
+  Object.values(map).forEach((m) => {
+    if (m.parent_key && map[m.parent_key]) {
+      map[m.parent_key].children.push(m);
+    } else {
+      roots.push(m);
+    }
+  });
 
   return (
     <aside style={styles.sidebar}>
       <nav>
-        <div style={styles.menuGroup}>
-          <div style={styles.groupTitle}>📌 Түгээмэл</div>
-          {perms.dashboard && licensed.dashboard && (
+        {roots.map((m) =>
+          m.children.length > 0 ? (
+            <SidebarGroup key={m.module_key} mod={m} />
+          ) : (
             <NavLink
-              to="/"
+              key={m.module_key}
+              to={modulePath(m)}
               style={({ isActive }) => styles.menuItem({ isActive })}
             >
-              Blue Link демо
+              {m.label}
             </NavLink>
-          )}
-          {perms.forms && licensed.forms && (
-            <NavLink
-              to="/forms"
-              style={({ isActive }) => styles.menuItem({ isActive })}
-            >
-              Маягтууд
-            </NavLink>
-          )}
-          {perms.reports && licensed.reports && (
-            <NavLink
-              to="/reports"
-              style={({ isActive }) => styles.menuItem({ isActive })}
-            >
-              Тайлан
-            </NavLink>
-          )}
-        </div>
-
-        <hr style={styles.divider} />
-
-        <div style={styles.menuGroup}>
-          <button
-            style={styles.groupBtn}
-            onClick={() => setOpenSettings((o) => !o)}
-          >
-            ⚙ Тохиргоо {openSettings ? "▾" : "▸"}
-          </button>
-          {openSettings && (
-            <>
-              {perms.settings && licensed.settings && (
-                <NavLink to="/settings" style={styles.menuItem} end>
-                  Ерөнхий
-                </NavLink>
-              )}
-              {licensed.company_licenses && (
-                <NavLink
-                  to="/settings/company-licenses"
-                  style={styles.menuItem}
-                >
-                  Лиценз
-                </NavLink>
-              )}
-              <button
-                style={styles.groupBtn}
-                onClick={() => setOpenUserSettings((o) => !o)}
-              >
-                👤 Хэрэглэгчийн тохиргоо {openUserSettings ? "▾" : "▸"}
-              </button>
-              {openUserSettings && (
-                <>
-                  {user?.role === "admin" && (
-                    <>
-                      {licensed.users && (
-                        <NavLink to="/settings/users" style={styles.menuItem}>
-                          Хэрэглэгчид
-                        </NavLink>
-                      )}
-                      {licensed.user_companies && (
-                        <NavLink
-                          to="/settings/user-companies"
-                          style={styles.menuItem}
-                        >
-                          Хэрэглэгчийн компаниуд
-                        </NavLink>
-                      )}
-                      {licensed.role_permissions && (
-                        <NavLink
-                          to="/settings/role-permissions"
-                          style={styles.menuItem}
-                        >
-                          Эрхийн тохиргоо
-                        </NavLink>
-                      )}
-                    </>
-                  )}
-                  {licensed.change_password && (
-                    <NavLink
-                      to="/settings/change-password"
-                      style={styles.menuItem}
-                    >
-                      Нууц үг солих
-                    </NavLink>
-                  )}
-                </>
-              )}
-              {user?.role === "admin" && (
-                <>
-                  <NavLink
-                    to="/settings/modules"
-                    style={styles.menuItem}
-                  >
-                    Модуль
-                  </NavLink>
-                  {licensed.tables_management && (
-                    <NavLink
-                      to="/settings/tables-management"
-                      style={styles.menuItem}
-                    >
-                      Хүснэгтийн удирдлага
-                    </NavLink>
-                  )}
-                  {licensed.forms_management && (
-                    <NavLink
-                      to="/settings/forms-management"
-                      style={styles.menuItem}
-                    >
-                      Маягтын удирдлага
-                    </NavLink>
-                  )}
-                  {licensed.report_management && (
-                    <NavLink
-                      to="/settings/report-management"
-                      style={styles.menuItem}
-                    >
-                      Тайлангийн удирдлага
-                    </NavLink>
-                  )}
-                </>
-              )}
-            </>
-          )}
-        </div>
+          ),
+        )}
       </nav>
     </aside>
   );
+}
+
+function SidebarGroup({ mod }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div style={styles.menuGroup}>
+      <button style={styles.groupBtn} onClick={() => setOpen((o) => !o)}>
+        {mod.label} {open ? '▾' : '▸'}
+      </button>
+      {open &&
+        mod.children.map((c) => (
+          <NavLink key={c.module_key} to={modulePath(c)} style={styles.menuItem}>
+            {c.label}
+          </NavLink>
+        ))}
+    </div>
+  );
+}
+
+function modulePath(m) {
+  if (m.parent_key === 'settings') return `/settings/${m.module_key}`;
+  if (!m.parent_key) {
+    if (m.module_key === 'dashboard') return '/';
+    return `/${m.module_key}`;
+  }
+  return `/${m.module_key}`;
 }
 
 /** A faux “window” wrapper around the main content **/

--- a/src/erp.mgt.mn/components/HeaderMenu.jsx
+++ b/src/erp.mgt.mn/components/HeaderMenu.jsx
@@ -1,13 +1,18 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRolePermissions } from '../hooks/useRolePermissions.js';
 
 export default function HeaderMenu({ onOpen }) {
   const perms = useRolePermissions();
-  const items = [
-    { id: 'gl', label: 'Ерөнхий журнал' },
-    { id: 'po', label: 'Худалдан авалтын захиалга' },
-    { id: 'sales', label: 'Борлуулалтын самбар' },
-  ];
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/modules', { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : []))
+      .then((rows) => {
+        setItems(rows.filter((r) => r.show_in_header));
+      })
+      .catch(() => setItems([]));
+  }, []);
 
   if (!perms) return null;
 
@@ -15,8 +20,12 @@ export default function HeaderMenu({ onOpen }) {
     <nav style={styles.menu}>
       {items.map(
         (m) =>
-          perms[m.id] && (
-            <button key={m.id} style={styles.btn} onClick={() => onOpen(m.id)}>
+          perms[m.module_key] && (
+            <button
+              key={m.module_key}
+              style={styles.btn}
+              onClick={() => onOpen(m.module_key)}
+            >
               {m.label}
             </button>
           ),

--- a/src/erp.mgt.mn/pages/Modules.jsx
+++ b/src/erp.mgt.mn/pages/Modules.jsx
@@ -22,11 +22,20 @@ export default function ModulesPage() {
     if (!moduleKey) return;
     const label = prompt('Label?');
     if (!label) return;
+    const parentKey = prompt('Parent key (optional)?', '');
+    const showInSidebar = window.confirm('Show in sidebar?');
+    const showInHeader = window.confirm('Show in header?');
     const res = await fetch('/api/modules', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ moduleKey, label })
+      body: JSON.stringify({
+        moduleKey,
+        label,
+        parentKey: parentKey || null,
+        showInSidebar,
+        showInHeader,
+      }),
     });
     if (!res.ok) {
       alert('Failed to save module');
@@ -38,11 +47,19 @@ export default function ModulesPage() {
   async function handleEdit(m) {
     const label = prompt('Label?', m.label);
     if (!label) return;
+    const parentKey = prompt('Parent key (optional)?', m.parent_key || '');
+    const showInSidebar = window.confirm('Show in sidebar?');
+    const showInHeader = window.confirm('Show in header?');
     const res = await fetch(`/api/modules/${m.module_key}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ label })
+      body: JSON.stringify({
+        label,
+        parentKey: parentKey || null,
+        showInSidebar,
+        showInHeader,
+      }),
     });
     if (!res.ok) {
       alert('Failed to update module');
@@ -78,6 +95,9 @@ export default function ModulesPage() {
             <tr style={{ backgroundColor: '#e5e7eb' }}>
               <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Key</th>
               <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Label</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Parent</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Sidebar</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Header</th>
               <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Action</th>
             </tr>
           </thead>
@@ -86,6 +106,9 @@ export default function ModulesPage() {
               <tr key={m.module_key}>
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{m.module_key}</td>
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{m.label}</td>
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{m.parent_key || ''}</td>
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db', textAlign: 'center' }}>{m.show_in_sidebar ? '✓' : ''}</td>
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db', textAlign: 'center' }}>{m.show_in_header ? '✓' : ''}</td>
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
                   <button onClick={() => handleEdit(m)}>Edit</button>
                 </td>


### PR DESCRIPTION
## Summary
- add migration for module hierarchy and display flags
- support parent/visibility in module APIs
- allow editing module hierarchy in modules page
- fetch menu definitions for header and sidebar
- render sidebar and header dynamically from modules

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684411ccc2348331a063dc12ed4429f1