### PR TITLE
Fix populate SQL generation when range disabled

### DIFF
--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -354,7 +354,7 @@ export default function CodingTablesPage() {
           vals.push(formatVal(v, colTypes[c]));
         });
       if (!hasData) continue;
-      if (vals.some((v) => v === '0' || v === 'NULL')) continue;
+      if (populateRange && vals.some((v) => v === '0' || v === 'NULL')) continue;
       const updates = cols.map((c) => `${c} = VALUES(${c})`);
       sqlStr += `INSERT INTO \`${tableName}\` (${cols.join(', ')}) VALUES (${vals.join(', ')}) ON DUPLICATE KEY UPDATE ${updates.join(', ')};\n`;
     }


### PR DESCRIPTION
## Summary
- fix coding tables SQL generation logic so rows are skipped for zero/NULL values only when Populate Range is selected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c6775fa0c8331ac9f5c2dafe747d0