### PR TITLE
Add header row selection for coding table uploads

### DIFF
--- a/api-server/controllers/codingTableController.js
+++ b/api-server/controllers/codingTableController.js
@@ -4,7 +4,7 @@ import { pool } from '../../db/index.js';
 
 export async function uploadCodingTable(req, res, next) {
   try {
-    const { sheet, tableName, idColumn, nameColumn } = req.body;
+    const { sheet, tableName, idColumn, nameColumn, headerRow } = req.body;
     if (!req.file) {
       return res.status(400).json({ error: 'File required' });
     }
@@ -14,7 +14,20 @@ export async function uploadCodingTable(req, res, next) {
     if (!ws) {
       return res.status(400).json({ error: 'Sheet not found' });
     }
-    const rows = xlsx.utils.sheet_to_json(ws);
+    const headerIndex = parseInt(headerRow || '1', 10);
+    const data = xlsx.utils.sheet_to_json(ws, { header: 1, blankrows: false });
+    const headers = data[headerIndex - 1];
+    if (!headers) {
+      fs.unlinkSync(req.file.path);
+      return res.status(400).json({ error: 'Header row not found' });
+    }
+    const rows = data.slice(headerIndex).map((row) => {
+      const obj = {};
+      headers.forEach((h, idx) => {
+        obj[h] = row[idx];
+      });
+      return obj;
+    });
     if (!tableName || !idColumn || !nameColumn) {
       return res.status(400).json({ error: 'Missing params' });
     }


### PR DESCRIPTION
## Summary
- extend coding table upload to allow picking header row
- filter potential ID columns by name containing `id`
- send header row information to API and parse accordingly

## Testing
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446ade6a488331a766284c1d6cf236