### PR TITLE
Fix undefined cookie by loading env early

### DIFF
--- a/api-server/app.js
+++ b/api-server/app.js
@@ -1,9 +1,9 @@
+import "dotenv/config";
 import path from "path";
 import { fileURLToPath } from "url";
 import express from "express";
 import cookieParser from "cookie-parser";
 import csurf from "csurf";
-import dotenv from "dotenv";
 import { testConnection } from "../db/index.js";
 import { errorHandler } from "./middlewares/errorHandler.js";
 import { logger } from "./middlewares/logging.js";
@@ -15,8 +15,6 @@ import userCompanyRoutes from "./routes/user_companies.js";
 import rolePermissionRoutes from "./routes/role_permissions.js";
 import moduleRoutes from "./routes/modules.js";
 import openaiRoutes from "./routes/openai.js";
-
-dotenv.config();
 
 // Polyfill for __dirname in ES modules
 const __filename = fileURLToPath(import.meta.url);

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -1,8 +1,8 @@
+import "dotenv/config";
 import path from "path";
 import { fileURLToPath } from "url";
 import express from "express";
 import cookieParser from "cookie-parser";
-import dotenv from "dotenv";
 import { testConnection } from "../db/index.js";
 import { errorHandler } from "./middlewares/errorHandler.js";
 import { logger } from "./middlewares/logging.js";
@@ -18,8 +18,6 @@ import tableRoutes from "./routes/tables.js";
 import codingTableRoutes from "./routes/coding_tables.js";
 import openaiRoutes from "./routes/openai.js";
 import { requireAuth } from "./middlewares/auth.js";
-
-dotenv.config();
 
 // Polyfill for __dirname in ES modules
 const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION
## Summary
- import `dotenv/config` first in both Express entry points
- remove redundant `dotenv.config` calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851264eddcc83319d4fa23a5d4b2584