### PR TITLE
Remove child module creation

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -147,13 +147,6 @@ export async function setFormConfig(table, name, config, options = {}) {
       true,
       false,
     );
-    await upsertModule(
-      moduleSlug,
-      name,
-      parentModuleKey,
-      showInSidebar,
-      showInHeader,
-    );
   } catch (err) {
     console.error('Failed to auto-create module', err);
   }

--- a/docs/transaction-form-config.md
+++ b/docs/transaction-form-config.md
@@ -60,8 +60,10 @@ To obtain a configuration for a specific transaction use
 `/api/transaction_forms?table=tbl&name=transaction`. New configurations are
 posted with `{ table, name, config, showInSidebar?, showInHeader? }` in the request body and can be removed via
 `DELETE /api/transaction_forms?table=tbl&name=transaction`.
-Saving a configuration automatically creates modules based on the provided
-`moduleKey`. If no `moduleKey` is supplied the value `finance_transactions` is
-used. The optional `moduleLabel` lets you set a custom name for the parent
-module. The optional `showInSidebar` and `showInHeader` flags determine where the
-generated module appears in the UI.
+Saving a configuration does **not** generate a module for every transaction.
+Only the parent module referenced by `moduleKey` is created (or updated) if it
+does not already exist.  All transactions share this parent module and are
+grouped under it.  If no `moduleKey` is supplied the value
+`finance_transactions` is used.  The optional `moduleLabel` lets you set a custom
+name for the parent module.  The optional `showInSidebar` and `showInHeader`
+flags previously applied to child modules and currently have no effect.

--- a/tests/db/transactionFormConfig.test.js
+++ b/tests/db/transactionFormConfig.test.js
@@ -39,13 +39,9 @@ await test('setFormConfig writes moduleKey and creates modules with slug', async
   restoreDb();
   const data = JSON.parse(await fs.readFile(filePath, 'utf8'));
   assert.equal(data.tbl['Sample Transaction'].moduleKey, 'parent_mod');
-  assert.equal(calls.length, 2);
+  assert.equal(calls.length, 1);
   assert.equal(calls[0].params[0], 'parent_mod');
   assert.equal(calls[0].params[1], slugify('parent_mod'));
-  assert.equal(
-    calls[1].params[0],
-    slugify('parent_mod_Sample Transaction')
-  );
   await restore();
 });
 
@@ -63,7 +59,7 @@ await test('setFormConfig uses moduleLabel when provided', async () => {
   restoreDb();
   const data = JSON.parse(await fs.readFile(filePath, 'utf8'));
   assert.equal(data.tbl.Labeled.moduleLabel, 'My Transactions');
-  assert.equal(calls.length, 2);
+  assert.equal(calls.length, 1);
   assert.equal(calls[0].params[0], 'parent_mod');
   assert.equal(calls[0].params[1], 'My Transactions');
   await restore();
@@ -85,10 +81,10 @@ await test('setFormConfig forwards sidebar/header flags and slug', async () => {
   restoreDb();
   const data = JSON.parse(await fs.readFile(filePath, 'utf8'));
   assert.equal(data.tbl.Flagged.moduleKey, 'parent_mod');
-  assert.equal(calls.length, 2);
-  assert.equal(calls[1].params[0], 'custom_slug');
-  assert.equal(calls[1].params[3], 0);
-  assert.equal(calls[1].params[4], 1);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].params[0], 'parent_mod');
+  assert.equal(calls[0].params[3], 1); // parent defaults showInSidebar true
+  assert.equal(calls[0].params[4], 0); // parent defaults showInHeader false
   await restore();
 });
 


### PR DESCRIPTION
## Summary
- stop auto-creating a module per transaction in `setFormConfig`
- update docs about module creation behaviour
- update unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a9506a630833185cac8ff28e804d1