### PR TITLE
Fix spinner causing lag in FormsManagement

### DIFF
--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -104,7 +104,7 @@ export default function FormsManagement() {
   }, [table, moduleKey]);
 
   useEffect(() => {
-    if (!table || !name) return;
+    if (!table || !name || !names.includes(name)) return;
     fetch(`/api/transaction_forms?table=${encodeURIComponent(table)}&name=${encodeURIComponent(name)}`, { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : {}))
       .then((cfg) => {
@@ -135,7 +135,7 @@ export default function FormsManagement() {
         });
         setModuleKey('');
       });
-  }, [table, name]);
+  }, [table, name, names]);
 
   // If a user selects a predefined transaction name, the associated module
   // parent key will be applied automatically based on the stored


### PR DESCRIPTION
## Summary
- avoid firing fetch while typing new transaction names

## Testing
- `node --test tests/api/detectType.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685bd029e4848331b826ac987851b88a