### PR TITLE
Use name in menus

### DIFF
--- a/src/erp.mgt.mn/components/UserMenu.jsx
+++ b/src/erp.mgt.mn/components/UserMenu.jsx
@@ -1,9 +1,11 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext.jsx';
 
 export default function UserMenu({ user, onLogout }) {
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
+  const { company } = useContext(AuthContext);
 
   if (!user) return null;
 
@@ -24,7 +26,9 @@ export default function UserMenu({ user, onLogout }) {
   return (
     <div style={styles.wrapper}>
       <button style={styles.userBtn} onClick={toggle}>
-        {user.full_name ? `${user.full_name} (${user.empid})` : user.empid} ▾
+        {company?.employee_name || user.name
+          ? `${company?.employee_name || user.name} (${company?.role || user.role})`
+          : `${user.empid} (${user.role})`} ▾
       </button>
       {open && (
         <div style={styles.menu}>

--- a/src/erp.mgt.mn/pages/BlueLinkPage.jsx
+++ b/src/erp.mgt.mn/pages/BlueLinkPage.jsx
@@ -29,7 +29,8 @@ export default function BlueLinkPage() {
     <div style={{ padding: '1rem' }}>
       <h2 style={{ marginTop: 0 }}>Blue Link демо</h2>
       <p>
-        Welcome, {user?.full_name || user?.username}
+        Welcome, {company?.employee_name || user?.name || user?.empid} (
+        {company?.role || user?.role})
         {company && ` (${company.company_name})`}
       </p>
       <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap', marginBottom: '1rem' }}>


### PR DESCRIPTION
## Summary
- show employee name and role in header dropdown
- greet user by name in BlueLink page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c17ee4fcc8331aed95e71b799ffbf