### PR TITLE
Fix table management inserts

### DIFF
--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -5,6 +5,7 @@ import {
   insertTableRow,
   deleteTableRow,
   listTableRelationships,
+  listTableColumns,
 } from '../../db/index.js';
 
 export async function getTables(req, res, next) {
@@ -41,6 +42,15 @@ export async function getTableRelations(req, res, next) {
   }
 }
 
+export async function getTableColumns(req, res, next) {
+  try {
+    const cols = await listTableColumns(req.params.table);
+    res.json(cols);
+  } catch (err) {
+    next(err);
+  }
+}
+
 export async function updateRow(req, res, next) {
   try {
     const updates = { ...req.body };
@@ -55,11 +65,14 @@ export async function updateRow(req, res, next) {
 
 export async function addRow(req, res, next) {
   try {
-    const row = {
-      ...req.body,
-      created_by: req.user?.empid,
-      created_at: new Date(),
-    };
+    const cols = await listTableColumns(req.params.table);
+    const row = { ...req.body };
+    if (cols.includes('created_by')) {
+      row.created_by = req.user?.empid;
+    }
+    if (cols.includes('created_at')) {
+      row.created_at = new Date();
+    }
     const result = await insertTableRow(req.params.table, row);
     res.status(201).json(result);
   } catch (err) {

--- a/api-server/routes/tables.js
+++ b/api-server/routes/tables.js
@@ -3,6 +3,7 @@ import {
   getTables,
   getTableRows,
   getTableRelations,
+  getTableColumns,
   updateRow,
   addRow,
   deleteRow,
@@ -14,6 +15,7 @@ const router = express.Router();
 router.get('/', requireAuth, getTables);
 router.get('/:table', requireAuth, getTableRows);
 router.get('/:table/relations', requireAuth, getTableRelations);
+router.get('/:table/columns', requireAuth, getTableColumns);
 router.put('/:table/:id', requireAuth, updateRow);
 router.post('/:table', requireAuth, addRow);
 router.delete('/:table/:id', requireAuth, deleteRow);

--- a/db/index.js
+++ b/db/index.js
@@ -467,6 +467,17 @@ export async function listDatabaseTables() {
   return rows.map((r) => Object.values(r)[0]);
 }
 
+export async function listTableColumns(tableName) {
+  const [rows] = await pool.query(
+    `SELECT COLUMN_NAME
+       FROM information_schema.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = ?`,
+    [tableName],
+  );
+  return rows.map((r) => r.COLUMN_NAME);
+}
+
 export async function listTableRelationships(tableName) {
   const [rows] = await pool.query(
     `SELECT COLUMN_NAME, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME


### PR DESCRIPTION
## Summary
- only attach audit fields when table has them
- allow creating rows in empty tables
- expose table column names through the API

## Testing
- `node --check api-server/server.js`
- `npm run build:erp` *(fails: vite not found)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684a67a30fd48331a448d7e2306dda45