### PR TITLE
Fix transaction field handling

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -165,7 +165,7 @@ export async function setFormConfig(table, name, config, options = {}) {
       continue;
     }
     if (key === 'dateField' || key === 'transactionTypeField' || key === 'transactionTypeValue') {
-      entry[key] = typeof value === 'string' ? value : undefined;
+      entry[key] = typeof value === 'string' && value !== '' ? value : undefined;
       continue;
     }
     if (key === 'imageNameFields') {


### PR DESCRIPTION
## Summary
- omit empty values for `dateField`, `transactionTypeField`, and `transactionTypeValue` in transaction form configs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d01c666988331b749958c64c1e684