### PR TITLE
Fix table error handling and hide Error Log menu

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -73,7 +73,6 @@ export default function TableManager({ table }) {
             return acc;
           }, {})
         );
-        setError('');
       })
       .catch((err) => {
         if (!canceled) {
@@ -90,7 +89,6 @@ export default function TableManager({ table }) {
         if (canceled) return;
         setColumnMeta(cols);
         setAutoInc(computeAutoInc(cols));
-        setError('');
       })
       .catch((err) => {
         if (!canceled) {

--- a/src/erp.mgt.mn/hooks/useModules.js
+++ b/src/erp.mgt.mn/hooks/useModules.js
@@ -15,8 +15,9 @@ export function useModules() {
     try {
       const res = await fetch('/api/modules', { credentials: 'include' });
       const rows = res.ok ? await res.json() : [];
-      cache.data = rows;
-      setModules(rows);
+      const filtered = rows.filter((m) => m.module_key !== 'error_log');
+      cache.data = filtered;
+      setModules(filtered);
     } catch (err) {
       console.error('Failed to load modules', err);
       setModules([]);


### PR DESCRIPTION
## Summary
- persist error messages in TableManager by not clearing them on individual fetch success
- filter out `error_log` module when loading module list so the menu no longer appears

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aefd260708331b74fd303aeaec524