### PR TITLE
Implement branch-based transaction configs

### DIFF
--- a/api-server/controllers/userCompanyController.js
+++ b/api-server/controllers/userCompanyController.js
@@ -30,8 +30,8 @@ export async function assignCompany(req, res, next) {
     if (req.user.role !== 'admin') {
       return res.sendStatus(403);
     }
-    const { empid, companyId, roleId } = req.body;
-    await assignCompanyToUser(empid, companyId, roleId, req.user.empid);
+    const { empid, companyId, roleId, branchId } = req.body;
+    await assignCompanyToUser(empid, companyId, roleId, branchId, req.user.empid);
     res.sendStatus(201);
   } catch (err) {
     if (err.code === 'ER_NO_REFERENCED_ROW_2') {
@@ -46,8 +46,8 @@ export async function updateAssignment(req, res, next) {
     if (req.user.role !== 'admin') {
       return res.sendStatus(403);
     }
-    const { empid, companyId, roleId } = req.body;
-    await updateCompanyAssignment(empid, companyId, roleId);
+    const { empid, companyId, roleId, branchId } = req.body;
+    await updateCompanyAssignment(empid, companyId, roleId, branchId);
     res.sendStatus(200);
   } catch (err) {
     next(err);

--- a/api-server/routes/transaction_forms.js
+++ b/api-server/routes/transaction_forms.js
@@ -12,7 +12,7 @@ const router = express.Router();
 
 router.get('/', requireAuth, async (req, res, next) => {
   try {
-    const { table, name } = req.query;
+    const { table, name, moduleKey, branchId } = req.query;
     if (table && name) {
       const cfg = await getFormConfig(table, name);
       res.json(cfg);
@@ -20,7 +20,7 @@ router.get('/', requireAuth, async (req, res, next) => {
       const all = await getConfigsByTable(table);
       res.json(all);
     } else {
-      const names = await listTransactionNames();
+      const names = await listTransactionNames({ moduleKey, branchId });
       res.json(names);
     }
   } catch (err) {
@@ -30,12 +30,13 @@ router.get('/', requireAuth, async (req, res, next) => {
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {
-    const { table, name, config, showInSidebar, showInHeader } = req.body;
+    const { table, name, config, showInSidebar, showInHeader, moduleKey } = req.body;
     if (!table || !name)
       return res.status(400).json({ message: 'table and name are required' });
     await setFormConfig(table, name, config || {}, {
       showInSidebar,
       showInHeader,
+      moduleKey,
     });
     res.sendStatus(204);
   } catch (err) {

--- a/db/index.js
+++ b/db/index.js
@@ -179,13 +179,14 @@ export async function assignCompanyToUser(
   empid,
   companyId,
   role_id,
+  branchId,
   createdBy,
 ) {
   const [result] = await pool.query(
-    `INSERT INTO user_companies (empid, company_id, role_id, created_by)
-     VALUES (?, ?, ?, ?)
-     ON DUPLICATE KEY UPDATE role_id = VALUES(role_id)`,
-    [empid, companyId, role_id, createdBy],
+    `INSERT INTO user_companies (empid, company_id, role_id, branch_id, created_by)
+     VALUES (?, ?, ?, ?, ?)
+     ON DUPLICATE KEY UPDATE role_id = VALUES(role_id), branch_id = VALUES(branch_id)`,
+    [empid, companyId, role_id, branchId, createdBy],
   );
   return { affectedRows: result.affectedRows };
 }
@@ -195,10 +196,12 @@ export async function assignCompanyToUser(
  */
 export async function listUserCompanies(empid) {
   const [rows] = await pool.query(
-    `SELECT uc.empid, uc.company_id, c.name AS company_name, uc.role_id, r.name AS role
+    `SELECT uc.empid, uc.company_id, c.name AS company_name, uc.role_id, r.name AS role,
+            uc.branch_id, b.name AS branch_name
      FROM user_companies uc
      JOIN companies c ON uc.company_id = c.id
      JOIN user_roles r ON uc.role_id = r.id
+     LEFT JOIN branches b ON uc.branch_id = b.id
      WHERE uc.empid = ?`,
     [empid],
   );
@@ -219,10 +222,10 @@ export async function removeCompanyAssignment(empid, companyId) {
 /**
  * Update a user's company assignment role
  */
-export async function updateCompanyAssignment(empid, companyId, role_id) {
+export async function updateCompanyAssignment(empid, companyId, role_id, branchId) {
   const [result] = await pool.query(
-    "UPDATE user_companies SET role_id = ? WHERE empid = ? AND company_id = ?",
-    [role_id, empid, companyId],
+    "UPDATE user_companies SET role_id = ?, branch_id = ? WHERE empid = ? AND company_id = ?",
+    [role_id, branchId, empid, companyId],
   );
   return result;
 }
@@ -238,10 +241,12 @@ export async function listAllUserCompanies(companyId) {
     params.push(companyId);
   }
   const [rows] = await pool.query(
-    `SELECT uc.empid, uc.company_id, c.name AS company_name, uc.role_id, r.name AS role
+    `SELECT uc.empid, uc.company_id, c.name AS company_name, uc.role_id, r.name AS role,
+            uc.branch_id, b.name AS branch_name
      FROM user_companies uc
      JOIN companies c ON uc.company_id = c.id
      JOIN user_roles r ON uc.role_id = r.id
+     LEFT JOIN branches b ON uc.branch_id = b.id
      ${where}`,
     params,
   );

--- a/src/erp.mgt.mn/components/LoginForm.jsx
+++ b/src/erp.mgt.mn/components/LoginForm.jsx
@@ -53,7 +53,7 @@ export default function LoginForm() {
         onSubmit={(e) => {
           e.preventDefault();
           const choice = companyChoices.find(
-            (c) => String(c.company_id) === selectedCompany,
+            (c) => `${c.company_id}-${c.branch_id || ''}` === selectedCompany,
           );
           if (choice) {
             setCompany(choice);
@@ -77,8 +77,11 @@ export default function LoginForm() {
               Сонгоно уу...
             </option>
             {companyChoices.map((c) => (
-              <option key={c.company_id} value={c.company_id}>
-                {c.company_name}
+              <option
+                key={c.company_id + '-' + (c.branch_id || '')}
+                value={`${c.company_id}-${c.branch_id || ''}`}
+              >
+                {c.branch_name ? `${c.branch_name} | ` : ''}{c.company_name}
               </option>
             ))}
           </select>

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -1,14 +1,17 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import TableManager from '../components/TableManager.jsx';
+import SearchSelect from '../components/SearchSelect.jsx';
+import { AuthContext } from '../context/AuthContext.jsx';
 
-export default function FinanceTransactions({ defaultName = '', hideSelector = false }) {
+export default function FinanceTransactions({ moduleKey = 'finance_transactions', defaultName = '', hideSelector = false }) {
   const [configs, setConfigs] = useState({});
   const [searchParams, setSearchParams] = useSearchParams();
   const [name, setName] = useState(() => defaultName || searchParams.get('name') || '');
   const [table, setTable] = useState('');
   const [config, setConfig] = useState(null);
   const [refreshId, setRefreshId] = useState(0);
+  const { company } = useContext(AuthContext);
 
   useEffect(() => {
     if (defaultName) setName(defaultName);
@@ -21,14 +24,17 @@ export default function FinanceTransactions({ defaultName = '', hideSelector = f
   }, [name, setSearchParams, defaultName]);
 
   useEffect(() => {
-    fetch('/api/transaction_forms', { credentials: 'include' })
+    const params = new URLSearchParams({ moduleKey });
+    if (company?.branch_id !== undefined)
+      params.set('branchId', company.branch_id);
+    fetch(`/api/transaction_forms?${params.toString()}`, { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : {}))
       .then((data) => {
         setConfigs(data);
         if (name && data[name]) setTable(data[name].table ?? data[name]);
       })
       .catch(() => setConfigs({}));
-  }, []);
+  }, [moduleKey, company]);
 
   useEffect(() => {
     if (name && configs[name]) setTable(configs[name].table ?? configs[name]);
@@ -48,13 +54,15 @@ export default function FinanceTransactions({ defaultName = '', hideSelector = f
     <div>
       <h2>{defaultName || 'Finance Transactions'}</h2>
       {!hideSelector && transactionNames.length > 0 && (
-        <div style={{ marginBottom: '0.5rem' }}>
-          <select value={name} onChange={(e) => { setName(e.target.value); setRefreshId((r) => r + 1); }}>
-            <option value="">-- select transaction --</option>
-            {transactionNames.map((t) => (
-              <option key={t} value={t}>{t}</option>
-            ))}
-          </select>
+        <div style={{ marginBottom: '0.5rem', maxWidth: '300px' }}>
+          <SearchSelect
+            value={name}
+            onChange={(v) => {
+              setName(v);
+              setRefreshId((r) => r + 1);
+            }}
+            options={transactionNames.map((t) => ({ value: t, label: t }))}
+          />
         </div>
       )}
       {table && config && (

--- a/src/erp.mgt.mn/pages/Forms.jsx
+++ b/src/erp.mgt.mn/pages/Forms.jsx
@@ -1,56 +1,45 @@
 // src/erp.mgt.mn/pages/Forms.jsx
 import React, { useEffect, useState } from 'react';
 import FinanceTransactionsPage from './FinanceTransactions.jsx';
-import { useTabs } from '../context/TabContext.jsx';
+import { useModules } from '../hooks/useModules.js';
 
 
 export default function Forms() {
-  const [transactions, setTransactions] = useState([]);
-  const { openTab } = useTabs();
+  const [transactions, setTransactions] = useState({});
+  const modules = useModules();
 
   useEffect(() => {
     fetch('/api/transaction_forms', { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : {}))
-      .then((data) =>
-        setTransactions(
-          Object.entries(data).map(([name, info]) => ({
-            name,
-            moduleKey: info.moduleKey,
-            table: info.table,
-          }))
-        )
-      )
+      .then((data) => {
+        const grouped = {};
+        Object.entries(data).forEach(([name, info]) => {
+          const key = info.moduleKey || 'finance_transactions';
+          if (!grouped[key]) grouped[key] = [];
+          grouped[key].push(name);
+        });
+        setTransactions(grouped);
+      })
       .catch((err) => console.error('Error fetching forms:', err));
   }, []);
+
+  const groups = Object.entries(transactions);
 
   return (
     <div>
       <h2>Маягтууд</h2>
-      {transactions.length === 0 ? (
+      {groups.length === 0 ? (
         <p>Маягт олдсонгүй.</p>
       ) : (
-        <ul>
-          {transactions.map((t) => (
-            <li key={t.moduleKey}>
-              <button
-                onClick={() =>
-                  openTab({
-                    key: t.moduleKey,
-                    label: t.name,
-                    content: (
-                      <FinanceTransactionsPage
-                        defaultName={t.name}
-                        hideSelector
-                      />
-                    ),
-                  })
-                }
-              >
-                {t.name}
-              </button>
-            </li>
-          ))}
-        </ul>
+        groups.map(([key, names]) => {
+          const mod = modules.find((m) => m.module_key === key);
+          return (
+            <div key={key} style={{ marginBottom: '1rem' }}>
+              <h3>{mod ? mod.label : key}</h3>
+              <FinanceTransactionsPage moduleKey={key} />
+            </div>
+          );
+        })
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- allow moduleKey and allowedBranches fields for transaction config
- filter transaction lists by module/branch
- handle branch in user-company assignments
- show branch options in login, user-company forms and transaction dropdowns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68551c02cff483318e7d5faae830a76c