### PR TITLE
Add department restrictions to forms config

### DIFF
--- a/api-server/routes/transaction_forms.js
+++ b/api-server/routes/transaction_forms.js
@@ -12,7 +12,7 @@ const router = express.Router();
 
 router.get('/', requireAuth, async (req, res, next) => {
   try {
-    const { table, name, moduleKey, branchId } = req.query;
+    const { table, name, moduleKey, branchId, departmentId } = req.query;
     if (table && name) {
       const cfg = await getFormConfig(table, name);
       res.json(cfg);
@@ -20,7 +20,7 @@ router.get('/', requireAuth, async (req, res, next) => {
       const all = await getConfigsByTable(table);
       res.json(all);
     } else {
-      const names = await listTransactionNames({ moduleKey, branchId });
+      const names = await listTransactionNames({ moduleKey, branchId, departmentId });
       res.json(names);
     }
   } catch (err) {

--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -32,6 +32,7 @@ export async function getFormConfig(table, name) {
       raw.companyIdFields || (raw.companyIdField ? [raw.companyIdField] : []),
     moduleKey: raw.moduleKey || 'finance_transactions',
     allowedBranches: raw.allowedBranches || [],
+    allowedDepartments: raw.allowedDepartments || [],
   };
 }
 
@@ -40,15 +41,17 @@ export async function getConfigsByTable(table) {
   return cfg[table] || {};
 }
 
-export async function listTransactionNames({ moduleKey, branchId } = {}) {
+export async function listTransactionNames({ moduleKey, branchId, departmentId } = {}) {
   const cfg = await readConfig();
   const result = {};
   for (const [tbl, names] of Object.entries(cfg)) {
     for (const [name, info] of Object.entries(names)) {
       const modKey = info.moduleKey || 'finance_transactions';
       const allowed = info.allowedBranches || [];
+      const deptAllowed = info.allowedDepartments || [];
       if (moduleKey && moduleKey !== modKey) continue;
       if (branchId && allowed.length > 0 && !allowed.includes(Number(branchId))) continue;
+      if (departmentId && deptAllowed.length > 0 && !deptAllowed.includes(Number(departmentId))) continue;
       result[name] = {
         table: tbl,
         moduleKey: modKey,
@@ -68,6 +71,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     branchIdFields = [],
     companyIdFields = [],
     allowedBranches = [],
+    allowedDepartments = [],
     userIdField,
     branchIdField,
     companyIdField,
@@ -100,6 +104,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     companyIdFields: cid,
     moduleKey,
     allowedBranches,
+    allowedDepartments,
   };
   await writeConfig(cfg);
   try {

--- a/docs/transaction-form-config.md
+++ b/docs/transaction-form-config.md
@@ -12,6 +12,8 @@ Each **transaction** entry allows you to specify:
 - **userIdFields** – fields automatically filled with the creating user ID
 - **branchIdFields** – fields automatically filled with the branch ID
 - **companyIdFields** – fields automatically filled with the company ID
+- **allowedBranches** – restrict usage to these branch IDs
+- **allowedDepartments** – restrict usage to these department IDs
 
 Example snippet:
 
@@ -25,7 +27,9 @@ Example snippet:
       "editableDefaultFields": ["status"],
       "userIdFields": ["created_by"],
       "branchIdFields": ["branch_id"],
-      "companyIdFields": ["company_id"]
+      "companyIdFields": ["company_id"],
+      "allowedBranches": [1, 2],
+      "allowedDepartments": [5]
     },
     "Issue": {
       "visibleFields": ["tran_date", "description"],
@@ -34,7 +38,9 @@ Example snippet:
       "editableDefaultFields": ["status"],
       "userIdFields": ["created_by"],
       "branchIdFields": ["branch_id"],
-      "companyIdFields": ["company_id"]
+      "companyIdFields": ["company_id"],
+      "allowedBranches": [1, 2],
+      "allowedDepartments": [5]
     }
   }
 }

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -8,6 +8,7 @@ export default function FormsManagement() {
   const [name, setName] = useState('');
   const [moduleKey, setModuleKey] = useState('finance_transactions');
   const [branches, setBranches] = useState([]);
+  const [departments, setDepartments] = useState([]);
   const [columns, setColumns] = useState([]);
   const modules = useModules();
   const [config, setConfig] = useState({
@@ -19,6 +20,7 @@ export default function FormsManagement() {
     branchIdFields: [],
     companyIdFields: [],
     allowedBranches: [],
+    allowedDepartments: [],
   });
 
   useEffect(() => {
@@ -31,6 +33,11 @@ export default function FormsManagement() {
       .then((res) => (res.ok ? res.json() : { rows: [] }))
       .then((data) => setBranches(data.rows || []))
       .catch(() => setBranches([]));
+
+    fetch('/api/tables/code_departments?perPage=500', { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : { rows: [] }))
+      .then((data) => setDepartments(data.rows || []))
+      .catch(() => setDepartments([]));
   }, []);
 
   useEffect(() => {
@@ -54,6 +61,7 @@ export default function FormsManagement() {
             branchIdFields: data[name].branchIdFields || [],
             companyIdFields: data[name].companyIdFields || [],
             allowedBranches: data[name].allowedBranches || [],
+            allowedDepartments: data[name].allowedDepartments || [],
           });
         } else {
           setName('');
@@ -66,6 +74,7 @@ export default function FormsManagement() {
             branchIdFields: [],
             companyIdFields: [],
             allowedBranches: [],
+            allowedDepartments: [],
           });
         }
       })
@@ -81,6 +90,7 @@ export default function FormsManagement() {
           branchIdFields: [],
           companyIdFields: [],
           allowedBranches: [],
+          allowedDepartments: [],
         });
         setModuleKey('finance_transactions');
       });
@@ -101,6 +111,7 @@ export default function FormsManagement() {
           branchIdFields: cfg.branchIdFields || [],
           companyIdFields: cfg.companyIdFields || [],
           allowedBranches: cfg.allowedBranches || [],
+          allowedDepartments: cfg.allowedDepartments || [],
         });
       })
       .catch(() => {
@@ -113,6 +124,7 @@ export default function FormsManagement() {
           branchIdFields: [],
           companyIdFields: [],
           allowedBranches: [],
+          allowedDepartments: [],
         });
         setModuleKey('finance_transactions');
       });
@@ -154,11 +166,16 @@ export default function FormsManagement() {
       alert('Please enter transaction name');
       return;
     }
+    const cfg = {
+      ...config,
+      allowedBranches: config.allowedBranches.map((b) => Number(b)).filter((b) => !Number.isNaN(b)),
+      allowedDepartments: config.allowedDepartments.map((d) => Number(d)).filter((d) => !Number.isNaN(d)),
+    };
     await fetch('/api/transaction_forms', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ table, name, config, moduleKey }),
+      body: JSON.stringify({ table, name, config: cfg, moduleKey }),
     });
     alert('Saved');
     if (!names.includes(name)) setNames((n) => [...n, name]);
@@ -182,6 +199,7 @@ export default function FormsManagement() {
       branchIdFields: [],
       companyIdFields: [],
       allowedBranches: [],
+      allowedDepartments: [],
     });
     setModuleKey('finance_transactions');
   }
@@ -305,6 +323,8 @@ export default function FormsManagement() {
                   </option>
                 ))}
               </select>
+              <button type="button" onClick={() => setConfig((c) => ({ ...c, userIdFields: columns }))}>All</button>
+              <button type="button" onClick={() => setConfig((c) => ({ ...c, userIdFields: [] }))}>None</button>
             </label>
             <label style={{ marginLeft: '1rem' }}>
               Branch ID fields:{' '}
@@ -324,6 +344,8 @@ export default function FormsManagement() {
                   </option>
                 ))}
               </select>
+              <button type="button" onClick={() => setConfig((c) => ({ ...c, branchIdFields: columns }))}>All</button>
+              <button type="button" onClick={() => setConfig((c) => ({ ...c, branchIdFields: [] }))}>None</button>
             </label>
             <label style={{ marginLeft: '1rem' }}>
               Company ID fields:{' '}
@@ -343,6 +365,8 @@ export default function FormsManagement() {
                   </option>
                 ))}
               </select>
+              <button type="button" onClick={() => setConfig((c) => ({ ...c, companyIdFields: columns }))}>All</button>
+              <button type="button" onClick={() => setConfig((c) => ({ ...c, companyIdFields: [] }))}>None</button>
             </label>
             <label style={{ marginLeft: '1rem' }}>
               Allowed branches:{' '}
@@ -362,6 +386,29 @@ export default function FormsManagement() {
                   </option>
                 ))}
               </select>
+              <button type="button" onClick={() => setConfig((c) => ({ ...c, allowedBranches: branches.map((b) => String(b.id)) }))}>All</button>
+              <button type="button" onClick={() => setConfig((c) => ({ ...c, allowedBranches: [] }))}>None</button>
+            </label>
+            <label style={{ marginLeft: '1rem' }}>
+              Allowed departments:{' '}
+              <select
+                multiple
+                value={config.allowedDepartments}
+                onChange={(e) =>
+                  setConfig((c) => ({
+                    ...c,
+                    allowedDepartments: Array.from(e.target.selectedOptions, (o) => o.value),
+                  }))
+                }
+              >
+                {departments.map((d) => (
+                  <option key={d.id} value={d.id}>
+                    {d.code} - {d.name}
+                  </option>
+                ))}
+              </select>
+              <button type="button" onClick={() => setConfig((c) => ({ ...c, allowedDepartments: departments.map((d) => String(d.id)) }))}>All</button>
+              <button type="button" onClick={() => setConfig((c) => ({ ...c, allowedDepartments: [] }))}>None</button>
             </label>
           </div>
           <div style={{ marginTop: '1rem' }}>


### PR DESCRIPTION
## Summary
- support `allowedDepartments` in transaction form configuration
- filter transaction name list by department ID when provided
- fetch department list in FormsManagement page and allow configuring per-department usage
- fix saving of branch & department restrictions and add select all/none helpers in the UI
- document new fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68552c46746c83318b7e94be1bbfdcaa