### PR TITLE
Fix display fields for related table

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -121,7 +121,6 @@ export default function TableManager({ table, refreshId = 0 }) {
                 let label = null;
                 if (
                   cfg &&
-                  cfg.idField === rel.column &&
                   Array.isArray(cfg.displayFields) &&
                   cfg.displayFields.length > 0
                 ) {


### PR DESCRIPTION
## Summary
- ensure related table fields always use configured `displayFields`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852df6df1088331a32554dea9116b94