### PR TITLE
Fix dynamic transaction form ordering and save logic

### DIFF
--- a/src/erp.mgt.mn/utils/csrfFetch.js
+++ b/src/erp.mgt.mn/utils/csrfFetch.js
@@ -36,5 +36,15 @@ window.fetch = async (url, options = {}, _retry) => {
       }
     }
   }
+  if (!res.ok) {
+    let respText = '';
+    try {
+      respText = await res.clone().text();
+    } catch {}
+    const payload = options.body ? options.body : '';
+    const details = `${method} ${url}\nPayload: ${payload}\nResponse: ${res.status} - ${respText}`;
+    if (import.meta.env.DEV) console.error('API Error:', details);
+    alert(`\u274C Request failed\n${details}`);
+  }
   return res;
 };


### PR DESCRIPTION
## Summary
- preserve configured field order in TableManager
- fix add transaction to use POST
- display detailed API errors and show success alert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853f821df548331ad9685784f128a38