### PR TITLE
Dynamic transaction module

### DIFF
--- a/db/defaultModules.js
+++ b/db/defaultModules.js
@@ -1,6 +1,5 @@
 export default [
   { moduleKey: 'dashboard', label: 'Самбар', parentKey: null, showInSidebar: true, showInHeader: false },
-  { moduleKey: 'finance_transactions', label: 'Finance Transactions', parentKey: null, showInSidebar: true, showInHeader: false },
   { moduleKey: 'forms', label: 'Маягтууд', parentKey: null, showInSidebar: true, showInHeader: false },
   { moduleKey: 'reports', label: 'Тайлан', parentKey: null, showInSidebar: true, showInHeader: false },
   { moduleKey: 'settings', label: 'Тохиргоо', parentKey: null, showInSidebar: true, showInHeader: false },

--- a/docs/transaction-form-config.md
+++ b/docs/transaction-form-config.md
@@ -57,7 +57,7 @@ To obtain a configuration for a specific transaction use
 `/api/transaction_forms?table=tbl&name=transaction`. New configurations are
 posted with `{ table, name, config, showInSidebar?, showInHeader? }` in the request body and can be removed via
 `DELETE /api/transaction_forms?table=tbl&name=transaction`.
-Saving a configuration automatically creates a module using a slug of the transaction
-name under the parent `finance_transactions`. If this parent module does not
-exist it will be created automatically. The optional `showInSidebar` and
-`showInHeader` flags determine where the generated module appears in the UI.
+Saving a configuration automatically creates modules based on the provided
+`moduleKey`. If no `moduleKey` is supplied the value `finance_transactions` is
+used. The optional `showInSidebar` and `showInHeader` flags determine where the
+generated module appears in the UI.

--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -68,7 +68,6 @@ export default function App() {
     forms_management: <FormsManagementPage />,
     report_management: <ReportManagementPage />,
     change_password: <ChangePasswordPage />,
-    finance_transactions: <FinanceTransactionsPage />,
   };
 
   modules.forEach((m) => {

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -84,7 +84,7 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
 
   return (
     <div>
-      <h2>{defaultName || 'Finance Transactions'}</h2>
+      <h2>{defaultName || 'Transactions'}</h2>
       {!hideSelector && transactionNames.length > 0 && (
         <div style={{ marginBottom: '0.5rem', maxWidth: '300px' }}>
           <SearchSelect

--- a/src/erp.mgt.mn/pages/Forms.jsx
+++ b/src/erp.mgt.mn/pages/Forms.jsx
@@ -14,7 +14,8 @@ export default function Forms() {
       .then((data) => {
         const grouped = {};
         Object.entries(data).forEach(([name, info]) => {
-          const key = info.moduleKey || 'finance_transactions';
+          const key = info.moduleKey;
+          if (!key) return;
           if (!grouped[key]) grouped[key] = [];
           grouped[key].push(name);
         });


### PR DESCRIPTION
## Summary
- remove default Finance Transactions menu module
- drop static `finance_transactions` mapping from router
- rename dynamic page header to just 'Transactions'
- group form list purely by configured `moduleKey`
- clarify docs around moduleKey auto-creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a5988ef4883319227684d0f4e0fcf