### PR TITLE
Fix password hashing in table management

### DIFF
--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -60,9 +60,13 @@ export async function updateRow(req, res, next) {
     delete updates.created_by;
     delete updates.created_at;
     const columns = await listTableColumns(req.params.table);
-    if (columns.includes('password') && updates.password) {
-      updates.password = await bcrypt.hash(updates.password, 10);
-    }
+    columns
+      .filter((c) => c.toLowerCase().includes('password'))
+      .forEach(async (pwCol) => {
+        if (updates[pwCol]) {
+          updates[pwCol] = await bcrypt.hash(updates[pwCol], 10);
+        }
+      });
     await updateTableRow(req.params.table, req.params.id, updates);
     res.sendStatus(204);
   } catch (err) {
@@ -78,9 +82,13 @@ export async function addRow(req, res, next) {
     if (columns.includes('created_at')) {
       row.created_at = formatDateForDb(new Date());
     }
-    if (columns.includes('password') && row.password) {
-      row.password = await bcrypt.hash(row.password, 10);
-    }
+    columns
+      .filter((c) => c.toLowerCase().includes('password'))
+      .forEach(async (pwCol) => {
+        if (row[pwCol]) {
+          row[pwCol] = await bcrypt.hash(row[pwCol], 10);
+        }
+      });
     const result = await insertTableRow(req.params.table, row);
     res.status(201).json(result);
   } catch (err) {

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -9,10 +9,12 @@ export default function RowFormModal({
   relations = {},
   disabledFields = [],
 }) {
+  const isPasswordField = (name) => name.toLowerCase().includes('password');
+
   const [formVals, setFormVals] = useState(() => {
     const init = {};
     columns.forEach((c) => {
-      init[c] = row ? String(row[c] ?? '') : '';
+      init[c] = row && !isPasswordField(c) ? String(row[c] ?? '') : '';
     });
     return init;
   });
@@ -21,7 +23,7 @@ export default function RowFormModal({
     if (!visible) return;
     const vals = {};
     columns.forEach((c) => {
-      vals[c] = row ? String(row[c] ?? '') : '';
+      vals[c] = row && !isPasswordField(c) ? String(row[c] ?? '') : '';
     });
     setFormVals(vals);
   }, [row, columns, visible]);
@@ -80,7 +82,7 @@ export default function RowFormModal({
                 </select>
               ) : (
                 <input
-                  type={c.toLowerCase() === 'password' ? 'password' : 'text'}
+                  type={isPasswordField(c) ? 'password' : 'text'}
                   value={formVals[c]}
                   onChange={(e) =>
                     setFormVals((v) => ({ ...v, [c]: e.target.value }))

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -322,7 +322,9 @@ export default function TableManager({ table }) {
       : rows[0]
       ? Object.keys(rows[0])
       : [];
-  const hiddenColumns = ['password', 'created_by', 'created_at'];
+  const hiddenColumns = allColumns
+    .filter((c) => c.toLowerCase().includes('password'))
+    .concat(['created_by', 'created_at']);
   const columns = allColumns.filter((c) => !hiddenColumns.includes(c));
 
   const relationOpts = {};
@@ -349,7 +351,10 @@ export default function TableManager({ table }) {
   const disabledFields = editing ? getKeyFields() : [];
   const formColumns = allColumns.filter(
     (c) =>
-      !autoCols.has(c) && c !== 'created_at' && c !== 'created_by'
+      !autoCols.has(c) &&
+      c !== 'created_at' &&
+      c !== 'created_by' &&
+      !c.toLowerCase().includes('password')
   );
 
   return (


### PR DESCRIPTION
## Summary
- hash all password-like fields when inserting/updating table rows
- hide password columns from TableManager and clear values when editing
- avoid sending existing hashed passwords from the form

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684acbf9037483319424f993de979a7c