### PR TITLE
Improve SQL upload progress handling

### DIFF
--- a/api-server/routes/generated_sql.js
+++ b/api-server/routes/generated_sql.js
@@ -23,8 +23,8 @@ router.post('/execute', requireAuth, async (req, res, next) => {
     if (!sql) {
       return res.status(400).json({ message: 'sql required' });
     }
-    await runSql(sql);
-    res.sendStatus(204);
+    const inserted = await runSql(sql);
+    res.json({ inserted });
   } catch (err) {
     next(err);
   }

--- a/api-server/services/generatedSql.js
+++ b/api-server/services/generatedSql.js
@@ -37,7 +37,12 @@ export async function runSql(sql) {
     .split(/;\s*\n/)
     .map((s) => s.trim())
     .filter(Boolean);
+  let inserted = 0;
   for (const stmt of statements) {
-    await pool.query(stmt);
+    const [res] = await pool.query(stmt);
+    if (res && typeof res.affectedRows === 'number') {
+      inserted += res.affectedRows;
+    }
   }
+  return inserted;
 }

--- a/src/erp.mgt.mn/index.css
+++ b/src/erp.mgt.mn/index.css
@@ -249,15 +249,16 @@ th {
   justify-content: center;
   align-items: center;
   background: rgba(255, 255, 255, 0.6);
-  z-index: 100;
+  z-index: 1000;
+  pointer-events: none;
 }
 
 .loading-spinner {
-  border: 4px solid #f3f3f3;
-  border-top: 4px solid #2563eb;
+  border: 3px solid #f3f3f3;
+  border-top: 3px solid #2563eb;
   border-radius: 50%;
-  width: 40px;
-  height: 40px;
+  width: 24px;
+  height: 24px;
   animation: spin 1s linear infinite;
 }
 


### PR DESCRIPTION
## Summary
- track inserted record count when executing generated SQL
- only save CREATE TABLE statement when SQL is huge
- tweak spinner styles so it remains visible
- API for executing generated SQL now returns inserted row count

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ebfc226d0833189bdb68edc8b32df