### PR TITLE
Improve tables management error handling

### DIFF
--- a/src/erp.mgt.mn/pages/TablesManagement.jsx
+++ b/src/erp.mgt.mn/pages/TablesManagement.jsx
@@ -4,17 +4,46 @@ import TableManager from '../components/TableManager.jsx';
 export default function TablesManagement() {
   const [tables, setTables] = useState([]);
   const [selectedTable, setSelectedTable] = useState('');
+  const [error, setError] = useState('');
+  const [errorLog, setErrorLog] = useState([]);
+
+  function logError(msg) {
+    setError(msg);
+    setErrorLog((log) => [...log, msg]);
+  }
 
   useEffect(() => {
+    setError('');
     fetch('/api/tables', { credentials: 'include' })
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error('Failed to load tables');
+        return res.json();
+      })
       .then(setTables)
-      .catch((err) => console.error('Failed to load tables', err));
+      .catch((err) => {
+        console.error('Failed to load tables', err);
+        logError(err.message);
+      });
   }, []);
 
   return (
     <div>
       <h2>Dynamic Tables</h2>
+      {error && (
+        <div style={{ color: 'red', marginBottom: '0.5rem' }}>{error}</div>
+      )}
+      {errorLog.length > 0 && (
+        <details style={{ marginBottom: '0.5rem' }}>
+          <summary>Error Log ({errorLog.length})</summary>
+          <ul>
+            {errorLog.map((e, i) => (
+              <li key={i} style={{ color: 'red' }}>
+                {e}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
       <select value={selectedTable} onChange={(e) => setSelectedTable(e.target.value)}>
         <option value="">-- select table --</option>
         {tables.map((t) => (


### PR DESCRIPTION
## Summary
- show API errors when loading table list
- surface API errors in TableManager
- show error banners in table management pages
- persist all errors in an expandable log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ada38a74c8331a28e137c3b637255