### PR TITLE
Implement POS-style dynamic transaction form updates

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -15,10 +15,13 @@ export default forwardRef(function InlineTransactionTable({
   totalAmountFields = [],
   totalCurrencyFields = [],
   collectRows = false,
+  minRows = 1,
   onRowSubmit = () => {},
   onRowsChange = () => {},
 }, ref) {
-  const [rows, setRows] = useState(() => (collectRows ? [{}] : []));
+  const [rows, setRows] = useState(() =>
+    collectRows ? Array.from({ length: minRows }, () => ({})) : [],
+  );
   const inputRefs = useRef({});
   const focusRow = useRef(collectRows ? 0 : null);
   const addBtnRef = useRef(null);
@@ -28,6 +31,13 @@ export default forwardRef(function InlineTransactionTable({
 
   useEffect(() => {
     if (!collectRows) return;
+    if (rows.length < minRows) {
+      setRows((r) => {
+        const next = [...r];
+        while (next.length < minRows) next.push({});
+        return next;
+      });
+    }
     if (focusRow.current === null) return;
     const idx = focusRow.current;
     const el = inputRefs.current[`${idx}-0`];
@@ -36,13 +46,15 @@ export default forwardRef(function InlineTransactionTable({
       if (el.select) el.select();
     }
     focusRow.current = null;
-  }, [rows, collectRows]);
+  }, [rows, collectRows, minRows]);
 
   useImperativeHandle(ref, () => ({
     getRows: () => rows,
     clearRows: () =>
       setRows(() => {
-        const next = collectRows ? [{}] : [];
+        const next = collectRows
+          ? Array.from({ length: minRows }, () => ({}))
+          : [];
         onRowsChange(next);
         return next;
       }),

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -192,7 +192,7 @@ export default function RowFormModal({
     setErrors(errs);
     if (Object.keys(errs).length === 0) {
       const ok = window.confirm(
-        'Save this transaction? Have you checked all data and accept responsibility?',
+        'Post this transaction? Have you checked all data and accept responsibility?',
       );
       if (ok) {
         const normalized = {};
@@ -301,6 +301,7 @@ export default function RowFormModal({
             totalAmountFields={totalAmountFields}
             totalCurrencyFields={totalCurrencyFields}
             collectRows={useGrid}
+            minRows={3}
             onRowSubmit={onSubmit}
           />
         </div>
@@ -460,7 +461,7 @@ export default function RowFormModal({
             Cancel
           </button>
           <button type="submit" className="px-3 py-1 bg-blue-600 text-white rounded">
-            Save
+            Post
           </button>
         </div>
         <div className="text-sm text-gray-600">


### PR DESCRIPTION
## Summary
- allow setting minimum visible rows for transactions
- use 3 visible rows when entering transactions
- rename Save button to **Post** for grid entry forms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fa34410e483318ef04a219e6950fc