### PR TITLE
Update transaction type dropdown values

### DIFF
--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -51,14 +51,14 @@ export default function FormsManagement() {
     fetch('/api/tables/code_transaction?perPage=500', { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : { rows: [] }))
       .then((data) =>
-        setTransTypes(
-          (data.rows || []).map((r) => ({
-            value: r.UITransTypeName,
-            label: r.UITransTypeName,
-          })),
-        ),
-      )
-      .catch(() => setTransTypes([]));
+          setTransTypes(
+            (data.rows || []).map((r) => ({
+              value: r.UITransType,
+              label: r.UITransTypeName,
+            })),
+          ),
+        )
+        .catch(() => setTransTypes([]));
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- use integer UITransType values in FormsManagement dropdown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cfa9e700c8331b483ddad7685dbde