### PR TITLE
Add multi-row transaction option

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -672,6 +672,12 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
         setIsAdding(false);
         const msg = isAdding ? 'New transaction saved' : 'Saved';
         addToast(msg, 'success');
+        if (isAdding) {
+          const again = window.confirm('Add another transaction row?');
+          if (again) {
+            setTimeout(() => openAdd(), 0);
+          }
+        }
       } else {
         let message = 'Save failed';
         try {


### PR DESCRIPTION
## Summary
- redesign transaction modal layout with table-style main section
- allow adding multiple rows after saving

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d718527d08331a47b56c56c058b9a