### PR TITLE
Add search‑select modals to finance transactions

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
+import SearchSelect from './SearchSelect.jsx';
 
 export default function RowFormModal({
   visible,
@@ -17,6 +18,16 @@ export default function RowFormModal({
     });
     return init;
   });
+
+  const inputRefs = useRef([]);
+
+  function handleKeyDown(e, idx) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const next = inputRefs.current[idx + 1];
+      if (next) next.focus();
+    }
+  }
 
   useEffect(() => {
     if (!visible) return;
@@ -60,27 +71,22 @@ export default function RowFormModal({
             onSubmit(formVals);
           }}
         >
-          {columns.map((c) => (
+          {columns.map((c, idx) => (
             <div key={c} style={{ marginBottom: '0.75rem' }}>
               <label style={{ display: 'block', marginBottom: '0.25rem' }}>
                 {labels[c] || c}
               </label>
               {Array.isArray(relations[c]) ? (
-                <select
+                <SearchSelect
                   value={formVals[c]}
-                  onChange={(e) =>
-                    setFormVals((v) => ({ ...v, [c]: e.target.value }))
+                  onChange={(val) =>
+                    setFormVals((v) => ({ ...v, [c]: val }))
                   }
+                  options={relations[c]}
                   disabled={row && disabledFields.includes(c)}
-                  style={{ width: '100%', padding: '0.5rem' }}
-                >
-                  <option value="">-- select --</option>
-                  {relations[c].map((opt) => (
-                    <option key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </option>
-                  ))}
-                </select>
+                  onKeyDown={(e) => handleKeyDown(e, idx)}
+                  inputRef={(el) => (inputRefs.current[idx] = el)}
+                />
               ) : (
                 <input
                   type="text"
@@ -90,6 +96,8 @@ export default function RowFormModal({
                   }
                   disabled={row && disabledFields.includes(c)}
                   style={{ width: '100%', padding: '0.5rem' }}
+                  ref={(el) => (inputRefs.current[idx] = el)}
+                  onKeyDown={(e) => handleKeyDown(e, idx)}
                 />
               )}
             </div>

--- a/src/erp.mgt.mn/components/SearchSelect.jsx
+++ b/src/erp.mgt.mn/components/SearchSelect.jsx
@@ -1,6 +1,13 @@
 import React, { useState } from 'react';
 
-export default function SearchSelect({ value, onChange, options = [], disabled }) {
+export default function SearchSelect({
+  value,
+  onChange,
+  options = [],
+  disabled,
+  onKeyDown,
+  inputRef,
+}) {
   const [filter, setFilter] = useState('');
   const id = React.useId();
 
@@ -22,6 +29,8 @@ export default function SearchSelect({ value, onChange, options = [], disabled }
           onChange(e.target.value);
           setFilter(e.target.value);
         }}
+        onKeyDown={onKeyDown}
+        ref={inputRef}
         disabled={disabled}
         style={{ width: '100%', padding: '0.5rem' }}
       />


### PR DESCRIPTION
## Summary
- enhance RowFormModal with searchable select fields and keyboard navigation
- extend SearchSelect to support keyboard events and refs
- overhaul FinanceTransactions page
  - inline add form with better styling and enter navigation
  - use RowFormModal, RowDetailModal, CascadeDeleteModal for edit/view/delete

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853dc9ff4c08331ba042e35849a3af9