### PR TITLE
Support multiple auto-fill fields in dynamic forms

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -19,16 +19,16 @@ async function writeConfig(cfg) {
 export async function getFormConfig(table, name) {
   const cfg = await readConfig();
   const byTable = cfg[table] || {};
-  return (
-    byTable[name] || {
-      visibleFields: [],
-      requiredFields: [],
-      defaultValues: {},
-      userIdField: null,
-      branchIdField: null,
-      companyIdField: null,
-    }
-  );
+  const raw = byTable[name] || {};
+  return {
+    visibleFields: raw.visibleFields || [],
+    requiredFields: raw.requiredFields || [],
+    defaultValues: raw.defaultValues || {},
+    userIdFields: raw.userIdFields || (raw.userIdField ? [raw.userIdField] : []),
+    branchIdFields: raw.branchIdFields || (raw.branchIdField ? [raw.branchIdField] : []),
+    companyIdFields:
+      raw.companyIdFields || (raw.companyIdField ? [raw.companyIdField] : []),
+  };
 }
 
 export async function getConfigsByTable(table) {
@@ -52,19 +52,33 @@ export async function setFormConfig(table, name, config) {
     visibleFields = [],
     requiredFields = [],
     defaultValues = {},
-    userIdField = null,
-    branchIdField = null,
-    companyIdField = null,
+    userIdFields = [],
+    branchIdFields = [],
+    companyIdFields = [],
+    userIdField,
+    branchIdField,
+    companyIdField,
   } = config || {};
+  const uid = userIdFields.length ? userIdFields : userIdField ? [userIdField] : [];
+  const bid = branchIdFields.length
+    ? branchIdFields
+    : branchIdField
+    ? [branchIdField]
+    : [];
+  const cid = companyIdFields.length
+    ? companyIdFields
+    : companyIdField
+    ? [companyIdField]
+    : [];
   const cfg = await readConfig();
   if (!cfg[table]) cfg[table] = {};
   cfg[table][name] = {
     visibleFields,
     requiredFields,
     defaultValues,
-    userIdField,
-    branchIdField,
-    companyIdField,
+    userIdFields: uid,
+    branchIdFields: bid,
+    companyIdFields: cid,
   };
   await writeConfig(cfg);
   return cfg[table][name];

--- a/docs/transaction-form-config.md
+++ b/docs/transaction-form-config.md
@@ -8,9 +8,9 @@ Each **transaction** entry allows you to specify:
 - **visibleFields** – list of columns shown in the form
 - **requiredFields** – columns that cannot be left empty
 - **defaultValues** – map of column default values
-- **userIdField** – field storing the creating user ID
-- **branchIdField** – field storing the branch ID
-- **companyIdField** – field storing the company ID
+- **userIdFields** – fields automatically filled with the creating user ID
+- **branchIdFields** – fields automatically filled with the branch ID
+- **companyIdFields** – fields automatically filled with the company ID
 
 Example snippet:
 
@@ -21,17 +21,17 @@ Example snippet:
       "visibleFields": ["tran_date", "description"],
       "requiredFields": ["tran_date"],
       "defaultValues": { "status": "N" },
-      "userIdField": "created_by",
-      "branchIdField": "branch_id",
-      "companyIdField": "company_id"
+      "userIdFields": ["created_by"],
+      "branchIdFields": ["branch_id"],
+      "companyIdFields": ["company_id"]
     },
     "Issue": {
       "visibleFields": ["tran_date", "description"],
       "requiredFields": ["tran_date"],
       "defaultValues": { "status": "N" },
-      "userIdField": "created_by",
-      "branchIdField": "branch_id",
-      "companyIdField": "company_id"
+      "userIdFields": ["created_by"],
+      "branchIdFields": ["branch_id"],
+      "companyIdFields": ["company_id"]
     }
   }
 }

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -63,9 +63,9 @@ export default function FinanceTransactions() {
     const vals = {};
     columns.forEach((c) => {
       let v = (config?.defaultValues || {})[c] || '';
-      if (config?.userIdField === c && user?.empid) v = user.empid;
-      if (config?.branchIdField === c && company?.branch_id !== undefined) v = company.branch_id;
-      if (config?.companyIdField === c && company?.company_id !== undefined) v = company.company_id;
+      if (config?.userIdFields?.includes(c) && user?.empid) v = user.empid;
+      if (config?.branchIdFields?.includes(c) && company?.branch_id !== undefined) v = company.branch_id;
+      if (config?.companyIdFields?.includes(c) && company?.company_id !== undefined) v = company.company_id;
       vals[c] = v;
     });
     setEditingId(null);

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -10,9 +10,9 @@ export default function FormsManagement() {
     visibleFields: [],
     requiredFields: [],
     defaultValues: {},
-    userIdField: '',
-    branchIdField: '',
-    companyIdField: '',
+    userIdFields: [],
+    branchIdFields: [],
+    companyIdFields: [],
   });
 
   useEffect(() => {
@@ -37,9 +37,9 @@ export default function FormsManagement() {
             visibleFields: data[name].visibleFields || [],
             requiredFields: data[name].requiredFields || [],
             defaultValues: data[name].defaultValues || {},
-            userIdField: data[name].userIdField || '',
-            branchIdField: data[name].branchIdField || '',
-            companyIdField: data[name].companyIdField || '',
+            userIdFields: data[name].userIdFields || [],
+            branchIdFields: data[name].branchIdFields || [],
+            companyIdFields: data[name].companyIdFields || [],
           });
         } else {
           setName('');
@@ -47,9 +47,9 @@ export default function FormsManagement() {
             visibleFields: [],
             requiredFields: [],
             defaultValues: {},
-            userIdField: '',
-            branchIdField: '',
-            companyIdField: '',
+            userIdFields: [],
+            branchIdFields: [],
+            companyIdFields: [],
           });
         }
       })
@@ -60,9 +60,9 @@ export default function FormsManagement() {
           visibleFields: [],
           requiredFields: [],
           defaultValues: {},
-          userIdField: '',
-          branchIdField: '',
-          companyIdField: '',
+          userIdFields: [],
+          branchIdFields: [],
+          companyIdFields: [],
         });
       });
   }, [table]);
@@ -76,9 +76,9 @@ export default function FormsManagement() {
           visibleFields: cfg.visibleFields || [],
           requiredFields: cfg.requiredFields || [],
           defaultValues: cfg.defaultValues || {},
-          userIdField: cfg.userIdField || '',
-          branchIdField: cfg.branchIdField || '',
-          companyIdField: cfg.companyIdField || '',
+          userIdFields: cfg.userIdFields || [],
+          branchIdFields: cfg.branchIdFields || [],
+          companyIdFields: cfg.companyIdFields || [],
         }),
       )
       .catch(() => {
@@ -86,9 +86,9 @@ export default function FormsManagement() {
           visibleFields: [],
           requiredFields: [],
           defaultValues: {},
-          userIdField: '',
-          branchIdField: '',
-          companyIdField: '',
+          userIdFields: [],
+          branchIdFields: [],
+          companyIdFields: [],
         });
       });
   }, [table, name]);
@@ -144,9 +144,9 @@ export default function FormsManagement() {
       visibleFields: [],
       requiredFields: [],
       defaultValues: {},
-      userIdField: '',
-      branchIdField: '',
-      companyIdField: '',
+      userIdFields: [],
+      branchIdFields: [],
+      companyIdFields: [],
     });
   }
 
@@ -230,12 +230,17 @@ export default function FormsManagement() {
           </table>
           <div style={{ marginTop: '1rem' }}>
             <label>
-              User ID field:{' '}
+              User ID fields:{' '}
               <select
-                value={config.userIdField}
-                onChange={(e) => setConfig((c) => ({ ...c, userIdField: e.target.value }))}
+                multiple
+                value={config.userIdFields}
+                onChange={(e) =>
+                  setConfig((c) => ({
+                    ...c,
+                    userIdFields: Array.from(e.target.selectedOptions, (o) => o.value),
+                  }))
+                }
               >
-                <option value="">-- none --</option>
                 {columns.map((c) => (
                   <option key={c} value={c}>
                     {c}
@@ -244,12 +249,17 @@ export default function FormsManagement() {
               </select>
             </label>
             <label style={{ marginLeft: '1rem' }}>
-              Branch ID field:{' '}
+              Branch ID fields:{' '}
               <select
-                value={config.branchIdField}
-                onChange={(e) => setConfig((c) => ({ ...c, branchIdField: e.target.value }))}
+                multiple
+                value={config.branchIdFields}
+                onChange={(e) =>
+                  setConfig((c) => ({
+                    ...c,
+                    branchIdFields: Array.from(e.target.selectedOptions, (o) => o.value),
+                  }))
+                }
               >
-                <option value="">-- none --</option>
                 {columns.map((c) => (
                   <option key={c} value={c}>
                     {c}
@@ -258,12 +268,17 @@ export default function FormsManagement() {
               </select>
             </label>
             <label style={{ marginLeft: '1rem' }}>
-              Company ID field:{' '}
+              Company ID fields:{' '}
               <select
-                value={config.companyIdField}
-                onChange={(e) => setConfig((c) => ({ ...c, companyIdField: e.target.value }))}
+                multiple
+                value={config.companyIdFields}
+                onChange={(e) =>
+                  setConfig((c) => ({
+                    ...c,
+                    companyIdFields: Array.from(e.target.selectedOptions, (o) => o.value),
+                  }))
+                }
               >
-                <option value="">-- none --</option>
                 {columns.map((c) => (
                   <option key={c} value={c}>
                     {c}


### PR DESCRIPTION
## Summary
- allow multiple user, branch and company fields in transaction form configs
- update form config API to handle arrays
- update finance transaction page to auto-fill multiple system fields
- update forms management UI to select system fields via multi-select
- document new configuration options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853afd7951083318f142e22bc0a28f3