### PR TITLE
Filter out incomplete coding table rows

### DIFF
--- a/api-server/controllers/codingTableController.js
+++ b/api-server/controllers/codingTableController.js
@@ -170,6 +170,9 @@ export async function uploadCodingTable(req, res, next) {
         }
       }
     }
+    finalRows = finalRows.filter(
+      (r) => !Object.values(r).some((v) => v === 0 || v === null)
+    );
     if (!tableName) {
       return res.status(400).json({ error: 'Missing params' });
     }

--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -283,6 +283,9 @@ export default function CodingTablesPage() {
         }
       }
     }
+    finalRows = finalRows.filter(
+      (r) => !r.some((v) => v === 0 || v === null)
+    );
 
     let defs = [];
     if (idColumn) {


### PR DESCRIPTION
## Summary
- skip rows with zero or null values when generating SQL in CodingTables page
- filter out rows with zero or null values on the server before inserting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c08edc8f88331b65a7135526ed36f