### PR TITLE
Fix row deletion refresh for dynamic tables

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -317,6 +317,8 @@ export default function TableManager({ table }) {
         throw new Error(data?.message || 'Delete failed');
       }
       const data = await fetchRows();
+      setRows(data.rows || []);
+      setCount(data.count || 0);
       const last = Math.max(1, Math.ceil((data.count || 0) / perPage));
       if (page > last) setPage(last);
       setSelectedRows(new Set());
@@ -349,6 +351,8 @@ export default function TableManager({ table }) {
       }
     }
     const data = await fetchRows();
+    setRows(data.rows || []);
+    setCount(data.count || 0);
     const last = Math.max(1, Math.ceil((data.count || 0) / perPage));
     if (page > last) setPage(last);
     setSelectedRows(new Set());


### PR DESCRIPTION
## Summary
- ensure TableManager refreshes rows/count after deleting a row
- ensure Delete Selected updates list as well

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684af2b4a61883319e6c698f47eb8585