### PR TITLE
feat: populate default modules

### DIFF
--- a/api-server/controllers/moduleController.js
+++ b/api-server/controllers/moduleController.js
@@ -1,6 +1,7 @@
 import {
   listModules as dbListModules,
   upsertModule,
+  populateDefaultModules,
   populateRoleModulePermissions,
   populateCompanyModuleLicenses,
 } from "../../db/index.js";
@@ -40,6 +41,7 @@ export async function saveModule(req, res, next) {
 export async function populatePermissions(req, res, next) {
   try {
     if (req.user.role !== 'admin') return res.sendStatus(403);
+    await populateDefaultModules();
     await populateCompanyModuleLicenses();
     await populateRoleModulePermissions();
     res.sendStatus(204);

--- a/db/defaultModules.js
+++ b/db/defaultModules.js
@@ -1,0 +1,20 @@
+export default [
+  { moduleKey: 'dashboard', label: 'Самбар', parentKey: null, showInSidebar: true, showInHeader: false },
+  { moduleKey: 'forms', label: 'Маягтууд', parentKey: null, showInSidebar: true, showInHeader: false },
+  { moduleKey: 'reports', label: 'Тайлан', parentKey: null, showInSidebar: true, showInHeader: false },
+  { moduleKey: 'settings', label: 'Тохиргоо', parentKey: null, showInSidebar: true, showInHeader: false },
+  { moduleKey: 'developer', label: 'Хөгжүүлэгч', parentKey: 'settings', showInSidebar: true, showInHeader: false },
+  { moduleKey: 'users', label: 'Хэрэглэгчид', parentKey: 'settings', showInSidebar: true, showInHeader: false },
+  { moduleKey: 'user_companies', label: 'Хэрэглэгчийн компаниуд', parentKey: 'settings', showInSidebar: true, showInHeader: false },
+  { moduleKey: 'role_permissions', label: 'Эрхийн тохиргоо', parentKey: 'settings', showInSidebar: true, showInHeader: false },
+  { moduleKey: 'modules', label: 'Модуль', parentKey: 'developer', showInSidebar: true, showInHeader: false },
+  { moduleKey: 'company_licenses', label: 'Лиценз', parentKey: 'settings', showInSidebar: true, showInHeader: false },
+  { moduleKey: 'tables_management', label: 'Хүснэгтийн удирдлага', parentKey: 'developer', showInSidebar: true, showInHeader: false },
+  { moduleKey: 'coding_tables', label: 'Кодын хүснэгтүүд', parentKey: 'developer', showInSidebar: true, showInHeader: false },
+  { moduleKey: 'forms_management', label: 'Маягтын удирдлага', parentKey: 'developer', showInSidebar: true, showInHeader: false },
+  { moduleKey: 'report_management', label: 'Тайлангийн удирдлага', parentKey: 'developer', showInSidebar: true, showInHeader: false },
+  { moduleKey: 'change_password', label: 'Нууц үг солих', parentKey: 'settings', showInSidebar: true, showInHeader: false },
+  { moduleKey: 'gl', label: 'Ерөнхий журнал', parentKey: null, showInSidebar: false, showInHeader: true },
+  { moduleKey: 'po', label: 'Худалдан авалтын захиалга', parentKey: null, showInSidebar: false, showInHeader: true },
+  { moduleKey: 'sales', label: 'Борлуулалтын самбар', parentKey: null, showInSidebar: false, showInHeader: true }
+];

--- a/db/index.js
+++ b/db/index.js
@@ -1,6 +1,7 @@
 import mysql from "mysql2/promise";
 import dotenv from "dotenv";
 import bcrypt from "bcryptjs";
+import defaultModules from "./defaultModules.js";
 
 dotenv.config();
 
@@ -300,6 +301,18 @@ export async function upsertModule(
     [moduleKey, label, parentKey, showInSidebar ? 1 : 0, showInHeader ? 1 : 0],
   );
   return { moduleKey, label, parentKey, showInSidebar, showInHeader };
+}
+
+export async function populateDefaultModules() {
+  for (const m of defaultModules) {
+    await upsertModule(
+      m.moduleKey,
+      m.label,
+      m.parentKey,
+      m.showInSidebar,
+      m.showInHeader,
+    );
+  }
 }
 
 export async function populateRoleDefaultModules() {


### PR DESCRIPTION
## Summary
- auto-add default modules when populating permissions
- hook into `/api/modules/populate` for menu sync

## Testing
- `node scripts/check-module-routes.cjs`
- `npm run build:erp` *(fails: vite not found)*
- `npm run build:homepage` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844646813208331a9fc425fcd8fe400