### PR TITLE
Add dynamic tables management view

### DIFF
--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -1,0 +1,28 @@
+import { listDatabaseTables, listTableRows, updateTableRow } from '../../db/index.js';
+
+export async function getTables(req, res, next) {
+  try {
+    const tables = await listDatabaseTables();
+    res.json(tables);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getTableRows(req, res, next) {
+  try {
+    const rows = await listTableRows(req.params.table);
+    res.json(rows);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function updateRow(req, res, next) {
+  try {
+    await updateTableRow(req.params.table, req.params.id, req.body);
+    res.sendStatus(204);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/api-server/routes/tables.js
+++ b/api-server/routes/tables.js
@@ -1,0 +1,11 @@
+import express from 'express';
+import { getTables, getTableRows, updateRow } from '../controllers/tableController.js';
+import { requireAuth } from '../middlewares/auth.js';
+
+const router = express.Router();
+
+router.get('/', requireAuth, getTables);
+router.get('/:table', requireAuth, getTableRows);
+router.put('/:table/:id', requireAuth, updateRow);
+
+export default router;

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -14,6 +14,7 @@ import userCompanyRoutes from "./routes/user_companies.js";
 import rolePermissionRoutes from "./routes/role_permissions.js";
 import moduleRoutes from "./routes/modules.js";
 import companyModuleRoutes from "./routes/company_modules.js";
+import tableRoutes from "./routes/tables.js";
 import { requireAuth } from "./middlewares/auth.js";
 
 dotenv.config();
@@ -47,6 +48,7 @@ app.use("/api/user_companies", requireAuth, userCompanyRoutes);
 app.use("/api/role_permissions", requireAuth, rolePermissionRoutes);
 app.use("/api/modules", requireAuth, moduleRoutes);
 app.use("/api/company_modules", requireAuth, companyModuleRoutes);
+app.use("/api/tables", requireAuth, tableRoutes);
 
 // Serve static React build and fallback to index.html
 // NOTE: adjust this path to where your SPA build actually lives.

--- a/db/index.js
+++ b/db/index.js
@@ -411,3 +411,31 @@ export async function setCompanyModuleLicense(companyId, moduleKey, licensed) {
   );
   return { companyId, moduleKey, licensed: !!licensed };
 }
+
+/**
+ * List all database tables (for dev tools)
+ */
+export async function listDatabaseTables() {
+  const [rows] = await pool.query('SHOW TABLES');
+  return rows.map((r) => Object.values(r)[0]);
+}
+
+/**
+ * Get up to 50 rows from a table
+ */
+export async function listTableRows(tableName) {
+  const [rows] = await pool.query('SELECT * FROM ?? LIMIT 50', [tableName]);
+  return rows;
+}
+
+/**
+ * Update a table row by id
+ */
+export async function updateTableRow(tableName, id, updates) {
+  const keys = Object.keys(updates);
+  if (keys.length === 0) return { id };
+  const values = Object.values(updates);
+  const setClause = keys.map((k) => `\`${k}\` = ?`).join(', ');
+  await pool.query(`UPDATE ?? SET ${setClause} WHERE id = ?`, [tableName, ...values, id]);
+  return { id };
+}

--- a/src/erp.mgt.mn/pages/TablesManagement.jsx
+++ b/src/erp.mgt.mn/pages/TablesManagement.jsx
@@ -1,10 +1,98 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 export default function TablesManagement() {
+  const [tables, setTables] = useState([]);
+  const [selectedTable, setSelectedTable] = useState('');
+  const [rows, setRows] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/tables', { credentials: 'include' })
+      .then((res) => res.json())
+      .then(setTables)
+      .catch((err) => console.error('Failed to load tables', err));
+  }, []);
+
+  function loadRows(table) {
+    fetch(`/api/tables/${table}`, { credentials: 'include' })
+      .then((res) => res.json())
+      .then(setRows)
+      .catch((err) => console.error('Failed to fetch rows', err));
+  }
+
+  function handleSelect(e) {
+    const t = e.target.value;
+    setSelectedTable(t);
+    if (t) {
+      loadRows(t);
+    } else {
+      setRows([]);
+    }
+  }
+
+  async function handleEdit(row) {
+    const updates = {};
+    for (const key of Object.keys(row)) {
+      if (key === 'id') continue;
+      const val = prompt(`${key}?`, row[key]);
+      if (val !== null && val !== String(row[key])) {
+        updates[key] = val;
+      }
+    }
+    if (Object.keys(updates).length === 0) return;
+    const res = await fetch(`/api/tables/${selectedTable}/${row.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(updates),
+    });
+    if (!res.ok) {
+      alert('Update failed');
+      return;
+    }
+    loadRows(selectedTable);
+  }
+
   return (
     <div>
-      <h2>Хүснэгтийн удирдлага</h2>
-      <p>Энд хүснэгтийн тохиргоо хийнэ.</p>
+      <h2>Dynamic Tables</h2>
+      <select value={selectedTable} onChange={handleSelect}>
+        <option value="">-- select table --</option>
+        {tables.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </select>
+      {rows.length > 0 && (
+        <table
+          style={{ width: '100%', marginTop: '0.5rem', borderCollapse: 'collapse' }}
+        >
+          <thead>
+            <tr style={{ backgroundColor: '#e5e7eb' }}>
+              {Object.keys(rows[0]).map((k) => (
+                <th key={k} style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
+                  {k}
+                </th>
+              ))}
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.id}>
+                {Object.keys(rows[0]).map((k) => (
+                  <td key={k} style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
+                    {String(r[k])}
+                  </td>
+                ))}
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
+                  <button onClick={() => handleEdit(r)}>Edit</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- implement listDatabaseTables, listTableRows and updateTableRow helpers
- add new API controller and routes for `/api/tables`
- register tables API routes in `server.js`
- replace `TablesManagement.jsx` with dynamic viewer and edit ability

## Testing
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68441bbec24c833182eb303246131eeb