### PR TITLE
Fix menu population to use hierarchy

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -303,18 +303,41 @@ export async function upsertModule(
 }
 
 export async function populateRoleDefaultModules() {
+  const modules = await listModules();
+
+  const map = {};
+  modules.forEach((m) => {
+    map[m.module_key] = m;
+  });
+
+  function rootKey(key) {
+    let cur = map[key];
+    while (cur && cur.parent_key) {
+      cur = map[cur.parent_key];
+    }
+    return cur ? cur.module_key : null;
+  }
+
+  const adminOnly = modules
+    .filter((m) => {
+      const root = rootKey(m.module_key);
+      return (
+        ["settings", "developer"].includes(root) && m.module_key !== "change_password"
+      );
+    })
+    .map((m) => m.module_key);
+
+  const cond = adminOnly.length
+    ? `m.module_key IN (${adminOnly.map((k) => pool.escape(k)).join(", ")})`
+    : "FALSE";
+
   await pool.query(
     `INSERT INTO role_default_modules (role_id, module_key, allowed)
      SELECT * FROM (
        SELECT ur.id AS role_id, m.module_key AS module_key,
               CASE
                 WHEN ur.name = 'admin' THEN 1
-                WHEN m.module_key IN (
-                  'settings', 'users', 'user_companies', 'role_permissions',
-                  'company_licenses', 'developer', 'modules',
-                  'tables_management', 'forms_management',
-                  'report_management'
-                ) THEN 0
+                WHEN ${cond} THEN 0
                 ELSE 1
               END AS allowed
          FROM user_roles ur


### PR DESCRIPTION
## Summary
- derive admin-only module defaults from the current module hierarchy
- handle empty admin-only set when populating permissions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844507e688483319b9d0e63b694d1a1