### PR TITLE
Add OpenAI helper with floating UI

### DIFF
--- a/api-server/app.js
+++ b/api-server/app.js
@@ -14,6 +14,7 @@ import settingsRoutes from "./routes/settings.js";
 import userCompanyRoutes from "./routes/user_companies.js";
 import rolePermissionRoutes from "./routes/role_permissions.js";
 import moduleRoutes from "./routes/modules.js";
+import openaiRoutes from "./routes/openai.js";
 
 dotenv.config();
 
@@ -55,6 +56,7 @@ app.use("/api/settings", settingsRoutes);
 app.use("/api/user_companies", userCompanyRoutes);
 app.use("/api/role_permissions", rolePermissionRoutes);
 app.use("/api/modules", moduleRoutes);
+app.use("/api/openai", openaiRoutes);
 
 // Serve static React build and fallback to index.html
 // NOTE: adjust this path to where your SPA build actually lives.

--- a/api-server/routes/openai.js
+++ b/api-server/routes/openai.js
@@ -1,0 +1,16 @@
+import express from 'express';
+import { getResponse } from '../utils/openaiClient.js';
+
+const router = express.Router();
+
+router.post('/', async (req, res, next) => {
+  try {
+    const { prompt } = req.body;
+    const response = await getResponse(prompt);
+    res.json({ response });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/api-server/utils/openaiClient.js
+++ b/api-server/utils/openaiClient.js
@@ -1,0 +1,15 @@
+import dotenv from 'dotenv';
+import OpenAI from 'openai';
+
+dotenv.config();
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+export async function getResponse(prompt) {
+  if (!prompt) throw new Error('Prompt is required');
+  const completion = await client.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: prompt }],
+  });
+  return completion.choices[0].message.content.trim();
+}

--- a/docs/openai-floating-bar.html
+++ b/docs/openai-floating-bar.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>OpenAI Floating Bar</title>
+  <style>
+    #openai-bar {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      width: 280px;
+      background: #fff;
+      border: 1px solid #ccc;
+      padding: 10px;
+      z-index: 1000;
+    }
+    #openai-bar header {
+      cursor: move;
+      background: #f0f0f0;
+      padding: 5px;
+      font-weight: bold;
+    }
+    #openai-bar textarea {
+      width: 100%;
+      height: 60px;
+    }
+    #openai-bar .response {
+      margin-top: 8px;
+      max-height: 150px;
+      overflow: auto;
+    }
+  </style>
+</head>
+<body>
+<div id="openai-bar">
+  <header>Ask AI</header>
+  <textarea id="ai-input" placeholder="Type a prompt..."></textarea>
+  <button id="ai-send">Send</button>
+  <div class="response" id="ai-response"></div>
+</div>
+<script>
+const bar = document.getElementById('openai-bar');
+let drag = false, offsetX = 0, offsetY = 0;
+bar.querySelector('header').addEventListener('mousedown', e => {
+  drag = true;
+  offsetX = e.clientX - bar.offsetLeft;
+  offsetY = e.clientY - bar.offsetTop;
+});
+document.addEventListener('mouseup', () => drag = false);
+document.addEventListener('mousemove', e => {
+  if (drag) {
+    bar.style.left = e.clientX - offsetX + 'px';
+    bar.style.top = e.clientY - offsetY + 'px';
+  }
+});
+
+document.getElementById('ai-send').addEventListener('click', async () => {
+  const prompt = document.getElementById('ai-input').value;
+  const res = await fetch('/api/openai', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt })
+  });
+  const data = await res.json();
+  document.getElementById('ai-response').textContent = data.response;
+});
+</script>
+</body>
+</html>

--- a/docs/openai-usage.md
+++ b/docs/openai-usage.md
@@ -1,0 +1,25 @@
+# OpenAI API Integration
+
+This project includes a small helper module for interacting with the OpenAI API and an optional floating bar UI for experimenting with prompts.
+
+## Setup
+1. Install dependencies via `npm install`.
+2. Create a `.env` file at the project root containing your API key:
+   ```
+   OPENAI_API_KEY=sk-...
+   ```
+
+## Developer Usage
+Developers can import the helper function `getResponse` in any server side code:
+```js
+import { getResponse } from './api-server/utils/openaiClient.js';
+
+const reply = await getResponse('Hello AI');
+console.log(reply);
+```
+This returns the response text from the chat completion API using the key loaded from `.env`.
+
+## End User Interface
+The file [`docs/openai-floating-bar.html`](./openai-floating-bar.html) demonstrates a movable floating bar that calls `/api/openai` to fetch a response. Serve it along with the API server and open it in the browser. Users can type prompts and read the replies directly on the page.
+
+The bar stays visible on every page and can be dragged to any position.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react-mosaic-component": "^6.0.0",
     "jsonwebtoken": "^9.0.0",
     "multer": "^1.4.5-lts.1",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "openai": "^4.24.0"
   },
   "devDependencies": {
     "vite": "^6.3.5",


### PR DESCRIPTION
## Summary
- add `openai` dependency
- provide `openaiClient.js` with `getResponse`
- expose `/api/openai` route from Express app
- document OpenAI usage and floating bar example
- add movable floating bar HTML sample

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68511048853083319e9eb9c48b9a6990