### PR TITLE
Add refresh buttons for table management

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -287,6 +287,32 @@ export default function TableManager({ table }) {
     setSelectedRows(new Set());
   }
 
+  async function refreshRows() {
+    if (!table) return;
+    const params = new URLSearchParams({ page, perPage });
+    if (sort.column) {
+      params.set('sort', sort.column);
+      params.set('dir', sort.dir);
+    }
+    Object.entries(filters).forEach(([k, v]) => {
+      if (v) params.set(k, v);
+    });
+    try {
+      const res = await fetch(
+        `/api/tables/${encodeURIComponent(table)}?${params.toString()}`,
+        { credentials: 'include' }
+      );
+      if (res.ok) {
+        const data = await res.json();
+        setRows(data.rows || []);
+        setCount(data.count || 0);
+        setSelectedRows(new Set());
+      }
+    } catch (err) {
+      console.error('Failed to refresh rows', err);
+    }
+  }
+
   if (!table) return null;
 
   const allColumns =
@@ -336,6 +362,9 @@ export default function TableManager({ table }) {
         </button>
         <button onClick={deselectAll} style={{ marginRight: '0.5rem' }}>
           Deselect All
+        </button>
+        <button onClick={refreshRows} style={{ marginRight: '0.5rem' }}>
+          Refresh Table
         </button>
         {selectedRows.size > 0 && (
           <button onClick={handleDeleteSelected}>Delete Selected</button>

--- a/src/erp.mgt.mn/pages/TablesManagement.jsx
+++ b/src/erp.mgt.mn/pages/TablesManagement.jsx
@@ -5,11 +5,23 @@ export default function TablesManagement() {
   const [tables, setTables] = useState([]);
   const [selectedTable, setSelectedTable] = useState('');
 
+  const loadTables = async () => {
+    try {
+      const res = await fetch('/api/tables', { credentials: 'include' });
+      if (res.ok) {
+        const data = await res.json();
+        setTables(data);
+        if (!data.includes(selectedTable)) {
+          setSelectedTable('');
+        }
+      }
+    } catch (err) {
+      console.error('Failed to load tables', err);
+    }
+  };
+
   useEffect(() => {
-    fetch('/api/tables', { credentials: 'include' })
-      .then((res) => res.json())
-      .then(setTables)
-      .catch((err) => console.error('Failed to load tables', err));
+    loadTables();
   }, []);
 
   return (
@@ -23,6 +35,7 @@ export default function TablesManagement() {
           </option>
         ))}
       </select>
+      <button onClick={loadTables} style={{ marginLeft: '0.5rem' }}>Refresh List</button>
       {selectedTable && <TableManager table={selectedTable} />}
     </div>
   );


### PR DESCRIPTION
## Summary
- refresh list of tables from the tables management page
- allow reloading row data in `TableManager`
- add buttons in UI to trigger these refreshes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c8a2c629083318c91aaca9ff736c1