### PR TITLE
Implement date & type filters

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -22,6 +22,14 @@ function parseEntry(raw = {}) {
     requiredFields: raw.requiredFields || [],
     defaultValues: raw.defaultValues || {},
     editableDefaultFields: raw.editableDefaultFields || [],
+    dateField: typeof raw.dateField === 'string' ? raw.dateField : '',
+    emailField: typeof raw.emailField === 'string' ? raw.emailField : '',
+    imagenameField: typeof raw.imagenameField === 'string' ? raw.imagenameField : '',
+    printField: typeof raw.printField === 'string' ? raw.printField : '',
+    transactionTypeField:
+      typeof raw.transactionTypeField === 'string' ? raw.transactionTypeField : '',
+    transactionTypeValue:
+      typeof raw.transactionTypeValue === 'string' ? raw.transactionTypeValue : '',
     userIdFields: raw.userIdFields || (raw.userIdField ? [raw.userIdField] : []),
     branchIdFields:
       raw.branchIdFields || (raw.branchIdField ? [raw.branchIdField] : []),
@@ -113,6 +121,14 @@ export async function setFormConfig(table, name, config, options = {}) {
   const ad = Array.isArray(allowedDepartments)
     ? allowedDepartments.map((v) => Number(v)).filter((v) => !Number.isNaN(v))
     : [];
+  const {
+    dateField = '',
+    emailField = '',
+    imagenameField = '',
+    printField = '',
+    transactionTypeField = '',
+    transactionTypeValue = '',
+  } = config || {};
   const cfg = await readConfig();
   if (!cfg[table]) cfg[table] = {};
   cfg[table][name] = {
@@ -120,6 +136,12 @@ export async function setFormConfig(table, name, config, options = {}) {
     requiredFields,
     defaultValues,
     editableDefaultFields,
+    dateField,
+    emailField,
+    imagenameField,
+    printField,
+    transactionTypeField,
+    transactionTypeValue,
     userIdFields: uid,
     branchIdFields: bid,
     companyIdFields: cid,

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -59,12 +59,12 @@ const deleteBtnStyle = {
   color: '#b91c1c',
 };
 
-export default forwardRef(function TableManager({ table, refreshId = 0, formConfig = null, initialPerPage = 10, addLabel = 'Add Row', showTable = true }, ref) {
+export default forwardRef(function TableManager({ table, refreshId = 0, formConfig = null, initialPerPage = 10, addLabel = 'Add Row', showTable = true, initialFilters = {} }, ref) {
   const [rows, setRows] = useState([]);
   const [count, setCount] = useState(0);
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(initialPerPage);
-  const [filters, setFilters] = useState({});
+  const [filters, setFilters] = useState(initialFilters);
   const [sort, setSort] = useState({ column: '', dir: 'asc' });
   const [relations, setRelations] = useState({});
   const [refData, setRefData] = useState({});
@@ -85,6 +85,10 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
   const [isAdding, setIsAdding] = useState(false);
   const { user, company } = useContext(AuthContext);
   const { addToast } = useToast();
+
+  useEffect(() => {
+    setFilters(initialFilters);
+  }, [initialFilters]);
 
   function computeAutoInc(meta) {
     const auto = meta

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -16,6 +16,8 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
   const [config, setConfig] = useState(() => sessionState.config || null);
   const [refreshId, setRefreshId] = useState(() => sessionState.refreshId || 0);
   const [showTable, setShowTable] = useState(() => sessionState.showTable || false);
+  const [dateFilter, setDateFilter] = useState('');
+  const [typeFilter, setTypeFilter] = useState('');
   const { company } = useContext(AuthContext);
   const perms = useRolePermissions();
   const licensed = useCompanyModules(company?.company_id);
@@ -128,6 +130,17 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
       .catch(() => setConfig(null));
   }, [table, name]);
 
+  useEffect(() => {
+    if (!config) return;
+    if (config.dateField) {
+      const today = new Date().toISOString().slice(0, 10);
+      setDateFilter(today);
+    }
+    if (config.transactionTypeField && config.transactionTypeValue) {
+      setTypeFilter(config.transactionTypeValue);
+    }
+  }, [config]);
+
   const transactionNames = Object.keys(configs);
 
   if (!perms || !licensed) return <p>Loading...</p>;
@@ -166,6 +179,27 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
           <button onClick={() => setShowTable((v) => !v)}>
             {showTable ? 'Hide Table' : 'View Table'}
           </button>
+          {config.dateField && (
+            <>
+              <input
+                type="date"
+                value={dateFilter}
+                onChange={(e) => setDateFilter(e.target.value)}
+                style={{ marginLeft: '0.5rem' }}
+              />
+              <button onClick={() => setDateFilter('')} style={{ marginLeft: '0.25rem' }}>
+                Clear Date Filter
+              </button>
+            </>
+          )}
+          {config.transactionTypeField && (
+            <>
+              <span style={{ marginLeft: '0.5rem' }}>Type: {typeFilter}</span>
+              <button onClick={() => setTypeFilter('')} style={{ marginLeft: '0.25rem' }}>
+                Clear Type Filter
+              </button>
+            </>
+          )}
         </div>
       )}
       {table && config && (
@@ -177,6 +211,10 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
           initialPerPage={10}
           addLabel="Add Transaction"
           showTable={showTable}
+          initialFilters={{
+            ...(config.dateField && dateFilter ? { [config.dateField]: dateFilter } : {}),
+            ...(config.transactionTypeField && typeFilter ? { [config.transactionTypeField]: typeFilter } : {}),
+          }}
         />
       )}
       {transactionNames.length === 0 && (

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { useModules } from '../hooks/useModules.js';
 import { refreshTxnModules } from '../hooks/useTxnModules.js';
+import AsyncSearchSelect from '../components/AsyncSearchSelect.jsx';
 
 export default function FormsManagement() {
   const [tables, setTables] = useState([]);
   const [table, setTable] = useState('');
   const [names, setNames] = useState([]);
   const [name, setName] = useState('');
+  const [dupName, setDupName] = useState('');
   const [moduleKey, setModuleKey] = useState('');
   const [branches, setBranches] = useState([]);
   const [departments, setDepartments] = useState([]);
@@ -20,6 +22,12 @@ export default function FormsManagement() {
     userIdFields: [],
     branchIdFields: [],
     companyIdFields: [],
+    dateField: '',
+    emailField: '',
+    imagenameField: '',
+    printField: '',
+    transactionTypeField: '',
+    transactionTypeValue: '',
     allowedBranches: [],
     allowedDepartments: [],
   });
@@ -67,6 +75,12 @@ export default function FormsManagement() {
             userIdFields: filtered[name].userIdFields || [],
             branchIdFields: filtered[name].branchIdFields || [],
             companyIdFields: filtered[name].companyIdFields || [],
+            dateField: filtered[name].dateField || '',
+            emailField: filtered[name].emailField || '',
+            imagenameField: filtered[name].imagenameField || '',
+            printField: filtered[name].printField || '',
+            transactionTypeField: filtered[name].transactionTypeField || '',
+            transactionTypeValue: filtered[name].transactionTypeValue || '',
             allowedBranches: (filtered[name].allowedBranches || []).map(String),
             allowedDepartments: (filtered[name].allowedDepartments || []).map(String),
           });
@@ -80,6 +94,12 @@ export default function FormsManagement() {
             userIdFields: [],
             branchIdFields: [],
             companyIdFields: [],
+            dateField: '',
+            emailField: '',
+            imagenameField: '',
+            printField: '',
+            transactionTypeField: '',
+            transactionTypeValue: '',
             allowedBranches: [],
             allowedDepartments: [],
           });
@@ -96,6 +116,12 @@ export default function FormsManagement() {
           userIdFields: [],
           branchIdFields: [],
           companyIdFields: [],
+          dateField: '',
+          emailField: '',
+          imagenameField: '',
+          printField: '',
+          transactionTypeField: '',
+          transactionTypeValue: '',
           allowedBranches: [],
           allowedDepartments: [],
         });
@@ -117,6 +143,12 @@ export default function FormsManagement() {
           userIdFields: cfg.userIdFields || [],
           branchIdFields: cfg.branchIdFields || [],
           companyIdFields: cfg.companyIdFields || [],
+          dateField: cfg.dateField || '',
+          emailField: cfg.emailField || '',
+          imagenameField: cfg.imagenameField || '',
+          printField: cfg.printField || '',
+          transactionTypeField: cfg.transactionTypeField || '',
+          transactionTypeValue: cfg.transactionTypeValue || '',
           allowedBranches: (cfg.allowedBranches || []).map(String),
           allowedDepartments: (cfg.allowedDepartments || []).map(String),
         });
@@ -136,6 +168,33 @@ export default function FormsManagement() {
         setModuleKey('');
       });
   }, [table, name, names]);
+
+  useEffect(() => {
+    if (!table || !dupName) return;
+    if (!names.includes(dupName)) return;
+    fetch(`/api/transaction_forms?table=${encodeURIComponent(table)}&name=${encodeURIComponent(dupName)}`, { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : {}))
+      .then((cfg) => {
+        setConfig({
+          visibleFields: cfg.visibleFields || [],
+          requiredFields: cfg.requiredFields || [],
+          defaultValues: cfg.defaultValues || {},
+          editableDefaultFields: cfg.editableDefaultFields || [],
+          userIdFields: cfg.userIdFields || [],
+          branchIdFields: cfg.branchIdFields || [],
+          companyIdFields: cfg.companyIdFields || [],
+          dateField: cfg.dateField || '',
+          emailField: cfg.emailField || '',
+          imagenameField: cfg.imagenameField || '',
+          printField: cfg.printField || '',
+          transactionTypeField: cfg.transactionTypeField || '',
+          transactionTypeValue: cfg.transactionTypeValue || '',
+          allowedBranches: (cfg.allowedBranches || []).map(String),
+          allowedDepartments: (cfg.allowedDepartments || []).map(String),
+        });
+      })
+      .catch(() => {});
+  }, [dupName, table, names]);
 
   // If a user selects a predefined transaction name, the associated module
   // parent key will be applied automatically based on the stored
@@ -185,6 +244,12 @@ export default function FormsManagement() {
       allowedBranches: config.allowedBranches.map((b) => Number(b)).filter((b) => !Number.isNaN(b)),
       allowedDepartments: config.allowedDepartments.map((d) => Number(d)).filter((d) => !Number.isNaN(d)),
     };
+    if (cfg.transactionTypeField && cfg.transactionTypeValue) {
+      cfg.defaultValues = {
+        ...cfg.defaultValues,
+        [cfg.transactionTypeField]: cfg.transactionTypeValue,
+      };
+    }
     await fetch('/api/transaction_forms', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -218,6 +283,12 @@ export default function FormsManagement() {
       userIdFields: [],
       branchIdFields: [],
       companyIdFields: [],
+      dateField: '',
+      emailField: '',
+      imagenameField: '',
+      printField: '',
+      transactionTypeField: '',
+      transactionTypeValue: '',
       allowedBranches: [],
       allowedDepartments: [],
     });
@@ -259,6 +330,18 @@ export default function FormsManagement() {
               onChange={(e) => setName(e.target.value)}
             />
             <select
+              value={dupName}
+              onChange={(e) => setDupName(e.target.value)}
+              style={{ marginLeft: '0.5rem' }}
+            >
+              <option value="">Duplicate from...</option>
+              {names.map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+            <select
               value={moduleKey}
               onChange={(e) => setModuleKey(e.target.value)}
               style={{ marginLeft: '0.5rem' }}
@@ -270,6 +353,28 @@ export default function FormsManagement() {
                 </option>
               ))}
             </select>
+            <select
+              value={config.transactionTypeField}
+              onChange={(e) =>
+                setConfig((c) => ({ ...c, transactionTypeField: e.target.value }))
+              }
+              style={{ marginLeft: '0.5rem' }}
+            >
+              <option value="">-- trans type field --</option>
+              {columns.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+            <AsyncSearchSelect
+              table="code_transaction"
+              searchColumn="tr_id"
+              labelFields={["tr_name"]}
+              value={config.transactionTypeValue}
+              onChange={(val) => setConfig((c) => ({ ...c, transactionTypeValue: val }))}
+              style={{ marginLeft: '0.5rem', width: '150px' }}
+            />
             
             {name && (
               <button onClick={handleDelete} style={{ marginLeft: '0.5rem' }}>
@@ -286,6 +391,13 @@ export default function FormsManagement() {
                 <th style={{ border: '1px solid #ccc', padding: '4px' }}>Required</th>
                 <th style={{ border: '1px solid #ccc', padding: '4px' }}>Default</th>
                 <th style={{ border: '1px solid #ccc', padding: '4px' }}>Editable</th>
+                <th style={{ border: '1px solid #ccc', padding: '4px' }}>Date Field</th>
+                <th style={{ border: '1px solid #ccc', padding: '4px' }}>Email Field</th>
+                <th style={{ border: '1px solid #ccc', padding: '4px' }}>Image Name</th>
+                <th style={{ border: '1px solid #ccc', padding: '4px' }}>Print Field</th>
+                <th style={{ border: '1px solid #ccc', padding: '4px' }}>User ID</th>
+                <th style={{ border: '1px solid #ccc', padding: '4px' }}>Branch ID</th>
+                <th style={{ border: '1px solid #ccc', padding: '4px' }}>Company ID</th>
               </tr>
             </thead>
             <tbody>
@@ -318,6 +430,77 @@ export default function FormsManagement() {
                       type="checkbox"
                       checked={config.editableDefaultFields.includes(col)}
                       onChange={() => toggleEditable(col)}
+                    />
+                  </td>
+                  <td style={{ border: '1px solid #ccc', padding: '4px', textAlign: 'center' }}>
+                    <input
+                      type="radio"
+                      name="dateField"
+                      checked={config.dateField === col}
+                      onChange={() => setConfig((c) => ({ ...c, dateField: col }))}
+                    />
+                  </td>
+                  <td style={{ border: '1px solid #ccc', padding: '4px', textAlign: 'center' }}>
+                    <input
+                      type="radio"
+                      name="emailField"
+                      checked={config.emailField === col}
+                      onChange={() => setConfig((c) => ({ ...c, emailField: col }))}
+                    />
+                  </td>
+                  <td style={{ border: '1px solid #ccc', padding: '4px', textAlign: 'center' }}>
+                    <input
+                      type="radio"
+                      name="imagenameField"
+                      checked={config.imagenameField === col}
+                      onChange={() => setConfig((c) => ({ ...c, imagenameField: col }))}
+                    />
+                  </td>
+                  <td style={{ border: '1px solid #ccc', padding: '4px', textAlign: 'center' }}>
+                    <input
+                      type="radio"
+                      name="printField"
+                      checked={config.printField === col}
+                      onChange={() => setConfig((c) => ({ ...c, printField: col }))}
+                    />
+                  </td>
+                  <td style={{ border: '1px solid #ccc', padding: '4px', textAlign: 'center' }}>
+                    <input
+                      type="checkbox"
+                      checked={config.userIdFields.includes(col)}
+                      onChange={() =>
+                        setConfig((c) => {
+                          const set = new Set(c.userIdFields);
+                          set.has(col) ? set.delete(col) : set.add(col);
+                          return { ...c, userIdFields: Array.from(set) };
+                        })
+                      }
+                    />
+                  </td>
+                  <td style={{ border: '1px solid #ccc', padding: '4px', textAlign: 'center' }}>
+                    <input
+                      type="checkbox"
+                      checked={config.branchIdFields.includes(col)}
+                      onChange={() =>
+                        setConfig((c) => {
+                          const set = new Set(c.branchIdFields);
+                          set.has(col) ? set.delete(col) : set.add(col);
+                          return { ...c, branchIdFields: Array.from(set) };
+                        })
+                      }
+                    />
+                  </td>
+                  <td style={{ border: '1px solid #ccc', padding: '4px', textAlign: 'center' }}>
+                    <input
+                      type="checkbox"
+                      checked={config.companyIdFields.includes(col)}
+                      onChange={() =>
+                        setConfig((c) => {
+                          const set = new Set(c.companyIdFields);
+                          set.has(col) ? set.delete(col) : set.add(col);
+                          return { ...c, companyIdFields: Array.from(set) };
+                        })
+                      }
                     />
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- expand transaction form configuration to include date, email, type and other helper fields
- support default filters in TableManager
- add filtering controls on FinanceTransactions page
- enhance form management with duplication option and new field selectors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d2733b8988331a30085348ae29cce