### PR TITLE
Add ChatGPT integration example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@ DB_HOST=localhost
 DB_USER=erp
 DB_PASS=changeme
 JWT_SECRET=changeme
+
+OPENAI_API_KEY=sk-yourkey

--- a/api-server/services/chatgptService.js
+++ b/api-server/services/chatgptService.js
@@ -1,0 +1,17 @@
+import { Configuration, OpenAIApi } from 'openai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const configuration = new Configuration({ apiKey: process.env.OPENAI_API_KEY });
+const openai = new OpenAIApi(configuration);
+
+export async function askChatGPT(prompt) {
+  const res = await openai.createChatCompletion({
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: prompt }],
+  });
+  const text = res.data.choices[0].message.content.trim();
+  console.log(text);
+  return text;
+}

--- a/docs/chatgpt-api-example.md
+++ b/docs/chatgpt-api-example.md
@@ -1,0 +1,40 @@
+# ChatGPT API Integration
+
+This example shows how to connect the Node.js backend to the ChatGPT API using the [openai](https://www.npmjs.com/package/openai) library.
+
+## Installation
+
+Install the OpenAI dependency:
+
+```bash
+npm install openai
+```
+
+## Usage
+
+Create a module (e.g. `chatgpt.js`) to send a prompt and log the response. Set your OpenAI API key in `.env` as `OPENAI_API_KEY`.
+
+```js
+// chatgpt.js
+import { Configuration, OpenAIApi } from 'openai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const configuration = new Configuration({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+const openai = new OpenAIApi(configuration);
+
+export async function askChatGPT(prompt) {
+  const res = await openai.createChatCompletion({
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: prompt }],
+  });
+  const reply = res.data.choices[0].message.content.trim();
+  console.log(reply);
+  return reply;
+}
+```
+
+Call `askChatGPT` from your server code and handle the returned text as needed.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-    "scripts": {
+  "scripts": {
     "dev": "vite",
     "build:homepage": "vite build --config vite.home.config.js",
     "build:erp": "vite build --config vite.config.js",
@@ -20,7 +20,8 @@
     "react-mosaic-component": "^6.0.0",
     "jsonwebtoken": "^9.0.0",
     "multer": "^1.4.5-lts.1",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "openai": "^4.18.0"
   },
   "devDependencies": {
     "vite": "^6.3.5",


### PR DESCRIPTION
## Summary
- document how to call the ChatGPT API using the `openai` library
- add `openai` dependency
- provide example service module
- update `.env.example` with `OPENAI_API_KEY`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68510b3a295883318ca9ea315b193f39