### PR TITLE
Fix detection of auto-increment fields

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -20,15 +20,18 @@ export default function TableManager({ table }) {
   const { user } = useContext(AuthContext);
 
   function computeAutoInc(meta) {
-    return new Set(
-      meta
-        .filter(
-          (c) =>
-            typeof c.extra === 'string' &&
-            c.extra.toLowerCase().includes('auto_increment'),
-        )
-        .map((c) => c.name),
-    );
+    const auto = meta
+      .filter(
+        (c) =>
+          typeof c.extra === 'string' &&
+          c.extra.toLowerCase().includes('auto_increment'),
+      )
+      .map((c) => c.name);
+    if (auto.length === 0) {
+      const pk = meta.filter((c) => c.key === 'PRI').map((c) => c.name);
+      if (pk.length === 1) return new Set(pk);
+    }
+    return new Set(auto);
   }
 
   useEffect(() => {
@@ -336,6 +339,10 @@ export default function TableManager({ table }) {
     });
   });
   const autoCols = new Set(autoInc);
+  if (columnMeta.length > 0 && autoCols.size === 0) {
+    const pk = columnMeta.filter((c) => c.key === 'PRI').map((c) => c.name);
+    if (pk.length === 1) autoCols.add(pk[0]);
+  }
   if (columnMeta.length === 0 && autoCols.size === 0 && allColumns.includes('id')) {
     autoCols.add('id');
   }


### PR DESCRIPTION
## Summary
- improve computeAutoInc fallback logic
- hide single primary key columns when auto increment info missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ac77d91188331a38053e350082ec1