### PR TITLE
Fix extraFields exclusion from insert SQL

### DIFF
--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -708,7 +708,7 @@ export default function CodingTablesPage() {
       return `CREATE TABLE IF NOT EXISTS \`${tableNameForSql}\` (\n  ${defArr.join(',\n  ')}\n)${idCol ? ` AUTO_INCREMENT=${autoIncStart}` : ''};\n`;
     }
 
-    function buildInsert(rows, tableNameForSql, fields = allHdrs) {
+    function buildInsert(rows, tableNameForSql, fields) {
       if (!rows.length || !fields.length) return '';
       const cols = fields.map((f) => `\`${dbCols[f] || cleanIdentifier(renameMap[f] || f)}\``);
       const idxMap = fields.map((f) => allHdrs.indexOf(f));
@@ -747,7 +747,7 @@ export default function CodingTablesPage() {
       return out;
     }
 
-    const allFields = Array.from(new Set([...headers, ...extraFields]));
+    const allFields = Object.keys(columnTypes || {});
 
     const structMainStr = buildStructure(tbl, true);
     const insertMainStr = buildInsert(mainRows, tbl, allFields);
@@ -1271,6 +1271,7 @@ export default function CodingTablesPage() {
         setCalcText(cfg.calcText || '');
         setColumnTypes(cfg.columnTypes || {});
         if (cfg.columnTypes) {
+          // include all fields defined in columnTypes, even ones listed as extraFields
           const hdrs = Object.keys(cfg.columnTypes || {});
           setHeaders(hdrs);
         }


### PR DESCRIPTION
## Summary
- include extraFields when loading column headers from saved config
- generate SQL using all fields from `columnTypes`
- adjust buildInsert to use provided field list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860dbc92e0c8331ac50bcfc43dfe402