### PR TITLE
Improve form transaction UX

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -472,7 +472,8 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
         setShowForm(false);
         setEditing(null);
         setIsAdding(false);
-        addToast('Saved', 'success');
+        const msg = isAdding ? 'New transaction saved' : 'Saved';
+        addToast(msg, 'success');
       } else {
         let message = 'Save failed';
         try {


### PR DESCRIPTION
## Summary
- validate date fields on Enter press
- update field value when pressing Enter quickly
- confirm transaction save
- show toast for new transaction saves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a3acc53c08331b49cf2a6947062b6