### PR TITLE
Fix user companies table lookups

### DIFF
--- a/src/erp.mgt.mn/pages/TablesManagement.jsx
+++ b/src/erp.mgt.mn/pages/TablesManagement.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 const RELATION_LOOKUPS = {
   role_id: { table: 'user_roles', value: 'id', label: 'name' },
-  empid: { table: 'users', value: 'empid', label: 'name' },
+  empid: { table: 'employee', value: 'empid', label: 'name' },
   company_id: { table: 'companies', value: 'id', label: 'name' },
   module_key: { table: 'modules', value: 'module_key', label: 'label' },
 };
@@ -77,13 +77,7 @@ export default function TablesManagement() {
     const obj = {};
     await Promise.all(
       cols
-        .filter((c) => {
-          if (!RELATION_LOOKUPS[c]) return false;
-          if (selectedTable === 'user_companies' && (c === 'empid' || c === 'role_id')) {
-            return false;
-          }
-          return true;
-        })
+        .filter((c) => RELATION_LOOKUPS[c])
         .map(async (c) => {
           const info = RELATION_LOOKUPS[c];
           const res = await fetch(`/api/tables/${info.table}?perPage=500`, { credentials: 'include' });

--- a/src/erp.mgt.mn/pages/UserCompanies.jsx
+++ b/src/erp.mgt.mn/pages/UserCompanies.jsx
@@ -6,7 +6,8 @@ export default function UserCompanies() {
   const [assignments, setAssignments] = useState([]);
   const [filterEmpId, setFilterEmpId] = useState('');
   const { company } = useContext(AuthContext);
-  const [usersList, setUsersList] = useState([]);
+  const [employeesList, setEmployeesList] = useState([]);
+  const [rolesList, setRolesList] = useState([]);
   const [companiesList, setCompaniesList] = useState([]);
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState(null);
@@ -32,13 +33,16 @@ export default function UserCompanies() {
   useEffect(() => {
     async function loadLists() {
       try {
-        const [uRes, cRes] = await Promise.all([
-          fetch('/api/users', { credentials: 'include' }),
+        const [eRes, rRes, cRes] = await Promise.all([
+          fetch('/api/tables/employee?perPage=500', { credentials: 'include' }),
+          fetch('/api/tables/user_roles?perPage=500', { credentials: 'include' }),
           fetch('/api/companies', { credentials: 'include' })
         ]);
-        const users = uRes.ok ? await uRes.json() : [];
+        const eJson = eRes.ok ? await eRes.json() : { rows: [] };
+        const rJson = rRes.ok ? await rRes.json() : { rows: [] };
         const companies = cRes.ok ? await cRes.json() : [];
-        setUsersList(users);
+        setEmployeesList(eJson.rows || eJson);
+        setRolesList(rJson.rows || rJson);
         setCompaniesList(companies);
       } catch (err) {
         console.error('Error loading lists:', err);
@@ -150,14 +154,23 @@ export default function UserCompanies() {
         }}
         onSubmit={handleFormSubmit}
         assignment={editing}
-        users={usersList}
+        users={employeesList}
+        roles={rolesList}
         companies={companiesList}
       />
     </div>
   );
 }
 
-function AssignmentFormModal({ visible, onCancel, onSubmit, assignment, users, companies }) {
+function AssignmentFormModal({
+  visible,
+  onCancel,
+  onSubmit,
+  assignment,
+  users,
+  companies,
+  roles,
+}) {
   const [empid, setEmpid] = useState(assignment?.empid || '');
   const [companyId, setCompanyId] = useState(assignment?.company_id || '');
   const [roleId, setRoleId] = useState(String(assignment?.role_id || 2));
@@ -249,8 +262,14 @@ function AssignmentFormModal({ visible, onCancel, onSubmit, assignment, users, c
               required
               style={{ width: '100%', padding: '0.5rem' }}
             >
-              <option value="1">admin</option>
-              <option value="2">user</option>
+              <option value="" disabled>
+                Сонгоно уу...
+              </option>
+              {roles.map((r) => (
+                <option key={r.id} value={r.id}>
+                  {r.name}
+                </option>
+              ))}
             </select>
           </div>
 


### PR DESCRIPTION
## Summary
- fetch employees and user roles when editing user-company assignments
- use employee table for empid lookups in dynamic table
- enable lookups for user_companies in dynamic tables

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68483270a55483318c6cb1086ae15edd