### PR TITLE
Improve error display spacing

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -265,7 +265,7 @@ const styles = {
     color: "#fff",
     cursor: "pointer",
     fontSize: "0.9rem",
-    padding: "0.25rem 0.5rem",
+    padding: "0.5rem 0.75rem",
   },
   userSection: {
     display: "flex",

--- a/src/erp.mgt.mn/components/ErrorMessage.jsx
+++ b/src/erp.mgt.mn/components/ErrorMessage.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function ErrorMessage({ message }) {
+  return (
+    <div style={{ color: 'red', marginBottom: '0.5rem', minHeight: '1.2em' }}>
+      {message || '\u00a0'}
+    </div>
+  );
+}

--- a/src/erp.mgt.mn/components/LoginForm.jsx
+++ b/src/erp.mgt.mn/components/LoginForm.jsx
@@ -3,6 +3,7 @@ import React, { useState, useContext } from 'react';
 import { login } from '../hooks/useAuth.jsx';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { useNavigate } from 'react-router-dom';
+import ErrorMessage from './ErrorMessage.jsx';
 
 export default function LoginForm() {
   // login using employee ID only
@@ -133,9 +134,7 @@ export default function LoginForm() {
         />
       </div>
 
-      {error && (
-        <p style={{ color: 'red', marginBottom: '0.75rem' }}>{error}</p>
-      )}
+      <ErrorMessage message={error} />
 
       <button
         type="submit"

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -94,10 +94,14 @@ export default function RowFormModal({
             </div>
           ))}
           <div style={{ textAlign: 'right' }}>
-            <button type="button" onClick={onCancel} style={{ marginRight: '0.5rem' }}>
+            <button
+              type="button"
+              onClick={onCancel}
+              style={{ marginRight: '0.5rem', padding: '0.4rem 0.75rem' }}
+            >
               Cancel
             </button>
-            <button type="submit">Save</button>
+            <button type="submit" style={{ padding: '0.4rem 0.75rem' }}>Save</button>
           </div>
         </form>
       </div>

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useContext } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
 import RowFormModal from './RowFormModal.jsx';
 import formatTimestamp from '../utils/formatTimestamp.js';
+import ErrorMessage from './ErrorMessage.jsx';
 
 async function parseJSON(res) {
   const ct = res.headers.get('content-type') || '';
@@ -400,21 +401,19 @@ export default function TableManager({ table }) {
 
   return (
     <div>
-      {error && (
-        <div style={{ color: 'red', marginBottom: '0.5rem' }}>{error}</div>
-      )}
+      <ErrorMessage message={error} />
       <div style={{ marginBottom: '0.5rem' }}>
-        <button onClick={openAdd} style={{ marginRight: '0.5rem' }}>
+        <button onClick={openAdd} style={{ marginRight: '0.5rem', padding: '0.4rem 0.75rem' }}>
           Add Row
         </button>
-        <button onClick={selectAll} style={{ marginRight: '0.5rem' }}>
+        <button onClick={selectAll} style={{ marginRight: '0.5rem', padding: '0.4rem 0.75rem' }}>
           Select All
         </button>
-        <button onClick={deselectAll} style={{ marginRight: '0.5rem' }}>
+        <button onClick={deselectAll} style={{ marginRight: '0.5rem', padding: '0.4rem 0.75rem' }}>
           Deselect All
         </button>
         {selectedRows.size > 0 && (
-          <button onClick={handleDeleteSelected}>Delete Selected</button>
+          <button onClick={handleDeleteSelected} style={{ padding: '0.4rem 0.75rem' }}>Delete Selected</button>
         )}
       </div>
       <div
@@ -444,13 +443,17 @@ export default function TableManager({ table }) {
           </select>
         </div>
         <div>
-          <button onClick={() => setPage(1)} disabled={page === 1} style={{ marginRight: '0.25rem' }}>
+          <button
+            onClick={() => setPage(1)}
+            disabled={page === 1}
+            style={{ marginRight: '0.25rem', padding: '0.3rem 0.6rem' }}
+          >
             {'<<'}
           </button>
           <button
             onClick={() => setPage((p) => Math.max(1, p - 1))}
             disabled={page === 1}
-            style={{ marginRight: '0.25rem' }}
+            style={{ marginRight: '0.25rem', padding: '0.3rem 0.6rem' }}
           >
             {'<'}
           </button>
@@ -460,14 +463,14 @@ export default function TableManager({ table }) {
           <button
             onClick={() => setPage((p) => Math.min(Math.ceil(count / perPage), p + 1))}
             disabled={page >= Math.ceil(count / perPage)}
-            style={{ marginLeft: '0.25rem' }}
+            style={{ marginLeft: '0.25rem', padding: '0.3rem 0.6rem' }}
           >
             {'>'}
           </button>
           <button
             onClick={() => setPage(Math.ceil(count / perPage))}
             disabled={page >= Math.ceil(count / perPage)}
-            style={{ marginLeft: '0.25rem' }}
+            style={{ marginLeft: '0.25rem', padding: '0.3rem 0.6rem' }}
           >
             {'>>'}
           </button>
@@ -547,8 +550,8 @@ export default function TableManager({ table }) {
                 </td>
               ))}
               <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
-                <button onClick={() => openEdit(r)}>Edit</button>
-                <button onClick={() => handleDelete(r)} style={{ marginLeft: '0.5rem' }}>
+                <button onClick={() => openEdit(r)} style={{ padding: '0.3rem 0.6rem' }}>Edit</button>
+                <button onClick={() => handleDelete(r)} style={{ marginLeft: '0.5rem', padding: '0.3rem 0.6rem' }}>
                   Delete
                 </button>
               </td>

--- a/src/erp.mgt.mn/pages/ChangePassword.jsx
+++ b/src/erp.mgt.mn/pages/ChangePassword.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import ErrorMessage from '../components/ErrorMessage.jsx';
 
 export default function ChangePasswordPage() {
   const [password, setPassword] = useState('');
@@ -36,7 +37,7 @@ export default function ChangePasswordPage() {
     <div style={{ padding: '1rem' }}>
       <h2>Нууц үг солих</h2>
       {success && <p style={{ color: 'green' }}>Нууц үг шинэчлэгдлээ</p>}
-      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <ErrorMessage message={error} />
       <form onSubmit={handleSubmit} style={{ maxWidth: '320px' }}>
         <div style={{ marginBottom: '0.75rem' }}>
           <label htmlFor="newpwd" style={{ display: 'block', marginBottom: '0.25rem' }}>

--- a/src/erp.mgt.mn/pages/ErrorLog.jsx
+++ b/src/erp.mgt.mn/pages/ErrorLog.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import ErrorMessage from '../components/ErrorMessage.jsx';
 
 export default function ErrorLogPage() {
   const [logs, setLogs] = useState('');
@@ -20,9 +21,7 @@ export default function ErrorLogPage() {
   return (
     <div>
       <h2>Error Log</h2>
-      {error && (
-        <div style={{ color: 'red', marginBottom: '0.5rem' }}>{error}</div>
-      )}
+      <ErrorMessage message={error} />
       <pre style={{ background: '#f3f4f6', padding: '1rem', whiteSpace: 'pre-wrap' }}>
         {logs}
       </pre>

--- a/src/erp.mgt.mn/pages/TablesManagement.jsx
+++ b/src/erp.mgt.mn/pages/TablesManagement.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import TableManager from '../components/TableManager.jsx';
+import ErrorMessage from '../components/ErrorMessage.jsx';
 
 export default function TablesManagement() {
   const [tables, setTables] = useState([]);
@@ -23,9 +24,7 @@ export default function TablesManagement() {
   return (
     <div>
       <h2>Dynamic Tables</h2>
-      {error && (
-        <div style={{ color: 'red', marginBottom: '0.5rem' }}>{error}</div>
-      )}
+      <ErrorMessage message={error} />
       <select value={selectedTable} onChange={(e) => setSelectedTable(e.target.value)}>
         <option value="">-- select table --</option>
         {tables.map((t) => (


### PR DESCRIPTION
## Summary
- ensure space for error messages with new `ErrorMessage` component
- add padding to tight buttons
- enlarge header buttons for easier clicking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aea25d4b48331ae56ba57bfcbd7e5