### PR TITLE
Remove child module creation

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -1,6 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { upsertModule, deleteModule } from '../../db/index.js';
+import { deleteModule } from '../../db/index.js';
 import { slugify } from '../utils/slugify.js';
 
 const filePath = path.join(process.cwd(), 'config', 'transactionForms.json');
@@ -92,13 +92,6 @@ export async function setFormConfig(table, name, config, options = {}) {
     branchIdField,
     companyIdField,
   } = config || {};
-  const {
-    showInSidebar = true,
-    showInHeader = false,
-    moduleKey: providedModuleKey,
-  } = options;
-  const moduleSlug =
-    providedModuleKey || slugify(`${parentModuleKey}_${name}`);
   const uid = (userIdFields.length ? userIdFields : userIdField ? [userIdField] : [])
     .map(String)
     .filter(Boolean);
@@ -138,25 +131,6 @@ export async function setFormConfig(table, name, config, options = {}) {
     allowedDepartments: ad,
   };
   await writeConfig(cfg);
-  try {
-    const parentLabel = moduleLabel || slugify(parentModuleKey);
-    await upsertModule(
-      parentModuleKey,
-      parentLabel,
-      null,
-      true,
-      false,
-    );
-    await upsertModule(
-      moduleSlug,
-      name,
-      parentModuleKey,
-      showInSidebar,
-      showInHeader,
-    );
-  } catch (err) {
-    console.error('Failed to auto-create module', err);
-  }
   return cfg[table][name];
 }
 

--- a/docs/transaction-form-config.md
+++ b/docs/transaction-form-config.md
@@ -58,10 +58,10 @@ configuration parsed from the file.  This allows the front‑end to populate
 forms without issuing additional requests or duplicating any parsing logic.
 To obtain a configuration for a specific transaction use
 `/api/transaction_forms?table=tbl&name=transaction`. New configurations are
-posted with `{ table, name, config, showInSidebar?, showInHeader? }` in the request body and can be removed via
+posted with `{ table, name, config }` in the request body and can be removed via
 `DELETE /api/transaction_forms?table=tbl&name=transaction`.
-Saving a configuration automatically creates modules based on the provided
-`moduleKey`. If no `moduleKey` is supplied the value `finance_transactions` is
-used. The optional `moduleLabel` lets you set a custom name for the parent
-module. The optional `showInSidebar` and `showInHeader` flags determine where the
-generated module appears in the UI.
+Saving a configuration does **not** create or update any modules.  The provided
+`moduleKey` is merely stored with the configuration so that transactions can be
+grouped under an existing parent module.  If no `moduleKey` is supplied the
+value `finance_transactions` is used.  The optional `moduleLabel` is only saved
+with the configuration and does not create a module with that label.

--- a/tests/db/transactionFormConfig.test.js
+++ b/tests/db/transactionFormConfig.test.js
@@ -28,7 +28,7 @@ function mockPool(handler) {
   };
 }
 
-await test('setFormConfig writes moduleKey and creates modules with slug', async () => {
+await test('setFormConfig writes moduleKey without creating modules', async () => {
   const { orig, restore } = await withTempFile();
   await fs.writeFile(filePath, '{}');
   const calls = [];
@@ -39,17 +39,11 @@ await test('setFormConfig writes moduleKey and creates modules with slug', async
   restoreDb();
   const data = JSON.parse(await fs.readFile(filePath, 'utf8'));
   assert.equal(data.tbl['Sample Transaction'].moduleKey, 'parent_mod');
-  assert.equal(calls.length, 2);
-  assert.equal(calls[0].params[0], 'parent_mod');
-  assert.equal(calls[0].params[1], slugify('parent_mod'));
-  assert.equal(
-    calls[1].params[0],
-    slugify('parent_mod_Sample Transaction')
-  );
+  assert.equal(calls.length, 0);
   await restore();
 });
 
-await test('setFormConfig uses moduleLabel when provided', async () => {
+await test('setFormConfig stores moduleLabel when provided', async () => {
   const { orig, restore } = await withTempFile();
   await fs.writeFile(filePath, '{}');
   const calls = [];
@@ -63,13 +57,11 @@ await test('setFormConfig uses moduleLabel when provided', async () => {
   restoreDb();
   const data = JSON.parse(await fs.readFile(filePath, 'utf8'));
   assert.equal(data.tbl.Labeled.moduleLabel, 'My Transactions');
-  assert.equal(calls.length, 2);
-  assert.equal(calls[0].params[0], 'parent_mod');
-  assert.equal(calls[0].params[1], 'My Transactions');
+  assert.equal(calls.length, 0);
   await restore();
 });
 
-await test('setFormConfig forwards sidebar/header flags and slug', async () => {
+await test('setFormConfig ignores sidebar/header flags and slug', async () => {
   const { orig, restore } = await withTempFile();
   await fs.writeFile(filePath, '{}');
   const calls = [];
@@ -85,10 +77,7 @@ await test('setFormConfig forwards sidebar/header flags and slug', async () => {
   restoreDb();
   const data = JSON.parse(await fs.readFile(filePath, 'utf8'));
   assert.equal(data.tbl.Flagged.moduleKey, 'parent_mod');
-  assert.equal(calls.length, 2);
-  assert.equal(calls[1].params[0], 'custom_slug');
-  assert.equal(calls[1].params[3], 0);
-  assert.equal(calls[1].params[4], 1);
+  assert.equal(calls.length, 0);
   await restore();
 });
 


### PR DESCRIPTION
## Summary
- stop creating modules when setting transaction form config
- update tests and docs for non-generation behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a9506a630833185cac8ff28e804d1