### PR TITLE
Add coding table config management

### DIFF
--- a/api-server/routes/coding_table_configs.js
+++ b/api-server/routes/coding_table_configs.js
@@ -1,5 +1,10 @@
 import express from 'express';
-import { getConfig, getAllConfigs, setConfig } from '../services/codingTableConfig.js';
+import {
+  getConfig,
+  getAllConfigs,
+  setConfig,
+  deleteConfig,
+} from '../services/codingTableConfig.js';
 import { requireAuth } from '../middlewares/auth.js';
 
 const router = express.Router();
@@ -25,6 +30,17 @@ router.post('/', requireAuth, async (req, res, next) => {
     if (!table) return res.status(400).json({ message: 'table is required' });
     await setConfig(table, config || {});
     res.status(200).json({ message: 'Config saved successfully' });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/', requireAuth, async (req, res, next) => {
+  try {
+    const table = req.query.table;
+    if (!table) return res.status(400).json({ message: 'table is required' });
+    await deleteConfig(table);
+    res.sendStatus(204);
   } catch (err) {
     next(err);
   }

--- a/api-server/services/codingTableConfig.js
+++ b/api-server/services/codingTableConfig.js
@@ -37,3 +37,11 @@ export async function setConfig(table, config = {}) {
   await writeConfig(cfg);
   return cfg[table];
 }
+
+export async function deleteConfig(table) {
+  const cfg = await readConfig();
+  if (cfg[table]) {
+    delete cfg[table];
+    await writeConfig(cfg);
+  }
+}


### PR DESCRIPTION
## Summary
- manage coding table configurations on the backend
- load saved configuration names on the client
- allow choosing/saving/deleting coding table configs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a417d504c83319bf4c9adf2fd5db2