### PR TITLE
Add grid popup for multi transaction entry

### DIFF
--- a/src/erp.mgt.mn/components/AsyncSearchSelect.jsx
+++ b/src/erp.mgt.mn/components/AsyncSearchSelect.jsx
@@ -74,7 +74,7 @@ export default function AsyncSearchSelect({
       if (idx >= 0 && idx < options.length) {
         e.preventDefault();
         const opt = options[idx];
-        onChange(opt.value);
+        onChange(opt.value, opt.label);
         setInput(String(opt.value));
         setShow(false);
       }
@@ -128,7 +128,7 @@ export default function AsyncSearchSelect({
             <li
               key={opt.value}
               onMouseDown={() => {
-                onChange(opt.value);
+                onChange(opt.value, opt.label);
                 setInput(String(opt.value));
                 setShow(false);
               }}

--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -1,50 +1,71 @@
-import React, { useState } from 'react';
+import React, { useState, forwardRef, useImperativeHandle } from 'react';
 import AsyncSearchSelect from './AsyncSearchSelect.jsx';
-import Modal from './Modal.jsx';
 
-export default function InlineTransactionTable({
+export default forwardRef(function InlineTransactionTable({
   fields = [],
   relations = {},
   relationConfigs = {},
   labels = {},
   totalAmountFields = [],
   totalCurrencyFields = [],
+  collectRows = false,
   onRowSubmit = () => {},
-}) {
+  onRowsChange = () => {},
+}, ref) {
   const [rows, setRows] = useState([]);
-  const [picker, setPicker] = useState(null); // { row, field }
 
   const totalAmountSet = new Set(totalAmountFields);
   const totalCurrencySet = new Set(totalCurrencyFields);
 
+  useImperativeHandle(ref, () => ({
+    getRows: () => rows,
+    clearRows: () => setRows(() => {
+      onRowsChange([]);
+      return [];
+    }),
+  }));
+
   function addRow() {
-    setRows((r) => [...r, {}]);
+    setRows((r) => {
+      const next = [...r, {}];
+      onRowsChange(next);
+      return next;
+    });
+  }
+
+  function removeRow(idx) {
+    setRows((r) => {
+      const next = r.filter((_, i) => i !== idx);
+      onRowsChange(next);
+      return next;
+    });
   }
 
   function handleChange(rowIdx, field, value) {
-    setRows((r) =>
-      r.map((row, i) => (i === rowIdx ? { ...row, [field]: value } : row)),
-    );
+    setRows((r) => {
+      const next = r.map((row, i) => (i === rowIdx ? { ...row, [field]: value } : row));
+      onRowsChange(next);
+      return next;
+    });
   }
 
   async function saveRow(idx) {
     const row = rows[idx] || {};
-    const ok = await Promise.resolve(onRowSubmit(row));
+    const cleaned = {};
+    Object.entries(row).forEach(([k, v]) => {
+      if (k === '_saved') return;
+      cleaned[k] = typeof v === 'object' && v !== null && 'value' in v ? v.value : v;
+    });
+    const ok = await Promise.resolve(onRowSubmit(cleaned));
     if (ok !== false) {
-      setRows((r) => r.map((row, i) => (i === idx ? { ...row, _saved: true } : row)));
+      setRows((r) => {
+        const next = r.map((row, i) => (i === idx ? { ...row, _saved: true } : row));
+        onRowsChange(next);
+        return next;
+      });
     }
   }
 
-  function openPicker(row, field) {
-    setPicker({ row, field });
-  }
-
-  function handlePickerSelect(value) {
-    if (picker) {
-      handleChange(picker.row, picker.field, value);
-    }
-    setPicker(null);
-  }
 
   const totals = {};
   fields.forEach((f) => {
@@ -59,21 +80,47 @@ export default function InlineTransactionTable({
   function renderCell(idx, f) {
     const val = rows[idx]?.[f] ?? '';
     const isRel = relationConfigs[f] || Array.isArray(relations[f]);
-    if (rows[idx]?._saved) {
+    if (rows[idx]?._saved && !collectRows) {
       return typeof val === 'object' ? val.label : val;
     }
     if (isRel) {
-      const label = typeof val === 'object' ? val.label : val;
-      return (
-        <div className="cursor-pointer" onClick={() => openPicker(idx, f)}>
-          {label || 'Select'}
-        </div>
-      );
+      if (relationConfigs[f]) {
+        const conf = relationConfigs[f];
+        const inputVal = typeof val === 'object' ? val.value : val;
+        return (
+          <AsyncSearchSelect
+            table={conf.table}
+            searchColumn={conf.column}
+            labelFields={conf.displayFields || []}
+            value={inputVal}
+            onChange={(v, label) =>
+              handleChange(idx, f, label ? { value: v, label } : v)
+            }
+          />
+        );
+      }
+      if (Array.isArray(relations[f])) {
+        const inputVal = typeof val === 'object' ? val.value : val;
+        return (
+          <select
+            className="w-full border px-1"
+            value={inputVal}
+            onChange={(e) => handleChange(idx, f, e.target.value)}
+          >
+            <option value="">-- select --</option>
+            {relations[f].map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        );
+      }
     }
     return (
       <input
         className="w-full border px-1"
-        value={val}
+        value={typeof val === 'object' ? val.value : val}
         onChange={(e) => handleChange(idx, f, e.target.value)}
       />
     );
@@ -101,7 +148,9 @@ export default function InlineTransactionTable({
                 </td>
               ))}
               <td className="border px-2 py-1 text-right">
-                {r._saved ? (
+                {collectRows ? (
+                  <button onClick={() => removeRow(idx)}>Delete</button>
+                ) : r._saved ? (
                   <button onClick={() => handleChange(idx, '_saved', false)}>
                     Edit
                   </button>
@@ -136,21 +185,6 @@ export default function InlineTransactionTable({
       <button onClick={addRow} className="mt-2 px-2 py-1 bg-gray-200 rounded">
         + Add Row
       </button>
-      {picker && (
-        <Modal
-          visible={true}
-          title={labels[picker.field] || picker.field}
-          onClose={() => setPicker(null)}
-        >
-          <AsyncSearchSelect
-            table={relationConfigs[picker.field]?.table}
-            searchColumn={relationConfigs[picker.field]?.column}
-            labelFields={relationConfigs[picker.field]?.displayFields || []}
-            value={rows[picker.row]?.[picker.field] || ''}
-            onChange={handlePickerSelect}
-          />
-        </Modal>
-      )}
     </div>
   );
-}
+});

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -23,6 +23,7 @@ export default function RowFormModal({
   totalAmountFields = [],
   totalCurrencyFields = [],
   inline = false,
+  useGrid = false,
 }) {
   const [formVals, setFormVals] = useState(() => {
     const init = {};
@@ -44,6 +45,7 @@ export default function RowFormModal({
   const inputRefs = useRef({});
   const [errors, setErrors] = useState({});
   const [submitLocked, setSubmitLocked] = useState(false);
+  const tableRef = useRef(null);
   const placeholders = React.useMemo(() => {
     const map = {};
     columns.forEach((c) => {
@@ -152,6 +154,21 @@ export default function RowFormModal({
   async function submitForm() {
     if (submitLocked) return;
     setSubmitLocked(true);
+    if (useGrid && tableRef.current) {
+      const rows = tableRef.current.getRows();
+      for (const r of rows) {
+        const normalized = {};
+        Object.entries(r).forEach(([k, v]) => {
+          normalized[k] = placeholders[k]
+            ? normalizeDateInput(v, placeholders[k])
+            : v;
+        });
+        await Promise.resolve(onSubmit(normalized));
+      }
+      tableRef.current.clearRows();
+      setSubmitLocked(false);
+      return;
+    }
     const errs = {};
     requiredFields.forEach((f) => {
       if (columns.includes(f) && !formVals[f]) {
@@ -257,17 +274,19 @@ export default function RowFormModal({
 
   function renderMainTable(cols) {
     if (cols.length === 0) return null;
-    if (inline) {
+    if (inline || useGrid) {
       return (
         <div className="mb-4">
           <h3 className="mt-0 mb-1 font-semibold">Main</h3>
           <InlineTransactionTable
+            ref={useGrid ? tableRef : undefined}
             fields={cols}
             relations={relations}
             relationConfigs={relationConfigs}
             labels={labels}
             totalAmountFields={totalAmountFields}
             totalCurrencyFields={totalCurrencyFields}
+            collectRows={useGrid}
             onRowSubmit={onSubmit}
           />
         </div>

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1442,7 +1442,7 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
       )}
       <RowFormModal
         visible={showForm}
-        inline
+        useGrid
         onCancel={() => {
           setShowForm(false);
           setEditing(null);


### PR DESCRIPTION
## Summary
- support returning option label from `AsyncSearchSelect`
- enhance `InlineTransactionTable` to allow collecting rows in a grid
- allow `RowFormModal` to display a grid inside the popup
- render grid popup from `TableManager`
- fix missing closing parentheses in `InlineTransactionTable`

## Testing
- `npm test`
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8cab53448331a2c25df8baaae7bb