### PR TITLE
Show employee name on account menu

### DIFF
--- a/api-server/controllers/authController.js
+++ b/api-server/controllers/authController.js
@@ -34,6 +34,8 @@ export async function login(req, res, next) {
       id: user.id,
       empid: user.empid,
       role: user.role,
+      name: user.employee_name || null,
+      role_id: user.role_id,
     });
   } catch (err) {
     next(err);
@@ -51,12 +53,22 @@ export async function logout(req, res) {
   res.sendStatus(204);
 }
 
-export async function getProfile(req, res) {
-  res.json({
-    id: req.user.id,
-    empid: req.user.empid,
-    role: req.user.role,
-  });
+export async function getProfile(req, res, next) {
+  try {
+    const user = await getUserById(req.user.id);
+    if (!user) {
+      return res.status(401).json({ message: 'User not found' });
+    }
+    res.json({
+      id: user.id,
+      empid: user.empid,
+      role: user.role,
+      name: user.employee_name || null,
+      role_id: user.role_id,
+    });
+  } catch (err) {
+    next(err);
+  }
 }
 
 export async function changePassword(req, res, next) {
@@ -97,6 +109,8 @@ export async function refresh(req, res) {
       id: user.id,
       empid: user.empid,
       role: user.role,
+      name: user.employee_name || null,
+      role_id: user.role_id,
     });
   } catch (err) {
     const opts = {

--- a/db/index.js
+++ b/db/index.js
@@ -77,9 +77,10 @@ export async function testConnection() {
  */
 export async function getUserByEmpId(empid) {
   const [rows] = await pool.query(
-    `SELECT u.*, r.name AS role
+    `SELECT u.*, r.name AS role, e.name AS employee_name
      FROM users u
      JOIN user_roles r ON u.role_id = r.id
+     LEFT JOIN employees e ON e.code = u.empid
      WHERE u.empid = ?
      LIMIT 1`,
     [empid],
@@ -119,9 +120,10 @@ export async function listUsersByCompany(companyId) {
  */
 export async function getUserById(id) {
   const [rows] = await pool.query(
-    `SELECT u.*, r.name AS role
+    `SELECT u.*, r.name AS role, e.name AS employee_name
      FROM users u
      JOIN user_roles r ON u.role_id = r.id
+     LEFT JOIN employees e ON e.code = u.empid
      WHERE u.id = ?`,
     [id],
   );

--- a/src/erp.mgt.mn/components/AppLayout.jsx
+++ b/src/erp.mgt.mn/components/AppLayout.jsx
@@ -54,7 +54,9 @@ export default function AppLayout({ children, title }) {
             )}
             {user && (
               <div className="relative group">
-                <button className="focus:outline-none">{user.empid}</button>
+                <button className="focus:outline-none">
+                  {user.name || user.empid} ({user.role})
+                </button>
                 <ul className="account-menu absolute right-0 mt-2 hidden group-focus-within:block group-hover:block">
                   <li>
                     <button


### PR DESCRIPTION
## Summary
- include employee name when fetching user data
- expose the new field from auth APIs
- show `name (role)` instead of employee ID in header menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c0d3d3c2c8331a74a71d776b0189d