### PR TITLE
Fix dynamic table deletion for user_companies

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -529,6 +529,15 @@ export async function updateTableRow(tableName, id, updates) {
     return { company_id: companyId, role_id: roleId, module_key: moduleKey };
   }
 
+  if (tableName === 'user_companies') {
+    const [empId, companyId] = String(id).split('-');
+    await pool.query(
+      `UPDATE user_companies SET ${setClause} WHERE empid = ? AND company_id = ?`,
+      [...values, empId, companyId],
+    );
+    return { empid: empId, company_id: companyId };
+  }
+
   await pool.query(`UPDATE ?? SET ${setClause} WHERE id = ?`, [tableName, ...values, id]);
   return { id };
 }
@@ -563,6 +572,15 @@ export async function deleteTableRow(tableName, id) {
       [companyId, roleId, moduleKey],
     );
     return { company_id: companyId, role_id: roleId, module_key: moduleKey };
+  }
+
+  if (tableName === 'user_companies') {
+    const [empId, companyId] = String(id).split('-');
+    await pool.query(
+      'DELETE FROM user_companies WHERE empid = ? AND company_id = ?',
+      [empId, companyId],
+    );
+    return { empid: empId, company_id: companyId };
   }
 
   await pool.query('DELETE FROM ?? WHERE id = ?', [tableName, id]);

--- a/src/erp.mgt.mn/pages/TablesManagement.jsx
+++ b/src/erp.mgt.mn/pages/TablesManagement.jsx
@@ -80,6 +80,8 @@ export default function TablesManagement() {
           rowId = `${row.company_id}-${row.module_key}`;
         } else if (selectedTable === 'role_module_permissions') {
           rowId = `${row.company_id}-${row.role_id}-${row.module_key}`;
+        } else if (selectedTable === 'user_companies') {
+          rowId = `${row.empid}-${row.company_id}`;
         } else {
           alert('Cannot update row: no id column');
           return;
@@ -131,6 +133,8 @@ export default function TablesManagement() {
         rowId = `${row.company_id}-${row.module_key}`;
       } else if (selectedTable === 'role_module_permissions') {
         rowId = `${row.company_id}-${row.role_id}-${row.module_key}`;
+      } else if (selectedTable === 'user_companies') {
+        rowId = `${row.empid}-${row.company_id}`;
       } else {
         alert('Cannot delete row: no id column');
         return;
@@ -182,6 +186,9 @@ export default function TablesManagement() {
     if (selectedTable === 'role_module_permissions') {
       return `${row.company_id}-${row.role_id}-${row.module_key}`;
     }
+    if (selectedTable === 'user_companies') {
+      return `${row.empid}-${row.company_id}`;
+    }
     return JSON.stringify(row);
   }
 
@@ -212,6 +219,8 @@ export default function TablesManagement() {
           rowId = `${r.company_id}-${r.module_key}`;
         } else if (selectedTable === 'role_module_permissions') {
           rowId = `${r.company_id}-${r.role_id}-${r.module_key}`;
+        } else if (selectedTable === 'user_companies') {
+          rowId = `${r.empid}-${r.company_id}`;
         } else {
           alert('Cannot delete row: no id column');
           continue;
@@ -295,6 +304,8 @@ export default function TablesManagement() {
                         ? `${r.company_id}-${r.module_key}`
                         : selectedTable === 'role_module_permissions'
                         ? `${r.company_id}-${r.role_id}-${r.module_key}`
+                        : selectedTable === 'user_companies'
+                        ? `${r.empid}-${r.company_id}`
                         : JSON.stringify(r))
                   }
                 >


### PR DESCRIPTION
## Summary
- allow updating and deleting rows in `user_companies` composite-key table
- support `user_companies` in Tables Management UI

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684808507f448331a67e151b14c935fb