### PR TITLE
Add modules refresh hook

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -1,5 +1,5 @@
 // src/erp.mgt.mn/components/ERPLayout.jsx
-import React, { useContext, useState, useEffect } from "react";
+import React, { useContext, useState } from "react";
 import HeaderMenu from "./HeaderMenu.jsx";
 import UserMenu from "./UserMenu.jsx";
 import { Outlet, NavLink, useNavigate, useLocation } from "react-router-dom";
@@ -7,6 +7,7 @@ import { AuthContext } from "../context/AuthContext.jsx";
 import { logout } from "../hooks/useAuth.jsx";
 import { useRolePermissions, refreshRolePermissions } from "../hooks/useRolePermissions.js";
 import { useCompanyModules } from "../hooks/useCompanyModules.js";
+import { useModules } from "../hooks/useModules.js";
 
 /**
  * A desktop‐style “ERPLayout” with:
@@ -100,14 +101,7 @@ function Sidebar() {
   const { company } = useContext(AuthContext);
   const perms = useRolePermissions();
   const licensed = useCompanyModules(company?.company_id);
-  const [modules, setModules] = useState([]);
-
-  useEffect(() => {
-    fetch('/api/modules', { credentials: 'include' })
-      .then((res) => (res.ok ? res.json() : []))
-      .then(setModules)
-      .catch(() => setModules([]));
-  }, []);
+  const modules = useModules();
 
   if (!perms || !licensed) return null;
 

--- a/src/erp.mgt.mn/components/HeaderMenu.jsx
+++ b/src/erp.mgt.mn/components/HeaderMenu.jsx
@@ -1,18 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useRolePermissions } from '../hooks/useRolePermissions.js';
+import { useModules } from '../hooks/useModules.js';
 
 export default function HeaderMenu({ onOpen }) {
   const perms = useRolePermissions();
-  const [items, setItems] = useState([]);
-
-  useEffect(() => {
-    fetch('/api/modules', { credentials: 'include' })
-      .then((res) => (res.ok ? res.json() : []))
-      .then((rows) => {
-        setItems(rows.filter((r) => r.show_in_header));
-      })
-      .catch(() => setItems([]));
-  }, []);
+  const modules = useModules();
+  const items = modules.filter((r) => r.show_in_header);
 
   if (!perms) return null;
 

--- a/src/erp.mgt.mn/hooks/useModules.js
+++ b/src/erp.mgt.mn/hooks/useModules.js
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+const cache = { data: null };
+const emitter = new EventTarget();
+
+export function refreshModules() {
+  delete cache.data;
+  emitter.dispatchEvent(new Event('refresh'));
+}
+
+export function useModules() {
+  const [modules, setModules] = useState(cache.data || []);
+
+  async function fetchModules() {
+    try {
+      const res = await fetch('/api/modules', { credentials: 'include' });
+      const rows = res.ok ? await res.json() : [];
+      cache.data = rows;
+      setModules(rows);
+    } catch (err) {
+      console.error('Failed to load modules', err);
+      setModules([]);
+    }
+  }
+
+  useEffect(() => {
+    if (!cache.data) {
+      fetchModules();
+    }
+  }, []);
+
+  useEffect(() => {
+    const handler = () => fetchModules();
+    emitter.addEventListener('refresh', handler);
+    return () => emitter.removeEventListener('refresh', handler);
+  }, []);
+
+  return modules;
+}

--- a/src/erp.mgt.mn/pages/Modules.jsx
+++ b/src/erp.mgt.mn/pages/Modules.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { refreshModules } from '../hooks/useModules.js';
 
 export default function ModulesPage() {
   const [modules, setModules] = useState([]);
@@ -42,6 +43,7 @@ export default function ModulesPage() {
       return;
     }
     loadModules();
+    refreshModules();
   }
 
   async function handleEdit(m) {
@@ -66,6 +68,7 @@ export default function ModulesPage() {
       return;
     }
     loadModules();
+    refreshModules();
   }
 
   async function handlePopulate() {
@@ -86,6 +89,9 @@ export default function ModulesPage() {
       <button onClick={handleAdd}>Add Module</button>
       <button onClick={handlePopulate} style={{ marginLeft: '0.5rem' }}>
         Populate Permissions
+      </button>
+      <button onClick={refreshModules} style={{ marginLeft: '0.5rem' }}>
+        Refresh Menus
       </button>
       {modules.length === 0 ? (
         <p>No modules.</p>


### PR DESCRIPTION
## Summary
- add a hook to fetch modules and expose a refresh function
- use the hook in the sidebar and header
- refresh menus when modules change

## Testing
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684427a88e5483319bf5da6eb06320ed