### PR TITLE
Fix sidebar children when parent module hidden

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -122,9 +122,10 @@ function Sidebar() {
   Object.values(map).forEach((m) => {
     if (m.parent_key && map[m.parent_key]) {
       map[m.parent_key].children.push(m);
-    } else {
+    } else if (!m.parent_key) {
       roots.push(m);
     }
+    // If the parent module isn't visible, the child is skipped
   });
 
   return (


### PR DESCRIPTION
## Summary
- skip sidebar children if their parent module isn't visible

## Testing
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684445a16e808331b3ac718bebe1b056