### PR TITLE
Fix coding table config save and SQL execution

### DIFF
--- a/api-server/controllers/codingTableController.js
+++ b/api-server/controllers/codingTableController.js
@@ -355,3 +355,20 @@ export async function uploadCodingTable(req, res, next) {
     next(err);
   }
 }
+
+export async function executeSql(req, res, next) {
+  try {
+    const { sql } = req.body;
+    if (!sql) return res.status(400).json({ error: 'sql required' });
+    const statements = sql
+      .split(/;\s*\n/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+    for (const stmt of statements) {
+      await pool.query(stmt);
+    }
+    res.sendStatus(204);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/api-server/routes/coding_tables.js
+++ b/api-server/routes/coding_tables.js
@@ -2,7 +2,7 @@ import express from 'express';
 import multer from 'multer';
 import fs from 'fs';
 import path from 'path';
-import { uploadCodingTable } from '../controllers/codingTableController.js';
+import { uploadCodingTable, executeSql } from '../controllers/codingTableController.js';
 import { requireAuth } from '../middlewares/auth.js';
 
 const router = express.Router();
@@ -13,5 +13,6 @@ if (!fs.existsSync(uploadDir)) {
 const upload = multer({ dest: uploadDir });
 
 router.post('/upload', requireAuth, upload.single('file'), uploadCodingTable);
+router.post('/execute', requireAuth, executeSql);
 
 export default router;


### PR DESCRIPTION
## Summary
- add SQL execution endpoint for coding tables
- save generated SQL with config
- rename and update coding table buttons
- provide client-side handler for executing generated SQL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68544dc9d88c8331b7755e8951170875