### PR TITLE
Add request activity logging

### DIFF
--- a/api-server/middlewares/logging.js
+++ b/api-server/middlewares/logging.js
@@ -1,4 +1,21 @@
+import jwt from 'jsonwebtoken';
+import { logActivity } from '../utils/activityLog.js';
+
 export function logger(req, res, next) {
-  console.log(`[${new Date().toISOString()}] ${req.method} ${req.url}`);
+  let user = 'anonymous';
+  if (req.user) {
+    user = req.user.empid || req.user.email || req.user.id;
+  } else if (req.cookies?.[process.env.COOKIE_NAME]) {
+    try {
+      const payload = jwt.verify(
+        req.cookies[process.env.COOKIE_NAME],
+        process.env.JWT_SECRET
+      );
+      user = payload.empid || payload.email || payload.id;
+    } catch {}
+  }
+  const msg = `${req.method} ${req.url} by ${user}`;
+  console.log(`[${new Date().toISOString()}] ${msg}`);
+  logActivity(msg);
   next();
 }

--- a/api-server/utils/activityLog.js
+++ b/api-server/utils/activityLog.js
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import path from 'path';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const logFile = path.resolve(process.cwd(), 'api-server', 'logs', 'activity.log');
+
+let logFileReady = false;
+let initLogged = false;
+
+function ensureLogFile() {
+  try {
+    fs.mkdirSync(path.dirname(logFile), { recursive: true });
+    if (!fs.existsSync(logFile)) {
+      fs.writeFileSync(logFile, '');
+      console.log(`Activity log created at ${logFile}`);
+    }
+    logFileReady = true;
+  } catch (err) {
+    console.error('Failed to initialize activity log:', err);
+  }
+}
+
+export function logActivity(message) {
+  try {
+    if (!logFileReady) ensureLogFile();
+    fs.appendFileSync(logFile, `[${new Date().toISOString()}] ${message}\n`);
+  } catch (err) {
+    console.error('Failed to write activity log:', err);
+  }
+}
+
+ensureLogFile();
+if (!initLogged) {
+  logActivity('Activity logger initialized');
+  initLogged = true;
+}


### PR DESCRIPTION
## Summary
- log user requests to a new `activity.log` file
- capture user from JWT cookie where possible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ec12d06d48331b875d9ea36e5f517