### PR TITLE
Fix single-letter coding table headers

### DIFF
--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -192,7 +192,7 @@ export default function CodingTablesPage() {
     const keepIdx = [];
     const map = {};
     raw.forEach((h, i) => {
-      if (String(h).length > 1) {
+      if (String(h).trim().length > 0) {
         hdrs.push(cleanIdentifier(h));
         keepIdx.push(i);
         const mnVal = mnRaw[i];
@@ -435,7 +435,7 @@ export default function CodingTablesPage() {
     const hdrs = [];
     const keepIdx = [];
     raw.forEach((h, i) => {
-      if (String(h).length > 1) {
+      if (String(h).trim().length > 0) {
         hdrs.push(cleanIdentifier(h));
         keepIdx.push(i);
       }


### PR DESCRIPTION
## Summary
- fix header extraction logic to allow single-character headers like `z`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c1835d4a88331a0b5b1182bd8c578