### PR TITLE
Fix coding table config save route

### DIFF
--- a/api-server/routes/coding_table_configs.js
+++ b/api-server/routes/coding_table_configs.js
@@ -24,7 +24,7 @@ router.post('/', requireAuth, async (req, res, next) => {
     const { table, config } = req.body;
     if (!table) return res.status(400).json({ message: 'table is required' });
     await setConfig(table, config || {});
-    res.sendStatus(204);
+    res.status(200).json({ message: 'Config saved successfully' });
   } catch (err) {
     next(err);
   }

--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -709,7 +709,7 @@ export default function CodingTablesPage() {
           text = await res.text();
         } catch {}
         console.error('Failed to save config', status, text);
-        addToast(`Failed to save config. Server returned ${status}`, 'error');
+        addToast('Failed to save config. Please check API availability.', 'error');
         return;
       }
       if (sql) {


### PR DESCRIPTION
## Summary
- add success response to coding table config POST route
- surface clearer error message in Coding Tables page when config save fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68545d531ef0833186a9330f54ef7077