### PR TITLE
Fix modal state reset in management pages

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -10,12 +10,13 @@ export default function RowFormModal({ visible, onCancel, onSubmit, columns, row
   });
 
   useEffect(() => {
+    if (!visible) return;
     const vals = {};
     columns.forEach((c) => {
       vals[c] = row ? String(row[c] ?? '') : '';
     });
     setFormVals(vals);
-  }, [row, columns]);
+  }, [row, columns, visible]);
 
   if (!visible) return null;
 

--- a/src/erp.mgt.mn/pages/UserCompanies.jsx
+++ b/src/erp.mgt.mn/pages/UserCompanies.jsx
@@ -163,10 +163,11 @@ function AssignmentFormModal({ visible, onCancel, onSubmit, assignment, users, c
   const [roleId, setRoleId] = useState(String(assignment?.role_id || 2));
 
   useEffect(() => {
+    if (!visible) return;
     setEmpid(assignment?.empid || '');
     setCompanyId(assignment?.company_id || '');
     setRoleId(String(assignment?.role_id || 2));
-  }, [assignment]);
+  }, [assignment, visible]);
 
   if (!visible) return null;
 


### PR DESCRIPTION
## Summary
- ensure `RowFormModal` resets form state when opened
- reset `AssignmentFormModal` fields each time the modal is shown

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68486d12616483318e54982e32450534