### PR TITLE
Add SQL script for company module licenses

### DIFF
--- a/db/scripts/populate_company_module_licenses.sql
+++ b/db/scripts/populate_company_module_licenses.sql
@@ -1,0 +1,7 @@
+-- Insert missing module license rows for each company
+-- Adds a row for every company/module pair that doesn't already exist
+-- Default licensed value is 0 so admins can enable as needed
+INSERT IGNORE INTO company_module_licenses (company_id, module_key, licensed)
+SELECT c.id AS company_id, m.module_key, 0 AS licensed
+FROM companies c
+CROSS JOIN modules m;


### PR DESCRIPTION
## Summary
- add db script to populate `company_module_licenses` with any missing module entries

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68442b26887c8331a7f936c3b7ec6cfd