### PR TITLE
Improve transaction form validation

### DIFF
--- a/src/erp.mgt.mn/components/AsyncSearchSelect.jsx
+++ b/src/erp.mgt.mn/components/AsyncSearchSelect.jsx
@@ -16,6 +16,7 @@ export default function AsyncSearchSelect({
   const [show, setShow] = useState(false);
   const [highlight, setHighlight] = useState(-1);
   const containerRef = useRef(null);
+  const match = options.find((o) => String(o.value) === String(input));
 
   useEffect(() => {
     setInput(value || '');
@@ -67,9 +68,11 @@ export default function AsyncSearchSelect({
       e.preventDefault();
       setHighlight((h) => Math.max(h - 1, 0));
     } else if (e.key === 'Enter') {
-      if (highlight >= 0 && highlight < options.length) {
+      let idx = highlight;
+      if (idx < 0 && options.length > 0) idx = 0;
+      if (idx >= 0 && idx < options.length) {
         e.preventDefault();
-        const opt = options[highlight];
+        const opt = options[idx];
         onChange(opt.value);
         setInput(String(opt.value));
         setShow(false);
@@ -95,8 +98,8 @@ export default function AsyncSearchSelect({
         onFocus={() => setShow(true)}
         onBlur={handleBlur}
         onKeyDown={(e) => {
-          if (onKeyDown) onKeyDown(e);
           handleSelectKeyDown(e);
+          if (onKeyDown) onKeyDown(e);
         }}
         disabled={disabled}
         style={{ width: '100%', padding: '0.5rem' }}
@@ -136,6 +139,9 @@ export default function AsyncSearchSelect({
             </li>
           ))}
         </ul>
+      )}
+      {match && (
+        <div style={{ fontSize: '0.8rem', color: '#555' }}>{match.label}</div>
       )}
     </div>
   );

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -47,6 +47,10 @@ export default function RowFormModal({
   function handleKeyDown(e, col) {
     if (e.key !== 'Enter') return;
     e.preventDefault();
+    if (requiredFields.includes(col) && !formVals[col]) {
+      setErrors((er) => ({ ...er, [col]: 'Please enter value' }));
+      return;
+    }
     const enabled = columns.filter((c) => !disabledFields.includes(c));
     const idx = enabled.indexOf(col);
     const next = enabled[idx + 1];
@@ -106,9 +110,10 @@ export default function RowFormModal({
                   searchColumn={relationConfigs[c].column}
                   labelFields={relationConfigs[c].displayFields || []}
                   value={formVals[c]}
-                  onChange={(val) =>
-                    setFormVals((v) => ({ ...v, [c]: val }))
-                  }
+                  onChange={(val) => {
+                    setFormVals((v) => ({ ...v, [c]: val }));
+                    setErrors((er) => ({ ...er, [c]: undefined }));
+                  }}
                   disabled={row && disabledFields.includes(c)}
                   onKeyDown={(e) => handleKeyDown(e, c)}
                   inputRef={(el) => (inputRefs.current[c] = el)}
@@ -118,9 +123,10 @@ export default function RowFormModal({
                   title={labels[c] || c}
                   ref={(el) => (inputRefs.current[c] = el)}
                   value={formVals[c]}
-                  onChange={(e) =>
-                    setFormVals((v) => ({ ...v, [c]: e.target.value }))
-                  }
+                  onChange={(e) => {
+                    setFormVals((v) => ({ ...v, [c]: e.target.value }));
+                    setErrors((er) => ({ ...er, [c]: undefined }));
+                  }}
                   onKeyDown={(e) => handleKeyDown(e, c)}
                   disabled={row && disabledFields.includes(c)}
                   style={inputStyle}
@@ -138,9 +144,10 @@ export default function RowFormModal({
                   ref={(el) => (inputRefs.current[c] = el)}
                   type="text"
                   value={formVals[c]}
-                  onChange={(e) =>
-                    setFormVals((v) => ({ ...v, [c]: e.target.value }))
-                  }
+                  onChange={(e) => {
+                    setFormVals((v) => ({ ...v, [c]: e.target.value }));
+                    setErrors((er) => ({ ...er, [c]: undefined }));
+                  }}
                   onKeyDown={(e) => handleKeyDown(e, c)}
                   disabled={row && disabledFields.includes(c)}
                   style={inputStyle}

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -446,19 +446,28 @@ export default function TableManager({ table, refreshId = 0, formConfig = null, 
           params.set('sort', sort.column);
           params.set('dir', sort.dir);
         }
-      Object.entries(filters).forEach(([k, v]) => {
-        if (v) params.set(k, v);
-      });
-      const data = await fetch(`/api/tables/${encodeURIComponent(table)}?${params.toString()}`, {
-        credentials: 'include',
-      }).then((r) => r.json());
-      setRows(data.rows || []);
-      setCount(data.count || 0);
+        Object.entries(filters).forEach(([k, v]) => {
+          if (v) params.set(k, v);
+        });
+        const data = await fetch(`/api/tables/${encodeURIComponent(table)}?${params.toString()}`, {
+          credentials: 'include',
+        }).then((r) => r.json());
+        setRows(data.rows || []);
+        setCount(data.count || 0);
         setSelectedRows(new Set());
         setShowForm(false);
         setEditing(null);
         setIsAdding(false);
         addToast('Saved', 'success');
+      } else {
+        let message = 'Save failed';
+        try {
+          const data = await res.json();
+          if (data && data.message) message += `: ${data.message}`;
+        } catch {
+          // ignore
+        }
+        addToast(message, 'error');
       }
     } catch (err) {
       console.error('Save failed', err);


### PR DESCRIPTION
## Summary
- prevent advancing with empty required fields
- keep modal values on save error and show error message
- enhance async search select to pick values with Enter and display matched label

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a2e74f570833183bf71cb0ccf815d