### PR TITLE
Add date and transaction type config options

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -35,6 +35,9 @@ function parseEntry(raw = {}) {
       ? raw.allowedDepartments.map((v) => Number(v)).filter((v) => !Number.isNaN(v))
       : [],
     moduleLabel: typeof raw.moduleLabel === 'string' ? raw.moduleLabel : '',
+    dateFields: raw.dateFields || [],
+    transTypeField: typeof raw.transTypeField === 'string' ? raw.transTypeField : '',
+    transTypeValue: raw.transTypeValue ?? '',
   };
 }
 
@@ -84,6 +87,9 @@ export async function setFormConfig(table, name, config, options = {}) {
     companyIdFields = [],
     allowedBranches = [],
     allowedDepartments = [],
+    dateFields = [],
+    transTypeField = '',
+    transTypeValue = '',
     moduleKey: parentModuleKey = '',
     moduleLabel,
     userIdField,
@@ -127,6 +133,9 @@ export async function setFormConfig(table, name, config, options = {}) {
     moduleLabel: moduleLabel || undefined,
     allowedBranches: ab,
     allowedDepartments: ad,
+    dateFields,
+    transTypeField,
+    transTypeValue,
   };
   await writeConfig(cfg);
   return cfg[table][name];

--- a/config/transactionForms.json
+++ b/config/transactionForms.json
@@ -61,7 +61,10 @@
       ],
       "allowedBranches": [],
       "allowedDepartments": [],
-      "moduleKey": "finance_transactions"
+      "moduleKey": "finance_transactions",
+      "dateFields": ["or_date"],
+      "transTypeField": "trtype",
+      "transTypeValue": "1914"
     }
   }
 }

--- a/docs/transaction-form-config.md
+++ b/docs/transaction-form-config.md
@@ -18,6 +18,10 @@ Each **transaction** entry allows you to specify:
 - **moduleLabel** – optional label for the parent module
 - **allowedBranches** – restrict usage to these branch IDs
 - **allowedDepartments** – restrict usage to these department IDs
+- **dateFields** – list of columns considered transaction dates
+- **transTypeField** – column that stores the transaction type
+- **transTypeValue** – value inserted into the transaction type field when adding
+  a new row
 
 Example snippet:
 
@@ -35,7 +39,10 @@ Example snippet:
       "moduleKey": "finance_transactions",
       "moduleLabel": "Finance",
       "allowedBranches": [1, 2],
-      "allowedDepartments": [5]
+      "allowedDepartments": [5],
+      "dateFields": ["tran_date"],
+      "transTypeField": "tran_type",
+      "transTypeValue": "SALE"
     },
     "Issue": {
       "visibleFields": ["tran_date", "description"],
@@ -48,7 +55,10 @@ Example snippet:
       "moduleKey": "finance_transactions",
       "moduleLabel": "Finance",
       "allowedBranches": [1, 2],
-      "allowedDepartments": [5]
+      "allowedDepartments": [5],
+      "dateFields": ["tran_date"],
+      "transTypeField": "tran_type",
+      "transTypeValue": "ISSUE"
     }
   }
 }

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -335,6 +335,12 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
       if (formConfig?.companyIdFields?.includes(c) && company?.company_id !== undefined) v = company.company_id;
       vals[c] = v;
     });
+    if (
+      formConfig?.transTypeField &&
+      all.includes(formConfig.transTypeField)
+    ) {
+      vals[formConfig.transTypeField] = formConfig.transTypeValue || '';
+    }
     setEditing(vals);
     setIsAdding(true);
     setShowForm(true);
@@ -441,6 +447,9 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
         if (columns.has(f) && company?.company_id !== undefined)
           merged[f] = company.company_id;
       });
+      if (formConfig?.transTypeField && columns.has(formConfig.transTypeField)) {
+        merged[formConfig.transTypeField] = formConfig.transTypeValue;
+      }
     }
 
     const required = formConfig?.requiredFields || [];

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -10,6 +10,7 @@ export default function FormsManagement() {
   const [moduleKey, setModuleKey] = useState('');
   const [branches, setBranches] = useState([]);
   const [departments, setDepartments] = useState([]);
+  const [transTypes, setTransTypes] = useState([]);
   const [columns, setColumns] = useState([]);
   const modules = useModules();
   const [config, setConfig] = useState({
@@ -22,6 +23,9 @@ export default function FormsManagement() {
     companyIdFields: [],
     allowedBranches: [],
     allowedDepartments: [],
+    dateFields: [],
+    transTypeField: '',
+    transTypeValue: '',
   });
 
   useEffect(() => {
@@ -39,6 +43,14 @@ export default function FormsManagement() {
       .then((res) => (res.ok ? res.json() : { rows: [] }))
       .then((data) => setDepartments(data.rows || []))
       .catch(() => setDepartments([]));
+
+    fetch('/api/tables/code_transaction?perPage=500', { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : { rows: [] }))
+      .then((data) => {
+        const rows = data.rows || [];
+        setTransTypes(rows.map((r) => ({ value: r.UITransType, label: `${r.UITransType} - ${r.UITransTypeName}` })));
+      })
+      .catch(() => setTransTypes([]));
   }, []);
 
   useEffect(() => {
@@ -69,6 +81,9 @@ export default function FormsManagement() {
             companyIdFields: filtered[name].companyIdFields || [],
             allowedBranches: (filtered[name].allowedBranches || []).map(String),
             allowedDepartments: (filtered[name].allowedDepartments || []).map(String),
+            dateFields: filtered[name].dateFields || [],
+            transTypeField: filtered[name].transTypeField || '',
+            transTypeValue: filtered[name].transTypeValue || '',
           });
         } else {
           setName('');
@@ -82,6 +97,9 @@ export default function FormsManagement() {
             companyIdFields: [],
             allowedBranches: [],
             allowedDepartments: [],
+            dateFields: [],
+            transTypeField: '',
+            transTypeValue: '',
           });
         }
       })
@@ -98,6 +116,9 @@ export default function FormsManagement() {
           companyIdFields: [],
           allowedBranches: [],
           allowedDepartments: [],
+          dateFields: [],
+          transTypeField: '',
+          transTypeValue: '',
         });
         setModuleKey('');
       });
@@ -119,6 +140,9 @@ export default function FormsManagement() {
           companyIdFields: cfg.companyIdFields || [],
           allowedBranches: (cfg.allowedBranches || []).map(String),
           allowedDepartments: (cfg.allowedDepartments || []).map(String),
+          dateFields: cfg.dateFields || [],
+          transTypeField: cfg.transTypeField || '',
+          transTypeValue: cfg.transTypeValue || '',
         });
       })
       .catch(() => {
@@ -132,6 +156,9 @@ export default function FormsManagement() {
           companyIdFields: [],
           allowedBranches: [],
           allowedDepartments: [],
+          dateFields: [],
+          transTypeField: '',
+          transTypeValue: '',
         });
         setModuleKey('');
       });
@@ -220,6 +247,9 @@ export default function FormsManagement() {
       companyIdFields: [],
       allowedBranches: [],
       allowedDepartments: [],
+      dateFields: [],
+      transTypeField: '',
+      transTypeValue: '',
     });
     setModuleKey('');
   }
@@ -393,6 +423,28 @@ export default function FormsManagement() {
               <button type="button" onClick={() => setConfig((c) => ({ ...c, companyIdFields: [] }))}>None</button>
             </label>
             <label style={{ marginLeft: '1rem' }}>
+              Date columns:{' '}
+              <select
+                multiple
+                size={8}
+                value={config.dateFields}
+                onChange={(e) =>
+                  setConfig((c) => ({
+                    ...c,
+                    dateFields: Array.from(e.target.selectedOptions, (o) => o.value),
+                  }))
+                }
+              >
+                {columns.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+              <button type="button" onClick={() => setConfig((c) => ({ ...c, dateFields: columns }))}>All</button>
+              <button type="button" onClick={() => setConfig((c) => ({ ...c, dateFields: [] }))}>None</button>
+            </label>
+            <label style={{ marginLeft: '1rem' }}>
               Allowed branches:{' '}
               <select
                 multiple
@@ -435,6 +487,34 @@ export default function FormsManagement() {
               </select>
               <button type="button" onClick={() => setConfig((c) => ({ ...c, allowedDepartments: departments.map((d) => String(d.id)) }))}>All</button>
               <button type="button" onClick={() => setConfig((c) => ({ ...c, allowedDepartments: [] }))}>None</button>
+            </label>
+            <label style={{ marginLeft: '1rem' }}>
+              Transaction type field:{' '}
+              <select
+                value={config.transTypeField}
+                onChange={(e) => setConfig((c) => ({ ...c, transTypeField: e.target.value }))}
+              >
+                <option value="">-- none --</option>
+                {columns.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label style={{ marginLeft: '1rem' }}>
+              Transaction type value:{' '}
+              <select
+                value={config.transTypeValue}
+                onChange={(e) => setConfig((c) => ({ ...c, transTypeValue: e.target.value }))}
+              >
+                <option value="">-- none --</option>
+                {transTypes.map((t) => (
+                  <option key={t.value} value={t.value}>
+                    {t.label}
+                  </option>
+                ))}
+              </select>
             </label>
           </div>
           <div style={{ marginTop: '1rem' }}>


### PR DESCRIPTION
## Summary
- support date fields and transaction type information in transaction form configs
- expose date/transaction options in FormsManagement UI
- prefill transaction type when creating rows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c505c9c78833193996e71bb2d9dfd