### PR TITLE
Add error log module

### DIFF
--- a/api-server/app.js
+++ b/api-server/app.js
@@ -14,6 +14,7 @@ import settingsRoutes from "./routes/settings.js";
 import userCompanyRoutes from "./routes/user_companies.js";
 import rolePermissionRoutes from "./routes/role_permissions.js";
 import moduleRoutes from "./routes/modules.js";
+import errorRoutes from "./routes/errors.js";
 
 dotenv.config();
 
@@ -55,6 +56,7 @@ app.use("/api/settings", settingsRoutes);
 app.use("/api/user_companies", userCompanyRoutes);
 app.use("/api/role_permissions", rolePermissionRoutes);
 app.use("/api/modules", moduleRoutes);
+app.use("/api/errors", errorRoutes);
 
 // Serve static React build and fallback to index.html
 // NOTE: adjust this path to where your SPA build actually lives.

--- a/api-server/controllers/errorLogController.js
+++ b/api-server/controllers/errorLogController.js
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import path from 'path';
+
+const logFile = path.resolve('api-server/logs/error.log');
+
+export async function listErrorLog(req, res, next) {
+  try {
+    if (!fs.existsSync(logFile)) {
+      return res.type('text/plain').send('');
+    }
+    const data = await fs.promises.readFile(logFile, 'utf8');
+    res.type('text/plain').send(data);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/api-server/middlewares/errorHandler.js
+++ b/api-server/middlewares/errorHandler.js
@@ -1,4 +1,17 @@
+import fs from 'fs';
+import path from 'path';
+
+const logDir = path.resolve('api-server/logs');
+const logFile = path.join(logDir, 'error.log');
+
 export function errorHandler(err, req, res, next) {
   console.error(err.stack);
-  res.status(err.status || 500).json({ message: err.message || 'Internal Server Error' });
+  const logLine = `[${new Date().toISOString()}] ${err.stack}\n`;
+  fs.promises
+    .mkdir(logDir, { recursive: true })
+    .then(() => fs.promises.appendFile(logFile, logLine))
+    .catch((e) => console.error('Failed to write log', e));
+  res
+    .status(err.status || 500)
+    .json({ message: err.message || 'Internal Server Error' });
 }

--- a/api-server/routes/errors.js
+++ b/api-server/routes/errors.js
@@ -1,0 +1,7 @@
+import express from 'express';
+import { listErrorLog } from '../controllers/errorLogController.js';
+import { requireAuth } from '../middlewares/auth.js';
+
+const router = express.Router();
+router.get('/', requireAuth, listErrorLog);
+export default router;

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -16,6 +16,7 @@ import moduleRoutes from "./routes/modules.js";
 import companyModuleRoutes from "./routes/company_modules.js";
 import tableRoutes from "./routes/tables.js";
 import codingTableRoutes from "./routes/coding_tables.js";
+import errorRoutes from "./routes/errors.js";
 import { requireAuth } from "./middlewares/auth.js";
 
 dotenv.config();
@@ -51,6 +52,7 @@ app.use("/api/modules", requireAuth, moduleRoutes);
 app.use("/api/company_modules", requireAuth, companyModuleRoutes);
 app.use("/api/coding_tables", requireAuth, codingTableRoutes);
 app.use("/api/tables", requireAuth, tableRoutes);
+app.use("/api/errors", requireAuth, errorRoutes);
 
 // Serve static React build and fallback to index.html
 // NOTE: adjust this path to where your SPA build actually lives.

--- a/db/defaultModules.js
+++ b/db/defaultModules.js
@@ -13,6 +13,7 @@ export default [
   { moduleKey: 'coding_tables', label: 'Кодын хүснэгтүүд', parentKey: 'developer', showInSidebar: true, showInHeader: false },
   { moduleKey: 'forms_management', label: 'Маягтын удирдлага', parentKey: 'developer', showInSidebar: true, showInHeader: false },
   { moduleKey: 'report_management', label: 'Тайлангийн удирдлага', parentKey: 'developer', showInSidebar: true, showInHeader: false },
+  { moduleKey: 'error_log', label: 'Алдааны лог', parentKey: 'developer', showInSidebar: true, showInHeader: false },
   { moduleKey: 'change_password', label: 'Нууц үг солих', parentKey: 'settings', showInSidebar: true, showInHeader: false },
   { moduleKey: 'gl', label: 'Ерөнхий журнал', parentKey: null, showInSidebar: false, showInHeader: true },
   { moduleKey: 'po', label: 'Худалдан авалтын захиалга', parentKey: null, showInSidebar: false, showInHeader: true },

--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -17,6 +17,7 @@ import ReportManagementPage from './pages/ReportManagement.jsx';
 import ModulesPage from './pages/Modules.jsx';
 import SettingsPage, { GeneralSettings } from './pages/Settings.jsx';
 import ChangePasswordPage from './pages/ChangePassword.jsx';
+import ErrorLogPage from './pages/ErrorLog.jsx';
 import BlueLinkPage from './pages/BlueLinkPage.jsx';
 import { useModules } from './hooks/useModules.js';
 
@@ -48,6 +49,7 @@ export default function App() {
     forms_management: <FormsManagementPage />,
     report_management: <ReportManagementPage />,
     change_password: <ChangePasswordPage />,
+    error_log: <ErrorLogPage />,
   };
 
   const indexComponents = {
@@ -64,6 +66,7 @@ export default function App() {
     'coding_tables',
     'forms_management',
     'report_management',
+    'error_log',
   ]);
 
   function renderRoute(mod) {

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -116,6 +116,7 @@ export default function TableManager({ table }) {
       setError('');
       return json;
     } catch (err) {
+      console.error('Failed to load rows', err);
       setError(err.message);
       return { rows: [], count: 0 };
     }
@@ -288,6 +289,7 @@ export default function TableManager({ table }) {
       setShowForm(false);
       setEditing(null);
     } catch (err) {
+      console.error('Failed to save row', err);
       setError(err.message);
     }
   }
@@ -309,6 +311,7 @@ export default function TableManager({ table }) {
       setSelectedRows(new Set());
       setError('');
     } catch (err) {
+      console.error('Failed to delete row', err);
       setError(err.message);
     }
   }
@@ -329,6 +332,7 @@ export default function TableManager({ table }) {
           throw new Error(data?.message || 'Delete failed');
         }
       } catch (err) {
+        console.error('Failed to delete row', err);
         setError(err.message);
         return;
       }

--- a/src/erp.mgt.mn/pages/ErrorLog.jsx
+++ b/src/erp.mgt.mn/pages/ErrorLog.jsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+
+export default function ErrorLogPage() {
+  const [logs, setLogs] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    fetch('/api/errors', { credentials: 'include' })
+      .then(res => {
+        if (!res.ok) throw new Error('Failed to fetch error log');
+        return res.text();
+      })
+      .then(setLogs)
+      .catch(err => {
+        console.error('Error fetching error log:', err);
+        setError(err.message);
+      });
+  }, []);
+
+  return (
+    <div>
+      <h2>Error Log</h2>
+      {error && (
+        <div style={{ color: 'red', marginBottom: '0.5rem' }}>{error}</div>
+      )}
+      <pre style={{ background: '#f3f4f6', padding: '1rem', whiteSpace: 'pre-wrap' }}>
+        {logs}
+      </pre>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `ErrorLogPage` for viewing server log output
- record errors to `api-server/logs/error.log`
- expose `/api/errors` endpoint
- register new `error_log` module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ae01076788331b5515dd0ddc52491