### PR TITLE
Fix password fields missing in TableManager

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -353,8 +353,7 @@ export default function TableManager({ table }) {
     (c) =>
       !autoCols.has(c) &&
       c !== 'created_at' &&
-      c !== 'created_by' &&
-      !c.toLowerCase().includes('password')
+      c !== 'created_by'
   );
 
   return (


### PR DESCRIPTION
## Summary
- show password fields when adding or editing rows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ad16a6ebc8331acc5f008bcadfa19