### PR TITLE
Add cascade delete confirmation

### DIFF
--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -4,6 +4,8 @@ import {
   updateTableRow,
   insertTableRow,
   deleteTableRow,
+  deleteTableRowCascade,
+  listRowReferences,
   listTableRelationships,
   listTableColumns,
   listTableColumnMeta,
@@ -95,8 +97,21 @@ export async function addRow(req, res, next) {
 
 export async function deleteRow(req, res, next) {
   try {
-    await deleteTableRow(req.params.table, req.params.id);
+    if (req.query.cascade === 'true') {
+      await deleteTableRowCascade(req.params.table, req.params.id);
+    } else {
+      await deleteTableRow(req.params.table, req.params.id);
+    }
     res.sendStatus(204);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getRowReferences(req, res, next) {
+  try {
+    const refs = await listRowReferences(req.params.table, req.params.id);
+    res.json(refs);
   } catch (err) {
     next(err);
   }

--- a/api-server/routes/tables.js
+++ b/api-server/routes/tables.js
@@ -7,6 +7,7 @@ import {
   updateRow,
   addRow,
   deleteRow,
+  getRowReferences,
 } from '../controllers/tableController.js';
 import { requireAuth } from '../middlewares/auth.js';
 
@@ -16,6 +17,7 @@ router.get('/', requireAuth, getTables);
 // More specific routes must be defined before the generic ':table' pattern
 router.get('/:table/relations', requireAuth, getTableRelations);
 router.get('/:table/columns', requireAuth, getTableColumnsMeta);
+router.get('/:table/:id/references', requireAuth, getRowReferences);
 router.put('/:table/:id', requireAuth, updateRow);
 router.delete('/:table/:id', requireAuth, deleteRow);
 router.post('/:table', requireAuth, addRow);

--- a/tests/db/references.test.js
+++ b/tests/db/references.test.js
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as db from '../../db/index.js';
+
+function mockPool(handler) {
+  const originalQuery = db.pool.query;
+  const originalGet = db.pool.getConnection;
+  db.pool.query = handler;
+  db.pool.getConnection = async () => ({
+    beginTransaction: async () => {},
+    commit: async () => {},
+    rollback: async () => {},
+    release: () => {},
+    query: handler,
+  });
+  return () => {
+    db.pool.query = originalQuery;
+    db.pool.getConnection = originalGet;
+  };
+}
+
+test('listRowReferences counts referencing rows', async () => {
+  let step = 0;
+  const restore = mockPool(async (sql, params) => {
+    step++;
+    if (sql.startsWith('SHOW KEYS')) {
+      return [[{ Column_name: 'id' }]];
+    }
+    if (sql.includes('information_schema.KEY_COLUMN_USAGE')) {
+      return [[{ TABLE_NAME: 'orders', COLUMN_NAME: 'user_id', REFERENCED_COLUMN_NAME: 'id' }]];
+    }
+    if (sql.startsWith('SELECT COUNT(*)')) {
+      assert.equal(params[0], 'orders');
+      assert.equal(params[1], 'user_id');
+      assert.equal(params[2], '5');
+      return [[{ count: 2 }]];
+    }
+    throw new Error('unexpected query');
+  });
+  const refs = await db.listRowReferences('users', '5');
+  restore();
+  assert.deepEqual(refs, [
+    { table: 'orders', column: 'user_id', value: '5', count: 2 },
+  ]);
+});
+
+test('deleteTableRowCascade deletes related rows first', async () => {
+  const calls = [];
+  const restore = mockPool(async (sql, params) => {
+    calls.push({ sql, params });
+    if (sql.startsWith('SHOW KEYS')) {
+      return [[{ Column_name: 'id' }]];
+    }
+    if (sql.includes('information_schema.KEY_COLUMN_USAGE')) {
+      return [[{ TABLE_NAME: 'orders', COLUMN_NAME: 'user_id', REFERENCED_COLUMN_NAME: 'id' }]];
+    }
+    if (sql.startsWith('SELECT COUNT(*)')) {
+      return [[{ count: 1 }]];
+    }
+    if (sql.startsWith('DELETE FROM')) {
+      return [{}];
+    }
+    throw new Error('unexpected query');
+  });
+  await db.deleteTableRowCascade('users', '7');
+  restore();
+  const deletes = calls.filter(c => c.sql.startsWith('DELETE FROM'));
+  assert.equal(deletes.length, 2);
+  assert.ok(deletes[0].params.includes('orders'));
+  assert.ok(deletes[1].params.includes('users'));
+});


### PR DESCRIPTION
## Summary
- allow listing foreign key references for table rows
- add cascade option when deleting rows
- prompt the user to confirm deleting related records on the client
- expose an API endpoint for row references
- test reference listing and cascade deletion
- handle reference fetch errors by defaulting to cascade
- ensure cascade deletion runs in a transaction

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ef88abb0c83318104e6537c1a0844