### PR TITLE
Fix bcrypt import for login

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -21,7 +21,8 @@ try {
 }
 let bcrypt;
 try {
-  bcrypt = await import("bcryptjs");
+  const mod = await import("bcryptjs");
+  bcrypt = mod.default || mod;
 } catch {
   bcrypt = { hash: async (s) => s, compare: async () => false };
 }


### PR DESCRIPTION
## Summary
- fix fallback so bcrypt functions load regardless of import style

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684bc53cae4083319124da158974ead5