### PR TITLE
Add transaction names to dynamic forms

### DIFF
--- a/docs/transaction-form-config.md
+++ b/docs/transaction-form-config.md
@@ -1,8 +1,9 @@
 # Transaction Form Configuration
 
-This module stores per-table settings used by the dynamic form renderer. Configuration is saved in `config/transactionForms.json` and can be accessed via `/api/transaction_forms`.
+This module stores form settings grouped by table and transaction name. The configuration
+file lives at `config/transactionForms.json` and is accessible via `/api/transaction_forms`.
 
-Each table entry allows you to specify:
+Each **transaction** entry allows you to specify:
 
 - **visibleFields** – list of columns shown in the form
 - **requiredFields** – columns that cannot be left empty
@@ -16,14 +17,28 @@ Example snippet:
 ```json
 {
   "inventory_transactions": {
-    "visibleFields": ["tran_date", "description"],
-    "requiredFields": ["tran_date"],
-    "defaultValues": { "status": "N" },
-    "userIdField": "created_by",
-    "branchIdField": "branch_id",
-    "companyIdField": "company_id"
+    "Receive": {
+      "visibleFields": ["tran_date", "description"],
+      "requiredFields": ["tran_date"],
+      "defaultValues": { "status": "N" },
+      "userIdField": "created_by",
+      "branchIdField": "branch_id",
+      "companyIdField": "company_id"
+    },
+    "Issue": {
+      "visibleFields": ["tran_date", "description"],
+      "requiredFields": ["tran_date"],
+      "defaultValues": { "status": "N" },
+      "userIdField": "created_by",
+      "branchIdField": "branch_id",
+      "companyIdField": "company_id"
+    }
   }
 }
 ```
 
-Clients can retrieve a single configuration using `/api/transaction_forms?table=tbl` or POST a new configuration with `{ table, config }` in the request body.
+Clients can retrieve a list of transaction names via `/api/transaction_forms`.
+To obtain a configuration for a specific transaction use
+`/api/transaction_forms?table=tbl&name=transaction`. New configurations are
+posted with `{ table, name, config }` in the request body and can be removed via
+`DELETE /api/transaction_forms?table=tbl&name=transaction`.

--- a/src/erp.mgt.mn/pages/Forms.jsx
+++ b/src/erp.mgt.mn/pages/Forms.jsx
@@ -22,7 +22,7 @@ export default function Forms() {
         <ul>
           {transactions.map((t) => (
             <li key={t}>
-              <button onClick={() => navigate(`/finance-transactions?table=${encodeURIComponent(t)}`)}>
+              <button onClick={() => navigate(`/finance-transactions?name=${encodeURIComponent(t)}`)}>
                 {t}
               </button>
             </li>


### PR DESCRIPTION
## Summary
- allow multiple transaction configurations per table
- expose new CRUD API for transactions
- store configs by table and transaction name
- update docs for new transaction form config
- support selecting transactions by name in UI
- manage named transactions in forms management module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853a5db5de48331ad8aed0c7e357e9c