### PR TITLE
Fix transaction module refresh behavior

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -8,7 +8,7 @@ import { logout } from "../hooks/useAuth.jsx";
 import { useRolePermissions, refreshRolePermissions } from "../hooks/useRolePermissions.js";
 import { useCompanyModules } from "../hooks/useCompanyModules.js";
 import { useModules } from "../hooks/useModules.js";
-import { useTransactionModules } from "../hooks/useTransactionModules.js";
+import { useTxnModules } from "../hooks/useTxnModules.js";
 import modulePath from "../utils/modulePath.js";
 import AskAIFloat from "./AskAIFloat.jsx";
 import { useTabs } from "../context/TabContext.jsx";
@@ -53,7 +53,7 @@ export default function ERPLayout() {
   const windowTitle = titleForPath(location.pathname);
 
   const { tabs, activeKey, openTab, closeTab, switchTab, setTabContent, cache } = useTabs();
-  const txnModuleKeys = useTransactionModules();
+  const txnModuleKeys = useTxnModules();
 
   useEffect(() => {
     const title = titleForPath(location.pathname);

--- a/src/erp.mgt.mn/hooks/useTransactionModules.js
+++ b/src/erp.mgt.mn/hooks/useTransactionModules.js
@@ -1,41 +1,4 @@
-import { useEffect, useState } from 'react';
-
-const cache = { keys: null };
-const emitter = new EventTarget();
-
-export function refreshTransactionModules() {
-  delete cache.keys;
-  emitter.dispatchEvent(new Event('refresh'));
-}
-
-export function useTransactionModules() {
-  const [keys, setKeys] = useState(cache.keys || new Set());
-
-  async function fetchKeys() {
-    try {
-      const res = await fetch('/api/transaction_forms', { credentials: 'include' });
-      const data = res.ok ? await res.json() : {};
-      const set = new Set();
-      Object.values(data).forEach((info) => {
-        if (info && info.moduleKey) set.add(info.moduleKey);
-      });
-      cache.keys = set;
-      setKeys(new Set(set));
-    } catch (err) {
-      console.error('Failed to load transaction modules', err);
-      setKeys(new Set());
-    }
-  }
-
-  useEffect(() => {
-    if (!cache.keys) fetchKeys();
-  }, []);
-
-  useEffect(() => {
-    const handler = () => fetchKeys();
-    emitter.addEventListener('refresh', handler);
-    return () => emitter.removeEventListener('refresh', handler);
-  }, []);
-
-  return keys;
-}
+export {
+  useTxnModules as useTransactionModules,
+  refreshTxnModules as refreshTransactionModules,
+} from './useTxnModules.js';

--- a/src/erp.mgt.mn/pages/Forms.jsx
+++ b/src/erp.mgt.mn/pages/Forms.jsx
@@ -5,6 +5,7 @@ import { useModules } from '../hooks/useModules.js';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { useRolePermissions } from '../hooks/useRolePermissions.js';
 import { useCompanyModules } from '../hooks/useCompanyModules.js';
+import { useTxnModules } from '../hooks/useTxnModules.js';
 
 
 export default function Forms() {
@@ -13,6 +14,7 @@ export default function Forms() {
   const { company } = useContext(AuthContext);
   const perms = useRolePermissions();
   const licensed = useCompanyModules(company?.company_id);
+  const txnModules = useTxnModules();
 
   useEffect(() => {
     const params = new URLSearchParams();
@@ -49,7 +51,7 @@ export default function Forms() {
         setTransactions(grouped);
       })
       .catch((err) => console.error('Error fetching forms:', err));
-  }, [company, perms, licensed]);
+  }, [company, perms, licensed, txnModules]);
 
   const groups = Object.entries(transactions);
 


### PR DESCRIPTION
## Summary
- alias old `useTransactionModules` to new `useTxnModules`
- swap to `useTxnModules` in `ERPLayout`
- reload forms when transaction modules change

## Testing
- `node --test` *(fails: Cannot find package 'react' imported from tests/hooks/useTxnModules.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_685a8ceae9f483318be4536d7c1e6173