### PR TITLE
Fix module route check to read module config

### DIFF
--- a/README_MIGRATION.md
+++ b/README_MIGRATION.md
@@ -46,4 +46,7 @@ If the sidebar links do not match the available React routes, run:
 node scripts/check-module-routes.cjs
 ```
 
-It prints `All sidebar modules have matching routes.` when every module has a corresponding route, or lists the missing ones so you can correct them.
+The script loads module definitions from `db/defaultModules.js` and compares them
+to the available React routes. It prints `All sidebar modules have matching routes.`
+when every module has a corresponding route, or lists the missing ones so you can
+correct them.

--- a/scripts/check-module-routes.cjs
+++ b/scripts/check-module-routes.cjs
@@ -14,17 +14,18 @@ while ((m = routeRegex.exec(appJsx))) {
 }
 routePaths.add('/');
 
-const roots = ['dashboard','forms','reports','settings'];
-const settingsChildren = [
-  'users',
-  'user_companies',
-  'role_permissions',
-  'company_licenses',
-  'tables_management',
-  'forms_management',
-  'report_management',
-  'change_password',
-];
+const { createRequire } = require('module');
+const path = require('path');
+const requireModule = createRequire(__filename);
+const defaultModules = requireModule('../db/defaultModules.js').default;
+
+const roots = defaultModules
+  .filter((m) => m.parentKey === null)
+  .map((m) => m.moduleKey);
+
+const settingsChildren = defaultModules
+  .filter((m) => m.parentKey === 'settings')
+  .map((m) => m.moduleKey);
 
 function modulePath(key, parent) {
   const segments = [];


### PR DESCRIPTION
## Summary
- update check-module-routes script to load module list from `db/defaultModules.js`
- document automatic module loading in the migration README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a806e6d288331a7f014f5e05a220d