### PR TITLE
Enable modal add/edit for user-company roles

### DIFF
--- a/api-server/app.js
+++ b/api-server/app.js
@@ -14,6 +14,7 @@ import settingsRoutes from "./routes/settings.js";
 import userCompanyRoutes from "./routes/user_companies.js";
 import rolePermissionRoutes from "./routes/role_permissions.js";
 import moduleRoutes from "./routes/modules.js";
+import userRoleRoutes from "./routes/user_roles.js";
 
 dotenv.config();
 
@@ -55,6 +56,7 @@ app.use("/api/settings", settingsRoutes);
 app.use("/api/user_companies", userCompanyRoutes);
 app.use("/api/role_permissions", rolePermissionRoutes);
 app.use("/api/modules", moduleRoutes);
+app.use("/api/user_roles", userRoleRoutes);
 
 // Serve static React build and fallback to index.html
 // NOTE: adjust this path to where your SPA build actually lives.

--- a/api-server/controllers/userRoleController.js
+++ b/api-server/controllers/userRoleController.js
@@ -1,0 +1,10 @@
+import { listUserRoles as dbListUserRoles } from '../../db/index.js';
+
+export async function listUserRoles(req, res, next) {
+  try {
+    const roles = await dbListUserRoles();
+    res.json(roles);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/api-server/routes/user_roles.js
+++ b/api-server/routes/user_roles.js
@@ -1,0 +1,7 @@
+import express from 'express';
+import { listUserRoles } from '../controllers/userRoleController.js';
+import { requireAuth } from '../middlewares/auth.js';
+
+const router = express.Router();
+router.get('/', requireAuth, listUserRoles);
+export default router;

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -16,6 +16,7 @@ import moduleRoutes from "./routes/modules.js";
 import companyModuleRoutes from "./routes/company_modules.js";
 import tableRoutes from "./routes/tables.js";
 import codingTableRoutes from "./routes/coding_tables.js";
+import userRoleRoutes from "./routes/user_roles.js";
 import { requireAuth } from "./middlewares/auth.js";
 
 dotenv.config();
@@ -50,6 +51,7 @@ app.use("/api/role_permissions", requireAuth, rolePermissionRoutes);
 app.use("/api/modules", requireAuth, moduleRoutes);
 app.use("/api/company_modules", requireAuth, companyModuleRoutes);
 app.use("/api/coding_tables", requireAuth, codingTableRoutes);
+app.use("/api/user_roles", requireAuth, userRoleRoutes);
 app.use("/api/tables", requireAuth, tableRoutes);
 
 // Serve static React build and fallback to index.html

--- a/db/index.js
+++ b/db/index.js
@@ -215,6 +215,16 @@ export async function listCompanies() {
 }
 
 /**
+ * List all user roles
+ */
+export async function listUserRoles() {
+  const [rows] = await pool.query(
+    "SELECT id, name FROM user_roles ORDER BY id",
+  );
+  return rows;
+}
+
+/**
  * Fetch report data by report ID
  */
 export async function fetchReportData(reportId, params = {}) {

--- a/src/erp.mgt.mn/pages/UserCompanies.jsx
+++ b/src/erp.mgt.mn/pages/UserCompanies.jsx
@@ -8,6 +8,7 @@ export default function UserCompanies() {
   const { company } = useContext(AuthContext);
   const [usersList, setUsersList] = useState([]);
   const [companiesList, setCompaniesList] = useState([]);
+  const [rolesList, setRolesList] = useState([]);
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState(null);
 
@@ -32,14 +33,17 @@ export default function UserCompanies() {
   useEffect(() => {
     async function loadLists() {
       try {
-        const [uRes, cRes] = await Promise.all([
+        const [uRes, cRes, rRes] = await Promise.all([
           fetch('/api/users', { credentials: 'include' }),
-          fetch('/api/companies', { credentials: 'include' })
+          fetch('/api/companies', { credentials: 'include' }),
+          fetch('/api/user_roles', { credentials: 'include' })
         ]);
         const users = uRes.ok ? await uRes.json() : [];
         const companies = cRes.ok ? await cRes.json() : [];
+        const roles = rRes.ok ? await rRes.json() : [];
         setUsersList(users);
         setCompaniesList(companies);
+        setRolesList(roles);
       } catch (err) {
         console.error('Error loading lists:', err);
       }
@@ -152,12 +156,13 @@ export default function UserCompanies() {
         assignment={editing}
         users={usersList}
         companies={companiesList}
+        roles={rolesList}
       />
     </div>
   );
 }
 
-function AssignmentFormModal({ visible, onCancel, onSubmit, assignment, users, companies }) {
+function AssignmentFormModal({ visible, onCancel, onSubmit, assignment, users, companies, roles }) {
   const [empid, setEmpid] = useState(assignment?.empid || '');
   const [companyId, setCompanyId] = useState(assignment?.company_id || '');
   const [roleId, setRoleId] = useState(String(assignment?.role_id || 2));
@@ -249,8 +254,20 @@ function AssignmentFormModal({ visible, onCancel, onSubmit, assignment, users, c
               required
               style={{ width: '100%', padding: '0.5rem' }}
             >
-              <option value="1">admin</option>
-              <option value="2">user</option>
+              {roles.length > 0
+                ? roles.map((r) => (
+                    <option key={r.id} value={r.id}>
+                      {r.name}
+                    </option>
+                  ))
+                : [
+                    <option key="1" value="1">
+                      admin
+                    </option>,
+                    <option key="2" value="2">
+                      user
+                    </option>,
+                  ]}
             </select>
           </div>
 


### PR DESCRIPTION
## Summary
- add `listUserRoles` db helper and API route
- expose user roles through new endpoint
- mount `/api/user_roles` in servers
- load roles list in UserCompanies page and populate modal selects

## Testing
- `node --check api-server/controllers/userRoleController.js`
- `node --check api-server/routes/user_roles.js`
- `node --check api-server/server.js`
- `node --check api-server/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6848700e717883318dedd719521bce83