### PR TITLE
Fix refresh buttons on table management

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -3,7 +3,7 @@ import { AuthContext } from '../context/AuthContext.jsx';
 import RowFormModal from './RowFormModal.jsx';
 import formatTimestamp from '../utils/formatTimestamp.js';
 
-export default function TableManager({ table }) {
+export default function TableManager({ table, refreshId = 0 }) {
   const [rows, setRows] = useState([]);
   const [count, setCount] = useState(0);
   const [page, setPage] = useState(1);
@@ -88,11 +88,11 @@ export default function TableManager({ table }) {
     return () => {
       canceled = true;
     };
-  }, [table, page, perPage, filters, sort]);
+  }, [table, page, perPage, filters, sort, refreshId]);
 
   useEffect(() => {
     setSelectedRows(new Set());
-  }, [table, page, perPage, filters, sort]);
+  }, [table, page, perPage, filters, sort, refreshId]);
 
   function getRowId(row) {
     const keys = getKeyFields();

--- a/src/erp.mgt.mn/pages/TablesManagement.jsx
+++ b/src/erp.mgt.mn/pages/TablesManagement.jsx
@@ -4,6 +4,7 @@ import TableManager from '../components/TableManager.jsx';
 export default function TablesManagement() {
   const [tables, setTables] = useState([]);
   const [selectedTable, setSelectedTable] = useState('');
+  const [refreshId, setRefreshId] = useState(0);
 
   const loadTables = async () => {
     try {
@@ -13,6 +14,9 @@ export default function TablesManagement() {
         setTables(data);
         if (!data.includes(selectedTable)) {
           setSelectedTable('');
+        } else if (selectedTable) {
+          // trigger refresh for currently selected table
+          setRefreshId((r) => r + 1);
         }
       }
     } catch (err) {
@@ -36,7 +40,9 @@ export default function TablesManagement() {
         ))}
       </select>
       <button onClick={loadTables} style={{ marginLeft: '0.5rem' }}>Refresh List</button>
-      {selectedTable && <TableManager table={selectedTable} />}
+      {selectedTable && (
+        <TableManager table={selectedTable} refreshId={refreshId} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- ensure TablesManagement reloads current table when list is refreshed
- trigger TableManager data reload using `refreshId`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c8fc8867c8331937031b249c614b6