### PR TITLE
Fix undefined cookie name

### DIFF
--- a/api-server/utils/cookieNames.js
+++ b/api-server/utils/cookieNames.js
@@ -1,6 +1,6 @@
 export function getCookieName() {
   const name = process.env.COOKIE_NAME;
-  return name && name !== 'undefined' ? name : 'token';
+  return name && name !== 'undefined' ? name : 'erp_token';
 }
 
 export function getRefreshCookieName() {


### PR DESCRIPTION
## Summary
- ensure cookie name fallback is `erp_token`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68512b2f6e988331bf5d16954143e3ce