### PR TITLE
Fix bcrypt import causing login error

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -21,7 +21,7 @@ try {
 }
 let bcrypt;
 try {
-  bcrypt = await import("bcryptjs");
+  bcrypt = (await import("bcryptjs")).default;
 } catch {
   bcrypt = { hash: async (s) => s, compare: async () => false };
 }


### PR DESCRIPTION
## Summary
- use `.default` when dynamically importing `bcryptjs` to access its functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bc1e9c94883319ebaf5e606cb6d3c