### PR TITLE
Sanitize SQL values when populating coding tables

### DIFF
--- a/api-server/controllers/codingTableController.js
+++ b/api-server/controllers/codingTableController.js
@@ -31,6 +31,13 @@ function parseExcelDate(val) {
   return d;
 }
 
+function sanitizeValue(val) {
+  if (typeof val === 'string') {
+    return val.replace(/[\\/"']/g, '');
+  }
+  return val;
+}
+
 export function detectType(name, vals) {
   const lower = String(name).toLowerCase();
   if (lower.includes('_per')) return 'DECIMAL(5,2)';
@@ -263,6 +270,7 @@ export async function uploadCodingTable(req, res, next) {
           const d = parseExcelDate(val);
           val = d || null;
         }
+        val = sanitizeValue(val);
         values.push(val);
         hasData = true;
       }
@@ -277,6 +285,7 @@ export async function uploadCodingTable(req, res, next) {
           const d = parseExcelDate(val);
           val = d || null;
         }
+        val = sanitizeValue(val);
         values.push(val);
         updates.push(`\`${c}\` = VALUES(\`${c}\`)`);
         hasData = true;
@@ -295,6 +304,7 @@ export async function uploadCodingTable(req, res, next) {
           val = null;
         }
         if (val !== undefined && val !== null && val !== '') hasData = true;
+        val = sanitizeValue(val);
         values.push(val);
         updates.push(`\`${c}\` = VALUES(\`${c}\`)`);
       }

--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -147,8 +147,14 @@ export default function CodingTablesPage() {
     extractHeaders(workbook, sheet, headerRow);
   }
 
+  function removeSqlUnsafeChars(v) {
+    if (typeof v !== 'string') return v;
+    return v.replace(/[\\/"']/g, '');
+  }
+
   function escapeSqlValue(v) {
-    return `'${String(v).replace(/'/g, "''")}'`;
+    const sanitized = removeSqlUnsafeChars(v);
+    return `'${String(sanitized).replace(/'/g, "''")}'`;
   }
 
   function detectType(name, vals) {


### PR DESCRIPTION
## Summary
- clean `/` `\` and quotes from inserted strings in `uploadCodingTable`
- sanitize values used in generated SQL on the Coding Tables page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e61059c508331a05f250861e2d5a8