### PR TITLE
Fix workbook reload in coding table page

### DIFF
--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -60,10 +60,7 @@ export default function CodingTablesPage() {
     setExtraFields((f) => f.filter((_, i) => i !== idx));
   }
 
-  function handleFile(e) {
-    const file = e.target.files[0];
-    if (!file) return;
-    setSelectedFile(file);
+  function loadWorkbook(file) {
     file.arrayBuffer().then((ab) => {
       const wb = XLSX.read(ab);
       setWorkbook(wb);
@@ -85,6 +82,13 @@ export default function CodingTablesPage() {
       setEndYear('');
       setAutoIncStart('1');
     });
+  }
+
+  function handleFile(e) {
+    const file = e.target.files[0];
+    if (!file) return;
+    setSelectedFile(file);
+    loadWorkbook(file);
   }
 
   function handleSheetChange(e) {
@@ -124,28 +128,10 @@ export default function CodingTablesPage() {
   }
 
   function refreshFile() {
-    if (!selectedFile) return;
-    selectedFile.arrayBuffer().then((ab) => {
-      const wb = XLSX.read(ab);
-      setWorkbook(wb);
-      setSheets(wb.SheetNames);
-      const firstSheet = wb.SheetNames[0];
-      setSheet(firstSheet);
-      setHeaderRow(1);
-      setHeaders([]);
-      setIdCandidates([]);
-      setIdColumn('');
-      setNameColumn('');
-      setSql('');
-      setOtherColumns([]);
-      setUniqueFields([]);
-      setColumnTypes({});
-      setNotNullMap({});
-      setPopulateRange(false);
-      setStartYear('');
-      setEndYear('');
-      setAutoIncStart('1');
-    });
+    if (!fileInputRef.current) return;
+    // allow re-selecting the same file to pick up any changes
+    fileInputRef.current.value = '';
+    fileInputRef.current.click();
   }
 
   function extractHeaders(wb, s, row) {


### PR DESCRIPTION
## Summary
- improve `refreshFile` to reopen the file picker so the latest Excel file is used
- factor workbook loading logic into `loadWorkbook` and reuse in `handleFile`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f1c3e02448331985f1c97e208c2b3