### PR TITLE
Fix Insert Records button condition

### DIFF
--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -1820,7 +1820,7 @@ export default function CodingTablesPage() {
               <button onClick={executeSeparateSql} style={{ marginLeft: '0.5rem' }}>
                 Create Tables & Records
               </button>
-              {(structSql || structSqlOther) && (
+              {(recordsSql || recordsSqlOther) && (
                 <button onClick={executeRecordsSql} style={{ marginLeft: '0.5rem' }}>
                   Insert Records
                 </button>


### PR DESCRIPTION
## Summary
- ensure Insert Records button appears when records SQL is generated by using `recordsSql` state in conditional

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860188f97bc8331adba08199f2fca26