### PR TITLE
Fix sidebar layout and form submission

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -331,12 +331,13 @@ const styles = {
     gap: "0.75rem",
   },
   iconBtn: {
-    background: "transparent",
-    border: "none",
+    background: "#374151",
+    border: "1px solid #4b5563",
     color: "#fff",
     cursor: "pointer",
     fontSize: "0.9rem",
     padding: "0.25rem 0.5rem",
+    borderRadius: "4px",
   },
   userSection: {
     display: "flex",
@@ -352,7 +353,7 @@ const styles = {
   logoutBtn: {
     backgroundColor: "#dc2626",
     color: "#fff",
-    border: "none",
+    border: "1px solid #dc2626",
     borderRadius: "3px",
     padding: "0.25rem 0.75rem",
     cursor: "pointer",
@@ -362,7 +363,8 @@ const styles = {
     display: "flex",
     flexGrow: 1,
     backgroundColor: "#f3f4f6",
-    overflow: "auto",
+    overflow: "hidden",
+    marginLeft: "240px",
   },
   sidebar: {
     width: "240px",
@@ -373,9 +375,11 @@ const styles = {
     padding: "1rem 0.5rem",
     flexShrink: 0,
     overflowY: "auto",
-    position: "sticky",
+    position: "fixed",
     top: "48px",
+    left: 0,
     height: "calc(100vh - 48px)",
+    zIndex: 10,
   },
   menuGroup: {
     marginBottom: "1rem",
@@ -389,7 +393,7 @@ const styles = {
     display: "block",
     width: "100%",
     background: "transparent",
-    border: "none",
+    border: "1px solid #4b5563",
     color: "#e5e7eb",
     textAlign: "left",
     padding: "0.4rem 0.75rem",
@@ -437,7 +441,7 @@ const styles = {
   windowHeaderBtn: {
     marginLeft: "0.5rem",
     background: "transparent",
-    border: "none",
+    border: "1px solid #f9fafb",
     color: "#f9fafb",
     cursor: "pointer",
     fontSize: "0.9rem",
@@ -472,12 +476,13 @@ const styles = {
   closeBtn: {
     marginLeft: "0.25rem",
     background: "transparent",
-    border: "none",
+    border: "1px solid #9ca3af",
     cursor: "pointer",
   },
   windowContent: {
     flexGrow: 1,
     padding: "1rem",
-    overflow: "auto",
+    overflowX: "auto",
+    overflowY: "auto",
   },
 };

--- a/src/erp.mgt.mn/components/LoginForm.jsx
+++ b/src/erp.mgt.mn/components/LoginForm.jsx
@@ -71,7 +71,12 @@ export default function LoginForm() {
             value={selectedCompany}
             onChange={(e) => setSelectedCompany(e.target.value)}
             required
-            style={{ width: '100%', padding: '0.5rem', borderRadius: '3px' }}
+            style={{
+              width: '100%',
+              padding: '0.5rem',
+              borderRadius: '3px',
+              border: '1px solid #9ca3af',
+            }}
           >
             <option value="" disabled>
               Сонгоно уу...
@@ -89,7 +94,7 @@ export default function LoginForm() {
             backgroundColor: '#2563eb',
             color: '#fff',
             padding: '0.5rem 1rem',
-            border: 'none',
+            border: '1px solid #2563eb',
             borderRadius: '3px',
             cursor: 'pointer',
           }}
@@ -112,7 +117,12 @@ export default function LoginForm() {
           value={empid}
           onChange={(ev) => setEmpid(ev.target.value)}
           required
-          style={{ width: '100%', padding: '0.5rem', borderRadius: '3px' }}
+          style={{
+            width: '100%',
+            padding: '0.5rem',
+            borderRadius: '3px',
+            border: '1px solid #9ca3af',
+          }}
         />
       </div>
 
@@ -129,7 +139,12 @@ export default function LoginForm() {
           value={password}
           onChange={(ev) => setPassword(ev.target.value)}
           required
-          style={{ width: '100%', padding: '0.5rem', borderRadius: '3px' }}
+          style={{
+            width: '100%',
+            padding: '0.5rem',
+            borderRadius: '3px',
+            border: '1px solid #9ca3af',
+          }}
         />
       </div>
 
@@ -143,7 +158,7 @@ export default function LoginForm() {
           backgroundColor: '#2563eb',
           color: '#fff',
           padding: '0.5rem 1rem',
-          border: 'none',
+          border: '1px solid #2563eb',
           borderRadius: '3px',
           cursor: 'pointer',
         }}

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -13,6 +13,7 @@ export default function RowFormModal({
   disabledFields = [],
   labels = {},
   requiredFields = [],
+  saving = false,
 }) {
   const [formVals, setFormVals] = useState(() => {
     const init = {};
@@ -152,7 +153,7 @@ export default function RowFormModal({
           <button type="button" onClick={onCancel} style={{ marginRight: '0.5rem' }}>
             Cancel
           </button>
-          <button type="submit">Save</button>
+          <button type="submit" disabled={saving}>Save</button>
         </div>
         <div style={{ marginTop: '0.5rem', gridColumn: '1 / span 2', fontSize: '0.85rem', color: '#555' }}>
           Press <strong>Enter</strong> to move to next field. Use arrow keys to navigate selections.

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -55,6 +55,8 @@ export default function TableManager({ table, refreshId = 0, formConfig = null, 
   const [editLabels, setEditLabels] = useState(false);
   const [labelEdits, setLabelEdits] = useState({});
   const [isAdding, setIsAdding] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const savingRef = useRef(false);
   const { user, company } = useContext(AuthContext);
   const { addToast } = useToast();
 
@@ -384,6 +386,9 @@ export default function TableManager({ table, refreshId = 0, formConfig = null, 
   }
 
   async function handleSubmit(values) {
+    if (savingRef.current) return;
+    savingRef.current = true;
+    setIsSaving(true);
     const columns = new Set(allColumns);
     const merged = { ...(editing || {}) };
     Object.entries(values).forEach(([k, v]) => {
@@ -462,6 +467,9 @@ export default function TableManager({ table, refreshId = 0, formConfig = null, 
       }
     } catch (err) {
       console.error('Save failed', err);
+    } finally {
+      savingRef.current = false;
+      setIsSaving(false);
     }
   }
 
@@ -966,6 +974,7 @@ export default function TableManager({ table, refreshId = 0, formConfig = null, 
           setIsAdding(false);
         }}
         onSubmit={handleSubmit}
+        saving={isSaving}
         columns={formColumns}
         row={editing}
         relations={relationOpts}

--- a/src/erp.mgt.mn/index.css
+++ b/src/erp.mgt.mn/index.css
@@ -221,3 +221,16 @@ th {
   text-align: left;
 }
 
+/* Default button styling for visibility */
+button {
+  border: 1px solid #9ca3af;
+  padding: 0.35rem 0.75rem;
+  border-radius: 4px;
+  background-color: #f3f4f6;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #e5e7eb;
+}
+

--- a/src/erp.mgt.mn/pages/Login.jsx
+++ b/src/erp.mgt.mn/pages/Login.jsx
@@ -4,8 +4,17 @@ import LoginForm from '../components/LoginForm.jsx';
 
 export default function LoginPage() {
   return (
-    <div style={{ padding: '2rem' }}>
-      <h1>Нэвтрэх</h1>
+    <div
+      style={{
+        padding: '2rem',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+      }}
+    >
+      <h1 style={{ marginBottom: '1rem' }}>Нэвтрэх</h1>
       <LoginForm />
     </div>
   );


### PR DESCRIPTION
## Summary
- keep sidebar fixed on the left
- center login page inputs with clear borders
- prevent duplicate row submissions with a save lock
- show scrollbars in tabbed pages
- ensure buttons have visible borders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854271b7ed883318a04c0024f1602e8