### PR TITLE
Fix autoincrement detection in row form

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -68,7 +68,7 @@ export default function RowFormModal({
                   onChange={(e) =>
                     setFormVals((v) => ({ ...v, [c]: e.target.value }))
                   }
-                  disabled={row && (c === 'id' || disabledFields.includes(c))}
+                  disabled={row && disabledFields.includes(c)}
                   style={{ width: '100%', padding: '0.5rem' }}
                 >
                   <option value="">-- select --</option>
@@ -85,7 +85,7 @@ export default function RowFormModal({
                   onChange={(e) =>
                     setFormVals((v) => ({ ...v, [c]: e.target.value }))
                   }
-                  disabled={row && (c === 'id' || disabledFields.includes(c))}
+                  disabled={row && disabledFields.includes(c)}
                   style={{ width: '100%', padding: '0.5rem' }}
                 />
               )}

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -20,18 +20,15 @@ export default function TableManager({ table }) {
   const { user } = useContext(AuthContext);
 
   function computeAutoInc(meta) {
-    const auto = new Set(
+    return new Set(
       meta
         .filter(
-          (c) => c.extra && c.extra.toLowerCase().includes('auto_increment'),
+          (c) =>
+            typeof c.extra === 'string' &&
+            c.extra.toLowerCase().includes('auto_increment'),
         )
         .map((c) => c.name),
     );
-    if (auto.size === 0) {
-      const pri = meta.filter((c) => c.key === 'PRI');
-      if (pri.length === 1) auto.add(pri[0].name);
-    }
-    return auto;
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- rely on column metadata to detect auto-increment fields
- don't hardcode `id` as a special case in row forms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ac571b84c8331b2a77d2954a73a72