### PR TITLE
Add extra field options and date filter

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -59,12 +59,12 @@ const deleteBtnStyle = {
   color: '#b91c1c',
 };
 
-export default forwardRef(function TableManager({ table, refreshId = 0, formConfig = null, initialPerPage = 10, addLabel = 'Add Row', showTable = true }, ref) {
+export default forwardRef(function TableManager({ table, refreshId = 0, formConfig = null, initialPerPage = 10, addLabel = 'Add Row', showTable = true, extraFilters = {} }, ref) {
   const [rows, setRows] = useState([]);
   const [count, setCount] = useState(0);
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(initialPerPage);
-  const [filters, setFilters] = useState({});
+  const [filters, setFilters] = useState(extraFilters);
   const [sort, setSort] = useState({ column: '', dir: 'asc' });
   const [relations, setRelations] = useState({});
   const [refData, setRefData] = useState({});
@@ -85,6 +85,10 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
   const [isAdding, setIsAdding] = useState(false);
   const { user, company } = useContext(AuthContext);
   const { addToast } = useToast();
+
+  useEffect(() => {
+    setFilters((f) => ({ ...f, ...extraFilters }));
+  }, [extraFilters]);
 
   function computeAutoInc(meta) {
     const auto = meta
@@ -262,7 +266,8 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
       params.set('sort', sort.column);
       params.set('dir', sort.dir);
     }
-    Object.entries(filters).forEach(([k, v]) => {
+    const qFilters = { ...filters, ...extraFilters };
+    Object.entries(qFilters).forEach(([k, v]) => {
       if (v) params.set(k, v);
     });
     fetch(`/api/tables/${encodeURIComponent(table)}?${params.toString()}`, {
@@ -279,11 +284,11 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
     return () => {
       canceled = true;
     };
-  }, [table, page, perPage, filters, sort, refreshId, localRefresh]);
+  }, [table, page, perPage, filters, sort, refreshId, localRefresh, extraFilters]);
 
   useEffect(() => {
     setSelectedRows(new Set());
-  }, [table, page, perPage, filters, sort, refreshId, localRefresh]);
+  }, [table, page, perPage, filters, sort, refreshId, localRefresh, extraFilters]);
 
   function getRowId(row) {
     const keys = getKeyFields();
@@ -484,7 +489,8 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
           params.set('sort', sort.column);
           params.set('dir', sort.dir);
         }
-        Object.entries(filters).forEach(([k, v]) => {
+        const qFilters3 = { ...filters, ...extraFilters };
+        Object.entries(qFilters3).forEach(([k, v]) => {
           if (v) params.set(k, v);
         });
         const data = await fetch(`/api/tables/${encodeURIComponent(table)}?${params.toString()}`, {
@@ -526,7 +532,8 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
         params.set('sort', sort.column);
         params.set('dir', sort.dir);
       }
-      Object.entries(filters).forEach(([k, v]) => {
+      const qFilters2 = { ...filters, ...extraFilters };
+      Object.entries(qFilters2).forEach(([k, v]) => {
         if (v) params.set(k, v);
       });
       const data = await fetch(
@@ -650,7 +657,8 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
       params.set('sort', sort.column);
       params.set('dir', sort.dir);
     }
-    Object.entries(filters).forEach(([k, v]) => {
+    const qFilters4 = { ...filters, ...extraFilters };
+    Object.entries(qFilters4).forEach(([k, v]) => {
       if (v) params.set(k, v);
     });
     const data = await fetch(`/api/tables/${encodeURIComponent(table)}?${params.toString()}`, {

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -16,6 +16,7 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
   const [config, setConfig] = useState(() => sessionState.config || null);
   const [refreshId, setRefreshId] = useState(() => sessionState.refreshId || 0);
   const [showTable, setShowTable] = useState(() => sessionState.showTable || false);
+  const [dateFilter, setDateFilter] = useState('');
   const { company } = useContext(AuthContext);
   const perms = useRolePermissions();
   const licensed = useCompanyModules(company?.company_id);
@@ -120,6 +121,11 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
       .then((cfg) => {
         if (cfg && cfg.moduleKey) {
           setConfig(cfg);
+          if (cfg.dateField) {
+            setDateFilter(new Date().toISOString().slice(0, 10));
+          } else {
+            setDateFilter('');
+          }
         } else {
           setConfig(null);
           setShowTable(false);
@@ -168,6 +174,17 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
           </button>
         </div>
       )}
+      {table && config?.dateField && (
+        <div style={{ marginBottom: '0.5rem' }}>
+          <input
+            type="date"
+            value={dateFilter}
+            onChange={(e) => setDateFilter(e.target.value)}
+            style={{ marginRight: '0.5rem' }}
+          />
+          <button onClick={() => setDateFilter('')}>Clear Date Filter</button>
+        </div>
+      )}
       {table && config && (
         <TableManager
           ref={tableRef}
@@ -177,6 +194,9 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
           initialPerPage={10}
           addLabel="Add Transaction"
           showTable={showTable}
+          extraFilters={
+            dateFilter && config.dateField ? { [config.dateField]: dateFilter } : {}
+          }
         />
       )}
       {transactionNames.length === 0 && (

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -20,6 +20,11 @@ export default function FormsManagement() {
     userIdFields: [],
     branchIdFields: [],
     companyIdFields: [],
+    dateField: '',
+    emailField: '',
+    imagenameField: '',
+    printEmpField: '',
+    printCustField: '',
     allowedBranches: [],
     allowedDepartments: [],
   });
@@ -67,6 +72,11 @@ export default function FormsManagement() {
             userIdFields: filtered[name].userIdFields || [],
             branchIdFields: filtered[name].branchIdFields || [],
             companyIdFields: filtered[name].companyIdFields || [],
+            dateField: filtered[name].dateField || '',
+            emailField: filtered[name].emailField || '',
+            imagenameField: filtered[name].imagenameField || '',
+            printEmpField: filtered[name].printEmpField || '',
+            printCustField: filtered[name].printCustField || '',
             allowedBranches: (filtered[name].allowedBranches || []).map(String),
             allowedDepartments: (filtered[name].allowedDepartments || []).map(String),
           });
@@ -80,6 +90,11 @@ export default function FormsManagement() {
             userIdFields: [],
             branchIdFields: [],
             companyIdFields: [],
+            dateField: '',
+            emailField: '',
+            imagenameField: '',
+            printEmpField: '',
+            printCustField: '',
             allowedBranches: [],
             allowedDepartments: [],
           });
@@ -96,6 +111,11 @@ export default function FormsManagement() {
           userIdFields: [],
           branchIdFields: [],
           companyIdFields: [],
+          dateField: '',
+          emailField: '',
+          imagenameField: '',
+          printEmpField: '',
+          printCustField: '',
           allowedBranches: [],
           allowedDepartments: [],
         });
@@ -117,6 +137,11 @@ export default function FormsManagement() {
           userIdFields: cfg.userIdFields || [],
           branchIdFields: cfg.branchIdFields || [],
           companyIdFields: cfg.companyIdFields || [],
+          dateField: cfg.dateField || '',
+          emailField: cfg.emailField || '',
+          imagenameField: cfg.imagenameField || '',
+          printEmpField: cfg.printEmpField || '',
+          printCustField: cfg.printCustField || '',
           allowedBranches: (cfg.allowedBranches || []).map(String),
           allowedDepartments: (cfg.allowedDepartments || []).map(String),
         });
@@ -130,6 +155,11 @@ export default function FormsManagement() {
           userIdFields: [],
           branchIdFields: [],
           companyIdFields: [],
+          dateField: '',
+          emailField: '',
+          imagenameField: '',
+          printEmpField: '',
+          printCustField: '',
           allowedBranches: [],
           allowedDepartments: [],
         });
@@ -172,6 +202,34 @@ export default function FormsManagement() {
       set.has(field) ? set.delete(field) : set.add(field);
       return { ...c, editableDefaultFields: Array.from(set) };
     });
+  }
+
+  function toggleUserId(field) {
+    setConfig((c) => {
+      const set = new Set(c.userIdFields);
+      set.has(field) ? set.delete(field) : set.add(field);
+      return { ...c, userIdFields: Array.from(set) };
+    });
+  }
+
+  function toggleBranchId(field) {
+    setConfig((c) => {
+      const set = new Set(c.branchIdFields);
+      set.has(field) ? set.delete(field) : set.add(field);
+      return { ...c, branchIdFields: Array.from(set) };
+    });
+  }
+
+  function toggleCompanyId(field) {
+    setConfig((c) => {
+      const set = new Set(c.companyIdFields);
+      set.has(field) ? set.delete(field) : set.add(field);
+      return { ...c, companyIdFields: Array.from(set) };
+    });
+  }
+
+  function selectSingle(key, field) {
+    setConfig((c) => ({ ...c, [key]: c[key] === field ? '' : field }));
   }
 
   async function handleSave() {
@@ -218,6 +276,11 @@ export default function FormsManagement() {
       userIdFields: [],
       branchIdFields: [],
       companyIdFields: [],
+      dateField: '',
+      emailField: '',
+      imagenameField: '',
+      printEmpField: '',
+      printCustField: '',
       allowedBranches: [],
       allowedDepartments: [],
     });
@@ -279,13 +342,21 @@ export default function FormsManagement() {
           </div>
           <div className="table-container overflow-x-auto" style={{ maxHeight: '70vh' }}>
           <table style={{ borderCollapse: 'collapse', width: '100%' }}>
-            <thead>
+            <thead className="sticky-header">
               <tr>
                 <th style={{ border: '1px solid #ccc', padding: '4px' }}>Field</th>
                 <th style={{ border: '1px solid #ccc', padding: '4px' }}>Visible</th>
                 <th style={{ border: '1px solid #ccc', padding: '4px' }}>Required</th>
                 <th style={{ border: '1px solid #ccc', padding: '4px' }}>Default</th>
                 <th style={{ border: '1px solid #ccc', padding: '4px' }}>Editable</th>
+                <th style={{ border: '1px solid #ccc', padding: '4px' }}>User ID</th>
+                <th style={{ border: '1px solid #ccc', padding: '4px' }}>Branch ID</th>
+                <th style={{ border: '1px solid #ccc', padding: '4px' }}>Company ID</th>
+                <th style={{ border: '1px solid #ccc', padding: '4px' }}>Date</th>
+                <th style={{ border: '1px solid #ccc', padding: '4px' }}>Email</th>
+                <th style={{ border: '1px solid #ccc', padding: '4px' }}>Image Name</th>
+                <th style={{ border: '1px solid #ccc', padding: '4px' }}>Print Emp</th>
+                <th style={{ border: '1px solid #ccc', padding: '4px' }}>Print Cust</th>
               </tr>
             </thead>
             <tbody>
@@ -320,78 +391,73 @@ export default function FormsManagement() {
                       onChange={() => toggleEditable(col)}
                     />
                   </td>
+                  <td style={{ border: '1px solid #ccc', padding: '4px', textAlign: 'center' }}>
+                    <input
+                      type="checkbox"
+                      checked={config.userIdFields.includes(col)}
+                      onChange={() => toggleUserId(col)}
+                    />
+                  </td>
+                  <td style={{ border: '1px solid #ccc', padding: '4px', textAlign: 'center' }}>
+                    <input
+                      type="checkbox"
+                      checked={config.branchIdFields.includes(col)}
+                      onChange={() => toggleBranchId(col)}
+                    />
+                  </td>
+                  <td style={{ border: '1px solid #ccc', padding: '4px', textAlign: 'center' }}>
+                    <input
+                      type="checkbox"
+                      checked={config.companyIdFields.includes(col)}
+                      onChange={() => toggleCompanyId(col)}
+                    />
+                  </td>
+                  <td style={{ border: '1px solid #ccc', padding: '4px', textAlign: 'center' }}>
+                    <input
+                      type="radio"
+                      name="dateField"
+                      checked={config.dateField === col}
+                      onChange={() => selectSingle('dateField', col)}
+                    />
+                  </td>
+                  <td style={{ border: '1px solid #ccc', padding: '4px', textAlign: 'center' }}>
+                    <input
+                      type="radio"
+                      name="emailField"
+                      checked={config.emailField === col}
+                      onChange={() => selectSingle('emailField', col)}
+                    />
+                  </td>
+                  <td style={{ border: '1px solid #ccc', padding: '4px', textAlign: 'center' }}>
+                    <input
+                      type="radio"
+                      name="imagenameField"
+                      checked={config.imagenameField === col}
+                      onChange={() => selectSingle('imagenameField', col)}
+                    />
+                  </td>
+                  <td style={{ border: '1px solid #ccc', padding: '4px', textAlign: 'center' }}>
+                    <input
+                      type="radio"
+                      name="printEmpField"
+                      checked={config.printEmpField === col}
+                      onChange={() => selectSingle('printEmpField', col)}
+                    />
+                  </td>
+                  <td style={{ border: '1px solid #ccc', padding: '4px', textAlign: 'center' }}>
+                    <input
+                      type="radio"
+                      name="printCustField"
+                      checked={config.printCustField === col}
+                      onChange={() => selectSingle('printCustField', col)}
+                    />
+                  </td>
                 </tr>
               ))}
             </tbody>
           </table>
           </div>
           <div style={{ marginTop: '1rem' }}>
-            <label>
-              User ID fields:{' '}
-              <select
-                multiple
-                size={8}
-                value={config.userIdFields}
-                onChange={(e) =>
-                  setConfig((c) => ({
-                    ...c,
-                    userIdFields: Array.from(e.target.selectedOptions, (o) => o.value),
-                  }))
-                }
-              >
-                {columns.map((c) => (
-                  <option key={c} value={c}>
-                    {c}
-                  </option>
-                ))}
-              </select>
-              <button type="button" onClick={() => setConfig((c) => ({ ...c, userIdFields: columns }))}>All</button>
-              <button type="button" onClick={() => setConfig((c) => ({ ...c, userIdFields: [] }))}>None</button>
-            </label>
-            <label style={{ marginLeft: '1rem' }}>
-              Branch ID fields:{' '}
-              <select
-                multiple
-                size={8}
-                value={config.branchIdFields}
-                onChange={(e) =>
-                  setConfig((c) => ({
-                    ...c,
-                    branchIdFields: Array.from(e.target.selectedOptions, (o) => o.value),
-                  }))
-                }
-              >
-                {columns.map((c) => (
-                  <option key={c} value={c}>
-                    {c}
-                  </option>
-                ))}
-              </select>
-              <button type="button" onClick={() => setConfig((c) => ({ ...c, branchIdFields: columns }))}>All</button>
-              <button type="button" onClick={() => setConfig((c) => ({ ...c, branchIdFields: [] }))}>None</button>
-            </label>
-            <label style={{ marginLeft: '1rem' }}>
-              Company ID fields:{' '}
-              <select
-                multiple
-                size={8}
-                value={config.companyIdFields}
-                onChange={(e) =>
-                  setConfig((c) => ({
-                    ...c,
-                    companyIdFields: Array.from(e.target.selectedOptions, (o) => o.value),
-                  }))
-                }
-              >
-                {columns.map((c) => (
-                  <option key={c} value={c}>
-                    {c}
-                  </option>
-                ))}
-              </select>
-              <button type="button" onClick={() => setConfig((c) => ({ ...c, companyIdFields: columns }))}>All</button>
-              <button type="button" onClick={() => setConfig((c) => ({ ...c, companyIdFields: [] }))}>None</button>
-            </label>
             <label style={{ marginLeft: '1rem' }}>
               Allowed branches:{' '}
               <select


### PR DESCRIPTION
## Summary
- extend FormsManagement configuration with date, email, imagename, print and id field columns
- keep table headers sticky on FormsManagement
- allow passing extra filters to TableManager
- filter FinanceTransactions by configurable date field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d2b42c21c8331a29a86d190e7afed