### PR TITLE
Add module-specific transaction session context

### DIFF
--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import { HashRouter, Routes, Route, Navigate, Outlet } from 'react-router-dom';
 import AuthContextProvider, { AuthContext } from './context/AuthContext.jsx';
 import { TabProvider } from './context/TabContext.jsx';
+import { TxnSessionProvider } from './context/TxnSessionContext.jsx';
 import { ToastProvider } from './context/ToastContext.jsx';
 import RequireAuth from './components/RequireAuth.jsx';
 import ERPLayout from './components/ERPLayout.jsx';
@@ -114,11 +115,12 @@ export default function App() {
   return (
     <ToastProvider>
       <AuthContextProvider>
-        <TabProvider>
-          <HashRouter>
+        <TxnSessionProvider>
+          <TabProvider>
+            <HashRouter>
           <Routes>
             <Route path="/login" element={<LoginPage />} />
-            <Route element={<RequireAuth />}>
+            <Route element={<RequireAuth />}> 
               <Route path="/" element={<ERPLayout />}>{roots.map(renderRoute)}</Route>
               <Route
                 path="/inventory-demo"
@@ -132,6 +134,7 @@ export default function App() {
           </Routes>
           </HashRouter>
         </TabProvider>
+        </TxnSessionProvider>
       </AuthContextProvider>
     </ToastProvider>
   );

--- a/src/erp.mgt.mn/context/TxnSessionContext.jsx
+++ b/src/erp.mgt.mn/context/TxnSessionContext.jsx
@@ -1,0 +1,42 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const TxnSessionContext = createContext();
+
+export function TxnSessionProvider({ children }) {
+  const [sessions, setSessions] = useState({});
+
+  const getSession = (key) => {
+    if (!sessions[key]) {
+      setSessions((s) => ({ ...s, [key]: {} }));
+      return {};
+    }
+    return sessions[key];
+  };
+
+  const setSession = (key, state) => {
+    setSessions((s) => ({ ...s, [key]: { ...s[key], ...state } }));
+  };
+
+  const clearSession = (key) => {
+    setSessions((s) => {
+      const copy = { ...s };
+      delete copy[key];
+      return copy;
+    });
+  };
+
+  return (
+    <TxnSessionContext.Provider value={{ getSession, setSession, clearSession }}>
+      {children}
+    </TxnSessionContext.Provider>
+  );
+}
+
+export function useTxnSession(key) {
+  const { getSession, setSession } = useContext(TxnSessionContext);
+  const session = getSession(key);
+  const update = (state) => setSession(key, state);
+  return [session, update];
+}
+
+export default TxnSessionContext;


### PR DESCRIPTION
## Summary
- introduce `TxnSessionContext` to store finance transaction UI state per module
- wrap the application with `TxnSessionProvider`
- persist FinanceTransactions page state in the new session context

## Testing
- `npm test` *(fails: Cannot find package 'react' for useTxnModules.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_685b8eb13650833188b7f4a8ff1539ca