### PR TITLE
Fix dynamic table relations for user companies

### DIFF
--- a/src/erp.mgt.mn/pages/TablesManagement.jsx
+++ b/src/erp.mgt.mn/pages/TablesManagement.jsx
@@ -77,7 +77,13 @@ export default function TablesManagement() {
     const obj = {};
     await Promise.all(
       cols
-        .filter((c) => RELATION_LOOKUPS[c])
+        .filter((c) => {
+          if (!RELATION_LOOKUPS[c]) return false;
+          if (selectedTable === 'user_companies' && (c === 'empid' || c === 'role_id')) {
+            return false;
+          }
+          return true;
+        })
         .map(async (c) => {
           const info = RELATION_LOOKUPS[c];
           const res = await fetch(`/api/tables/${info.table}?perPage=500`, { credentials: 'include' });


### PR DESCRIPTION
## Summary
- avoid fetching lookup data for `empid` and `role_id` when editing `user_companies`

## Testing
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684830d231608331903be5a5b6e5094c