### PR TITLE
Update coding tables to use standard id/name

### DIFF
--- a/api-server/controllers/codingTableController.js
+++ b/api-server/controllers/codingTableController.js
@@ -122,13 +122,15 @@ export async function uploadCodingTable(req, res, next) {
     if (!tableName) {
       return res.status(400).json({ error: 'Missing params' });
     }
+    const dbIdCol = idColumn ? 'id' : null;
+    const dbNameCol = nameColumn ? 'name' : null;
     let defs = [];
     if (idColumn) {
-      defs.push(`\`${idColumn}\` INT AUTO_INCREMENT PRIMARY KEY`);
+      defs.push(`\`${dbIdCol}\` INT AUTO_INCREMENT PRIMARY KEY`);
     }
     if (nameColumn) {
       defs.push(
-        `\`${nameColumn}\` ${
+        `\`${dbNameCol}\` ${
           columnTypes[nameColumn] || 'VARCHAR(255)'
         } NOT NULL`
       );
@@ -145,7 +147,7 @@ export async function uploadCodingTable(req, res, next) {
       defs.push(`\`${cf.name}\` INT AS (${cf.expression}) STORED`);
     });
     const uniqueKeyFields = [
-      ...(uniqueCols.includes(nameColumn) ? [nameColumn] : []),
+      ...(uniqueCols.includes(nameColumn) ? [dbNameCol] : []),
       ...uniqueOnly,
     ];
     if (uniqueKeyFields.length > 0) {
@@ -165,9 +167,9 @@ export async function uploadCodingTable(req, res, next) {
       if (nameColumn) {
         const nameVal = r[nameColumn];
         if (nameVal === undefined || nameVal === null || nameVal === '') continue;
-        cols.push(`\`${nameColumn}\``);
+        cols.push(`\`${dbNameCol}\``);
         placeholders.push('?');
-        updates.push(`\`${nameColumn}\` = VALUES(\`${nameColumn}\`)`);
+        updates.push(`\`${dbNameCol}\` = VALUES(\`${dbNameCol}\`)`);
         let val = nameVal;
         if (columnTypes[nameColumn] === 'DATE') {
           const d = parseExcelDate(val);

--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -219,6 +219,8 @@ export default function CodingTablesPage() {
     }
     const idIdx = hdrs.indexOf(idColumn);
     const nameIdx = hdrs.indexOf(nameColumn);
+    const dbIdCol = idColumn ? 'id' : null;
+    const dbNameCol = nameColumn ? 'name' : null;
     if (idColumn && idIdx === -1) return;
     if (nameColumn && nameIdx === -1) return;
     const uniqueIdx = uniqueOnly.map((c) => hdrs.indexOf(c));
@@ -228,10 +230,10 @@ export default function CodingTablesPage() {
 
     let defs = [];
     if (idColumn) {
-      defs.push(`\`${idColumn}\` INT AUTO_INCREMENT PRIMARY KEY`);
+      defs.push(`\`${dbIdCol}\` INT AUTO_INCREMENT PRIMARY KEY`);
     }
     if (nameColumn) {
-      defs.push(`\`${nameColumn}\` ${colTypes[nameColumn]} NOT NULL`);
+      defs.push(`\`${dbNameCol}\` ${colTypes[nameColumn]} NOT NULL`);
     }
     uniqueOnly.forEach((c) => {
       defs.push(`\`${c}\` ${colTypes[c]} NOT NULL`);
@@ -246,7 +248,7 @@ export default function CodingTablesPage() {
       defs.push(`\`${cf.name}\` INT AS (${cf.expression}) STORED`);
     });
     const uniqueKeyFields = [
-      ...(uniqueFields.includes(nameColumn) ? [nameColumn] : []),
+      ...(uniqueFields.includes(nameColumn) ? [dbNameCol] : []),
       ...uniqueOnly,
     ];
     if (uniqueKeyFields.length > 0) {
@@ -265,7 +267,7 @@ export default function CodingTablesPage() {
       if (nameColumn) {
         const nameVal = r[nameIdx];
         if (nameVal === undefined || nameVal === null || nameVal === '') continue;
-        cols.push(`\`${nameColumn}\``);
+        cols.push(`\`${dbNameCol}\``);
         vals.push(formatVal(nameVal, colTypes[nameColumn]));
         hasData = true;
       }


### PR DESCRIPTION
## Summary
- adjust Coding Tables UI to insert `id` and `name` fields when selected
- update codingTableController to write `id` and `name` in created table

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684bec7646b48331923ae5e66ed56c5c