### PR TITLE
Fix dynamic transaction form check

### DIFF
--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -99,9 +99,21 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
 
   useEffect(() => {
     if (!table || !name) return;
-    fetch(`/api/transaction_forms?table=${encodeURIComponent(table)}&name=${encodeURIComponent(name)}`, { credentials: 'include' })
+    fetch(
+      `/api/transaction_forms?table=${encodeURIComponent(
+        table,
+      )}&name=${encodeURIComponent(name)}`,
+      { credentials: 'include' },
+    )
       .then((res) => (res.ok ? res.json() : null))
-      .then((cfg) => setConfig(cfg))
+      .then((cfg) => {
+        if (cfg && cfg.moduleKey) {
+          setConfig(cfg);
+        } else {
+          setConfig(null);
+          setShowTable(false);
+        }
+      })
       .catch(() => setConfig(null));
   }, [table, name]);
 


### PR DESCRIPTION
## Summary
- ensure FinanceTransactions page only renders the dynamic form when `/api/transaction_forms` returns a config with a valid `moduleKey`

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_685aee9a55148331a671041bee07e41c