### PR TITLE
Fix sidebar group for Developer module

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -118,6 +118,18 @@ function Sidebar() {
     }
   });
 
+  // Ensure parents exist for permitted modules so children don't become
+  // "orphans" when the parent itself is not accessible. This allows modules
+  // like the Developer group to appear if any child is shown.
+  Object.values(map).forEach((m) => {
+    let pKey = m.parent_key;
+    while (pKey && !map[pKey] && allMap[pKey]) {
+      const parent = allMap[pKey];
+      map[pKey] = { ...parent, children: [] };
+      pKey = parent.parent_key;
+    }
+  });
+
   const roots = [];
   const orphans = [];
   Object.values(map).forEach((m) => {


### PR DESCRIPTION
## Summary
- ensure sidebar shows missing parent modules so children under Developer menu no longer appear under 'Other'

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684457a132a88331860ab7befb9d66be