### PR TITLE
Show finance transactions

### DIFF
--- a/api-server/controllers/formController.js
+++ b/api-server/controllers/formController.js
@@ -1,8 +1,13 @@
 import fs from 'fs';
 import path from 'path';
+
 export function getFormSchemas(req, res) {
-  const schemasDir = path.resolve('config/formSchemas');
-  const files = fs.readdirSync(schemasDir);
-  const schemas = files.map(f => JSON.parse(fs.readFileSync(path.join(schemasDir, f))));
-  res.json(schemas);
+  const cfgPath = path.resolve('config/forms.json');
+  let data = { forms: [] };
+  try {
+    data = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+  } catch {
+    // ignore
+  }
+  res.json(data.forms || []);
 }

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -19,6 +19,7 @@ import codingTableRoutes from "./routes/coding_tables.js";
 import openaiRoutes from "./routes/openai.js";
 import headerMappingRoutes from "./routes/header_mappings.js";
 import displayFieldRoutes from "./routes/display_fields.js";
+import formsRoutes from "./routes/forms.js";
 import transactionFormRoutes from "./routes/transaction_forms.js";
 import { requireAuth } from "./middlewares/auth.js";
 
@@ -55,6 +56,7 @@ app.use("/api/coding_tables", requireAuth, codingTableRoutes);
 app.use("/api/header_mappings", requireAuth, headerMappingRoutes);
 app.use("/api/openai", openaiRoutes);
 app.use("/api/display_fields", displayFieldRoutes);
+app.use("/api/forms", formsRoutes);
 app.use("/api/transaction_forms", transactionFormRoutes);
 app.use("/api/tables", requireAuth, tableRoutes);
 

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -1,16 +1,26 @@
 import React, { useState, useEffect, useContext } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext.jsx';
 
 export default function FinanceTransactions() {
   const { user, company } = useContext(AuthContext);
   const [configs, setConfigs] = useState({});
-  const [table, setTable] = useState('');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [table, setTable] = useState(() => searchParams.get('table') || '');
   const [columns, setColumns] = useState([]);
   const [rows, setRows] = useState([]);
   const [config, setConfig] = useState(null);
   const [showForm, setShowForm] = useState(false);
   const [formVals, setFormVals] = useState({});
   const [editingId, setEditingId] = useState(null);
+
+  useEffect(() => {
+    if (table) {
+      setSearchParams({ table });
+    } else {
+      setSearchParams({});
+    }
+  }, [table, setSearchParams]);
 
   useEffect(() => {
     fetch('/api/transaction_forms', { credentials: 'include' })
@@ -104,6 +114,16 @@ export default function FinanceTransactions() {
   }
 
   const fields = config?.visibleFields?.length ? config.visibleFields : columns;
+  const transactionNames = Object.keys(configs);
+
+  if (transactionNames.length === 0) {
+    return (
+      <div>
+        <h2>Finance Transactions</h2>
+        <p>No transactions configured.</p>
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/src/erp.mgt.mn/pages/Forms.jsx
+++ b/src/erp.mgt.mn/pages/Forms.jsx
@@ -1,28 +1,31 @@
 // src/erp.mgt.mn/pages/Forms.jsx
 import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export default function Forms() {
-  const [formsList, setFormsList] = useState([]);
+  const [transactions, setTransactions] = useState([]);
+  const navigate = useNavigate();
 
   useEffect(() => {
-    fetch('/api/forms', { credentials: 'include' })
-      .then((res) => {
-        if (!res.ok) throw new Error('Failed to fetch forms');
-        return res.json();
-      })
-      .then((data) => setFormsList(data))
+    fetch('/api/transaction_forms', { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : {}))
+      .then((data) => setTransactions(Object.keys(data)))
       .catch((err) => console.error('Error fetching forms:', err));
   }, []);
 
   return (
     <div>
       <h2>Маягтууд</h2>
-      {formsList.length === 0 ? (
+      {transactions.length === 0 ? (
         <p>Маягт олдсонгүй.</p>
       ) : (
         <ul>
-          {formsList.map((f) => (
-            <li key={f.id}>{f.name}</li>
+          {transactions.map((t) => (
+            <li key={t}>
+              <button onClick={() => navigate(`/finance-transactions?table=${encodeURIComponent(t)}`)}>
+                {t}
+              </button>
+            </li>
           ))}
         </ul>
       )}


### PR DESCRIPTION
## Summary
- expose `/api/forms` route and load forms config
- navigate to Finance Transactions from Forms page
- sync Finance Transactions table with URL query
- show message when no transactions configured

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68531ce764548331b8f4eb30819041ff