### PR TITLE
Add forms table and table relation API

### DIFF
--- a/api-server/controllers/formController.js
+++ b/api-server/controllers/formController.js
@@ -1,8 +1,15 @@
-import fs from 'fs';
-import path from 'path';
-export function getFormSchemas(req, res) {
-  const schemasDir = path.resolve('config/formSchemas');
-  const files = fs.readdirSync(schemasDir);
-  const schemas = files.map(f => JSON.parse(fs.readFileSync(path.join(schemasDir, f))));
-  res.json(schemas);
+import { listForms } from '../../db/index.js';
+
+export async function getFormSchemas(req, res, next) {
+  try {
+    const forms = await listForms();
+    const schemas = forms.map(f => ({
+      id: f.id,
+      name: f.name,
+      schema: typeof f.schema_json === 'string' ? JSON.parse(f.schema_json) : f.schema_json,
+    }));
+    res.json(schemas);
+  } catch (err) {
+    next(err);
+  }
 }

--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -1,6 +1,7 @@
 import {
   listDatabaseTables,
   listTableRows,
+  listTableRelations,
   updateTableRow,
   insertTableRow,
   deleteTableRow,
@@ -26,6 +27,15 @@ export async function getTableRows(req, res, next) {
       sort: { column: sort, dir },
     });
     res.json(result);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getTableRelations(req, res, next) {
+  try {
+    const relations = await listTableRelations(req.params.table);
+    res.json(relations);
   } catch (err) {
     next(err);
   }

--- a/api-server/routes/tables.js
+++ b/api-server/routes/tables.js
@@ -2,6 +2,7 @@ import express from 'express';
 import {
   getTables,
   getTableRows,
+  getTableRelations,
   updateRow,
   addRow,
   deleteRow,
@@ -11,6 +12,7 @@ import { requireAuth } from '../middlewares/auth.js';
 const router = express.Router();
 
 router.get('/', requireAuth, getTables);
+router.get('/:table/relations', requireAuth, getTableRelations);
 router.get('/:table', requireAuth, getTableRows);
 router.put('/:table/:id', requireAuth, updateRow);
 router.post('/:table', requireAuth, addRow);

--- a/db/index.js
+++ b/db/index.js
@@ -458,6 +458,34 @@ export async function setCompanyModuleLicense(companyId, moduleKey, licensed) {
   );
   return { companyId, moduleKey, licensed: !!licensed };
 }
+/**
+ * CRUD for dynamic forms
+ */
+export async function listForms() {
+  const [rows] = await pool.query("SELECT id, name, schema_json FROM forms");
+  return rows;
+}
+
+export async function getFormById(id) {
+  const [rows] = await pool.query("SELECT id, name, schema_json FROM forms WHERE id = ?", [id]);
+  return rows[0] || null;
+}
+
+export async function saveForm({ id, name, schema_json }) {
+  if (id) {
+    await pool.query("UPDATE forms SET name = ?, schema_json = ? WHERE id = ?", [name, JSON.stringify(schema_json), id]);
+    return { id };
+  } else {
+    const [result] = await pool.query("INSERT INTO forms (name, schema_json) VALUES (?, ?)", [name, JSON.stringify(schema_json)]);
+    return { id: result.insertId };
+  }
+}
+
+export async function deleteForm(id) {
+  await pool.query("DELETE FROM forms WHERE id = ?", [id]);
+  return { id };
+}
+
 
 /**
  * List all database tables (for dev tools)
@@ -466,6 +494,11 @@ export async function listDatabaseTables() {
   const [rows] = await pool.query('SHOW TABLES');
   return rows.map((r) => Object.values(r)[0]);
 }
+export async function listTableRelations(tableName) {
+  const [rows] = await pool.query(`SELECT column_name, referenced_table_name, referenced_column_name FROM information_schema.KEY_COLUMN_USAGE WHERE table_schema = DATABASE() AND table_name = ? AND referenced_table_name IS NOT NULL`, [tableName]);
+  return rows;
+}
+
 
 /**
  * Get up to 50 rows from a table

--- a/db/migrations/2025-06-18_forms_table.sql
+++ b/db/migrations/2025-06-18_forms_table.sql
@@ -1,0 +1,7 @@
+-- Create forms table for dynamic modal forms
+CREATE TABLE IF NOT EXISTS forms (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  schema_json JSON NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/db/schema_v4.sql
+++ b/db/schema_v4.sql
@@ -247,6 +247,14 @@ CREATE TABLE IF NOT EXISTS `form_submissions` (
   `data` JSON NOT NULL,
   `submitted_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB;
+-- Form definitions
+CREATE TABLE IF NOT EXISTS `forms` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `name` VARCHAR(100) NOT NULL,
+  `schema_json` JSON NOT NULL,
+  `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
 
 -- Seed initial admin user with known password 'Admin@123'
 -- Generate hash via Node: `require('bcrypt').hash('Admin@123', 10, console.log)`


### PR DESCRIPTION
## Summary
- add `forms` table migration and schema
- add form CRUD helpers in db layer
- load forms from DB in `getFormSchemas`
- expose table relations through API

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68483f57b9d883319b08d68483bf3487