### PR TITLE
Add personalized dashboard route and UI

### DIFF
--- a/api-server/app.js
+++ b/api-server/app.js
@@ -15,6 +15,7 @@ import userCompanyRoutes from "./routes/user_companies.js";
 import rolePermissionRoutes from "./routes/role_permissions.js";
 import moduleRoutes from "./routes/modules.js";
 import openaiRoutes from "./routes/openai.js";
+import dashboardRoutes from "./routes/dashboard.js";
 import headerMappingRoutes from "./routes/header_mappings.js";
 
 // Polyfill for __dirname in ES modules
@@ -57,6 +58,7 @@ app.use("/api/role_permissions", rolePermissionRoutes);
 app.use("/api/modules", moduleRoutes);
 app.use("/api/header_mappings", headerMappingRoutes);
 app.use("/api/openai", openaiRoutes);
+app.use("/api/dashboard", dashboardRoutes);
 
 // Serve static React build and fallback to index.html
 // NOTE: adjust this path to where your SPA build actually lives.

--- a/api-server/controllers/dashboardController.js
+++ b/api-server/controllers/dashboardController.js
@@ -1,0 +1,10 @@
+import { fetchDashboard } from '../services/dashboardService.js';
+
+export async function getUserDashboard(req, res, next) {
+  try {
+    const data = await fetchDashboard(req.user.empid);
+    res.json(data);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/api-server/data/dashboard.js
+++ b/api-server/data/dashboard.js
@@ -1,0 +1,20 @@
+export const dashboards = {
+  E1: {
+    tasks: [
+      { id: 1, title: 'Complete sales report', progress: 80, due: '2025-06-30' },
+      { id: 2, title: 'Prepare Q2 presentation', progress: 40, due: '2025-06-20' },
+    ],
+    projects: [
+      { id: 1, name: 'ERP Rollout', progress: 50 },
+      { id: 2, name: 'Website Redesign', progress: 20 },
+    ],
+    notifications: [
+      { id: 1, message: 'Server maintenance this Friday 7pm.' },
+      { id: 2, message: 'Policy review meeting next week.' },
+    ],
+  },
+};
+
+export function getDashboard(empid) {
+  return dashboards[empid] || { tasks: [], projects: [], notifications: [] };
+}

--- a/api-server/routes/dashboard.js
+++ b/api-server/routes/dashboard.js
@@ -1,0 +1,9 @@
+import express from 'express';
+import { getUserDashboard } from '../controllers/dashboardController.js';
+import { requireAuth } from '../middlewares/auth.js';
+
+const router = express.Router();
+
+router.get('/', requireAuth, getUserDashboard);
+
+export default router;

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -17,6 +17,7 @@ import companyModuleRoutes from "./routes/company_modules.js";
 import tableRoutes from "./routes/tables.js";
 import codingTableRoutes from "./routes/coding_tables.js";
 import openaiRoutes from "./routes/openai.js";
+import dashboardRoutes from "./routes/dashboard.js";
 import headerMappingRoutes from "./routes/header_mappings.js";
 import displayFieldRoutes from "./routes/display_fields.js";
 import { requireAuth } from "./middlewares/auth.js";
@@ -54,6 +55,7 @@ app.use("/api/coding_tables", requireAuth, codingTableRoutes);
 app.use("/api/header_mappings", requireAuth, headerMappingRoutes);
 app.use("/api/display_fields", requireAuth, displayFieldRoutes);
 app.use("/api/openai", openaiRoutes);
+app.use("/api/dashboard", requireAuth, dashboardRoutes);
 app.use("/api/tables", requireAuth, tableRoutes);
 
 // Serve static React build and fallback to index.html

--- a/api-server/services/dashboardService.js
+++ b/api-server/services/dashboardService.js
@@ -1,0 +1,13 @@
+import { getDashboard } from '../data/dashboard.js';
+import { getResponse } from '../utils/openaiClient.js';
+
+export async function fetchDashboard(empid) {
+  const data = getDashboard(empid);
+  try {
+    const prompt = `Summarize these tasks, projects and notifications: ${JSON.stringify(data)}`;
+    const summary = await getResponse(prompt);
+    return { ...data, summary };
+  } catch {
+    return { ...data, summary: null };
+  }
+}

--- a/src/erp.mgt.mn/windows/SalesDashboard.jsx
+++ b/src/erp.mgt.mn/windows/SalesDashboard.jsx
@@ -1,5 +1,70 @@
-import React from 'react';
+import React, { useContext, useEffect, useState } from 'react';
+import { AuthContext } from '../context/AuthContext.jsx';
 
 export default function SalesDashboard() {
-  return <div>Sales Dashboard Module</div>;
+  const { user } = useContext(AuthContext);
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/dashboard', { credentials: 'include' });
+        if (res.ok) {
+          setData(await res.json());
+        }
+      } catch (err) {
+        console.error('Failed to load dashboard', err);
+      }
+    }
+    if (user) load();
+  }, [user]);
+
+  if (!user) return <div>Please login to view the dashboard.</div>;
+  if (!data) return <div>Loading dashboard...</div>;
+
+  return (
+    <div>
+      <h3>Dashboard for {user.empid}</h3>
+
+      <section>
+        <h4>Tasks</h4>
+        <ul>
+          {data.tasks.map((t) => (
+            <li key={t.id}>
+              <strong>{t.title}</strong>
+              {t.progress !== undefined && ` – ${t.progress}%`}
+              {t.due && ` (due ${t.due})`}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h4>Projects</h4>
+        <ul>
+          {data.projects.map((p) => (
+            <li key={p.id}>
+              {p.name} – {p.progress}%
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h4>Notifications</h4>
+        <ul>
+          {data.notifications.map((n) => (
+            <li key={n.id}>{n.message}</li>
+          ))}
+        </ul>
+      </section>
+
+      {data.summary && (
+        <section>
+          <h4>AI Summary</h4>
+          <p>{data.summary}</p>
+        </section>
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add API route to serve personalized dashboard data
- summarize tasks and notifications with OpenAI
- display user-specific tasks, projects and notifications in SalesDashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685267d63d84833196bfff02ec2f435b