### PR TITLE
Fix forms config parsing

### DIFF
--- a/docs/transaction-form-config.md
+++ b/docs/transaction-form-config.md
@@ -50,9 +50,9 @@ Example snippet:
 ```
 
 Clients can retrieve a list of transaction names via `/api/transaction_forms`.
-Each item in the returned object now includes the underlying table and the
-`moduleKey` (slug) used for routing so the front‑end can build links without
-replicating the slugify logic.
+Each entry includes the underlying table, `moduleKey` slug and the full
+configuration parsed from the file.  This allows the front‑end to populate
+forms without issuing additional requests or duplicating any parsing logic.
 To obtain a configuration for a specific transaction use
 `/api/transaction_forms?table=tbl&name=transaction`. New configurations are
 posted with `{ table, name, config, showInSidebar?, showInHeader? }` in the request body and can be removed via


### PR DESCRIPTION
## Summary
- parse transaction form entries in service layer
- return parsed config for list and table endpoints
- document that list endpoint returns full config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685552bcda148331a340c4aa60d014ef