### PR TITLE
Add delete option for dynamic table rows

### DIFF
--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -3,6 +3,7 @@ import {
   listTableRows,
   updateTableRow,
   insertTableRow,
+  deleteTableRow,
 } from '../../db/index.js';
 
 export async function getTables(req, res, next) {
@@ -42,6 +43,15 @@ export async function addRow(req, res, next) {
   try {
     const result = await insertTableRow(req.params.table, req.body);
     res.status(201).json(result);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function deleteRow(req, res, next) {
+  try {
+    await deleteTableRow(req.params.table, req.params.id);
+    res.sendStatus(204);
   } catch (err) {
     next(err);
   }

--- a/api-server/routes/tables.js
+++ b/api-server/routes/tables.js
@@ -4,6 +4,7 @@ import {
   getTableRows,
   updateRow,
   addRow,
+  deleteRow,
 } from '../controllers/tableController.js';
 import { requireAuth } from '../middlewares/auth.js';
 
@@ -13,5 +14,6 @@ router.get('/', requireAuth, getTables);
 router.get('/:table', requireAuth, getTableRows);
 router.put('/:table/:id', requireAuth, updateRow);
 router.post('/:table', requireAuth, addRow);
+router.delete('/:table/:id', requireAuth, deleteRow);
 
 export default router;

--- a/db/index.js
+++ b/db/index.js
@@ -536,3 +536,17 @@ export async function insertTableRow(tableName, row) {
   );
   return { id: result.insertId };
 }
+
+export async function deleteTableRow(tableName, id) {
+  if (tableName === 'company_module_licenses') {
+    const [companyId, moduleKey] = String(id).split('-');
+    await pool.query(
+      'DELETE FROM company_module_licenses WHERE company_id = ? AND module_key = ?',
+      [companyId, moduleKey],
+    );
+    return { company_id: companyId, module_key: moduleKey };
+  }
+
+  await pool.query('DELETE FROM ?? WHERE id = ?', [tableName, id]);
+  return { id };
+}

--- a/src/erp.mgt.mn/pages/TablesManagement.jsx
+++ b/src/erp.mgt.mn/pages/TablesManagement.jsx
@@ -120,6 +120,28 @@ export default function TablesManagement() {
     loadRows(selectedTable);
   }
 
+  async function handleDelete(row) {
+    if (!confirm('Delete row?')) return;
+    let rowId = row.id;
+    if (rowId === undefined) {
+      if (selectedTable === 'company_module_licenses') {
+        rowId = `${row.company_id}-${row.module_key}`;
+      } else {
+        alert('Cannot delete row: no id column');
+        return;
+      }
+    }
+    const res = await fetch(
+      `/api/tables/${selectedTable}/${encodeURIComponent(rowId)}`,
+      { method: 'DELETE', credentials: 'include' },
+    );
+    if (!res.ok) {
+      alert('Delete failed');
+      return;
+    }
+    loadRows(selectedTable);
+  }
+
   function handleSort(col) {
     if (sort.column === col) {
       setSort({ column: col, dir: sort.dir === 'asc' ? 'desc' : 'asc' });
@@ -201,6 +223,7 @@ export default function TablesManagement() {
                   ))}
                   <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
                     <button onClick={() => handleEdit(r)}>Edit</button>
+                    <button onClick={() => handleDelete(r)} style={{ marginLeft: '0.5rem' }}>Delete</button>
                   </td>
                 </tr>
               ))}


### PR DESCRIPTION
## Summary
- enable row deletion in table management
- expose DELETE endpoint for tables

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847c8c010488331969d60116d69a794