### PR TITLE
Auto set table row metadata

### DIFF
--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -43,7 +43,10 @@ export async function getTableRelations(req, res, next) {
 
 export async function updateRow(req, res, next) {
   try {
-    await updateTableRow(req.params.table, req.params.id, req.body);
+    const updates = { ...req.body };
+    delete updates.created_by;
+    delete updates.created_at;
+    await updateTableRow(req.params.table, req.params.id, updates);
     res.sendStatus(204);
   } catch (err) {
     next(err);
@@ -52,7 +55,12 @@ export async function updateRow(req, res, next) {
 
 export async function addRow(req, res, next) {
   try {
-    const result = await insertTableRow(req.params.table, req.body);
+    const row = {
+      ...req.body,
+      created_by: req.user?.empid,
+      created_at: new Date(),
+    };
+    const result = await insertTableRow(req.params.table, row);
     res.status(201).json(result);
   } catch (err) {
     next(err);

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
+import { AuthContext } from '../context/AuthContext.jsx';
 import RowFormModal from './RowFormModal.jsx';
 
 export default function TableManager({ table }) {
@@ -7,6 +8,7 @@ export default function TableManager({ table }) {
   const [refData, setRefData] = useState({});
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState(null);
+  const { user } = useContext(AuthContext);
 
   useEffect(() => {
     if (!table) return;
@@ -103,6 +105,14 @@ export default function TableManager({ table }) {
     const url = editing
       ? `/api/tables/${table}/${encodeURIComponent(getRowId(editing))}`
       : `/api/tables/${table}`;
+
+    if (!editing) {
+      values = {
+        ...values,
+        created_by: user?.empid,
+        created_at: new Date().toISOString(),
+      };
+    }
     const res = await fetch(url, {
       method,
       headers: { 'Content-Type': 'application/json' },
@@ -152,7 +162,8 @@ export default function TableManager({ table }) {
     });
   });
   const disabledFields = editing ? getKeyFields() : [];
-  const formColumns = editing ? columns : columns.filter((c) => c !== 'id');
+  const formColumns = columns
+    .filter((c) => c !== 'id' && c !== 'created_at' && c !== 'created_by');
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- exclude `created_by` and `created_at` fields from table row forms
- include current user and timestamp when creating rows on frontend
- ignore creation fields on update and set them automatically in backend

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a65e86bf483319c3a2227c6c88e26