### PR TITLE
Allow additional columns in ID dropdown

### DIFF
--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -38,13 +38,15 @@ export default function CodingTablesPage() {
     [allHeaders]
   );
 
-  function computeIdCandidates(hdrs, mode) {
+  function computeIdCandidates(hdrs, extras, mode) {
     const strs = hdrs.filter((h) => typeof h === 'string');
+    const extraList = extras.filter((f) => typeof f === 'string' && f.trim() !== '');
     if (mode === 'contains') {
       const ids = strs.filter((h) => h.toLowerCase().includes('id'));
-      return ids.length > 0 ? ids : strs;
+      const base = ids.length > 0 ? ids : strs;
+      return Array.from(new Set([...base, ...extraList]));
     }
-    return strs;
+    return Array.from(new Set([...strs, ...extraList]));
   }
 
   function handleFile(e) {
@@ -464,7 +466,7 @@ export default function CodingTablesPage() {
   }
 
   useEffect(() => {
-    setIdCandidates(computeIdCandidates(allHeaders, idFilterMode));
+    setIdCandidates(computeIdCandidates(allHeaders, extraFields, idFilterMode));
     setUniqueFields((u) => u.filter((f) => allHeaders.includes(f)));
     setOtherColumns((o) => o.filter((f) => allHeaders.includes(f)));
     setNotNullMap((m) => {


### PR DESCRIPTION
## Summary
- let computeIdCandidates include extra columns
- use updated computeIdCandidates when updating options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e747e579c8331aeb5f17a58917846