### PR TITLE
Fix update for company module licenses in dev tables view

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -436,6 +436,16 @@ export async function updateTableRow(tableName, id, updates) {
   if (keys.length === 0) return { id };
   const values = Object.values(updates);
   const setClause = keys.map((k) => `\`${k}\` = ?`).join(', ');
+
+  if (tableName === 'company_module_licenses') {
+    const [companyId, moduleKey] = String(id).split('-');
+    await pool.query(
+      `UPDATE company_module_licenses SET ${setClause} WHERE company_id = ? AND module_key = ?`,
+      [...values, companyId, moduleKey],
+    );
+    return { company_id: companyId, module_key: moduleKey };
+  }
+
   await pool.query(`UPDATE ?? SET ${setClause} WHERE id = ?`, [tableName, ...values, id]);
   return { id };
 }


### PR DESCRIPTION
## Summary
- handle rows without `id` on table management page
- support composite key in `company_module_licenses` table when updating rows

## Testing
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684435ab63ec8331921382eaf491abc1