### PR TITLE
Fix UNIQUE KEY SQL template string

### DIFF
--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -151,7 +151,7 @@ export default function CodingTablesPage() {
       sqlStr += `,\n  \`${c}\` ${sqlType}`;
     });
     if (uniqueColumns.length > 0) {
-      sqlStr += `,\n  UNIQUE KEY \`uk_${tableName}\` (${uniqueColumns.map((c) => \`\`${c}\`\`).join(', ')})`;
+      sqlStr += `,\n  UNIQUE KEY \`uk_${tableName}\` (${uniqueColumns.map((c) => \`${c}\`).join(', ')})`;
     }
     sqlStr += '\n);\n';
 


### PR DESCRIPTION
## Summary
- correct quoting of `uniqueColumns` in CodingTables so build passes

## Testing
- `npm run build:erp` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_684708fbd8588331aa237dccba24ca88