### PR TITLE
Support continuous row entry in modal

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -147,7 +147,7 @@ export default function RowFormModal({
     }
   }
 
-  async function submitForm() {
+  async function submitForm(addAnother = false) {
     if (submitLocked) return;
     setSubmitLocked(true);
     const errs = {};
@@ -168,7 +168,7 @@ export default function RowFormModal({
             ? normalizeDateInput(v, placeholders[k])
             : v;
         });
-        await Promise.resolve(onSubmit(normalized));
+        await Promise.resolve(onSubmit(normalized, { addAnother }));
       } else {
         setSubmitLocked(false);
         return;
@@ -389,14 +389,24 @@ export default function RowFormModal({
             Print Cust
           </button>
           <button
+            type="submit"
+            className="px-3 py-1 bg-blue-600 text-white rounded"
+          >
+            Save Transaction
+          </button>
+          <button
+            type="button"
+            onClick={() => submitForm(true)}
+            className="px-3 py-1 bg-blue-600 text-white rounded"
+          >
+            Save and Add Another
+          </button>
+          <button
             type="button"
             onClick={onCancel}
             className="px-3 py-1 bg-gray-200 rounded"
           >
             Cancel
-          </button>
-          <button type="submit" className="px-3 py-1 bg-blue-600 text-white rounded">
-            Save
           </button>
         </div>
         <div className="text-sm text-gray-600">

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -592,7 +592,7 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
     setSelectedRows(new Set());
   }
 
-  async function handleSubmit(values) {
+  async function handleSubmit(values, { addAnother = false } = {}) {
     const columns = new Set(allColumns);
     const merged = { ...(editing || {}) };
     Object.entries(values).forEach(([k, v]) => {
@@ -667,16 +667,26 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
         setRows(data.rows || []);
         setCount(data.count || 0);
         setSelectedRows(new Set());
-        setShowForm(false);
-        setEditing(null);
-        setIsAdding(false);
         const msg = isAdding ? 'New transaction saved' : 'Saved';
         addToast(msg, 'success');
         if (isAdding) {
-          const again = window.confirm('Add another transaction row?');
-          if (again) {
-            setTimeout(() => openAdd(), 0);
+          let again = addAnother;
+          if (!addAnother) {
+            again = window.confirm(
+              'Transaction saved successfully. Do you want to add another?',
+            );
           }
+          if (again) {
+            await openAdd();
+          } else {
+            setShowForm(false);
+            setEditing(null);
+            setIsAdding(false);
+          }
+        } else {
+          setShowForm(false);
+          setEditing(null);
+          setIsAdding(false);
         }
       } else {
         let message = 'Save failed';


### PR DESCRIPTION
## Summary
- allow RowFormModal to request more entries without closing
- add `Save and Add Another` option for the form
- keep modal open in TableManager when adding multiple rows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d8d6c3fc0833199bef71ab11dd199