### PR TITLE
Fix created_at timestamp format

### DIFF
--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -8,6 +8,7 @@ import {
   listTableColumns,
 } from '../../db/index.js';
 import bcrypt from 'bcryptjs';
+import { formatDateForDb } from '../utils/formatDate.js';
 
 export async function getTables(req, res, next) {
   try {
@@ -63,7 +64,9 @@ export async function addRow(req, res, next) {
     const columns = await listTableColumns(req.params.table);
     const row = { ...req.body };
     if (columns.includes('created_by')) row.created_by = req.user?.empid;
-    if (columns.includes('created_at')) row.created_at = new Date();
+    if (columns.includes('created_at')) {
+      row.created_at = formatDateForDb(new Date());
+    }
     if (req.params.table === 'users' && row.password) {
       row.password = await bcrypt.hash(row.password, 10);
     }

--- a/api-server/utils/formatDate.js
+++ b/api-server/utils/formatDate.js
@@ -1,0 +1,4 @@
+export function formatDateForDb(date) {
+  const d = date instanceof Date ? date : new Date(date);
+  return d.toISOString().slice(0, 19).replace('T', ' ');
+}

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
 import RowFormModal from './RowFormModal.jsx';
+import formatTimestamp from '../utils/formatTimestamp.js';
 
 export default function TableManager({ table }) {
   const [rows, setRows] = useState([]);
@@ -175,7 +176,9 @@ export default function TableManager({ table }) {
 
     if (!editing) {
       if (columns.has('created_by')) cleaned.created_by = user?.empid;
-      if (columns.has('created_at')) cleaned.created_at = new Date().toISOString();
+      if (columns.has('created_at')) {
+        cleaned.created_at = formatTimestamp(new Date());
+      }
     }
 
     try {

--- a/src/erp.mgt.mn/utils/formatTimestamp.js
+++ b/src/erp.mgt.mn/utils/formatTimestamp.js
@@ -1,0 +1,4 @@
+export default function formatTimestamp(date) {
+  const d = date instanceof Date ? date : new Date(date);
+  return d.toISOString().slice(0, 19).replace('T', ' ');
+}


### PR DESCRIPTION
## Summary
- add shared utils to format timestamps for MySQL
- apply format in `TableManager` and table controller

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684aa1fcac4883319908804a71e1a34e