### PR TITLE
Show role and employee name in company selections

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -199,11 +199,12 @@ export async function assignCompanyToUser(
 export async function listUserCompanies(empid) {
   const [rows] = await pool.query(
     `SELECT uc.empid, uc.company_id, c.name AS company_name, uc.role_id, r.name AS role,
-            uc.branch_id, b.name AS branch_name
+            uc.branch_id, b.name AS branch_name, e.name AS employee_name
      FROM user_companies uc
      JOIN companies c ON uc.company_id = c.id
      JOIN user_roles r ON uc.role_id = r.id
     LEFT JOIN code_branches b ON uc.branch_id = b.id
+    LEFT JOIN employees e ON uc.empid = e.code
      WHERE uc.empid = ?`,
     [empid],
   );
@@ -244,11 +245,12 @@ export async function listAllUserCompanies(companyId) {
   }
   const [rows] = await pool.query(
     `SELECT uc.empid, uc.company_id, c.name AS company_name, uc.role_id, r.name AS role,
-            uc.branch_id, b.name AS branch_name
+            uc.branch_id, b.name AS branch_name, e.name AS employee_name
      FROM user_companies uc
      JOIN companies c ON uc.company_id = c.id
      JOIN user_roles r ON uc.role_id = r.id
      LEFT JOIN code_branches b ON uc.branch_id = b.id
+     LEFT JOIN employees e ON uc.empid = e.code
      ${where}`,
     params,
   );

--- a/src/erp.mgt.mn/components/AppLayout.jsx
+++ b/src/erp.mgt.mn/components/AppLayout.jsx
@@ -55,7 +55,8 @@ export default function AppLayout({ children, title }) {
             {user && (
               <div className="relative group">
                 <button className="focus:outline-none">
-                  {user.name || user.empid} ({user.role})
+                  {company?.employee_name || user.name || user.empid} (
+                  {company?.role || user.role})
                 </button>
                 <ul className="account-menu absolute right-0 mt-2 hidden group-focus-within:block group-hover:block">
                   <li>


### PR DESCRIPTION
## Summary
- include employee name when listing company assignments
- show selected company's role and employee name in the header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c1422a850833189ed4f7cc47e25b7