### PR TITLE
Fix auto-increment detection for add/edit modal

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -115,12 +115,29 @@ export default function TableManager({ table }) {
     return ['id'];
   }
 
-  function openAdd() {
+  async function ensureColumnMeta() {
+    if (columnMeta.length > 0 || !table) return;
+    try {
+      const res = await fetch(`/api/tables/${table}/columns`, {
+        credentials: 'include',
+      });
+      if (res.ok) {
+        const cols = await res.json();
+        if (Array.isArray(cols)) setColumnMeta(cols);
+      }
+    } catch (err) {
+      console.error('Failed to fetch column metadata', err);
+    }
+  }
+
+  async function openAdd() {
+    await ensureColumnMeta();
     setEditing(null);
     setShowForm(true);
   }
 
-  function openEdit(row) {
+  async function openEdit(row) {
+    await ensureColumnMeta();
     setEditing(row);
     setShowForm(true);
   }


### PR DESCRIPTION
## Summary
- ensure column metadata is loaded before opening add/edit modal

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684aad87fdac8331962512e5629edd6b