### PR TITLE
Add Tailwind layout demo

### DIFF
--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -5,6 +5,7 @@ import { TabProvider } from './context/TabContext.jsx';
 import { ToastProvider } from './context/ToastContext.jsx';
 import RequireAuth from './components/RequireAuth.jsx';
 import ERPLayout from './components/ERPLayout.jsx';
+import AppLayout from './components/AppLayout.jsx';
 import LoginPage from './pages/Login.jsx';
 import FormsPage from './pages/Forms.jsx';
 import ReportsPage from './pages/Reports.jsx';
@@ -20,6 +21,7 @@ import ModulesPage from './pages/Modules.jsx';
 import SettingsPage, { GeneralSettings } from './pages/Settings.jsx';
 import ChangePasswordPage from './pages/ChangePassword.jsx';
 import BlueLinkPage from './pages/BlueLinkPage.jsx';
+import InventoryPage from './pages/InventoryPage.jsx';
 import FinanceTransactionsPage from './pages/FinanceTransactions.jsx';
 import { useModules } from './hooks/useModules.js';
 
@@ -117,6 +119,14 @@ export default function App() {
             <Route path="/login" element={<LoginPage />} />
             <Route element={<RequireAuth />}>
               <Route path="/" element={<ERPLayout />}>{roots.map(renderRoute)}</Route>
+              <Route
+                path="/inventory-demo"
+                element={
+                  <AppLayout title="Inventory">
+                    <InventoryPage />
+                  </AppLayout>
+                }
+              />
             </Route>
           </Routes>
           </HashRouter>

--- a/src/erp.mgt.mn/components/AppLayout.jsx
+++ b/src/erp.mgt.mn/components/AppLayout.jsx
@@ -1,0 +1,74 @@
+import React, { useContext } from 'react';
+import { NavLink, useNavigate } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext.jsx';
+import { logout } from '../hooks/useAuth.jsx';
+
+export default function AppLayout({ children, title }) {
+  const { user, company } = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  async function handleLogout() {
+    await logout();
+    navigate('/login');
+  }
+
+  return (
+    <div className="flex h-screen">
+      <aside className="w-64 bg-gray-800 text-white sticky top-0 h-screen overflow-y-auto flex-shrink-0">
+        <nav className="p-4 space-y-2">
+          <NavLink
+            to="/"
+            className={({ isActive }) =>
+              `block px-3 py-2 rounded hover:bg-gray-700 ${isActive ? 'bg-gray-700' : ''}`
+            }
+          >
+            Самбар
+          </NavLink>
+          <NavLink
+            to="/finance-transactions"
+            className={({ isActive }) =>
+              `block px-3 py-2 rounded hover:bg-gray-700 ${isActive ? 'bg-gray-700' : ''}`
+            }
+          >
+            Санхүүгийн гүйлгээ
+          </NavLink>
+          <NavLink
+            to="/reports"
+            className={({ isActive }) =>
+              `block px-3 py-2 rounded hover:bg-gray-700 ${isActive ? 'bg-gray-700' : ''}`
+            }
+          >
+            Тайлан
+          </NavLink>
+        </nav>
+      </aside>
+      <div className="flex flex-col flex-grow min-w-0">
+        <header className="sticky top-0 z-10 bg-white shadow-md flex items-center justify-between px-4 py-2">
+          <h1 className="text-lg font-semibold">{title || 'ERP'}</h1>
+          <div className="flex items-center space-x-3 text-sm">
+            {company && (
+              <span>
+                {company.branch_name && `${company.branch_name} | `}
+                {company.company_name}
+              </span>
+            )}
+            {user && (
+              <div className="relative group">
+                <button className="focus:outline-none">{user.empid}</button>
+                <div className="absolute right-0 mt-2 hidden group-focus-within:block group-hover:block bg-white text-gray-700 shadow-lg rounded border">
+                  <button
+                    onClick={handleLogout}
+                    className="block w-full text-left px-4 py-2 hover:bg-gray-100"
+                  >
+                    Logout
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        </header>
+        <main className="flex-grow overflow-auto p-4 bg-gray-100">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/src/erp.mgt.mn/index.html
+++ b/src/erp.mgt.mn/index.html
@@ -9,6 +9,7 @@
       rel="stylesheet"
       href="https://unpkg.com/@blueprintjs/core@5.0.0/lib/css/blueprint.css"
     />
+    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/erp.mgt.mn/pages/InventoryPage.jsx
+++ b/src/erp.mgt.mn/pages/InventoryPage.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+const data = [
+  { id: 1, name: 'Бараа 1', qty: 10, price: 1000 },
+  { id: 2, name: 'Бараа 2', qty: 5, price: 2000 },
+  { id: 3, name: 'Бараа 3', qty: 8, price: 1500 },
+];
+
+export default function InventoryPage() {
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full border text-sm bg-white max-h-[70vh] overflow-auto">
+        <thead className="sticky top-0 bg-white z-10">
+          <tr>
+            <th className="px-4 py-2 border-b">#</th>
+            <th className="px-4 py-2 border-b">Нэр</th>
+            <th className="px-4 py-2 border-b">Тоо</th>
+            <th className="px-4 py-2 border-b">Үнэ</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row) => (
+            <tr key={row.id} className="odd:bg-gray-50">
+              <td className="px-4 py-2 border-b whitespace-nowrap">{row.id}</td>
+              <td className="px-4 py-2 border-b whitespace-nowrap">{row.name}</td>
+              <td className="px-4 py-2 border-b whitespace-nowrap text-right">{row.qty}</td>
+              <td className="px-4 py-2 border-b whitespace-nowrap text-right">{row.price}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add CDN Tailwind to HTML
- create reusable `AppLayout` component with sticky sidebar and header using Tailwind classes
- add example `InventoryPage` with scrollable table
- register demo route `/inventory-demo` using the new layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685417f888288331a7191a794ea6a24c