### PR TITLE
Fix extraFields handling in coding table

### DIFF
--- a/api-server/controllers/codingTableController.js
+++ b/api-server/controllers/codingTableController.js
@@ -183,17 +183,18 @@ export async function uploadCodingTable(req, res, next) {
         cols.push(`\`${c}\``);
         placeholders.push('?');
         let val = r[c];
+        const hasProp = Object.prototype.hasOwnProperty.call(r, c);
         if (columnTypes[c] === 'DATE') {
           const d = parseExcelDate(val);
           val = d || null;
         }
-        if (val === undefined || val === null || val === '') {
+        if (hasProp && (val === undefined || val === null || val === '')) {
           skip = true;
           break;
         }
-        values.push(val);
+        values.push(val === undefined ? null : val);
         updates.push(`\`${c}\` = VALUES(\`${c}\`)`);
-        hasData = true;
+        if (val !== undefined && val !== null && val !== '') hasData = true;
       }
       if (skip) continue;
       for (const c of extraFiltered) {

--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -234,7 +234,6 @@ export default function CodingTablesPage() {
     if (idColumn && idIdx === -1) return;
     if (nameColumn && nameIdx === -1) return;
     const uniqueIdx = uniqueOnly.map((c) => hdrs.indexOf(c));
-    if (uniqueIdx.some((i) => i === -1)) return;
     const otherIdx = otherFiltered.map((c) => hdrs.indexOf(c));
 
     let defs = [];
@@ -283,8 +282,9 @@ export default function CodingTablesPage() {
       let skip = false;
       uniqueOnly.forEach((c, idx2) => {
         if (skip) return;
-        const v = r[uniqueIdx[idx2]];
-        if (v === undefined || v === null || v === '') {
+        const ui = uniqueIdx[idx2];
+        const v = ui === -1 ? undefined : r[ui];
+        if (ui !== -1 && (v === undefined || v === null || v === '')) {
           skip = true;
           return;
         }


### PR DESCRIPTION
## Summary
- handle extraFields properly when generating SQL for coding tables
- allow server to insert NULLs for unique fields not present in the Excel sheet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bf60504248331ad832573e748c772