### PR TITLE
Remove automatic module updates

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -1,7 +1,5 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { upsertModule, deleteModule } from '../../db/index.js';
-import { slugify } from '../utils/slugify.js';
 
 const filePath = path.join(process.cwd(), 'config', 'transactionForms.json');
 
@@ -95,10 +93,7 @@ export async function setFormConfig(table, name, config, options = {}) {
   const {
     showInSidebar = true,
     showInHeader = false,
-    moduleKey: providedModuleKey,
   } = options;
-  const moduleSlug =
-    providedModuleKey || slugify(`${parentModuleKey}_${name}`);
   const uid = (userIdFields.length ? userIdFields : userIdField ? [userIdField] : [])
     .map(String)
     .filter(Boolean);
@@ -138,43 +133,13 @@ export async function setFormConfig(table, name, config, options = {}) {
     allowedDepartments: ad,
   };
   await writeConfig(cfg);
-  try {
-    const parentLabel = moduleLabel || slugify(parentModuleKey);
-    await upsertModule(
-      parentModuleKey,
-      parentLabel,
-      null,
-      true,
-      false,
-    );
-  } catch (err) {
-    console.error('Failed to auto-create module', err);
-  }
   return cfg[table][name];
 }
 
 export async function deleteFormConfig(table, name) {
   const cfg = await readConfig();
   if (!cfg[table] || !cfg[table][name]) return;
-  const { moduleKey: parentKey } = parseEntry(cfg[table][name]);
-  const slug = slugify(`${parentKey}_${name}`);
   delete cfg[table][name];
   if (Object.keys(cfg[table]).length === 0) delete cfg[table];
   await writeConfig(cfg);
-  try {
-    await deleteModule(slug);
-    let used = false;
-    for (const tbl of Object.values(cfg)) {
-      for (const info of Object.values(tbl)) {
-        if (parseEntry(info).moduleKey === parentKey) {
-          used = true;
-          break;
-        }
-      }
-      if (used) break;
-    }
-    if (!used) await deleteModule(parentKey);
-  } catch (err) {
-    console.error('Failed to auto-delete module', err);
-  }
 }

--- a/docs/transaction-form-config.md
+++ b/docs/transaction-form-config.md
@@ -60,10 +60,7 @@ To obtain a configuration for a specific transaction use
 `/api/transaction_forms?table=tbl&name=transaction`. New configurations are
 posted with `{ table, name, config, showInSidebar?, showInHeader? }` in the request body and can be removed via
 `DELETE /api/transaction_forms?table=tbl&name=transaction`.
-Saving a configuration does **not** generate a module for every transaction.
-Only the parent module referenced by `moduleKey` is created (or updated) if it
-does not already exist.  All transactions share this parent module and are
-grouped under it.  If no `moduleKey` is supplied the value
-`finance_transactions` is used.  The optional `moduleLabel` lets you set a custom
-name for the parent module.  The optional `showInSidebar` and `showInHeader`
-flags previously applied to child modules and currently have no effect.
+Saving a configuration does **not** create or update any modules. The optional
+`moduleKey` and `moduleLabel` values are stored with the form entry but must be
+managed separately in the modules table. The optional `showInSidebar` and
+`showInHeader` flags currently have no effect.


### PR DESCRIPTION
## Summary
- stop creating or deleting modules in transaction form config service
- drop related DB expectations in unit tests
- document that saving configs no longer manipulates modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a9b1cb7dc83318c0044e20d80b93f