### PR TITLE
Add multi-transaction entry modal

### DIFF
--- a/src/erp.mgt.mn/components/MultiTransactionModal.jsx
+++ b/src/erp.mgt.mn/components/MultiTransactionModal.jsx
@@ -1,0 +1,57 @@
+import React, { useRef } from 'react';
+import Modal from './Modal.jsx';
+import InlineTransactionTable from './InlineTransactionTable.jsx';
+
+export default function MultiTransactionModal({
+  visible,
+  onClose,
+  fields = [],
+  relations = {},
+  relationConfigs = {},
+  labels = {},
+  totalAmountFields = [],
+  totalCurrencyFields = [],
+  onSubmit = () => {},
+}) {
+  const tableRef = useRef(null);
+
+  function handleSubmit() {
+    if (!tableRef.current) return;
+    const rows = tableRef.current.getRows();
+    const cleaned = rows
+      .map((row) => {
+        const obj = {};
+        fields.forEach((f) => {
+          const val = row[f];
+          obj[f] = typeof val === 'object' && val !== null && 'value' in val ? val.value : val;
+        });
+        return obj;
+      })
+      .filter((r) => Object.values(r).some((v) => v !== '' && v !== null && v !== undefined));
+    onSubmit(cleaned);
+    tableRef.current.clearRows();
+  }
+
+  if (!visible) return null;
+
+  return (
+    <Modal visible={visible} title="Transactions" onClose={onClose} width="90%">
+      <InlineTransactionTable
+        ref={tableRef}
+        fields={fields}
+        relations={relations}
+        relationConfigs={relationConfigs}
+        labels={labels}
+        totalAmountFields={totalAmountFields}
+        totalCurrencyFields={totalCurrencyFields}
+        collectRows={true}
+      />
+      <div style={{ marginTop: '0.5rem', textAlign: 'right' }}>
+        <button onClick={onClose} style={{ marginRight: '0.5rem' }}>
+          Cancel
+        </button>
+        <button onClick={handleSubmit}>Submit</button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/erp.mgt.mn/pages/MultiTransactionDemo.jsx
+++ b/src/erp.mgt.mn/pages/MultiTransactionDemo.jsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import MultiTransactionModal from '../components/MultiTransactionModal.jsx';
+
+export default function MultiTransactionDemo() {
+  const [show, setShow] = useState(false);
+  const fields = ['inventory_code', 'qty', 'employee_id'];
+
+  const relationConfigs = {
+    inventory_code: {
+      table: 'inventory_items',
+      column: 'inventory_code',
+      displayFields: ['item_name'],
+    },
+    employee_id: {
+      table: 'employees',
+      column: 'employee_id',
+      displayFields: ['emp_fname', 'emp_lname'],
+    },
+  };
+
+  function handleSubmit(rows) {
+    // rows contain only codes and numeric values
+    console.log('Submitted', rows);
+    setShow(false);
+  }
+
+  return (
+    <div>
+      <button onClick={() => setShow(true)}>Add Transactions</button>
+      <MultiTransactionModal
+        visible={show}
+        onClose={() => setShow(false)}
+        fields={fields}
+        relationConfigs={relationConfigs}
+        labels={{ inventory_code: 'Inventory', qty: 'Qty', employee_id: 'Employee' }}
+        totalAmountFields={['qty']}
+        onSubmit={handleSubmit}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `MultiTransactionModal` for entering rows in a popup
- demo new modal on `MultiTransactionDemo` page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e9c1b590883319020ca826617c89c