### PR TITLE
Update finance transaction form navigation

### DIFF
--- a/src/erp.mgt.mn/pages/Forms.jsx
+++ b/src/erp.mgt.mn/pages/Forms.jsx
@@ -1,6 +1,7 @@
 // src/erp.mgt.mn/pages/Forms.jsx
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import slugify from '../utils/slugify.js';
 
 export default function Forms() {
   const [transactions, setTransactions] = useState([]);
@@ -22,7 +23,7 @@ export default function Forms() {
         <ul>
           {transactions.map((t) => (
             <li key={t}>
-              <button onClick={() => navigate(`/finance-transactions?name=${encodeURIComponent(t)}`)}>
+              <button onClick={() => navigate(`/finance-transactions/${slugify(t)}`)}>
                 {t}
               </button>
             </li>

--- a/src/erp.mgt.mn/utils/slugify.js
+++ b/src/erp.mgt.mn/utils/slugify.js
@@ -1,0 +1,16 @@
+export default function slugify(text) {
+  const basic = String(text)
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 64);
+  if (basic) return basic;
+  const bytes = new TextEncoder().encode(String(text));
+  let hex = '';
+  for (const b of bytes) {
+    hex += b.toString(16).padStart(2, '0');
+  }
+  return 't_' + hex.slice(0, 32);
+}


### PR DESCRIPTION
## Summary
- add client-side `slugify` helper
- navigate to finance transaction forms using slug paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853cbb549808331b4807c9204daa492