### PR TITLE
Add route consistency check

### DIFF
--- a/README_MIGRATION.md
+++ b/README_MIGRATION.md
@@ -37,3 +37,13 @@ Two SQL utilities assist with default module permissions:
 * `db/migrations/2025-06-14_role_module_permissions_company_id.sql` – adds a `company_id` column so permissions are scoped per company.
 
 Run the script after applying the migration to initialize permissions for all roles.
+
+### Sidebar route check
+
+If the sidebar links do not match the available React routes, run:
+
+```bash
+node scripts/check-module-routes.cjs
+```
+
+It prints `All sidebar modules have matching routes.` when every module has a corresponding route, or lists the missing ones so you can correct them.

--- a/scripts/check-module-routes.cjs
+++ b/scripts/check-module-routes.cjs
@@ -1,0 +1,56 @@
+// Usage: `node scripts/check-module-routes.cjs`
+// Prints a warning if any sidebar module does not have a matching route
+
+const fs = require('fs');
+
+const appJsx = fs.readFileSync('src/erp.mgt.mn/App.jsx', 'utf8');
+const routeRegex = /path="([^"]+)"/g;
+const routePaths = new Set();
+let m;
+while ((m = routeRegex.exec(appJsx))) {
+  let p = m[1];
+  if (!p.startsWith('/')) p = '/' + p;
+  routePaths.add(p);
+}
+routePaths.add('/');
+
+const roots = ['dashboard','forms','reports','settings'];
+const settingsChildren = [
+  'users',
+  'user_companies',
+  'role_permissions',
+  'company_licenses',
+  'tables_management',
+  'forms_management',
+  'report_management',
+  'change_password',
+];
+
+function modulePath(key, parent) {
+  const k = key.replace(/_/g, '-');
+  if (parent === 'settings') return `/settings/${k}`;
+  if (!parent) {
+    if (key === 'dashboard') return '/';
+    return `/${k}`;
+  }
+  return `/${k}`;
+}
+
+function pathExists(p) {
+  if (routePaths.has(p)) return true;
+  if (p.startsWith('/settings/') && routePaths.has(p.replace('/settings', ''))) return true;
+  return false;
+}
+
+const expectedPaths = [];
+roots.forEach(k => expectedPaths.push(modulePath(k, null)));
+settingsChildren.forEach(k => expectedPaths.push(modulePath(k, 'settings')));
+
+const unmatched = expectedPaths.filter(p => !pathExists(p));
+
+if (unmatched.length === 0) {
+  console.log('All sidebar modules have matching routes.');
+} else {
+  console.log('Routes missing for modules:');
+  unmatched.forEach(p => console.log('  ' + p));
+}


### PR DESCRIPTION
## Summary
- add a small Node script that checks if the sidebar module list has matching routes in `src/erp.mgt.mn/App.jsx`
- document how to run the script

## Testing
- `node scripts/check-module-routes.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68441df4dadc833189b6ba9551e40972