### PR TITLE
Fix table manager view and modal controls

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -7,6 +7,7 @@ export default function RowFormModal({
   columns,
   row,
   relations = {},
+  disabledFields = [],
 }) {
   const [formVals, setFormVals] = useState(() => {
     const init = {};
@@ -67,7 +68,7 @@ export default function RowFormModal({
                   onChange={(e) =>
                     setFormVals((v) => ({ ...v, [c]: e.target.value }))
                   }
-                  disabled={row && c === 'id'}
+                  disabled={row && (c === 'id' || disabledFields.includes(c))}
                   style={{ width: '100%', padding: '0.5rem' }}
                 >
                   <option value="">-- select --</option>
@@ -84,7 +85,7 @@ export default function RowFormModal({
                   onChange={(e) =>
                     setFormVals((v) => ({ ...v, [c]: e.target.value }))
                   }
-                  disabled={row && c === 'id'}
+                  disabled={row && (c === 'id' || disabledFields.includes(c))}
                   style={{ width: '100%', padding: '0.5rem' }}
                 />
               )}

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -10,6 +10,9 @@ export default function TableManager({ table }) {
 
   useEffect(() => {
     if (!table) return;
+    setRows([]);
+    setRelations({});
+    setRefData({});
     fetch(`/api/tables/${table}`, { credentials: 'include' })
       .then((res) => res.json())
       .then((data) => setRows(data.rows || []));
@@ -46,6 +49,33 @@ export default function TableManager({ table }) {
     });
   }, [relations]);
 
+  function getRowId(row) {
+    if (row.id !== undefined) return row.id;
+    if (table === 'company_module_licenses') {
+      return `${row.company_id}-${row.module_key}`;
+    }
+    if (table === 'role_module_permissions') {
+      return `${row.company_id}-${row.role_id}-${row.module_key}`;
+    }
+    if (table === 'user_companies') {
+      return `${row.empid}-${row.company_id}`;
+    }
+    return undefined;
+  }
+
+  function getKeyFields() {
+    if (table === 'company_module_licenses') {
+      return ['company_id', 'module_key'];
+    }
+    if (table === 'role_module_permissions') {
+      return ['company_id', 'role_id', 'module_key'];
+    }
+    if (table === 'user_companies') {
+      return ['empid', 'company_id'];
+    }
+    return ['id'];
+  }
+
   function openAdd() {
     setEditing(null);
     setShowForm(true);
@@ -59,7 +89,7 @@ export default function TableManager({ table }) {
   async function handleSubmit(values) {
     const method = editing ? 'PUT' : 'POST';
     const url = editing
-      ? `/api/tables/${table}/${encodeURIComponent(editing.id)}`
+      ? `/api/tables/${table}/${encodeURIComponent(getRowId(editing))}`
       : `/api/tables/${table}`;
     const res = await fetch(url, {
       method,
@@ -81,12 +111,12 @@ export default function TableManager({ table }) {
 
   async function handleDelete(row) {
     if (!window.confirm('Delete row?')) return;
-    const res = await fetch(`/api/tables/${table}/${encodeURIComponent(row.id)}`, {
-      method: 'DELETE',
-      credentials: 'include',
-    });
+    const res = await fetch(
+      `/api/tables/${table}/${encodeURIComponent(getRowId(row))}`,
+      { method: 'DELETE', credentials: 'include' }
+    );
     if (res.ok) {
-      setRows((r) => r.filter((x) => x.id !== row.id));
+      setRows((r) => r.filter((x) => getRowId(x) !== getRowId(row)));
     } else {
       alert('Delete failed');
     }
@@ -102,6 +132,14 @@ export default function TableManager({ table }) {
       relationOpts[c] = refData[c];
     }
   });
+  const labelMap = {};
+  Object.entries(relationOpts).forEach(([col, opts]) => {
+    labelMap[col] = {};
+    opts.forEach((o) => {
+      labelMap[col][o.value] = o.label;
+    });
+  });
+  const disabledFields = editing ? getKeyFields() : [];
 
   return (
     <div>
@@ -124,7 +162,7 @@ export default function TableManager({ table }) {
             <tr key={r.id || JSON.stringify(r)}>
               {columns.map((c) => (
                 <td key={c} style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
-                  {String(r[c])}
+                  {relationOpts[c] ? labelMap[c][r[c]] || String(r[c]) : String(r[c])}
                 </td>
               ))}
               <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
@@ -144,6 +182,7 @@ export default function TableManager({ table }) {
         columns={columns}
         row={editing}
         relations={relationOpts}
+        disabledFields={disabledFields}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- support disabling custom PK fields in `RowFormModal`
- enhance `TableManager` to reset data on table change
- show foreign key labels in the table view
- handle composite keys when editing/deleting rows

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a5f745ee48331aa6fcb9e03f29f3f