### PR TITLE
Fix expired token cleanup

### DIFF
--- a/api-server/controllers/authController.js
+++ b/api-server/controllers/authController.js
@@ -41,8 +41,13 @@ export async function login(req, res, next) {
 }
 
 export async function logout(req, res) {
-  res.clearCookie(getCookieName());
-  res.clearCookie(getRefreshCookieName());
+  const opts = {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+  };
+  res.clearCookie(getCookieName(), opts);
+  res.clearCookie(getRefreshCookieName(), opts);
   res.sendStatus(204);
 }
 
@@ -94,8 +99,13 @@ export async function refresh(req, res) {
       role: user.role,
     });
   } catch (err) {
-    res.clearCookie(getCookieName());
-    res.clearCookie(getRefreshCookieName());
+    const opts = {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+    };
+    res.clearCookie(getCookieName(), opts);
+    res.clearCookie(getRefreshCookieName(), opts);
     return res.status(401).json({ message: 'Invalid or expired refresh token' });
   }
 }

--- a/api-server/middlewares/auth.js
+++ b/api-server/middlewares/auth.js
@@ -1,6 +1,6 @@
 // api-server/middlewares/auth.js
 import * as jwtService from '../services/jwtService.js';
-import { getCookieName } from '../utils/cookieNames.js';
+import { getCookieName, getRefreshCookieName } from '../utils/cookieNames.js';
 
 export function requireAuth(req, res, next) {
   // Read from req.cookies (not req.signedCookies) because we didn't sign it
@@ -15,8 +15,38 @@ export function requireAuth(req, res, next) {
     req.user = payload; // { id, empid, role, iat, exp }
     next();
   } catch (err) {
+    let refreshed = false;
+    if (err.name === 'TokenExpiredError') {
+      const rToken = req.cookies?.[getRefreshCookieName()];
+      if (rToken) {
+        try {
+          const rPayload = jwtService.verifyRefresh(rToken);
+          const newAccess = jwtService.sign({
+            id: rPayload.id,
+            empid: rPayload.empid,
+            role: rPayload.role,
+          });
+          res.cookie(getCookieName(), newAccess, {
+            httpOnly: true,
+            secure: process.env.NODE_ENV === 'production',
+            sameSite: 'lax',
+            maxAge: jwtService.getExpiryMillis(),
+          });
+          req.user = jwtService.verify(newAccess);
+          refreshed = true;
+        } catch {}
+      }
+    }
+    if (refreshed) return next();
+
     console.error('JWT verification failed:', err);
-    res.clearCookie(getCookieName());
+    const opts = {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+    };
+    res.clearCookie(getCookieName(), opts);
+    res.clearCookie(getRefreshCookieName(), opts);
     return res.status(401).json({ message: 'Invalid or expired token' });
   }
 }


### PR DESCRIPTION
## Summary
- attempt automatic refresh if token expired
- clear auth cookies with full options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68512a00dc5083319761a319b81cd53e