### PR TITLE
Integrate table display field config

### DIFF
--- a/config/tableDisplayFields.json
+++ b/config/tableDisplayFields.json
@@ -2,7 +2,7 @@
   "tbl_employee": {
     "idField": "emp_id",
     "displayFields": ["emp_fname", "emp_lname"]
-  }
+  },
   "users": {
     "idField": "empid",
     "displayFields": ["emp_fname", "emp_lname"]

--- a/docs/table-display-fields.md
+++ b/docs/table-display-fields.md
@@ -15,3 +15,9 @@ The configuration file lives at `config/tableDisplayFields.json` and has the fol
 
 Applications can fetch or update this information via `/api/display_fields`.
 
+When a table contains a foreign key to another table, dynamic forms look up the
+target table's configuration. If a mapping exists, option labels are composed
+from the listed `displayFields` and the underlying value comes from `idField`.
+If no configuration is found the first two columns of the row are used as the
+label.
+

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -97,18 +97,34 @@ export default function TableManager({ table, refreshId = 0 }) {
         for (const [col, rel] of Object.entries(map)) {
           try {
             const params = new URLSearchParams({ perPage: 100 });
-            const refRes = await fetch(
-              `/api/tables/${encodeURIComponent(rel.table)}?${params.toString()}`,
-              { credentials: 'include' },
-            );
+            const [cfgRes, refRes] = await Promise.all([
+              fetch(
+                `/api/display_fields?table=${encodeURIComponent(rel.table)}`,
+                { credentials: 'include' },
+              ).catch(() => null),
+              fetch(
+                `/api/tables/${encodeURIComponent(rel.table)}?${params.toString()}`,
+                { credentials: 'include' },
+              ),
+            ]);
+            const cfg = cfgRes && cfgRes.ok ? await cfgRes.json() : {};
             const json = await refRes.json();
             if (Array.isArray(json.rows)) {
               dataMap[col] = json.rows.map((row) => {
-                const cells = Object.values(row).slice(0, 2);
-                return {
-                  value: row[rel.column],
-                  label: cells.join(' - '),
-                };
+                const idField = cfg.idField || rel.column;
+                const value = row[idField];
+                let label;
+                if (Array.isArray(cfg.displayFields) && cfg.displayFields.length > 0) {
+                  label = cfg.displayFields
+                    .map((f) => row[f])
+                    .filter((v) => v !== undefined && v !== null)
+                    .join(' - ');
+                  if (!label) label = String(value);
+                } else {
+                  const cells = Object.values(row).slice(0, 2);
+                  label = cells.join(' - ');
+                }
+                return { value, label };
               });
             }
           } catch {

--- a/tests/db/displayFieldConfig.test.js
+++ b/tests/db/displayFieldConfig.test.js
@@ -31,3 +31,11 @@ await test('set and get display fields', async (t) => {
   assert.deepEqual(cfg, { idField: 'id', displayFields: ['a', 'b'] });
   await restore();
 });
+
+await test('getDisplayFields returns defaults when missing', async (t) => {
+  const { orig, restore } = await withTempFile();
+  await fs.writeFile(filePath, '{}');
+  const cfg = await getDisplayFields('unknown');
+  assert.deepEqual(cfg, { idField: null, displayFields: [] });
+  await restore();
+});


### PR DESCRIPTION
## Summary
- enable JSON for table display fields
- document how forms use display field config
- use `/api/display_fields` in TableManager relations
- test default display field behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852ab7d00c483319c42682c447a3ac5