### PR TITLE
Add floating ChatGPT bar to homepage

### DIFF
--- a/src/homepage/index.css
+++ b/src/homepage/index.css
@@ -7,3 +7,30 @@ nav { max-width:960px; margin:0 auto; display:flex; justify-content:space-betwee
 .button:hover { background:#0056b3; }
 main { max-width:960px; margin:2rem auto; padding:0 1rem; }
 footer { text-align:center; padding:1rem; background:#f1f1f1; font-size:0.9rem; }
+
+/* Styles for the floating OpenAI bar */
+#openai-bar {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 280px;
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 10px;
+  z-index: 1000;
+}
+#openai-bar header {
+  cursor: move;
+  background: #f0f0f0;
+  padding: 5px;
+  font-weight: bold;
+}
+#openai-bar textarea {
+  width: 100%;
+  height: 60px;
+}
+#openai-bar .response {
+  margin-top: 8px;
+  max-height: 150px;
+  overflow: auto;
+}

--- a/src/homepage/index.html
+++ b/src/homepage/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>ERP Home</title>
+  <link rel="stylesheet" href="./index.css">
 </head>
 <body>
   <h1>Welcome to Our Service</h1>
@@ -18,11 +19,43 @@
     <li><a href="https://erp.mgt.mn/">ERP Portal</a></li>
     <li><a href="https://customer.mgt.mn/">Customer Portal</a></li>
   </ul>
+  <!-- Floating OpenAI Bar -->
+  <div id="openai-bar">
+    <header>Ask AI</header>
+    <textarea id="ai-input" placeholder="Type a prompt..."></textarea>
+    <button id="ai-send">Send</button>
+    <div class="response" id="ai-response"></div>
+  </div>
   <script>
     document.getElementById('portalForm').addEventListener('submit', function(e) {
       e.preventDefault();
       var url = document.getElementById('portalSelect').value;
       window.location.href = url;
+    });
+    // Simple draggable floating bar for OpenAI chat
+    const bar = document.getElementById('openai-bar');
+    let drag = false, offsetX = 0, offsetY = 0;
+    bar.querySelector('header').addEventListener('mousedown', e => {
+      drag = true;
+      offsetX = e.clientX - bar.offsetLeft;
+      offsetY = e.clientY - bar.offsetTop;
+    });
+    document.addEventListener('mouseup', () => drag = false);
+    document.addEventListener('mousemove', e => {
+      if (drag) {
+        bar.style.left = e.clientX - offsetX + 'px';
+        bar.style.top = e.clientY - offsetY + 'px';
+      }
+    });
+    document.getElementById('ai-send').addEventListener('click', async () => {
+      const prompt = document.getElementById('ai-input').value;
+      const res = await fetch('/api/openai', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt })
+      });
+      const data = await res.json();
+      document.getElementById('ai-response').textContent = data.response;
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- include home page stylesheet
- add movable OpenAI bar in the homepage HTML
- style the new bar via CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685139684b808331bf697ae3bd8103a3