### PR TITLE
Fix table management logging

### DIFF
--- a/db/debugLog.js
+++ b/db/debugLog.js
@@ -1,10 +1,12 @@
 import fs from 'fs';
-import { dirname } from 'path';
+import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
-// Resolve the log file via URL semantics so bundlers keep the path correct.
+// Resolve the log file relative to the project root rather than to this module.
+// Using process.cwd() ensures the location is stable regardless of how the file
+// is executed (e.g. bundled or transpiled to a temp directory).
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const logFile = fileURLToPath(new URL('../api-server/logs/db.log', import.meta.url));
+const logFile = path.resolve(process.cwd(), 'api-server', 'logs', 'db.log');
 
 let logFileReady = false;
 let initLogged = false;

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -100,9 +100,7 @@ export default function TableManager({ table, refreshId = 0 }) {
     if (keys.length === 0) return undefined;
     const idVal =
       keys.length === 1 ? row[keys[0]] : keys.map((k) => row[k]).join('-');
-    if (import.meta.env.DEV) {
-      console.log('Row id for', table, '=>', idVal);
-    }
+    console.log('Row id for', table, '=>', idVal);
     return idVal;
   }
 
@@ -117,9 +115,7 @@ export default function TableManager({ table, refreshId = 0 }) {
         result = ['id'];
       }
     }
-    if (import.meta.env.DEV) {
-      console.log('Key fields for', table, ':', result);
-    }
+    console.log('Key fields for', table, ':', result);
     return result;
   }
 


### PR DESCRIPTION
## Summary
- point debug log file path at project root so it is always created
- always display key field debug messages in TableManager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ebe34ca408331b0e4ec44f0e5cdea