### PR TITLE
Add default value handling and editable defaults

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -26,6 +26,7 @@ export async function getFormConfig(table, name) {
     visibleFields: raw.visibleFields || [],
     requiredFields: raw.requiredFields || [],
     defaultValues: raw.defaultValues || {},
+    editableDefaultFields: raw.editableDefaultFields || [],
     userIdFields: raw.userIdFields || (raw.userIdField ? [raw.userIdField] : []),
     branchIdFields: raw.branchIdFields || (raw.branchIdField ? [raw.branchIdField] : []),
     companyIdFields:
@@ -57,6 +58,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     visibleFields = [],
     requiredFields = [],
     defaultValues = {},
+    editableDefaultFields = [],
     userIdFields = [],
     branchIdFields = [],
     companyIdFields = [],
@@ -82,6 +84,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     visibleFields,
     requiredFields,
     defaultValues,
+    editableDefaultFields,
     userIdFields: uid,
     branchIdFields: bid,
     companyIdFields: cid,

--- a/docs/transaction-form-config.md
+++ b/docs/transaction-form-config.md
@@ -8,6 +8,7 @@ Each **transaction** entry allows you to specify:
 - **visibleFields** – list of columns shown in the form
 - **requiredFields** – columns that cannot be left empty
 - **defaultValues** – map of column default values
+- **editableDefaultFields** – list of columns where users may change the prefilled default
 - **userIdFields** – fields automatically filled with the creating user ID
 - **branchIdFields** – fields automatically filled with the branch ID
 - **companyIdFields** – fields automatically filled with the company ID
@@ -21,6 +22,7 @@ Example snippet:
       "visibleFields": ["tran_date", "description"],
       "requiredFields": ["tran_date"],
       "defaultValues": { "status": "N" },
+      "editableDefaultFields": ["status"],
       "userIdFields": ["created_by"],
       "branchIdFields": ["branch_id"],
       "companyIdFields": ["company_id"]
@@ -29,6 +31,7 @@ Example snippet:
       "visibleFields": ["tran_date", "description"],
       "requiredFields": ["tran_date"],
       "defaultValues": { "status": "N" },
+      "editableDefaultFields": ["status"],
       "userIdFields": ["created_by"],
       "branchIdFields": ["branch_id"],
       "companyIdFields": ["company_id"]

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -669,7 +669,17 @@ export default function TableManager({ table, refreshId = 0, formConfig = null, 
   if (columnMeta.length === 0 && autoCols.size === 0 && allColumns.includes('id')) {
     autoCols.add('id');
   }
-  const disabledFields = editing ? getKeyFields() : [];
+  const lockedDefaults = Object.entries(formConfig?.defaultValues || {})
+    .filter(
+      ([k, v]) =>
+        v !== undefined && v !== '' &&
+        !(formConfig?.editableDefaultFields || []).includes(k)
+    )
+    .map(([k]) => k);
+
+  const disabledFields = editing
+    ? [...getKeyFields(), ...lockedDefaults]
+    : lockedDefaults;
   let formColumns = ordered.filter(
     (c) => !autoCols.has(c) && c !== 'created_at' && c !== 'created_by'
   );

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -10,6 +10,7 @@ export default function FormsManagement() {
     visibleFields: [],
     requiredFields: [],
     defaultValues: {},
+    editableDefaultFields: [],
     userIdFields: [],
     branchIdFields: [],
     companyIdFields: [],
@@ -37,6 +38,7 @@ export default function FormsManagement() {
             visibleFields: data[name].visibleFields || [],
             requiredFields: data[name].requiredFields || [],
             defaultValues: data[name].defaultValues || {},
+            editableDefaultFields: data[name].editableDefaultFields || [],
             userIdFields: data[name].userIdFields || [],
             branchIdFields: data[name].branchIdFields || [],
             companyIdFields: data[name].companyIdFields || [],
@@ -47,6 +49,7 @@ export default function FormsManagement() {
             visibleFields: [],
             requiredFields: [],
             defaultValues: {},
+            editableDefaultFields: [],
             userIdFields: [],
             branchIdFields: [],
             companyIdFields: [],
@@ -60,6 +63,7 @@ export default function FormsManagement() {
           visibleFields: [],
           requiredFields: [],
           defaultValues: {},
+          editableDefaultFields: [],
           userIdFields: [],
           branchIdFields: [],
           companyIdFields: [],
@@ -76,6 +80,7 @@ export default function FormsManagement() {
           visibleFields: cfg.visibleFields || [],
           requiredFields: cfg.requiredFields || [],
           defaultValues: cfg.defaultValues || {},
+          editableDefaultFields: cfg.editableDefaultFields || [],
           userIdFields: cfg.userIdFields || [],
           branchIdFields: cfg.branchIdFields || [],
           companyIdFields: cfg.companyIdFields || [],
@@ -86,6 +91,7 @@ export default function FormsManagement() {
           visibleFields: [],
           requiredFields: [],
           defaultValues: {},
+          editableDefaultFields: [],
           userIdFields: [],
           branchIdFields: [],
           companyIdFields: [],
@@ -116,6 +122,14 @@ export default function FormsManagement() {
     }));
   }
 
+  function toggleEditable(field) {
+    setConfig((c) => {
+      const set = new Set(c.editableDefaultFields);
+      set.has(field) ? set.delete(field) : set.add(field);
+      return { ...c, editableDefaultFields: Array.from(set) };
+    });
+  }
+
   async function handleSave() {
     if (!name) {
       alert('Please enter transaction name');
@@ -140,14 +154,15 @@ export default function FormsManagement() {
     });
     setNames((n) => n.filter((x) => x !== name));
     setName('');
-    setConfig({
-      visibleFields: [],
-      requiredFields: [],
-      defaultValues: {},
-      userIdFields: [],
-      branchIdFields: [],
-      companyIdFields: [],
-    });
+        setConfig({
+          visibleFields: [],
+          requiredFields: [],
+          defaultValues: {},
+          editableDefaultFields: [],
+          userIdFields: [],
+          branchIdFields: [],
+          companyIdFields: [],
+        });
   }
 
   return (
@@ -198,6 +213,7 @@ export default function FormsManagement() {
                 <th style={{ border: '1px solid #ccc', padding: '4px' }}>Visible</th>
                 <th style={{ border: '1px solid #ccc', padding: '4px' }}>Required</th>
                 <th style={{ border: '1px solid #ccc', padding: '4px' }}>Default</th>
+                <th style={{ border: '1px solid #ccc', padding: '4px' }}>Editable</th>
               </tr>
             </thead>
             <tbody>
@@ -223,6 +239,13 @@ export default function FormsManagement() {
                       type="text"
                       value={config.defaultValues[col] || ''}
                       onChange={(e) => changeDefault(col, e.target.value)}
+                    />
+                  </td>
+                  <td style={{ border: '1px solid #ccc', padding: '4px', textAlign: 'center' }}>
+                    <input
+                      type="checkbox"
+                      checked={config.editableDefaultFields.includes(col)}
+                      onChange={() => toggleEditable(col)}
                     />
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- allow setting default column values when creating coding tables
- store editable default field list in transaction form configs
- expose editable default setting in form management UI
- disable non-editable defaults in TableManager
- document new `editableDefaultFields` option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68542f8fd45483319c5654c45eb03b63