### PR TITLE
Auto module creation for transactions

### DIFF
--- a/api-server/routes/transaction_forms.js
+++ b/api-server/routes/transaction_forms.js
@@ -30,10 +30,13 @@ router.get('/', requireAuth, async (req, res, next) => {
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {
-    const { table, name, config } = req.body;
+    const { table, name, config, showInSidebar, showInHeader } = req.body;
     if (!table || !name)
       return res.status(400).json({ message: 'table and name are required' });
-    await setFormConfig(table, name, config || {});
+    await setFormConfig(table, name, config || {}, {
+      showInSidebar,
+      showInHeader,
+    });
     res.sendStatus(204);
   } catch (err) {
     next(err);

--- a/api-server/utils/slugify.js
+++ b/api-server/utils/slugify.js
@@ -1,0 +1,9 @@
+export function slugify(text) {
+  return String(text)
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 64);
+}

--- a/docs/transaction-form-config.md
+++ b/docs/transaction-form-config.md
@@ -40,5 +40,8 @@ Example snippet:
 Clients can retrieve a list of transaction names via `/api/transaction_forms`.
 To obtain a configuration for a specific transaction use
 `/api/transaction_forms?table=tbl&name=transaction`. New configurations are
-posted with `{ table, name, config }` in the request body and can be removed via
+posted with `{ table, name, config, showInSidebar?, showInHeader? }` in the request body and can be removed via
 `DELETE /api/transaction_forms?table=tbl&name=transaction`.
+Saving a configuration automatically creates a module using a slug of the transaction
+name under the parent `finance_transactions`. The optional `showInSidebar` and
+`showInHeader` flags determine where the generated module appears in the UI.


### PR DESCRIPTION
## Summary
- create `slugify` helper
- auto-create module entries when saving a transaction form
- allow `showInSidebar` and `showInHeader` options in the API
- document automatic module creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853baf85b3c83318deb6bf447bfd5d1