### PR TITLE
Add company license initialization

### DIFF
--- a/api-server/controllers/moduleController.js
+++ b/api-server/controllers/moduleController.js
@@ -2,6 +2,7 @@ import {
   listModules as dbListModules,
   upsertModule,
   populateRoleModulePermissions,
+  populateCompanyModuleLicenses,
 } from "../../db/index.js";
 
 export async function listModules(req, res, next) {
@@ -39,6 +40,7 @@ export async function saveModule(req, res, next) {
 export async function populatePermissions(req, res, next) {
   try {
     if (req.user.role !== 'admin') return res.sendStatus(403);
+    await populateCompanyModuleLicenses();
     await populateRoleModulePermissions();
     res.sendStatus(204);
   } catch (err) {

--- a/db/index.js
+++ b/db/index.js
@@ -333,6 +333,15 @@ export async function populateRoleModulePermissions() {
   );
 }
 
+export async function populateCompanyModuleLicenses() {
+  await pool.query(
+    `INSERT IGNORE INTO company_module_licenses (company_id, module_key, licensed)
+     SELECT c.id AS company_id, m.module_key, 0
+       FROM companies c
+       CROSS JOIN modules m`,
+  );
+}
+
 /**
  * List module permissions for roles
  */


### PR DESCRIPTION
## Summary
- add helper to fill `company_module_licenses`
- run that helper when populating permissions

## Testing
- `npm run build:erp` *(fails: vite not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68443801a2688331b9b3b4cc86eaf42f