### PR TITLE
Implement dynamic module routing

### DIFF
--- a/scripts/check-module-routes.cjs
+++ b/scripts/check-module-routes.cjs
@@ -27,18 +27,21 @@ const settingsChildren = [
 ];
 
 function modulePath(key, parent) {
-  const k = key.replace(/_/g, '-');
-  if (parent === 'settings') return `/settings/${k}`;
-  if (!parent) {
-    if (key === 'dashboard') return '/';
-    return `/${k}`;
+  const segments = [];
+  let cur = { module_key: key, parent_key: parent };
+  while (cur) {
+    segments.unshift(cur.module_key.replace(/_/g, '-'));
+    cur = cur.parent_key ? { module_key: cur.parent_key, parent_key: null } : null;
   }
-  return `/${k}`;
+  let p = '/' + segments.join('/');
+  if (p === '/dashboard') p = '/';
+  return p;
 }
 
 function pathExists(p) {
   if (routePaths.has(p)) return true;
-  if (p.startsWith('/settings/') && routePaths.has(p.replace('/settings', ''))) return true;
+  const alt = p === '/' ? '/' : p.replace(/^\//, '');
+  if (routePaths.has('/' + alt)) return true;
   return false;
 }
 

--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { HashRouter, Routes, Route } from 'react-router-dom';
-import AuthContextProvider from './context/AuthContext.jsx';
+import React, { useContext } from 'react';
+import { HashRouter, Routes, Route, Navigate } from 'react-router-dom';
+import AuthContextProvider, { AuthContext } from './context/AuthContext.jsx';
 import RequireAuth from './components/RequireAuth.jsx';
-import RequireAdmin from './components/RequireAdmin.jsx';
 import ERPLayout from './components/ERPLayout.jsx';
 import LoginPage from './pages/Login.jsx';
 import FormsPage from './pages/Forms.jsx';
@@ -17,41 +16,98 @@ import ReportManagementPage from './pages/ReportManagement.jsx';
 import ModulesPage from './pages/Modules.jsx';
 import SettingsPage, { GeneralSettings } from './pages/Settings.jsx';
 import ChangePasswordPage from './pages/ChangePassword.jsx';
-import Dashboard from './pages/Dashboard.jsx';
 import BlueLinkPage from './pages/BlueLinkPage.jsx';
+import { useModules } from './hooks/useModules.js';
 
 export default function App() {
+  const modules = useModules();
+
+  const moduleMap = {};
+  modules.forEach((m) => {
+    moduleMap[m.module_key] = { ...m, children: [] };
+  });
+  modules.forEach((m) => {
+    if (m.parent_key && moduleMap[m.parent_key]) {
+      moduleMap[m.parent_key].children.push(moduleMap[m.module_key]);
+    }
+  });
+
+  const componentMap = {
+    dashboard: <BlueLinkPage />,
+    forms: <FormsPage />,
+    reports: <ReportsPage />,
+    settings: <SettingsPage />,
+    users: <UsersPage />,
+    user_companies: <UserCompaniesPage />,
+    role_permissions: <RolePermissionsPage />,
+    modules: <ModulesPage />,
+    company_licenses: <CompanyLicensesPage />,
+    tables_management: <TablesManagementPage />,
+    forms_management: <FormsManagementPage />,
+    report_management: <ReportManagementPage />,
+    change_password: <ChangePasswordPage />,
+  };
+
+  const indexComponents = {
+    settings: <GeneralSettings />,
+  };
+
+  const adminOnly = new Set([
+    'users',
+    'user_companies',
+    'role_permissions',
+    'modules',
+    'company_licenses',
+    'tables_management',
+    'forms_management',
+    'report_management',
+  ]);
+
+  function renderRoute(mod) {
+    const slug = mod.module_key.replace(/_/g, '-');
+    const children = mod.children.map(renderRoute);
+    let element = componentMap[mod.module_key] || <div>{mod.label}</div>;
+
+    if (adminOnly.has(mod.module_key)) {
+      element = <RequireAdminPage>{element}</RequireAdminPage>;
+    }
+
+    if (!mod.parent_key && mod.module_key === 'dashboard') {
+      return <Route key={mod.module_key} index element={element} />;
+    }
+
+    return (
+      <Route key={mod.module_key} path={slug} element={element}>
+        {indexComponents[mod.module_key] && (
+          <Route index element={indexComponents[mod.module_key]} />
+        )}
+        {children}
+      </Route>
+    );
+  }
+
+  const roots = modules
+    .filter((m) => !m.parent_key)
+    .map((m) => moduleMap[m.module_key]);
+
   return (
     <AuthContextProvider>
       <HashRouter>
         <Routes>
-          {/* Public route for login without sidebar/layout */}
           <Route path="/login" element={<LoginPage />} />
-
-          {/* Protected app routes */}
           <Route element={<RequireAuth />}>
-            <Route path="/" element={<ERPLayout />}>
-              <Route index element={<BlueLinkPage />} />
-              <Route path="forms" element={<FormsPage />} />
-              <Route path="reports" element={<ReportsPage />} />
-              <Route path="settings" element={<SettingsPage />}>
-                <Route index element={<GeneralSettings />} />
-                <Route element={<RequireAdmin />}>
-                  <Route path="users" element={<UsersPage />} />
-                  <Route path="user-companies" element={<UserCompaniesPage />} />
-                  <Route path="role-permissions" element={<RolePermissionsPage />} />
-                  <Route path="modules" element={<ModulesPage />} />
-                  <Route path="company-licenses" element={<CompanyLicensesPage />} />
-                  <Route path="tables-management" element={<TablesManagementPage />} />
-                  <Route path="forms-management" element={<FormsManagementPage />} />
-                  <Route path="report-management" element={<ReportManagementPage />} />
-                </Route>
-                <Route path="change-password" element={<ChangePasswordPage />} />
-              </Route>
-            </Route>
+            <Route path="/" element={<ERPLayout />}>{roots.map(renderRoute)}</Route>
           </Route>
         </Routes>
       </HashRouter>
     </AuthContextProvider>
   );
+}
+
+function RequireAdminPage({ children }) {
+  const { user } = useContext(AuthContext);
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+  return user.role === 'admin' ? children : <Navigate to="/" replace />;
 }

--- a/src/erp.mgt.mn/utils/modulePath.js
+++ b/src/erp.mgt.mn/utils/modulePath.js
@@ -1,0 +1,11 @@
+export default function modulePath(mod, map) {
+  const segments = [];
+  let cur = mod;
+  while (cur) {
+    segments.unshift(cur.module_key.replace(/_/g, '-'));
+    cur = cur.parent_key ? map[cur.parent_key] : null;
+  }
+  let path = '/' + segments.join('/');
+  if (path === '/dashboard') path = '/';
+  return path;
+}


### PR DESCRIPTION
## Summary
- compute module paths recursively in a shared helper
- build sidebar tree using a map of all modules
- generate `App` routes from module list
- adjust module route checking script

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68443c74ac008331a6e7e3dc3c0de37f