### PR TITLE
Add PK logging to table operations

### DIFF
--- a/db/debugLog.js
+++ b/db/debugLog.js
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Resolve the log path relative to the repo regardless of CWD
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const logFile = path.join(__dirname, '../api-server/logs/db.log');
+
+export function logDb(message) {
+  try {
+    fs.mkdirSync(path.dirname(logFile), { recursive: true });
+    fs.appendFileSync(logFile, `[${new Date().toISOString()}] ${message}\n`);
+  } catch {
+    // ignore logging errors
+  }
+  console.log(message);
+}

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -98,20 +98,25 @@ export default function TableManager({ table, refreshId = 0 }) {
   function getRowId(row) {
     const keys = getKeyFields();
     if (keys.length === 0) return undefined;
-    if (keys.length === 1) return row[keys[0]];
-    return keys.map((k) => row[k]).join('-');
+    const idVal =
+      keys.length === 1 ? row[keys[0]] : keys.map((k) => row[k]).join('-');
+    console.log('Row id for', table, '=>', idVal);
+    return idVal;
   }
 
   function getKeyFields() {
     const keys = columnMeta
       .filter((c) => c.key === 'PRI')
       .map((c) => c.name);
-    if (keys.length > 0) return keys;
-    if (columnMeta.some((c) => c.name === 'id')) return ['id'];
-    if (rows[0] && Object.prototype.hasOwnProperty.call(rows[0], 'id')) {
-      return ['id'];
+    let result = keys;
+    if (result.length === 0) {
+      if (columnMeta.some((c) => c.name === 'id')) result = ['id'];
+      else if (rows[0] && Object.prototype.hasOwnProperty.call(rows[0], 'id')) {
+        result = ['id'];
+      }
     }
-    return [];
+    console.log('Key fields for', table, ':', result);
+    return result;
   }
 
   async function ensureColumnMeta() {


### PR DESCRIPTION
## Summary
- add debug logger utility
- log detected key fields in TableManager UI
- log PK columns for update and delete operations
- fix debug logger path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e957ac9548331a62290f73ff25cfb