### PR TITLE
Fix login query for no email column

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -32,36 +32,18 @@ export async function testConnection() {
  * Fetch a user by employee ID
  */
 export async function getUserByEmpid(empid) {
-  try {
-    const [rows] = await pool.query(
-      `SELECT u.*, r.name AS role
-       FROM users u
-       JOIN user_roles r ON u.role_id = r.id
-       WHERE u.empid = ? OR u.email = ?
-       LIMIT 1`,
-      [empid, empid],
-    );
-    if (rows.length === 0) return null;
-    const user = rows[0];
-    user.verifyPassword = async (plain) => bcrypt.compare(plain, user.password);
-    return user;
-  } catch (err) {
-    if (err.code === 'ER_BAD_FIELD_ERROR' && /u\.email/.test(err.message)) {
-      const [rows] = await pool.query(
-        `SELECT u.*, r.name AS role
-         FROM users u
-         JOIN user_roles r ON u.role_id = r.id
-         WHERE u.empid = ?
-         LIMIT 1`,
-        [empid],
-      );
-      if (rows.length === 0) return null;
-      const user = rows[0];
-      user.verifyPassword = async (plain) => bcrypt.compare(plain, user.password);
-      return user;
-    }
-    throw err;
-  }
+  const [rows] = await pool.query(
+    `SELECT u.*, r.name AS role
+     FROM users u
+     JOIN user_roles r ON u.role_id = r.id
+     WHERE u.empid = ?
+     LIMIT 1`,
+    [empid],
+  );
+  if (rows.length === 0) return null;
+  const user = rows[0];
+  user.verifyPassword = async (plain) => bcrypt.compare(plain, user.password);
+  return user;
 }
 
 /**


### PR DESCRIPTION
## Summary
- update getUserByEmpid query to not reference nonexistent email column

## Testing
- `npm run build:erp` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684a83e0663c8331b25a2b23a29c9caf