### PR TITLE
Fix transaction form defaults

### DIFF
--- a/docs/transaction-form-config.md
+++ b/docs/transaction-form-config.md
@@ -23,6 +23,11 @@ Each **transaction** entry allows you to specify:
 - **transTypeValue** – default value for `transTypeField`
 - **transTypeLabel** – human readable label for the selected type
 
+When creating or updating a configuration, always include the
+`dateColumn`, `transTypeField` and `transTypeValue` properties in the
+POST body. Omitting them will result in empty values being stored on
+disk.
+
 Example snippet:
 
 ```json

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -212,8 +212,16 @@ export default function FormsManagement() {
     const cfg = {
       ...config,
       moduleKey,
-      allowedBranches: config.allowedBranches.map((b) => Number(b)).filter((b) => !Number.isNaN(b)),
-      allowedDepartments: config.allowedDepartments.map((d) => Number(d)).filter((d) => !Number.isNaN(d)),
+      allowedBranches: config.allowedBranches
+        .map((b) => Number(b))
+        .filter((b) => !Number.isNaN(b)),
+      allowedDepartments: config.allowedDepartments
+        .map((d) => Number(d))
+        .filter((d) => !Number.isNaN(d)),
+      dateColumn: config.dateColumn || '',
+      transTypeField: config.transTypeField || '',
+      transTypeValue: config.transTypeValue || '',
+      transTypeLabel: config.transTypeLabel || '',
     };
     await fetch('/api/transaction_forms', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- always include date and transaction type fields when saving form configs
- clarify docs about sending these fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c43592e98833180a5cbf3280fcc28