### PR TITLE
Add Mongolian headers mapping

### DIFF
--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -9,6 +9,7 @@ import {
   listTableRelationships,
   listTableColumns,
   listTableColumnMeta,
+  saveTableColumnLabels,
 } from '../../db/index.js';
 let bcrypt;
 try {
@@ -112,6 +113,17 @@ export async function getRowReferences(req, res, next) {
   try {
     const refs = await listRowReferences(req.params.table, req.params.id);
     res.json(refs);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function saveColumnLabels(req, res, next) {
+  try {
+    if (req.user.role !== 'admin') return res.sendStatus(403);
+    const labels = req.body.labels || {};
+    await saveTableColumnLabels(req.params.table, labels);
+    res.sendStatus(204);
   } catch (err) {
     next(err);
   }

--- a/api-server/routes/tables.js
+++ b/api-server/routes/tables.js
@@ -4,6 +4,7 @@ import {
   getTableRows,
   getTableRelations,
   getTableColumnsMeta,
+  saveColumnLabels,
   updateRow,
   addRow,
   deleteRow,
@@ -17,6 +18,7 @@ router.get('/', requireAuth, getTables);
 // More specific routes must be defined before the generic ':table' pattern
 router.get('/:table/relations', requireAuth, getTableRelations);
 router.get('/:table/columns', requireAuth, getTableColumnsMeta);
+router.put('/:table/labels', requireAuth, saveColumnLabels);
 router.get('/:table/:id/references', requireAuth, getRowReferences);
 router.put('/:table/:id', requireAuth, updateRow);
 router.delete('/:table/:id', requireAuth, deleteRow);

--- a/db/migrations/2025-06-19_table_column_labels.sql
+++ b/db/migrations/2025-06-19_table_column_labels.sql
@@ -1,0 +1,7 @@
+-- Store Mongolian labels for table columns
+CREATE TABLE IF NOT EXISTS table_column_labels (
+  table_name VARCHAR(100) NOT NULL,
+  column_name VARCHAR(100) NOT NULL,
+  mn_label VARCHAR(255) NOT NULL,
+  PRIMARY KEY (table_name, column_name)
+);

--- a/src/erp.mgt.mn/components/RowDetailModal.jsx
+++ b/src/erp.mgt.mn/components/RowDetailModal.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function RowDetailModal({ visible, onClose, row = {}, columns = [], relations = {}, references = [] }) {
+export default function RowDetailModal({ visible, onClose, row = {}, columns = [], relations = {}, references = [], labels = {} }) {
   if (!visible) return null;
 
   const overlay = {
@@ -42,7 +42,7 @@ export default function RowDetailModal({ visible, onClose, row = {}, columns = [
           <tbody>
             {cols.map((c) => (
               <tr key={c}>
-                <th style={{ textAlign: 'left', padding: '0.25rem', border: '1px solid #d1d5db' }}>{c}</th>
+                <th style={{ textAlign: 'left', padding: '0.25rem', border: '1px solid #d1d5db' }}>{labels[c] || c}</th>
                 <td style={{ padding: '0.25rem', border: '1px solid #d1d5db' }}>
                   {relations[c] ? labelMap[c][row[c]] || String(row[c]) : String(row[c])}
                 </td>

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -8,6 +8,7 @@ export default function RowFormModal({
   row,
   relations = {},
   disabledFields = [],
+  labels = {},
 }) {
   const [formVals, setFormVals] = useState(() => {
     const init = {};
@@ -61,7 +62,9 @@ export default function RowFormModal({
         >
           {columns.map((c) => (
             <div key={c} style={{ marginBottom: '0.75rem' }}>
-              <label style={{ display: 'block', marginBottom: '0.25rem' }}>{c}</label>
+              <label style={{ display: 'block', marginBottom: '0.25rem' }}>
+                {labels[c] || c}
+              </label>
               {Array.isArray(relations[c]) ? (
                 <select
                   value={formVals[c]}


### PR DESCRIPTION
## Summary
- allow storing Mongolian column labels
- expose API to update column labels
- update coding table upload to send header map
- show Mongolian labels in table manager and row modals
- let admins edit labels from table manager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685166ace7248331b130ddf6baf56834