### PR TITLE
Fix login employee name query

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -77,12 +77,13 @@ export async function testConnection() {
  */
 export async function getUserByEmpId(empid) {
   const [rows] = await pool.query(
-    `SELECT u.*, r.name AS role, e.name AS employee_name
-     FROM users u
-     JOIN user_roles r ON u.role_id = r.id
-     LEFT JOIN tbl_employee e ON e.code = u.empid
-     WHERE u.empid = ?
-     LIMIT 1`,
+    `SELECT u.*, r.name AS role,
+            CONCAT_WS(' ', e.emp_fname, e.emp_lname) AS employee_name
+       FROM users u
+       JOIN user_roles r ON u.role_id = r.id
+  LEFT JOIN tbl_employee e ON e.emp_id = u.empid
+      WHERE u.empid = ?
+      LIMIT 1`,
     [empid],
   );
   if (rows.length === 0) return null;
@@ -96,19 +97,25 @@ export async function getUserByEmpId(empid) {
  */
 export async function listUsers() {
   const [rows] = await pool.query(
-    `SELECT u.id, u.empid, u.role_id, r.name AS role, u.created_at
-     FROM users u
-     JOIN user_roles r ON u.role_id = r.id`,
+    `SELECT u.id, u.empid, u.role_id, r.name AS role,
+            CONCAT_WS(' ', e.emp_fname, e.emp_lname) AS employee_name,
+            u.created_at
+       FROM users u
+       JOIN user_roles r ON u.role_id = r.id
+  LEFT JOIN tbl_employee e ON e.emp_id = u.empid`,
   );
   return rows;
 }
 
 export async function listUsersByCompany(companyId) {
   const [rows] = await pool.query(
-    `SELECT u.id, u.empid, uc.role_id, r.name AS role, u.created_at
+    `SELECT u.id, u.empid, uc.role_id, r.name AS role,
+            CONCAT_WS(' ', e.emp_fname, e.emp_lname) AS employee_name,
+            u.created_at
        FROM users u
        JOIN user_companies uc ON u.empid = uc.empid
        JOIN user_roles r ON uc.role_id = r.id
+  LEFT JOIN tbl_employee e ON e.emp_id = u.empid
       WHERE uc.company_id = ?`,
     [companyId],
   );
@@ -120,10 +127,11 @@ export async function listUsersByCompany(companyId) {
  */
 export async function getUserById(id) {
   const [rows] = await pool.query(
-    `SELECT u.*, r.name AS role, e.name AS employee_name
+    `SELECT u.*, r.name AS role,
+            CONCAT_WS(' ', e.emp_fname, e.emp_lname) AS employee_name
      FROM users u
      JOIN user_roles r ON u.role_id = r.id
-     LEFT JOIN tbl_employee e ON e.code = u.empid
+    LEFT JOIN tbl_employee e ON e.emp_id = u.empid
      WHERE u.id = ?`,
     [id],
   );
@@ -199,12 +207,13 @@ export async function assignCompanyToUser(
 export async function listUserCompanies(empid) {
   const [rows] = await pool.query(
     `SELECT uc.empid, uc.company_id, c.name AS company_name, uc.role_id, r.name AS role,
-            uc.branch_id, b.name AS branch_name, e.name AS employee_name
+            uc.branch_id, b.name AS branch_name,
+            CONCAT_WS(' ', e.emp_fname, e.emp_lname) AS employee_name
      FROM user_companies uc
      JOIN companies c ON uc.company_id = c.id
      JOIN user_roles r ON uc.role_id = r.id
     LEFT JOIN code_branches b ON uc.branch_id = b.id
-    LEFT JOIN tbl_employee e ON uc.empid = e.code
+    LEFT JOIN tbl_employee e ON uc.empid = e.emp_id
      WHERE uc.empid = ?`,
     [empid],
   );
@@ -245,13 +254,14 @@ export async function listAllUserCompanies(companyId) {
   }
   const [rows] = await pool.query(
     `SELECT uc.empid, uc.company_id, c.name AS company_name, uc.role_id, r.name AS role,
-            uc.branch_id, b.name AS branch_name, e.name AS employee_name
-     FROM user_companies uc
-     JOIN companies c ON uc.company_id = c.id
-     JOIN user_roles r ON uc.role_id = r.id
-     LEFT JOIN code_branches b ON uc.branch_id = b.id
-     LEFT JOIN tbl_employee e ON uc.empid = e.code
-     ${where}`,
+            uc.branch_id, b.name AS branch_name,
+            CONCAT_WS(' ', e.emp_fname, e.emp_lname) AS employee_name
+       FROM user_companies uc
+       JOIN companies c ON uc.company_id = c.id
+       JOIN user_roles r ON uc.role_id = r.id
+       LEFT JOIN code_branches b ON uc.branch_id = b.id
+       LEFT JOIN tbl_employee e ON uc.empid = e.emp_id
+       ${where}`,
     params,
   );
   return rows;


### PR DESCRIPTION
## Summary
- fix login queries by concatenating first and last name in `tbl_employee`
- use `e.emp_id` as join field for employee lookups
- include employee names when listing users

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d18cdba808331980bf7ec1a8074e8