### PR TITLE
Fix modal forms by adding columns endpoint

### DIFF
--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -2,6 +2,7 @@ import {
   listDatabaseTables,
   listTableRows,
   listTableRelations,
+  listTableColumns,
   updateTableRow,
   insertTableRow,
   deleteTableRow,
@@ -36,6 +37,15 @@ export async function getTableRelations(req, res, next) {
   try {
     const relations = await listTableRelations(req.params.table);
     res.json(relations);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getTableColumns(req, res, next) {
+  try {
+    const cols = await listTableColumns(req.params.table);
+    res.json(cols);
   } catch (err) {
     next(err);
   }

--- a/api-server/routes/tables.js
+++ b/api-server/routes/tables.js
@@ -3,6 +3,7 @@ import {
   getTables,
   getTableRows,
   getTableRelations,
+  getTableColumns,
   updateRow,
   addRow,
   deleteRow,
@@ -13,6 +14,7 @@ const router = express.Router();
 
 router.get('/', requireAuth, getTables);
 router.get('/:table/relations', requireAuth, getTableRelations);
+router.get('/:table/columns', requireAuth, getTableColumns);
 router.get('/:table', requireAuth, getTableRows);
 router.put('/:table/:id', requireAuth, updateRow);
 router.post('/:table', requireAuth, addRow);

--- a/db/index.js
+++ b/db/index.js
@@ -619,3 +619,8 @@ export async function deleteTableRow(tableName, id) {
   await pool.query('DELETE FROM ?? WHERE id = ?', [tableName, id]);
   return { id };
 }
+
+export async function listTableColumns(tableName) {
+  const [rows] = await pool.query('SHOW COLUMNS FROM ??', [tableName]);
+  return rows.map((r) => r.Field);
+}

--- a/src/erp.mgt.mn/pages/TablesManagement.jsx
+++ b/src/erp.mgt.mn/pages/TablesManagement.jsx
@@ -13,6 +13,7 @@ export default function TablesManagement() {
   const [selectedRows, setSelectedRows] = useState([]);
   const [showForm, setShowForm] = useState(false);
   const [editingRow, setEditingRow] = useState(null);
+  const [tableColumns, setTableColumns] = useState([]);
 
   useEffect(() => {
     fetch('/api/tables', { credentials: 'include' })
@@ -48,6 +49,14 @@ export default function TablesManagement() {
       .then((data) => {
         setRows(data.rows);
         setTotal(data.count);
+        if (data.rows.length > 0) {
+          setTableColumns(Object.keys(data.rows[0]));
+        } else {
+          fetch(`/api/tables/${table}/columns`, { credentials: 'include' })
+            .then((r) => (r.ok ? r.json() : []))
+            .then(setTableColumns)
+            .catch(() => setTableColumns([]));
+        }
       })
       .catch((err) => console.error('Failed to fetch rows', err));
   }
@@ -58,6 +67,7 @@ export default function TablesManagement() {
     setPage(1);
     setFilters({});
     setSort({ column: '', dir: 'asc' });
+    setTableColumns([]);
     if (t) {
       loadRows(t);
     } else {
@@ -72,7 +82,10 @@ export default function TablesManagement() {
   }
 
   async function handleAdd() {
-    if (rows.length === 0) return;
+    if (tableColumns.length === 0) {
+      alert('Unable to determine table columns');
+      return;
+    }
     setEditingRow(null);
     setShowForm(true);
   }
@@ -389,7 +402,7 @@ export default function TablesManagement() {
           setEditingRow(null);
         }}
         onSubmit={handleFormSubmit}
-        columns={rows.length > 0 ? Object.keys(rows[0]) : []}
+        columns={tableColumns}
         row={editingRow}
       />
     </div>


### PR DESCRIPTION
## Summary
- expose DB helper to list table columns
- add `/api/tables/:table/columns` endpoint
- fetch table columns in dynamic table UI
- use columns when table is empty

## Testing
- `node scripts/check-module-routes.cjs`
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486af282ac8331a5667c5cfc695ba6