### PR TITLE
Validate dynamic column names and add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:homepage": "vite build --config vite.home.config.js",
     "build:erp": "vite build --config vite.config.js",
     "serve": "node api-server/server.js",
-    "test": "echo \"No tests yet\""
+    "test": "node --test"
   },
   "dependencies": {
     "express": "^4.21.2",

--- a/tests/db/validation.test.js
+++ b/tests/db/validation.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as db from '../../db/index.js';
+
+function mockPool(columns) {
+  const original = db.pool.query;
+  db.pool.query = async (sql, params) => {
+    if (sql.includes('information_schema.COLUMNS')) {
+      return [columns.map((c) => ({ COLUMN_NAME: c }))];
+    }
+    return [[]];
+  };
+  return () => {
+    db.pool.query = original;
+  };
+}
+
+test('listTableRows rejects invalid filter column', async () => {
+  const restore = mockPool(['id', 'name']);
+  await assert.rejects(
+    db.listTableRows('users', { filters: { bad: 'x' } }),
+    /Invalid column name/
+  );
+  restore();
+});
+
+test('updateTableRow rejects invalid column', async () => {
+  const restore = mockPool(['id', 'name']);
+  await assert.rejects(
+    db.updateTableRow('users', 1, { bad: 'x' }),
+    /Invalid column name/
+  );
+  restore();
+});
+
+test('insertTableRow rejects invalid column', async () => {
+  const restore = mockPool(['id', 'name']);
+  await assert.rejects(
+    db.insertTableRow('users', { bad: 'x' }),
+    /Invalid column name/
+  );
+  restore();
+});


### PR DESCRIPTION
## Summary
- add runtime fallbacks for optional MySQL, dotenv and bcrypt modules
- cache and verify table column names in list/insert/update helpers
- reject invalid columns before building SQL
- add unit tests for invalid column usage
- enable `npm test` via `node --test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ab7ee9fe88331ab826d0bcc1f1110