### PR TITLE
Update coding table SQL execution

### DIFF
--- a/api-server/routes/generated_sql.js
+++ b/api-server/routes/generated_sql.js
@@ -23,8 +23,8 @@ router.post('/execute', requireAuth, async (req, res, next) => {
     if (!sql) {
       return res.status(400).json({ message: 'sql required' });
     }
-    const inserted = await runSql(sql);
-    res.json({ inserted });
+    const { inserted, failed } = await runSql(sql);
+    res.json({ inserted, failed });
   } catch (err) {
     next(err);
   }

--- a/api-server/services/generatedSql.js
+++ b/api-server/services/generatedSql.js
@@ -38,14 +38,19 @@ export async function runSql(sql) {
     .map((s) => s.trim())
     .filter(Boolean);
   let inserted = 0;
+  const failed = [];
   for (const stmt of statements) {
-    const [res] = await pool.query(stmt);
-    if (res && typeof res.affectedRows === 'number') {
-      const change = typeof res.changedRows === 'number' ? res.changedRows : 0;
-      inserted += res.affectedRows - change;
+    try {
+      const [res] = await pool.query(stmt);
+      if (res && typeof res.affectedRows === 'number') {
+        const change = typeof res.changedRows === 'number' ? res.changedRows : 0;
+        inserted += res.affectedRows - change;
+      }
+    } catch (err) {
+      failed.push(stmt);
     }
   }
-  return inserted;
+  return { inserted, failed };
 }
 
 export async function getTableStructure(table) {


### PR DESCRIPTION
## Summary
- return failed statements from SQL execution API
- collect failed SQL during table creation and show in UI
- keep existing field settings when loading table structure
- improve SQL parsing and save only structure when saving config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fc8bf8f2083319256dc5582c3fca9