### PR TITLE
Add moduleLabel to transaction forms

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -36,6 +36,7 @@ function parseEntry(raw = {}) {
     allowedDepartments: Array.isArray(raw.allowedDepartments)
       ? raw.allowedDepartments.map((v) => Number(v)).filter((v) => !Number.isNaN(v))
       : [],
+    moduleLabel: typeof raw.moduleLabel === 'string' ? raw.moduleLabel : '',
   };
 }
 
@@ -86,6 +87,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     allowedBranches = [],
     allowedDepartments = [],
     moduleKey: parentModuleKey = 'finance_transactions',
+    moduleLabel,
     userIdField,
     branchIdField,
     companyIdField,
@@ -131,14 +133,16 @@ export async function setFormConfig(table, name, config, options = {}) {
     branchIdFields: bid,
     companyIdFields: cid,
     moduleKey: parentModuleKey,
+    moduleLabel: moduleLabel || undefined,
     allowedBranches: ab,
     allowedDepartments: ad,
   };
   await writeConfig(cfg);
   try {
+    const parentLabel = moduleLabel || slugify(parentModuleKey);
     await upsertModule(
       parentModuleKey,
-      parentModuleKey,
+      parentLabel,
       null,
       true,
       false,

--- a/docs/transaction-form-config.md
+++ b/docs/transaction-form-config.md
@@ -13,6 +13,7 @@ Each **transaction** entry allows you to specify:
 - **branchIdFields** – fields automatically filled with the branch ID
 - **companyIdFields** – fields automatically filled with the company ID
 - **moduleKey** – module slug used to group the form under a module
+- **moduleLabel** – optional label for the parent module
 - **allowedBranches** – restrict usage to these branch IDs
 - **allowedDepartments** – restrict usage to these department IDs
 
@@ -30,6 +31,7 @@ Example snippet:
       "branchIdFields": ["branch_id"],
       "companyIdFields": ["company_id"],
       "moduleKey": "finance_transactions",
+      "moduleLabel": "Finance",
       "allowedBranches": [1, 2],
       "allowedDepartments": [5]
     },
@@ -42,6 +44,7 @@ Example snippet:
       "branchIdFields": ["branch_id"],
       "companyIdFields": ["company_id"],
       "moduleKey": "finance_transactions",
+      "moduleLabel": "Finance",
       "allowedBranches": [1, 2],
       "allowedDepartments": [5]
     }
@@ -59,5 +62,6 @@ posted with `{ table, name, config, showInSidebar?, showInHeader? }` in the requ
 `DELETE /api/transaction_forms?table=tbl&name=transaction`.
 Saving a configuration automatically creates modules based on the provided
 `moduleKey`. If no `moduleKey` is supplied the value `finance_transactions` is
-used. The optional `showInSidebar` and `showInHeader` flags determine where the
+used. The optional `moduleLabel` lets you set a custom name for the parent
+module. The optional `showInSidebar` and `showInHeader` flags determine where the
 generated module appears in the UI.

--- a/tests/db/transactionFormConfig.test.js
+++ b/tests/db/transactionFormConfig.test.js
@@ -41,10 +41,31 @@ await test('setFormConfig writes moduleKey and creates modules with slug', async
   assert.equal(data.tbl['Sample Transaction'].moduleKey, 'parent_mod');
   assert.equal(calls.length, 2);
   assert.equal(calls[0].params[0], 'parent_mod');
+  assert.equal(calls[0].params[1], slugify('parent_mod'));
   assert.equal(
     calls[1].params[0],
     slugify('parent_mod_Sample Transaction')
   );
+  await restore();
+});
+
+await test('setFormConfig uses moduleLabel when provided', async () => {
+  const { orig, restore } = await withTempFile();
+  await fs.writeFile(filePath, '{}');
+  const calls = [];
+  const restoreDb = mockPool((sql, params) => calls.push({ sql, params }));
+
+  await setFormConfig('tbl', 'Labeled', {
+    moduleKey: 'parent_mod',
+    moduleLabel: 'My Transactions',
+  });
+
+  restoreDb();
+  const data = JSON.parse(await fs.readFile(filePath, 'utf8'));
+  assert.equal(data.tbl.Labeled.moduleLabel, 'My Transactions');
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].params[0], 'parent_mod');
+  assert.equal(calls[0].params[1], 'My Transactions');
   await restore();
 });
 


### PR DESCRIPTION
## Summary
- support optional `moduleLabel` for transaction forms
- use moduleLabel when creating parent module
- document the `moduleLabel` field
- test label behaviour in transaction form config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a8978b5e483318e74209ab59ad286