### PR TITLE
Improve dashboard and modal UX

### DIFF
--- a/src/erp.mgt.mn/components/CascadeDeleteModal.jsx
+++ b/src/erp.mgt.mn/components/CascadeDeleteModal.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import Modal from './Modal.jsx';
 
 export default function CascadeDeleteModal({ visible, references = [], onCancel, onConfirm }) {
   const [rowsByTable, setRowsByTable] = useState({});
@@ -29,31 +30,8 @@ export default function CascadeDeleteModal({ visible, references = [], onCancel,
 
   if (!visible) return null;
 
-  const overlay = {
-    position: 'fixed',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    backgroundColor: 'rgba(0,0,0,0.4)',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-  };
-
-  const modal = {
-    backgroundColor: '#fff',
-    padding: '1rem',
-    borderRadius: '4px',
-    maxHeight: '90vh',
-    overflowY: 'auto',
-    minWidth: '300px',
-  };
-
   return (
-    <div style={overlay}>
-      <div style={modal}>
-        <h3 style={{ marginTop: 0 }}>Delete Related Records?</h3>
+    <Modal visible={visible} title="Delete Related Records?" onClose={onCancel}>
         {references.map((r) => (
           <div key={`${r.table}-${r.column}-${r.value}`} style={{ marginBottom: '1rem' }}>
             <strong>{r.table}</strong> ({r.count})
@@ -76,7 +54,6 @@ export default function CascadeDeleteModal({ visible, references = [], onCancel,
           </button>
           <button type="button" onClick={onConfirm}>Delete All</button>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }

--- a/src/erp.mgt.mn/components/Modal.jsx
+++ b/src/erp.mgt.mn/components/Modal.jsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+export default function Modal({ visible, title, onClose, children, width = 'auto' }) {
+  const [closing, setClosing] = useState(false);
+  const modalRef = useRef(null);
+  const posRef = useRef({ x: 0, y: 0 });
+
+  useEffect(() => {
+    if (!visible) return;
+    function handleKey(e) {
+      if (e.key === 'Escape') handleClose();
+    }
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [visible]);
+
+  function handleClose() {
+    if (closing) return;
+    setClosing(true);
+    setTimeout(() => {
+      setClosing(false);
+      onClose && onClose();
+    }, 200);
+  }
+
+  function startDrag(e) {
+    const rect = modalRef.current?.getBoundingClientRect() || { left: 0, top: 0 };
+    const offsetX = e.clientX - rect.left;
+    const offsetY = e.clientY - rect.top;
+    function move(ev) {
+      posRef.current = { x: ev.clientX - offsetX, y: ev.clientY - offsetY };
+      if (modalRef.current) {
+        modalRef.current.style.transform = `translate(${posRef.current.x}px, ${posRef.current.y}px)`;
+      }
+    }
+    function up() {
+      window.removeEventListener('mousemove', move);
+      window.removeEventListener('mouseup', up);
+    }
+    window.addEventListener('mousemove', move);
+    window.addEventListener('mouseup', up);
+    e.preventDefault();
+  }
+
+  if (!visible && !closing) return null;
+
+  const overlayStyle = {
+    position: 'fixed',
+    inset: 0,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    opacity: closing ? 0 : 1,
+    transition: 'opacity 0.2s',
+    zIndex: 1000,
+  };
+
+  const modalStyle = {
+    backgroundColor: '#fff',
+    borderRadius: '4px',
+    boxShadow: '0 2px 8px rgba(0,0,0,0.2)',
+    maxHeight: '90vh',
+    overflowY: 'auto',
+    width,
+    minWidth: '300px',
+  };
+
+  const headerStyle = {
+    cursor: 'move',
+    padding: '0.5rem 1rem',
+    borderBottom: '1px solid #ddd',
+    background: '#f7f7f7',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  };
+
+  return (
+    <div style={overlayStyle} onClick={(e) => e.target === e.currentTarget && handleClose()}>
+      <div ref={modalRef} style={modalStyle}>
+        <div style={headerStyle} onMouseDown={startDrag}>
+          <span>{title}</span>
+          <button onClick={handleClose} style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '1rem' }}>×</button>
+        </div>
+        <div style={{ padding: '1rem' }}>{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/erp.mgt.mn/components/RowDetailModal.jsx
+++ b/src/erp.mgt.mn/components/RowDetailModal.jsx
@@ -1,28 +1,8 @@
 import React from 'react';
+import Modal from './Modal.jsx';
 
 export default function RowDetailModal({ visible, onClose, row = {}, columns = [], relations = {}, references = [], labels = {} }) {
   if (!visible) return null;
-
-  const overlay = {
-    position: 'fixed',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    backgroundColor: 'rgba(0,0,0,0.4)',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-  };
-
-  const modal = {
-    backgroundColor: '#fff',
-    padding: '1rem',
-    borderRadius: '4px',
-    maxHeight: '90vh',
-    overflowY: 'auto',
-    minWidth: '300px',
-  };
 
   const labelMap = {};
   Object.entries(relations).forEach(([col, opts]) => {
@@ -35,9 +15,7 @@ export default function RowDetailModal({ visible, onClose, row = {}, columns = [
   const cols = columns.length > 0 ? columns : Object.keys(row);
 
   return (
-    <div style={overlay}>
-      <div style={modal}>
-        <h3 style={{ marginTop: 0 }}>Row Details</h3>
+    <Modal visible={visible} title="Row Details" onClose={onClose}>
         <table style={{ width: '100%', borderCollapse: 'collapse', marginBottom: '1rem' }}>
           <tbody>
             {cols.map((c) => (
@@ -63,7 +41,6 @@ export default function RowDetailModal({ visible, onClose, row = {}, columns = [
         <div style={{ textAlign: 'right' }}>
           <button type="button" onClick={onClose}>Close</button>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import AsyncSearchSelect from './AsyncSearchSelect.jsx';
+import Modal from './Modal.jsx';
 
 export default function RowFormModal({
   visible,
@@ -36,29 +37,6 @@ export default function RowFormModal({
 
   if (!visible) return null;
 
-  const overlay = {
-    position: 'fixed',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    backgroundColor: 'rgba(0,0,0,0.4)',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-  };
-
-  const modal = {
-    backgroundColor: '#fff',
-    padding: '1rem',
-    borderRadius: '4px',
-    maxHeight: '90vh',
-    overflowY: 'auto',
-    width: '70vw',
-    maxWidth: '800px',
-    minWidth: '300px',
-  };
-
   const formStyle = {
     display: 'grid',
     gridTemplateColumns: '1fr 1fr',
@@ -94,16 +72,14 @@ export default function RowFormModal({
   }
 
   return (
-    <div style={overlay}>
-      <div style={modal}>
-        <h3 style={{ marginTop: 0 }}>{row ? 'Edit Row' : 'Add Row'}</h3>
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            submitForm();
-          }}
-          style={formStyle}
-        >
+    <Modal visible={visible} title={row ? 'Edit Row' : 'Add Row'} onClose={onCancel} width="70vw">
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          submitForm();
+        }}
+        style={formStyle}
+      >
           {columns.map((c) => {
             const err = errors[c];
             const inputStyle = {
@@ -172,17 +148,16 @@ export default function RowFormModal({
             </div>
           );
           })}
-          <div style={{ textAlign: 'right', gridColumn: '1 / span 2' }}>
-            <button type="button" onClick={onCancel} style={{ marginRight: '0.5rem' }}>
-              Cancel
-            </button>
-            <button type="submit">Save</button>
-          </div>
+        <div style={{ textAlign: 'right', gridColumn: '1 / span 2' }}>
+          <button type="button" onClick={onCancel} style={{ marginRight: '0.5rem' }}>
+            Cancel
+          </button>
+          <button type="submit">Save</button>
+        </div>
         <div style={{ marginTop: '0.5rem', gridColumn: '1 / span 2', fontSize: '0.85rem', color: '#555' }}>
           Press <strong>Enter</strong> to move to next field. Use arrow keys to navigate selections.
         </div>
       </form>
-      </div>
-    </div>
+    </Modal>
   );
 }

--- a/src/erp.mgt.mn/pages/BlueLinkPage.jsx
+++ b/src/erp.mgt.mn/pages/BlueLinkPage.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import MosaicLayout from '../components/MosaicLayout.jsx';
+import { AuthContext } from '../context/AuthContext.jsx';
 
 const initialLayout = {
   direction: 'row',
@@ -14,9 +15,37 @@ const initialLayout = {
 };
 
 export default function BlueLinkPage() {
+  const { user, company } = useContext(AuthContext);
+
+  const cardStyle = {
+    background: '#f0f4ff',
+    padding: '1rem',
+    borderRadius: '4px',
+    boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+    minWidth: '140px',
+  };
+
   return (
-    <div>
-      <h2>Blue Link демо</h2>
+    <div style={{ padding: '1rem' }}>
+      <h2 style={{ marginTop: 0 }}>Blue Link демо</h2>
+      <p>
+        Welcome, {user?.full_name || user?.username}
+        {company && ` (${company.company_name})`}
+      </p>
+      <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap', marginBottom: '1rem' }}>
+        <div style={cardStyle}>
+          <div style={{ fontSize: '0.9rem', color: '#555' }}>Today&apos;s Income</div>
+          <div style={{ fontSize: '1.5rem', fontWeight: 'bold' }}>$0</div>
+        </div>
+        <div style={cardStyle}>
+          <div style={{ fontSize: '0.9rem', color: '#555' }}>Low Stock</div>
+          <div style={{ fontSize: '1.5rem', fontWeight: 'bold' }}>0 items</div>
+        </div>
+        <div style={cardStyle}>
+          <div style={{ fontSize: '0.9rem', color: '#555' }}>New Orders</div>
+          <div style={{ fontSize: '1.5rem', fontWeight: 'bold' }}>0</div>
+        </div>
+      </div>
       <MosaicLayout initialLayout={initialLayout} />
     </div>
   );


### PR DESCRIPTION
## Summary
- implement reusable `Modal` component with draggable header, escape handling and overlay click
- refactor existing modals to use the new component
- expand **Blue Link демо** page with basic dashboard info cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68540d9bc93c83318e13b90a4819817f