### PR TITLE
Fix cookie name when env var undefined

### DIFF
--- a/api-server/controllers/authController.js
+++ b/api-server/controllers/authController.js
@@ -1,6 +1,7 @@
 import { getUserByEmpId, getUserById, updateUserPassword } from '../../db/index.js';
 import { hash } from '../services/passwordService.js';
 import * as jwtService from '../services/jwtService.js';
+import { getCookieName, getRefreshCookieName } from '../utils/cookieNames.js';
 
 export async function login(req, res, next) {
   try {
@@ -17,13 +18,13 @@ export async function login(req, res, next) {
 
     const refreshToken = jwtService.signRefresh({ id: user.id });
 
-    res.cookie(process.env.COOKIE_NAME || 'token', token, {
+    res.cookie(getCookieName(), token, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
       maxAge: jwtService.getExpiryMillis(),
     });
-    res.cookie(process.env.REFRESH_COOKIE_NAME || 'refresh_token', refreshToken, {
+    res.cookie(getRefreshCookieName(), refreshToken, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
@@ -40,8 +41,8 @@ export async function login(req, res, next) {
 }
 
 export async function logout(req, res) {
-  res.clearCookie(process.env.COOKIE_NAME || 'token');
-  res.clearCookie(process.env.REFRESH_COOKIE_NAME || 'refresh_token');
+  res.clearCookie(getCookieName());
+  res.clearCookie(getRefreshCookieName());
   res.sendStatus(204);
 }
 
@@ -81,7 +82,7 @@ export async function refresh(req, res) {
       empid: user.empid,
       role: user.role,
     });
-    res.cookie(process.env.COOKIE_NAME || 'token', newAccess, {
+    res.cookie(getCookieName(), newAccess, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
@@ -93,8 +94,8 @@ export async function refresh(req, res) {
       role: user.role,
     });
   } catch (err) {
-    res.clearCookie(process.env.COOKIE_NAME || 'token');
-    res.clearCookie(process.env.REFRESH_COOKIE_NAME || 'refresh_token');
+    res.clearCookie(getCookieName());
+    res.clearCookie(getRefreshCookieName());
     return res.status(401).json({ message: 'Invalid or expired refresh token' });
   }
 }

--- a/api-server/middlewares/auth.js
+++ b/api-server/middlewares/auth.js
@@ -1,9 +1,10 @@
 // api-server/middlewares/auth.js
 import * as jwtService from '../services/jwtService.js';
+import { getCookieName } from '../utils/cookieNames.js';
 
 export function requireAuth(req, res, next) {
   // Read from req.cookies (not req.signedCookies) because we didn't sign it
-  const token = req.cookies?.[process.env.COOKIE_NAME || 'token'];
+  const token = req.cookies?.[getCookieName()];
   if (!token) {
     return res.status(401).json({ message: 'Authentication required' });
   }
@@ -15,7 +16,7 @@ export function requireAuth(req, res, next) {
     next();
   } catch (err) {
     console.error('JWT verification failed:', err);
-    res.clearCookie(process.env.COOKIE_NAME || 'token');
+    res.clearCookie(getCookieName());
     return res.status(401).json({ message: 'Invalid or expired token' });
   }
 }

--- a/api-server/middlewares/logging.js
+++ b/api-server/middlewares/logging.js
@@ -1,15 +1,14 @@
 import * as jwtService from '../services/jwtService.js';
 import { logActivity } from '../utils/activityLog.js';
+import { getCookieName } from '../utils/cookieNames.js';
 
 export function logger(req, res, next) {
   let user = 'anonymous';
   if (req.user) {
     user = req.user.empid || req.user.id;
-  } else if (req.cookies?.[process.env.COOKIE_NAME || 'token']) {
+  } else if (req.cookies?.[getCookieName()]) {
     try {
-      const payload = jwtService.verify(
-        req.cookies[process.env.COOKIE_NAME || 'token']
-      );
+      const payload = jwtService.verify(req.cookies[getCookieName()]);
       user = payload.empid || payload.id;
     } catch {}
   }

--- a/api-server/utils/cookieNames.js
+++ b/api-server/utils/cookieNames.js
@@ -1,0 +1,9 @@
+export function getCookieName() {
+  const name = process.env.COOKIE_NAME;
+  return name && name !== 'undefined' ? name : 'token';
+}
+
+export function getRefreshCookieName() {
+  const name = process.env.REFRESH_COOKIE_NAME;
+  return name && name !== 'undefined' ? name : 'refresh_token';
+}


### PR DESCRIPTION
## Summary
- avoid setting cookies with name `undefined`
- centralize cookie name logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685127e78f948331acc6db752d744ba1