### PR TITLE
Handle state-based imports

### DIFF
--- a/api-server/services/generatedSql.js
+++ b/api-server/services/generatedSql.js
@@ -41,7 +41,9 @@ export async function runSql(sql) {
   for (const stmt of statements) {
     const [res] = await pool.query(stmt);
     if (res && typeof res.affectedRows === 'number') {
-      inserted += res.affectedRows;
+      if (/^insert/i.test(stmt)) {
+        inserted += res.affectedRows === 1 ? 1 : 0;
+      }
     }
   }
   return inserted;


### PR DESCRIPTION
## Summary
- update SQL progress tracking so duplicate updates aren't double-counted
- generate a second SQL script for `_other` table
- add `otherSql` textarea and execution button in CodingTables page
- filter rows by `state` value when creating SQL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ec5d65ffc8331bc7a8657401bd703