### PR TITLE
Expose OpenAI endpoint in main server

### DIFF
--- a/api-server/server.js
+++ b/api-server/server.js
@@ -16,6 +16,7 @@ import moduleRoutes from "./routes/modules.js";
 import companyModuleRoutes from "./routes/company_modules.js";
 import tableRoutes from "./routes/tables.js";
 import codingTableRoutes from "./routes/coding_tables.js";
+import openaiRoutes from "./routes/openai.js";
 import { requireAuth } from "./middlewares/auth.js";
 
 dotenv.config();
@@ -50,6 +51,7 @@ app.use("/api/role_permissions", requireAuth, rolePermissionRoutes);
 app.use("/api/modules", requireAuth, moduleRoutes);
 app.use("/api/company_modules", requireAuth, companyModuleRoutes);
 app.use("/api/coding_tables", requireAuth, codingTableRoutes);
+app.use("/api/openai", openaiRoutes);
 app.use("/api/tables", requireAuth, tableRoutes);
 
 // Serve static React build and fallback to index.html

--- a/docs/openai-usage.md
+++ b/docs/openai-usage.md
@@ -8,6 +8,7 @@ This project includes a small helper module for interacting with the OpenAI API 
    ```
    OPENAI_API_KEY=sk-...
    ```
+3. Start the API server with `npm run serve`.
 
 ## Developer Usage
 Developers can import the helper function `getResponse` in any server side code:


### PR DESCRIPTION
## Summary
- register `/api/openai` on the primary server
- clarify docs with `npm run serve` step

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851131d198883318f73e50955f322a9