### PR TITLE
Fix transaction dropdown handling

### DIFF
--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -72,7 +72,16 @@ export default function App() {
           moduleKey={m.module_key}
           defaultName={m.label}
           hideSelector
+          title={m.label}
         />
+      );
+    }
+  });
+
+  modules.forEach((m) => {
+    if (!componentMap[m.module_key]) {
+      componentMap[m.module_key] = (
+        <FinanceTransactionsPage moduleKey={m.module_key} title={m.label} />
       );
     }
   });

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -51,7 +51,10 @@ const deleteBtnStyle = {
   color: '#b91c1c',
 };
 
-export default forwardRef(function TableManager({ table, refreshId = 0, formConfig = null, initialPerPage = 10, addLabel = 'Add Row' }, ref) {
+export default forwardRef(function TableManager(
+  { table, refreshId = 0, formConfig = null, initialPerPage = 10, addLabel = 'Add Row', visible = true },
+  ref,
+) {
   const [rows, setRows] = useState([]);
   const [count, setCount] = useState(0);
   const [page, setPage] = useState(1);
@@ -752,6 +755,8 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
 
   return (
     <div>
+      {visible && (
+        <>
       <div
         style={{
           marginBottom: '0.5rem',
@@ -1052,6 +1057,8 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
           </button>
         </div>
       </div>
+      </>
+      )}
       <RowFormModal
         visible={showForm}
         onCancel={() => {

--- a/src/erp.mgt.mn/index.css
+++ b/src/erp.mgt.mn/index.css
@@ -11,6 +11,10 @@ button {
   background-color: #f3f4f6;
   cursor: pointer;
 }
+select {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
 button:hover {
   background-color: #e5e7eb;
 }

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -6,10 +6,17 @@ import { AuthContext } from '../context/AuthContext.jsx';
 import { useRolePermissions } from '../hooks/useRolePermissions.js';
 import { useCompanyModules } from '../hooks/useCompanyModules.js';
 
-export default function FinanceTransactions({ moduleKey = 'finance_transactions', defaultName = '', hideSelector = false }) {
+export default function FinanceTransactions({
+  moduleKey = 'finance_transactions',
+  defaultName = '',
+  hideSelector = false,
+  title = '',
+}) {
   const [configs, setConfigs] = useState({});
   const [searchParams, setSearchParams] = useSearchParams();
-  const [name, setName] = useState(() => defaultName || searchParams.get('name') || '');
+  const [name, setName] = useState(() =>
+    hideSelector && defaultName ? defaultName : searchParams.get('name') || '',
+  );
   const [table, setTable] = useState('');
   const [config, setConfig] = useState(null);
   const [refreshId, setRefreshId] = useState(0);
@@ -20,14 +27,14 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
   const tableRef = useRef(null);
 
   useEffect(() => {
-    if (defaultName) setName(defaultName);
-  }, [defaultName]);
+    if (hideSelector && defaultName) setName(defaultName);
+  }, [defaultName, hideSelector]);
 
   useEffect(() => {
-    if (defaultName) return;
+    if (hideSelector) return;
     if (name) setSearchParams({ name });
     else setSearchParams({});
-  }, [name, setSearchParams, defaultName]);
+  }, [name, setSearchParams, hideSelector]);
 
   useEffect(() => {
     const params = new URLSearchParams({ moduleKey });
@@ -43,6 +50,7 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
           const allowedB = info.allowedBranches || [];
           const allowedD = info.allowedDepartments || [];
           const mKey = info.moduleKey || 'finance_transactions';
+          if (mKey !== moduleKey) return;
           if (
             allowedB.length > 0 &&
             company?.branch_id !== undefined &&
@@ -84,7 +92,7 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
 
   return (
     <div>
-      <h2>{defaultName || 'Finance Transactions'}</h2>
+      <h2>{title || 'Finance Transactions'}</h2>
       {!hideSelector && transactionNames.length > 0 && (
         <div style={{ marginBottom: '0.5rem', maxWidth: '300px' }}>
           <SearchSelect
@@ -95,10 +103,10 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
               setShowTable(false);
             }}
             options={[
-              { value: '', label: 'Choose transaction' },
+              { value: '', label: '-- Choose transaction --' },
               ...transactionNames.map((t) => ({ value: t, label: t })),
             ]}
-            placeholder="Choose transaction"
+            placeholder="-- Choose transaction --"
           />
         </div>
       )}
@@ -113,16 +121,15 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
         </div>
       )}
       {table && config && (
-        <div style={{ display: showTable ? 'block' : 'none' }}>
-          <TableManager
-            ref={tableRef}
-            table={table}
-            refreshId={refreshId}
-            formConfig={config}
-            initialPerPage={10}
-            addLabel="Add Transaction"
-          />
-        </div>
+        <TableManager
+          ref={tableRef}
+          table={table}
+          refreshId={refreshId}
+          formConfig={config}
+          initialPerPage={10}
+          addLabel="Add Transaction"
+          visible={showTable}
+        />
       )}
       {transactionNames.length === 0 && (
         <p>No transactions configured.</p>

--- a/src/erp.mgt.mn/pages/Forms.jsx
+++ b/src/erp.mgt.mn/pages/Forms.jsx
@@ -37,7 +37,7 @@ export default function Forms() {
             <div key={key} style={{ marginBottom: '1rem' }}>
               <FinanceTransactionsPage
                 moduleKey={key}
-                defaultName={mod ? mod.label : key}
+                title={mod ? mod.label : key}
               />
             </div>
           );


### PR DESCRIPTION
## Summary
- support custom titles in FinanceTransactions page
- hide table section using new `visible` prop on TableManager
- restrict dropdown options to the current module
- ensure dropdown shows all options with placeholder text
- style select elements with borders
- enable dynamic forms for any module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a4f7a6208833197fcab2de74416f3