### PR TITLE
Fix display fields endpoint

### DIFF
--- a/api-server/app.js
+++ b/api-server/app.js
@@ -16,6 +16,7 @@ import rolePermissionRoutes from "./routes/role_permissions.js";
 import moduleRoutes from "./routes/modules.js";
 import openaiRoutes from "./routes/openai.js";
 import headerMappingRoutes from "./routes/header_mappings.js";
+import displayFieldRoutes from "./routes/display_fields.js";
 
 // Polyfill for __dirname in ES modules
 const __filename = fileURLToPath(import.meta.url);
@@ -57,6 +58,7 @@ app.use("/api/role_permissions", rolePermissionRoutes);
 app.use("/api/modules", moduleRoutes);
 app.use("/api/header_mappings", headerMappingRoutes);
 app.use("/api/openai", openaiRoutes);
+app.use("/api/display_fields", displayFieldRoutes);
 
 // Serve static React build and fallback to index.html
 // NOTE: adjust this path to where your SPA build actually lives.

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -18,6 +18,7 @@ import tableRoutes from "./routes/tables.js";
 import codingTableRoutes from "./routes/coding_tables.js";
 import openaiRoutes from "./routes/openai.js";
 import headerMappingRoutes from "./routes/header_mappings.js";
+import displayFieldRoutes from "./routes/display_fields.js";
 import { requireAuth } from "./middlewares/auth.js";
 
 // Polyfill for __dirname in ES modules
@@ -52,6 +53,7 @@ app.use("/api/company_modules", requireAuth, companyModuleRoutes);
 app.use("/api/coding_tables", requireAuth, codingTableRoutes);
 app.use("/api/header_mappings", requireAuth, headerMappingRoutes);
 app.use("/api/openai", openaiRoutes);
+app.use("/api/display_fields", displayFieldRoutes);
 app.use("/api/tables", requireAuth, tableRoutes);
 
 // Serve static React build and fallback to index.html


### PR DESCRIPTION
## Summary
- mount the display_fields API route so TableManager can load its config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852e3c04a988331844ef9eec1d0c103