### PR TITLE
Enhance coding table management

### DIFF
--- a/api-server/controllers/codingTableController.js
+++ b/api-server/controllers/codingTableController.js
@@ -125,7 +125,7 @@ export async function uploadCodingTable(req, res, next) {
     const keepIdx = [];
     const headers = [];
     rawHeaders.forEach((h, idx) => {
-      if (String(h).length > 1) {
+      if (String(h).trim().length > 0) {
         const clean = cleanIdentifier(h);
         headers.push(clean);
         keepIdx.push(idx);


### PR DESCRIPTION
## Summary
- support renaming columns and choosing defaults from another column
- show duplicate rows and summary info when generating SQL
- allow creating the `_other` table from the UI
- keep one-letter headers when reading Excel sheets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ed38e25488331bd420145d1c489a9