### PR TITLE
Fix Dynamic Forms for all transaction types

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -85,6 +85,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     companyIdFields = [],
     allowedBranches = [],
     allowedDepartments = [],
+    moduleKey: parentModuleKey = 'finance_transactions',
     userIdField,
     branchIdField,
     companyIdField,
@@ -94,7 +95,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     showInHeader = false,
     moduleKey: providedModuleKey,
   } = options;
-  const moduleKey = providedModuleKey || slugify(name);
+  const moduleSlug = providedModuleKey || slugify(name);
   const uid = (userIdFields.length ? userIdFields : userIdField ? [userIdField] : [])
     .map(String)
     .filter(Boolean);
@@ -128,16 +129,23 @@ export async function setFormConfig(table, name, config, options = {}) {
     userIdFields: uid,
     branchIdFields: bid,
     companyIdFields: cid,
-    moduleKey,
+    moduleKey: parentModuleKey,
     allowedBranches: ab,
     allowedDepartments: ad,
   };
   await writeConfig(cfg);
   try {
     await upsertModule(
-      moduleKey,
+      parentModuleKey,
+      parentModuleKey,
+      null,
+      true,
+      false,
+    );
+    await upsertModule(
+      moduleSlug,
       name,
-      'finance_transactions',
+      parentModuleKey,
       showInSidebar,
       showInHeader,
     );

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -51,7 +51,7 @@ const deleteBtnStyle = {
   color: '#b91c1c',
 };
 
-export default forwardRef(function TableManager({ table, refreshId = 0, formConfig = null, initialPerPage = 10, addLabel = 'Add Row' }, ref) {
+export default forwardRef(function TableManager({ table, refreshId = 0, formConfig = null, initialPerPage = 10, addLabel = 'Add Row', showTable = true }, ref) {
   const [rows, setRows] = useState([]);
   const [count, setCount] = useState(0);
   const [page, setPage] = useState(1);
@@ -779,6 +779,8 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
           <button onClick={handleDeleteSelected}>Delete Selected</button>
         )}
       </div>
+      {showTable && (
+        <>
       <div
         style={{
           display: 'flex',
@@ -1052,6 +1054,8 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
           </button>
         </div>
       </div>
+        </>
+      )}
       <RowFormModal
         visible={showForm}
         onCancel={() => {

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -113,16 +113,15 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
         </div>
       )}
       {table && config && (
-        <div style={{ display: showTable ? 'block' : 'none' }}>
-          <TableManager
-            ref={tableRef}
-            table={table}
-            refreshId={refreshId}
-            formConfig={config}
-            initialPerPage={10}
-            addLabel="Add Transaction"
-          />
-        </div>
+        <TableManager
+          ref={tableRef}
+          table={table}
+          refreshId={refreshId}
+          formConfig={config}
+          initialPerPage={10}
+          addLabel="Add Transaction"
+          showTable={showTable}
+        />
       )}
       {transactionNames.length === 0 && (
         <p>No transactions configured.</p>


### PR DESCRIPTION
## Summary
- support generic transaction modules instead of being finance-only
- create parent modules dynamically when saving transaction forms
- show/hide tables correctly to make Add Transaction usable without viewing table
- expose dynamic forms in any module based on configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a550eca288331afdc319f13b3c2d4