### PR TITLE
Fix dynamic form cleanup

### DIFF
--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -89,6 +89,15 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
   }, [name, configs]);
 
   useEffect(() => {
+    if (Object.keys(configs).length === 0) {
+      setName('');
+      setTable('');
+      setConfig(null);
+      setShowTable(false);
+    }
+  }, [configs]);
+
+  useEffect(() => {
     if (!table || !name) return;
     fetch(`/api/transaction_forms?table=${encodeURIComponent(table)}&name=${encodeURIComponent(name)}`, { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : null))


### PR DESCRIPTION
## Summary
- clear selected form when a module has no transactions

## Testing
- `npm test` *(fails: cannot find package 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685aaf9be3b88331b5c835dd9c2a5f71