### PR TITLE
Add table display field configuration

### DIFF
--- a/api-server/routes/display_fields.js
+++ b/api-server/routes/display_fields.js
@@ -1,0 +1,33 @@
+import express from 'express';
+import { getAllDisplayFields, getDisplayFields, setDisplayFields } from '../services/displayFieldConfig.js';
+import { requireAuth } from '../middlewares/auth.js';
+
+const router = express.Router();
+
+router.get('/', requireAuth, async (req, res, next) => {
+  try {
+    const table = req.query.table;
+    if (table) {
+      const config = await getDisplayFields(table);
+      res.json(config);
+    } else {
+      const configs = await getAllDisplayFields();
+      res.json(configs);
+    }
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/', requireAuth, async (req, res, next) => {
+  try {
+    const { table, idField, displayFields } = req.body;
+    if (!table) return res.status(400).json({ message: 'table is required' });
+    await setDisplayFields(table, { idField, displayFields });
+    res.sendStatus(204);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -18,6 +18,7 @@ import tableRoutes from "./routes/tables.js";
 import codingTableRoutes from "./routes/coding_tables.js";
 import openaiRoutes from "./routes/openai.js";
 import headerMappingRoutes from "./routes/header_mappings.js";
+import displayFieldRoutes from "./routes/display_fields.js";
 import { requireAuth } from "./middlewares/auth.js";
 
 // Polyfill for __dirname in ES modules
@@ -51,6 +52,7 @@ app.use("/api/modules", requireAuth, moduleRoutes);
 app.use("/api/company_modules", requireAuth, companyModuleRoutes);
 app.use("/api/coding_tables", requireAuth, codingTableRoutes);
 app.use("/api/header_mappings", requireAuth, headerMappingRoutes);
+app.use("/api/display_fields", requireAuth, displayFieldRoutes);
 app.use("/api/openai", openaiRoutes);
 app.use("/api/tables", requireAuth, tableRoutes);
 

--- a/api-server/services/displayFieldConfig.js
+++ b/api-server/services/displayFieldConfig.js
@@ -1,0 +1,37 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+const filePath = path.join(process.cwd(), 'config', 'tableDisplayFields.json');
+
+async function readConfig() {
+  try {
+    const data = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(data);
+  } catch {
+    return {};
+  }
+}
+
+async function writeConfig(cfg) {
+  await fs.writeFile(filePath, JSON.stringify(cfg, null, 2));
+}
+
+export async function getDisplayFields(table) {
+  const cfg = await readConfig();
+  return cfg[table] || { idField: null, displayFields: [] };
+}
+
+export async function getAllDisplayFields() {
+  return readConfig();
+}
+
+export async function setDisplayFields(table, { idField, displayFields }) {
+  if (!Array.isArray(displayFields)) displayFields = [];
+  if (displayFields.length > 20) {
+    throw new Error('Up to 20 display fields can be configured');
+  }
+  const cfg = await readConfig();
+  cfg[table] = { idField, displayFields };
+  await writeConfig(cfg);
+  return cfg[table];
+}

--- a/config/tableDisplayFields.json
+++ b/config/tableDisplayFields.json
@@ -1,0 +1,6 @@
+{
+  "tbl_employee": {
+    "idField": "emp_id",
+    "displayFields": ["emp_fname", "emp_lname"]
+  }
+}

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -31,9 +31,11 @@ This document outlines the roadmap, scope, architecture, milestones, and deliver
    - Launchable modules (SalesDashboard, GLInquiry, etc.) in resizable tiles.  
    - Layout persistence per user.
 
-5. **Settings**  
-   - Global & tenant-specific configs.  
- - Feature toggles (e.g. enable/disable mosaic).
+5. **Settings**
+   - Global & tenant-specific configs.
+   - Feature toggles (e.g. enable/disable mosaic).
+   - `tableDisplayFields` JSON file maps table names to up to 20 user-facing fields
+     for dynamic forms.
 
 6. **Coding Tables Upload**
    - Upload Excel sheets to create simple lookup tables.

--- a/docs/table-display-fields.md
+++ b/docs/table-display-fields.md
@@ -1,0 +1,17 @@
+# Table Display Field Configuration
+
+Dynamic forms rely on a per-table configuration that declares which columns are shown to the user.  Each table can specify an `idField` used for storing references and a list of up to **20** `displayFields` that are rendered in selection lists or forms.
+
+The configuration file lives at `config/tableDisplayFields.json` and has the following structure:
+
+```json
+{
+  "tbl_employee": {
+    "idField": "emp_id",
+    "displayFields": ["emp_fname", "emp_lname"]
+  }
+}
+```
+
+Applications can fetch or update this information via `/api/display_fields`.
+

--- a/tests/db/displayFieldConfig.test.js
+++ b/tests/db/displayFieldConfig.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import path from 'path';
+import { getDisplayFields, setDisplayFields } from '../../api-server/services/displayFieldConfig.js';
+
+const filePath = path.join(process.cwd(), 'config', 'tableDisplayFields.json');
+
+function withTempFile() {
+  return fs.readFile(filePath, 'utf8')
+    .catch(() => '{}')
+    .then((orig) => ({
+      orig,
+      restore: () => fs.writeFile(filePath, orig),
+    }));
+}
+
+await test('setDisplayFields enforces limit', async (t) => {
+  const { orig, restore } = await withTempFile();
+  await fs.writeFile(filePath, '{}');
+  const fields = Array.from({ length: 21 }, (_, i) => `f${i}`);
+  await assert.rejects(() => setDisplayFields('tbl', { idField: 'id', displayFields: fields }));
+  await restore();
+});
+
+await test('set and get display fields', async (t) => {
+  const { orig, restore } = await withTempFile();
+  await fs.writeFile(filePath, '{}');
+  await setDisplayFields('tbl', { idField: 'id', displayFields: ['a', 'b'] });
+  const cfg = await getDisplayFields('tbl');
+  assert.deepEqual(cfg, { idField: 'id', displayFields: ['a', 'b'] });
+  await restore();
+});


### PR DESCRIPTION
## Summary
- create `tableDisplayFields.json` config for mapping table id and display fields
- add service & API route to read/write display field settings
- document configuration in PROJECT_PLAN and in a new markdown doc
- unit tests for the new config utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851ab892150833181ddfda3832162e0