### PR TITLE
Fix missing populate records button

### DIFF
--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -1613,7 +1613,7 @@ export default function CodingTablesPage() {
               <button onClick={executeSeparateSql} style={{ marginLeft: '0.5rem' }}>
                 Create Tables & Records
               </button>
-              {(recordsSql || recordsSqlOther) && (
+              {(structSql || structSqlOther) && (
                 <button onClick={executeRecordsSql} style={{ marginLeft: '0.5rem' }}>
                   Populate Records
                 </button>
@@ -1637,6 +1637,7 @@ export default function CodingTablesPage() {
                       onChange={(e) => setRecordsSql(e.target.value)}
                       rows={10}
                       cols={40}
+                      placeholder="No records generated"
                     />
                   </div>
                 </div>
@@ -1658,6 +1659,7 @@ export default function CodingTablesPage() {
                     onChange={(e) => setRecordsSqlOther(e.target.value)}
                     rows={10}
                     cols={40}
+                    placeholder="No records generated"
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- ensure Populate Records button shows whenever table SQL is present
- show placeholder text when no record SQL exists

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68600d4d97448331ac22b223f94edf6a