### PR TITLE
Add Excel coding table upload feature

### DIFF
--- a/api-server/controllers/codingTableController.js
+++ b/api-server/controllers/codingTableController.js
@@ -1,0 +1,44 @@
+import fs from 'fs';
+import xlsx from 'xlsx';
+import { pool } from '../../db/index.js';
+
+export async function uploadCodingTable(req, res, next) {
+  try {
+    const { sheet, tableName, idColumn, nameColumn } = req.body;
+    if (!req.file) {
+      return res.status(400).json({ error: 'File required' });
+    }
+    const workbook = xlsx.readFile(req.file.path);
+    const sheetName = sheet || workbook.SheetNames[0];
+    const ws = workbook.Sheets[sheetName];
+    if (!ws) {
+      return res.status(400).json({ error: 'Sheet not found' });
+    }
+    const rows = xlsx.utils.sheet_to_json(ws);
+    if (!tableName || !idColumn || !nameColumn) {
+      return res.status(400).json({ error: 'Missing params' });
+    }
+    await pool.query(
+      `CREATE TABLE IF NOT EXISTS \`${tableName}\` (
+        id VARCHAR(255) PRIMARY KEY,
+        name VARCHAR(255)
+      )`
+    );
+    let count = 0;
+    for (const r of rows) {
+      const id = r[idColumn];
+      const name = r[nameColumn];
+      if (id === undefined || name === undefined) continue;
+      await pool.query(
+        `INSERT INTO \`${tableName}\` (id, name)
+         VALUES (?, ?) ON DUPLICATE KEY UPDATE name = VALUES(name)`,
+        [String(id), String(name)]
+      );
+      count++;
+    }
+    fs.unlinkSync(req.file.path);
+    res.json({ inserted: count });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/api-server/routes/coding_tables.js
+++ b/api-server/routes/coding_tables.js
@@ -1,0 +1,11 @@
+import express from 'express';
+import multer from 'multer';
+import { uploadCodingTable } from '../controllers/codingTableController.js';
+import { requireAuth } from '../middlewares/auth.js';
+
+const router = express.Router();
+const upload = multer({ dest: 'uploads/' });
+
+router.post('/upload', requireAuth, upload.single('file'), uploadCodingTable);
+
+export default router;

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -15,6 +15,7 @@ import rolePermissionRoutes from "./routes/role_permissions.js";
 import moduleRoutes from "./routes/modules.js";
 import companyModuleRoutes from "./routes/company_modules.js";
 import tableRoutes from "./routes/tables.js";
+import codingTableRoutes from "./routes/coding_tables.js";
 import { requireAuth } from "./middlewares/auth.js";
 
 dotenv.config();
@@ -48,6 +49,7 @@ app.use("/api/user_companies", requireAuth, userCompanyRoutes);
 app.use("/api/role_permissions", requireAuth, rolePermissionRoutes);
 app.use("/api/modules", requireAuth, moduleRoutes);
 app.use("/api/company_modules", requireAuth, companyModuleRoutes);
+app.use("/api/coding_tables", requireAuth, codingTableRoutes);
 app.use("/api/tables", requireAuth, tableRoutes);
 
 // Serve static React build and fallback to index.html

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -33,7 +33,10 @@ This document outlines the roadmap, scope, architecture, milestones, and deliver
 
 5. **Settings**  
    - Global & tenant-specific configs.  
-   - Feature toggles (e.g. enable/disable mosaic).
+ - Feature toggles (e.g. enable/disable mosaic).
+
+6. **Coding Tables Upload**
+   - Upload Excel sheets to create simple lookup tables.
 
 ## 4. Architecture & Tech Stack
 - **Front-end**  

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "cookie-parser": "^1.4.6",
     "csurf": "^1.11.0",
     "react-mosaic-component": "^6.0.0",
-    "jsonwebtoken": "^9.0.0"
+    "jsonwebtoken": "^9.0.0",
+    "multer": "^1.4.5-lts.1",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "vite": "^6.3.5",

--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -11,6 +11,7 @@ import UserCompaniesPage from './pages/UserCompanies.jsx';
 import RolePermissionsPage from './pages/RolePermissions.jsx';
 import CompanyLicensesPage from './pages/CompanyLicenses.jsx';
 import TablesManagementPage from './pages/TablesManagement.jsx';
+import CodingTablesPage from './pages/CodingTables.jsx';
 import FormsManagementPage from './pages/FormsManagement.jsx';
 import ReportManagementPage from './pages/ReportManagement.jsx';
 import ModulesPage from './pages/Modules.jsx';
@@ -43,6 +44,7 @@ export default function App() {
     modules: <ModulesPage />,
     company_licenses: <CompanyLicensesPage />,
     tables_management: <TablesManagementPage />,
+    coding_tables: <CodingTablesPage />,
     forms_management: <FormsManagementPage />,
     report_management: <ReportManagementPage />,
     change_password: <ChangePasswordPage />,
@@ -59,6 +61,7 @@ export default function App() {
     'modules',
     'company_licenses',
     'tables_management',
+    'coding_tables',
     'forms_management',
     'report_management',
   ]);

--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react';
+import * as XLSX from 'xlsx';
+
+export default function CodingTablesPage() {
+  const [sheets, setSheets] = useState([]);
+  const [workbook, setWorkbook] = useState(null);
+  const [sheet, setSheet] = useState('');
+  const [headers, setHeaders] = useState([]);
+  const [tableName, setTableName] = useState('');
+  const [idColumn, setIdColumn] = useState('');
+  const [nameColumn, setNameColumn] = useState('');
+
+  function handleFile(e) {
+    const file = e.target.files[0];
+    if (!file) return;
+    file.arrayBuffer().then((ab) => {
+      const wb = XLSX.read(ab);
+      setWorkbook(wb);
+      setSheets(wb.SheetNames);
+      setSheet(wb.SheetNames[0]);
+      const data = XLSX.utils.sheet_to_json(wb.Sheets[wb.SheetNames[0]], {
+        header: 1,
+      });
+      setHeaders(data[0] || []);
+    });
+  }
+
+  function handleSheetChange(e) {
+    const s = e.target.value;
+    setSheet(s);
+    if (workbook) {
+      const data = XLSX.utils.sheet_to_json(workbook.Sheets[s], { header: 1 });
+      setHeaders(data[0] || []);
+    }
+  }
+
+  async function handleUpload() {
+    if (!workbook || !sheet || !tableName || !idColumn || !nameColumn) return;
+    const ws = workbook.Sheets[sheet];
+    const rows = XLSX.utils.sheet_to_json(ws);
+    const formData = new FormData();
+    const blob = new Blob([XLSX.write(workbook, { bookType: 'xlsx', type: 'array' })]);
+    formData.append('file', blob, 'upload.xlsx');
+    formData.append('sheet', sheet);
+    formData.append('tableName', tableName);
+    formData.append('idColumn', idColumn);
+    formData.append('nameColumn', nameColumn);
+    const res = await fetch('/api/coding_tables/upload', {
+      method: 'POST',
+      credentials: 'include',
+      body: formData,
+    });
+    if (!res.ok) {
+      alert('Upload failed');
+      return;
+    }
+    const json = await res.json();
+    alert(`Inserted ${json.inserted} rows`);
+  }
+
+  return (
+    <div>
+      <h2>Coding Table Upload</h2>
+      <input type="file" accept=".xlsx,.xls" onChange={handleFile} />
+      {sheets.length > 0 && (
+        <div>
+          <div>
+            Sheet:
+            <select value={sheet} onChange={handleSheetChange}>
+              {sheets.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            Table Name:
+            <input value={tableName} onChange={(e) => setTableName(e.target.value)} />
+          </div>
+          <div>
+            ID Column:
+            <select value={idColumn} onChange={(e) => setIdColumn(e.target.value)}>
+              <option value="">--select--</option>
+              {headers.map((h) => (
+                <option key={h} value={h}>
+                  {h}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            Name Column:
+            <select value={nameColumn} onChange={(e) => setNameColumn(e.target.value)}>
+              <option value="">--select--</option>
+              {headers.map((h) => (
+                <option key={h} value={h}>
+                  {h}
+                </option>
+              ))}
+            </select>
+          </div>
+          <button onClick={handleUpload}>Upload</button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow Excel upload for coding tables
- expose `/api/coding_tables/upload` API for new tables
- support file parsing via multer and xlsx
- add Coding Tables page in the React app
- document new feature in PROJECT_PLAN

## Testing
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684460cb462c8331819af22d2d5f8273