### PR TITLE
Update form save logic

### DIFF
--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -174,6 +174,7 @@ export default function FormsManagement() {
     }
     const cfg = {
       ...config,
+      moduleKey,
       allowedBranches: config.allowedBranches.map((b) => Number(b)).filter((b) => !Number.isNaN(b)),
       allowedDepartments: config.allowedDepartments.map((d) => Number(d)).filter((d) => !Number.isNaN(d)),
     };
@@ -181,7 +182,7 @@ export default function FormsManagement() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ table, name, config: cfg, moduleKey }),
+      body: JSON.stringify({ table, name, config: cfg }),
     });
     alert('Saved');
     if (!names.includes(name)) setNames((n) => [...n, name]);

--- a/tests/db/transactionFormConfig.test.js
+++ b/tests/db/transactionFormConfig.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import path from 'path';
+import { setFormConfig } from '../../api-server/services/transactionFormConfig.js';
+import * as db from '../../db/index.js';
+import { slugify } from '../../api-server/utils/slugify.js';
+
+const filePath = path.join(process.cwd(), 'config', 'transactionForms.json');
+
+function withTempFile() {
+  return fs.readFile(filePath, 'utf8')
+    .catch(() => '{}')
+    .then((orig) => ({
+      orig,
+      restore: () => fs.writeFile(filePath, orig),
+    }));
+}
+
+function mockPool(handler) {
+  const original = db.pool.query;
+  db.pool.query = async (...args) => {
+    await handler(...args);
+    return [{}];
+  };
+  return () => {
+    db.pool.query = original;
+  };
+}
+
+await test('setFormConfig writes moduleKey and creates modules with slug', async () => {
+  const { orig, restore } = await withTempFile();
+  await fs.writeFile(filePath, '{}');
+  const calls = [];
+  const restoreDb = mockPool((sql, params) => calls.push({ sql, params }));
+
+  await setFormConfig('tbl', 'Sample Transaction', { moduleKey: 'parent_mod' });
+
+  restoreDb();
+  const data = JSON.parse(await fs.readFile(filePath, 'utf8'));
+  assert.equal(data.tbl['Sample Transaction'].moduleKey, 'parent_mod');
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].params[0], 'parent_mod');
+  assert.equal(calls[1].params[0], slugify('Sample Transaction'));
+  await restore();
+});


### PR DESCRIPTION
## Summary
- send `moduleKey` inside config when saving forms
- test module key persistence and slug handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a6f6aec448331a1a974e640f46c21