### PR TITLE
Log debug logger init once

### DIFF
--- a/db/debugLog.js
+++ b/db/debugLog.js
@@ -7,6 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const logFile = fileURLToPath(new URL('../api-server/logs/db.log', import.meta.url));
 
 let logFileReady = false;
+let initLogged = false;
 
 function ensureLogFile() {
   try {
@@ -33,4 +34,7 @@ export function logDb(message) {
 
 // Ensure the log file is created when this module is loaded
 ensureLogFile();
-logDb('Debug logger initialized');
+if (!initLogged) {
+  logDb('Debug logger initialized');
+  initLogged = true;
+}


### PR DESCRIPTION
## Summary
- ensure initialization message for DB debug log only appears once

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684eb506996883319ec236d3accf63e9