### PR TITLE
Fix sidebar hierarchy and permissions

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -303,25 +303,42 @@ export async function upsertModule(
 }
 
 export async function populateRoleDefaultModules() {
-  await pool.query(
-    `INSERT INTO role_default_modules (role_id, module_key, allowed)
-     SELECT * FROM (
-       SELECT ur.id AS role_id, m.module_key AS module_key,
-              CASE
-                WHEN ur.name = 'admin' THEN 1
-                WHEN m.module_key IN (
-                  'settings', 'users', 'user_companies', 'role_permissions',
-                  'company_licenses', 'developer', 'modules',
-                  'tables_management', 'forms_management',
-                  'report_management'
-                ) THEN 0
-                ELSE 1
-              END AS allowed
-         FROM user_roles ur
-         CROSS JOIN modules m
-     ) AS vals
-     ON DUPLICATE KEY UPDATE allowed = vals.allowed`,
+  const [mods] = await pool.query(
+    'SELECT module_key, parent_key FROM modules',
   );
+  const [roles] = await pool.query('SELECT id, name FROM user_roles');
+
+  const parent = {};
+  mods.forEach((m) => {
+    parent[m.module_key] = m.parent_key;
+  });
+
+  function isRestricted(key) {
+    let cur = key;
+    while (cur) {
+      if (cur === 'settings' || cur === 'developer') return true;
+      cur = parent[cur];
+    }
+    return false;
+  }
+
+  const values = [];
+  roles.forEach((r) => {
+    mods.forEach((m) => {
+      const allowed =
+        r.name === 'admin' ? 1 : isRestricted(m.module_key) ? 0 : 1;
+      values.push([r.id, m.module_key, allowed]);
+    });
+  });
+
+  if (values.length > 0) {
+    await pool.query(
+      `INSERT INTO role_default_modules (role_id, module_key, allowed)
+       VALUES ?
+       ON DUPLICATE KEY UPDATE allowed = VALUES(allowed)`,
+      [values],
+    );
+  }
 }
 
 export async function populateRoleModulePermissions() {

--- a/db/scripts/populate_role_module_permissions.sql
+++ b/db/scripts/populate_role_module_permissions.sql
@@ -1,18 +1,21 @@
 -- Populate role_default_modules with any new modules
+WITH RECURSIVE restricted AS (
+  SELECT module_key, parent_key FROM modules WHERE module_key IN ('settings','developer')
+  UNION ALL
+  SELECT m.module_key, m.parent_key
+    FROM modules m
+    JOIN restricted r ON m.parent_key = r.module_key
+)
 INSERT INTO role_default_modules (role_id, module_key, allowed)
 SELECT * FROM (
-  SELECT ur.id AS role_id, m.module_key AS module_key,
+  SELECT ur.id AS role_id, m.module_key,
          CASE
            WHEN ur.name = 'admin' THEN 1
-           WHEN m.module_key IN (
-            'settings', 'users', 'user_companies', 'role_permissions',
-            'company_licenses', 'developer', 'modules',
-            'tables_management', 'forms_management', 'report_management'
-           ) THEN 0
+           WHEN m.module_key IN (SELECT module_key FROM restricted) THEN 0
            ELSE 1
          END AS allowed
-  FROM user_roles ur
-  CROSS JOIN modules m
+    FROM user_roles ur
+    CROSS JOIN modules m
 ) AS vals
 ON DUPLICATE KEY UPDATE allowed = vals.allowed;
 

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -111,9 +111,16 @@ function Sidebar() {
     allMap[m.module_key] = { ...m };
   });
 
+  function canShow(key) {
+    const mod = allMap[key];
+    if (!mod) return false;
+    if (!perms[key] || !licensed[key] || !mod.show_in_sidebar) return false;
+    return mod.parent_key ? canShow(mod.parent_key) : true;
+  }
+
   const map = {};
   modules.forEach((m) => {
-    if (perms[m.module_key] && licensed[m.module_key] && m.show_in_sidebar) {
+    if (canShow(m.module_key)) {
       map[m.module_key] = { ...m, children: [] };
     }
   });


### PR DESCRIPTION
## Summary
- ensure child modules only show when ancestors are allowed in the sidebar
- update permission population logic to evaluate module hierarchy
- derive restricted modules for defaults via recursive SQL

## Testing
- `node scripts/check-module-routes.cjs`

------
https://chatgpt.com/codex/tasks/task_e_6844478275cc83318b14d6d266a083b2