### PR TITLE
Fix table switch errors

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -429,12 +429,13 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
       credentials: 'include',
     })
       .then((res) => {
+        if (canceled) return { rows: [], count: 0 };
         if (!res.ok) {
           addToast('Failed to load table data', 'error');
           return { rows: [], count: 0 };
         }
         return res.json().catch(() => {
-          addToast('Failed to parse table data', 'error');
+          if (!canceled) addToast('Failed to parse table data', 'error');
           return { rows: [], count: 0 };
         });
       })
@@ -446,7 +447,7 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
         setSelectedRows(new Set());
       })
       .catch(() => {
-        addToast('Failed to load table data', 'error');
+        if (!canceled) addToast('Failed to load table data', 'error');
       });
     return () => {
       canceled = true;
@@ -885,7 +886,7 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
       : [];
 
   const ordered = formConfig?.visibleFields?.length
-    ? formConfig.visibleFields.filter((c) => allColumns.includes(c))
+    ? allColumns.filter((c) => formConfig.visibleFields.includes(c))
     : allColumns;
   const labels = {};
   columnMeta.forEach((c) => {
@@ -1007,7 +1008,12 @@ export default forwardRef(function TableManager({ table, refreshId = 0, formConf
   const totals = useMemo(() => {
     const sums = {};
     columns.forEach((c) => {
-      if (totalAmountSet.has(c) || totalCurrencySet.has(c) || c === 'TotalCur') {
+      if (
+        totalAmountSet.has(c) ||
+        totalCurrencySet.has(c) ||
+        c === 'TotalCur' ||
+        c === 'TotalAmt'
+      ) {
         sums[c] = rows.reduce((sum, r) => sum + Number(r[c] || 0), 0);
       }
     });

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -124,6 +124,7 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
 
   useEffect(() => {
     if (!table || !name) return;
+    let canceled = false;
     fetch(
       `/api/transaction_forms?table=${encodeURIComponent(
         table,
@@ -131,6 +132,7 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
       { credentials: 'include' },
     )
       .then((res) => {
+        if (canceled) return null;
         if (!res.ok) {
           addToast('Failed to load transaction configuration', 'error');
           return null;
@@ -138,6 +140,7 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
         return res.json().catch(() => null);
       })
       .then((cfg) => {
+        if (canceled) return;
         if (cfg && cfg.moduleKey) {
           setConfig(cfg);
         } else {
@@ -147,10 +150,15 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
         }
       })
       .catch(() => {
-        setConfig(null);
-        setShowTable(false);
-        addToast('Failed to load transaction configuration', 'error');
+        if (!canceled) {
+          setConfig(null);
+          setShowTable(false);
+          addToast('Failed to load transaction configuration', 'error');
+        }
       });
+    return () => {
+      canceled = true;
+    };
   }, [table, name, addToast]);
 
   const transactionNames = Object.keys(configs);


### PR DESCRIPTION
## Summary
- avoid stale network errors when switching tables
- preserve database column order when rendering table
- include `TotalAmt` in totals calculation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fb712cbd4833185cebfd6603a5f54