### PR TITLE
Fix records SQL textarea visibility

### DIFF
--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -1820,13 +1820,13 @@ export default function CodingTablesPage() {
               <button onClick={executeSeparateSql} style={{ marginLeft: '0.5rem' }}>
                 Create Tables & Records
               </button>
-              {(structSql || structSqlOther) && (
+              {(recordsSql || recordsSqlOther) && (
                 <button onClick={executeRecordsSql} style={{ marginLeft: '0.5rem' }}>
                   Insert Records
                 </button>
               )}
             </div>
-              {structSql && (
+              {(structSql || recordsSql) && (
                 <div style={{ marginTop: '0.5rem', display: 'flex', gap: '0.5rem' }}>
                   <div>
                     <div>Main table structure:</div>
@@ -1849,6 +1849,7 @@ export default function CodingTablesPage() {
                   </div>
                 </div>
               )}
+              {(structSqlOther || recordsSqlOther) && (
               <div style={{ marginTop: '0.5rem', display: 'flex', gap: '0.5rem' }}>
                 <div>
                   <div>_other table structure:</div>
@@ -1870,6 +1871,7 @@ export default function CodingTablesPage() {
                   />
                 </div>
               </div>
+              )}
               {sqlMove && (
                 <div style={{ marginTop: '0.5rem' }}>
                   <div>SQL to move unsuccessful rows:</div>


### PR DESCRIPTION
## Summary
- show generated record SQL textareas when only records SQL is created
- keep `_other` table areas hidden until structure or records exist

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860188f97bc8331adba08199f2fca26