### PR TITLE
Handle failed deletes

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -213,6 +213,11 @@ export async function removeCompanyAssignment(empid, companyId) {
     "DELETE FROM user_companies WHERE empid = ? AND company_id = ?",
     [empid, companyId],
   );
+  if (result.affectedRows === 0) {
+    const err = new Error("Assignment not found");
+    err.status = 404;
+    throw err;
+  }
   return result;
 }
 
@@ -643,33 +648,60 @@ export async function insertTableRow(tableName, row) {
 }
 
 export async function deleteTableRow(tableName, id) {
-  if (tableName === 'company_module_licenses') {
-    const [companyId, moduleKey] = String(id).split('-');
-    await pool.query(
-      'DELETE FROM company_module_licenses WHERE company_id = ? AND module_key = ?',
-      [companyId, moduleKey],
-    );
-    return { company_id: companyId, module_key: moduleKey };
-  }
+  try {
+    if (tableName === 'company_module_licenses') {
+      const [companyId, moduleKey] = String(id).split('-');
+      const [result] = await pool.query(
+        'DELETE FROM company_module_licenses WHERE company_id = ? AND module_key = ?',
+        [companyId, moduleKey],
+      );
+      if (result.affectedRows === 0) {
+        const err = new Error('Row not found');
+        err.status = 404;
+        throw err;
+      }
+      return { company_id: companyId, module_key: moduleKey };
+    }
 
-  if (tableName === 'role_module_permissions') {
-    const [companyId, roleId, moduleKey] = String(id).split('-');
-    await pool.query(
-      'DELETE FROM role_module_permissions WHERE company_id = ? AND role_id = ? AND module_key = ?',
-      [companyId, roleId, moduleKey],
-    );
-    return { company_id: companyId, role_id: roleId, module_key: moduleKey };
-  }
+    if (tableName === 'role_module_permissions') {
+      const [companyId, roleId, moduleKey] = String(id).split('-');
+      const [result] = await pool.query(
+        'DELETE FROM role_module_permissions WHERE company_id = ? AND role_id = ? AND module_key = ?',
+        [companyId, roleId, moduleKey],
+      );
+      if (result.affectedRows === 0) {
+        const err = new Error('Row not found');
+        err.status = 404;
+        throw err;
+      }
+      return { company_id: companyId, role_id: roleId, module_key: moduleKey };
+    }
 
-  if (tableName === 'user_companies') {
-    const [empId, companyId] = String(id).split('-');
-    await pool.query(
-      'DELETE FROM user_companies WHERE empid = ? AND company_id = ?',
-      [empId, companyId],
-    );
-    return { empid: empId, company_id: companyId };
-  }
+    if (tableName === 'user_companies') {
+      const [empId, companyId] = String(id).split('-');
+      const [result] = await pool.query(
+        'DELETE FROM user_companies WHERE empid = ? AND company_id = ?',
+        [empId, companyId],
+      );
+      if (result.affectedRows === 0) {
+        const err = new Error('Row not found');
+        err.status = 404;
+        throw err;
+      }
+      return { empid: empId, company_id: companyId };
+    }
 
-  await pool.query('DELETE FROM ?? WHERE id = ?', [tableName, id]);
-  return { id };
+    const [result] = await pool.query('DELETE FROM ?? WHERE id = ?', [tableName, id]);
+    if (result.affectedRows === 0) {
+      const err = new Error('Row not found');
+      err.status = 404;
+      throw err;
+    }
+    return { id };
+  } catch (err) {
+    if (err.code === 'ER_ROW_IS_REFERENCED_2') {
+      err.status = 400;
+    }
+    throw err;
+  }
 }

--- a/tests/db/validation.test.js
+++ b/tests/db/validation.test.js
@@ -15,6 +15,16 @@ function mockPool(columns) {
   };
 }
 
+test('deleteTableRow rejects when nothing deleted', async () => {
+  const original = db.pool.query;
+  db.pool.query = async () => [{ affectedRows: 0 }];
+  await assert.rejects(
+    db.deleteTableRow('users', 1),
+    /Row not found/
+  );
+  db.pool.query = original;
+});
+
 test('listTableRows rejects invalid filter column', async () => {
   const restore = mockPool(['id', 'name']);
   await assert.rejects(


### PR DESCRIPTION
## Summary
- detect missing user-company assignment rows
- report missing rows and FK failures in `deleteTableRow`
- test row-not-found error path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aecc6669c83319b3d0621c7b25b59