### PR TITLE
Fix transaction table switching bug

### DIFF
--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -110,7 +110,20 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
   }, [moduleKey, company, perms, licensed]);
 
   useEffect(() => {
-    if (name && configs[name]) setTable(configs[name].table ?? configs[name]);
+    if (!name) {
+      setTable('');
+      setConfig(null);
+      setShowTable(false);
+      return;
+    }
+    if (configs[name]) {
+      const tbl = configs[name].table ?? configs[name];
+      if (tbl !== table) {
+        setTable(tbl);
+        setConfig(null);
+        setShowTable(false);
+      }
+    }
   }, [name, configs]);
 
   useEffect(() => {
@@ -123,7 +136,10 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
   }, [configs]);
 
   useEffect(() => {
-    if (!table || !name) return;
+    if (!table || !name) {
+      setConfig(null);
+      return;
+    }
     let canceled = false;
     fetch(
       `/api/transaction_forms?table=${encodeURIComponent(
@@ -176,9 +192,20 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
             <select
               value={name}
               onChange={(e) => {
-                setName(e.target.value);
+                const newName = e.target.value;
+                setName(newName);
                 setRefreshId((r) => r + 1);
                 setShowTable(false);
+                if (!newName) {
+                  setTable('');
+                  setConfig(null);
+                } else if (configs[newName]) {
+                  const tbl = configs[newName].table ?? configs[newName];
+                  if (tbl !== table) {
+                    setTable(tbl);
+                    setConfig(null);
+                  }
+                }
               }}
               style={{ width: '100%', padding: '0.5rem', borderRadius: '3px', border: '1px solid #ccc' }}
             >


### PR DESCRIPTION
## Summary
- reset table and config when switching transactions
- avoid invalid filter columns while loading new table
- clear table buttons when no transaction selected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fbe56c1a8833198543e5eb3d64ef6