### PR TITLE
Fix deletion for user_companies in table manager

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -307,6 +307,7 @@ export default function TableManager({ table }) {
 
   async function handleDelete(row) {
     if (!window.confirm('Delete row?')) return;
+    await ensureColumnMeta();
     try {
       const res = await fetch(
         `/api/tables/${table}/${encodeURIComponent(getRowId(row))}`,
@@ -332,6 +333,7 @@ export default function TableManager({ table }) {
   async function handleDeleteSelected() {
     if (selectedRows.size === 0) return;
     if (!window.confirm('Delete selected rows?')) return;
+    await ensureColumnMeta();
     for (const row of rows) {
       const id = getRowId(row);
       if (!selectedRows.has(id)) continue;


### PR DESCRIPTION
## Summary
- ensure column metadata is loaded before deleting rows
- avoid incorrect row id when metadata has not yet loaded

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684afc7ba38083318d3555966a2f004a