### PR TITLE
Allow generating coding table SQL with minimal column selection

### DIFF
--- a/api-server/controllers/codingTableController.js
+++ b/api-server/controllers/codingTableController.js
@@ -91,6 +91,16 @@ export async function uploadCodingTable(req, res, next) {
     if (!tableName) {
       return res.status(400).json({ error: 'Missing params' });
     }
+    const uniqueOnly = uniqueCols.filter(
+      (c) => c !== idColumn && c !== nameColumn && !extraCols.includes(c)
+    );
+    const extraFiltered = extraCols.filter(
+      (c) => c !== idColumn && c !== nameColumn && !uniqueOnly.includes(c)
+    );
+    if (!idColumn && !nameColumn && uniqueOnly.length === 0 && extraFiltered.length === 0) {
+      fs.unlinkSync(req.file.path);
+      return res.status(400).json({ error: 'No columns selected' });
+    }
     let defs = [];
     if (idColumn) {
       defs.push(`\`${idColumn}\` INT AUTO_INCREMENT PRIMARY KEY`);

--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -185,9 +185,13 @@ export default function CodingTablesPage() {
     );
     const uniqueIdx = uniqueOnly.map((c) => hdrs.indexOf(c));
     if (uniqueIdx.some((i) => i === -1)) return;
-    const otherIdx = otherColumns
-      .filter((c) => c !== idColumn && c !== nameColumn && !uniqueOnly.includes(c))
-      .map((c) => hdrs.indexOf(c));
+    const otherFiltered = otherColumns
+      .filter((c) => c !== idColumn && c !== nameColumn && !uniqueOnly.includes(c));
+    if (!idColumn && !nameColumn && uniqueOnly.length === 0 && otherFiltered.length === 0) {
+      alert('Please select at least one ID, Name, Unique or Other column');
+      return;
+    }
+    const otherIdx = otherFiltered.map((c) => hdrs.indexOf(c));
     if (otherIdx.some((i) => i === -1)) return;
 
     let defs = [];
@@ -200,12 +204,10 @@ export default function CodingTablesPage() {
     uniqueOnly.forEach((c) => {
       defs.push(`\`${c}\` ${colTypes[c]} NOT NULL`);
     });
-    otherColumns
-      .filter((c) => c !== idColumn && c !== nameColumn && !uniqueOnly.includes(c))
-      .forEach((c) => {
-        let def = `\`${c}\` ${colTypes[c]}`;
-        if (notNullMap[c]) def += ' NOT NULL';
-        defs.push(def);
+    otherFiltered.forEach((c) => {
+      let def = `\`${c}\` ${colTypes[c]}`;
+      if (notNullMap[c]) def += ' NOT NULL';
+      defs.push(def);
       });
     const calcFields = parseCalcFields(calcText);
     calcFields.forEach((cf) => {
@@ -244,9 +246,7 @@ export default function CodingTablesPage() {
         hasData = true;
       });
       if (skip) continue;
-      otherColumns
-        .filter((c) => c !== idColumn && c !== nameColumn && !uniqueOnly.includes(c))
-        .forEach((c) => {
+      otherFiltered.forEach((c) => {
           const ci = hdrs.indexOf(c);
           const v = r[ci];
           if (v !== undefined && v !== null && v !== '') hasData = true;
@@ -262,6 +262,16 @@ export default function CodingTablesPage() {
 
   async function handleUpload() {
     if (!workbook || !sheet || !tableName) return;
+    const uniqueOnly = uniqueFields.filter(
+      (c) => c !== idColumn && c !== nameColumn && !otherColumns.includes(c)
+    );
+    const otherFiltered = otherColumns.filter(
+      (c) => c !== idColumn && c !== nameColumn && !uniqueOnly.includes(c)
+    );
+    if (!idColumn && !nameColumn && uniqueOnly.length === 0 && otherFiltered.length === 0) {
+      alert('Please select at least one ID, Name, Unique or Other column');
+      return;
+    }
     setSql('');
     setUploading(true);
     try {


### PR DESCRIPTION
## Summary
- allow generating SQL without choosing ID or name column
- verify at least one of ID, name, unique or other columns is selected before generating SQL or uploading data
- mirror the same validation on the server API

## Testing
- `node --test` *(fails: Cannot find package 'mysql2')*

------
https://chatgpt.com/codex/tasks/task_e_684bba17b4c08331a4dd37b2ae42ab07