### PR TITLE
Fix coding table config extras restoration

### DIFF
--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -1289,17 +1289,20 @@ export default function CodingTablesPage() {
         setUniqueFields(cfg.uniqueFields || []);
         setCalcText(cfg.calcText || '');
         setColumnTypes(cfg.columnTypes || {});
+        const extras =
+          cfg.extraFields && cfg.extraFields.length > 0 ? cfg.extraFields : [''];
+        setExtraFields(extras);
+        if (cfg.columnTypes) {
+          const hdrs = Object.keys(cfg.columnTypes).filter(
+            (h) => !extras.includes(h)
+          );
+          setHeaders(hdrs);
+        }
         setNotNullMap(cfg.notNullMap || {});
         setAllowZeroMap(cfg.allowZeroMap || {});
         setDefaultValues(cfg.defaultValues || {});
         setDefaultFrom(cfg.defaultFrom || {});
         setRenameMap(cfg.renameMap || {});
-        if (cfg.columnTypes) {
-          setHeaders(Object.keys(cfg.columnTypes));
-        }
-        setExtraFields(
-          cfg.extraFields && cfg.extraFields.length > 0 ? cfg.extraFields : ['']
-        );
         setPopulateRange(cfg.populateRange || false);
         setStartYear(cfg.startYear || '');
         setEndYear(cfg.endYear || '');


### PR DESCRIPTION
## Summary
- restore extra field settings when loading coding table configs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686046057c88833198b71ad292af16ab