### PR TITLE
Fix varchar length detection

### DIFF
--- a/api-server/controllers/codingTableController.js
+++ b/api-server/controllers/codingTableController.js
@@ -48,13 +48,20 @@ export function detectType(name, vals) {
     if (!Number.isNaN(n)) {
       const str = String(v);
       const digits = str.replace(/[-.]/g, '');
-      if (digits.length > 8) return 'VARCHAR(255)';
+      if (digits.length > 8) break;
       if (str.includes('.')) return 'DECIMAL(10,2)';
       return 'INT';
     }
     break;
   }
-  return 'VARCHAR(255)';
+  let maxLen = 1;
+  for (const v of vals) {
+    if (v === undefined || v === null) continue;
+    const len = String(v).length;
+    if (len > maxLen) maxLen = len;
+  }
+  if (maxLen > 255) maxLen = 255;
+  return `VARCHAR(${maxLen})`;
 }
 
 function defaultValForType(type) {

--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -237,13 +237,20 @@ export default function CodingTablesPage() {
       if (!Number.isNaN(n)) {
         const str = String(v);
         const digits = str.replace(/[-.]/g, '');
-        if (digits.length > 8) return 'VARCHAR(255)';
+        if (digits.length > 8) break;
         if (str.includes('.')) return 'DECIMAL(10,2)';
         return 'INT';
       }
       break;
     }
-    return 'VARCHAR(255)';
+    let maxLen = 1;
+    for (const v of vals) {
+      if (v === undefined || v === null) continue;
+      const len = String(v).length;
+      if (len > maxLen) maxLen = len;
+    }
+    if (maxLen > 255) maxLen = 255;
+    return `VARCHAR(${maxLen})`;
   }
 
   function parseExcelDate(val) {

--- a/tests/api/detectType.test.js
+++ b/tests/api/detectType.test.js
@@ -10,3 +10,8 @@ test('detectType ignores per when not preceded by underscore', () => {
   assert.notEqual(detectType('percentage', []), 'DECIMAL(5,2)');
   assert.notEqual(detectType('person', []), 'DECIMAL(5,2)');
 });
+
+test('detectType limits VARCHAR length to max data length', () => {
+  const vals = ['a', 'abcd', 'abc'];
+  assert.equal(detectType('name', vals), 'VARCHAR(4)');
+});


### PR DESCRIPTION
## Summary
- allow numeric overflow to fall back to string
- size VARCHAR columns to max data length
- test for varchar length detection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852fb0507188331aae47494a585528a