### PR TITLE
Fix delete cascade prompt when reference check fails

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -266,8 +266,9 @@ export default function TableManager({ table, refreshId = 0 }) {
             : 'Delete row?';
         if (!window.confirm(msg)) return;
         cascade = total > 0;
-      } else if (!window.confirm('Delete row?')) {
-        return;
+      } else {
+        if (!window.confirm('Delete row and related records?')) return;
+        cascade = true;
       }
     } catch {
       if (!window.confirm('Delete row and related records?')) return;
@@ -331,8 +332,9 @@ export default function TableManager({ table, refreshId = 0 }) {
               : 'Delete row?';
           if (!window.confirm(msg)) return;
           cascade = total > 0;
-        } else if (!window.confirm('Delete row?')) {
-          return;
+        } else {
+          if (!window.confirm('Delete row and related records?')) return;
+          cascade = true;
         }
       } catch {
         if (!window.confirm('Delete row and related records?')) return;


### PR DESCRIPTION
## Summary
- handle failed reference lookup by prompting for cascade deletion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f00dffa34833198d05c04d2ed7f58