### PR TITLE
Fix varchar limit

### DIFF
--- a/api-server/controllers/codingTableController.js
+++ b/api-server/controllers/codingTableController.js
@@ -60,7 +60,6 @@ export function detectType(name, vals) {
     const len = String(v).length;
     if (len > maxLen) maxLen = len;
   }
-  if (maxLen > 255) maxLen = 255;
   return `VARCHAR(${maxLen})`;
 }
 

--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -249,7 +249,6 @@ export default function CodingTablesPage() {
       const len = String(v).length;
       if (len > maxLen) maxLen = len;
     }
-    if (maxLen > 255) maxLen = 255;
     return `VARCHAR(${maxLen})`;
   }
 


### PR DESCRIPTION
## Summary
- remove hardcoded varchar length cap from coding table generator

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852fe7d5cac8331ace4aade9f22d445