### PR TITLE
Fix Load Structure parsing

### DIFF
--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -369,11 +369,15 @@ export default function CodingTablesPage() {
   }
 
   function parseSqlConfig(sqlText) {
-    const m = sqlText.match(/CREATE TABLE(?: IF NOT EXISTS)?\s+`([^`]+)`\s*\(([^]*?)\)\s*(?:.*?AUTO_INCREMENT=(\d+))?/m);
+    const m = sqlText.match(/CREATE TABLE(?: IF NOT EXISTS)?\s+`([^`]+)`/i);
     if (!m) return null;
     const table = m[1];
-    const body = m[2];
-    const autoInc = m[3] || '1';
+    const start = sqlText.indexOf('(', m.index + m[0].length);
+    const end = sqlText.lastIndexOf(')');
+    if (start === -1 || end === -1 || end <= start) return null;
+    const body = sqlText.slice(start + 1, end);
+    const autoMatch = sqlText.slice(end).match(/AUTO_INCREMENT=(\d+)/i);
+    const autoInc = autoMatch ? autoMatch[1] : '1';
     const lines = body
       .split(/,\s*\n/)
       .map((l) => l.trim())


### PR DESCRIPTION
## Summary
- fix `parseSqlConfig` so it grabs full table body when loading structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fcbda9fd88331818dd3d7a12b3b9b