### PR TITLE
Fix coding table save and SQL execution

### DIFF
--- a/api-server/routes/generated_sql.js
+++ b/api-server/routes/generated_sql.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { saveSql } from '../services/generatedSql.js';
+import { saveSql, runSql } from '../services/generatedSql.js';
 import { requireAuth } from '../middlewares/auth.js';
 
 const router = express.Router();
@@ -11,6 +11,19 @@ router.post('/', requireAuth, async (req, res, next) => {
       return res.status(400).json({ message: 'table and sql required' });
     }
     await saveSql(table, sql);
+    res.sendStatus(204);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/execute', requireAuth, async (req, res, next) => {
+  try {
+    const { sql } = req.body;
+    if (!sql) {
+      return res.status(400).json({ message: 'sql required' });
+    }
+    await runSql(sql);
     res.sendStatus(204);
   } catch (err) {
     next(err);

--- a/api-server/services/generatedSql.js
+++ b/api-server/services/generatedSql.js
@@ -1,5 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
+import { pool } from '../../db/index.js';
 
 const jsonPath = path.join(process.cwd(), 'config', 'generatedSql.json');
 const sqlPath = path.join(process.cwd(), 'config', 'generated.sql');
@@ -29,4 +30,14 @@ export async function saveSql(table, sql) {
   const map = await readMap();
   map[table] = sql;
   await writeFiles(map);
+}
+
+export async function runSql(sql) {
+  const statements = sql
+    .split(/;\s*\n/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  for (const stmt of statements) {
+    await pool.query(stmt);
+  }
 }


### PR DESCRIPTION
## Summary
- improve generated SQL service with runSql
- add endpoint for executing generated SQL
- update coding tables page to execute SQL and handle config save properly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854513e4a5083319dc78bba02b57846