### PR TITLE
Fix default values for unique extra fields

### DIFF
--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -184,6 +184,13 @@ export default function CodingTablesPage() {
     return escapeSqlValue(val);
   }
 
+  function defaultValForType(type) {
+    if (!type) return 0;
+    if (type === 'DATE') return 0;
+    if (type === 'INT' || type.startsWith('DECIMAL')) return 0;
+    return 0;
+  }
+
   function handleGenerateSql() {
     if (!workbook || !sheet || !tableName) return;
     const data = XLSX.utils.sheet_to_json(workbook.Sheets[sheet], { header: 1 });
@@ -283,7 +290,7 @@ export default function CodingTablesPage() {
       uniqueOnly.forEach((c, idx2) => {
         if (skip) return;
         const ui = uniqueIdx[idx2];
-        const v = ui === -1 ? undefined : r[ui];
+        let v = ui === -1 ? defaultValForType(colTypes[c]) : r[ui];
         if (ui !== -1 && (v === undefined || v === null || v === '')) {
           skip = true;
           return;


### PR DESCRIPTION
## Summary
- default extra field values to 0 when used as unique columns in Coding Tables
- ensure SQL generation uses these defaults

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bf8381b3c83319b1d596bc40dd22c