### PR TITLE
Fix auto-increment ID handling in coding table inserts

### DIFF
--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -586,7 +586,7 @@ export default function CodingTablesPage() {
     const stateIdx = allHdrs.findIndex((h) => /state/i.test(h));
 
     const fieldsToCheck = [
-      ...(idCol ? [idCol] : []),
+      ...(idCol && idIdx !== -1 ? [idCol] : []),
       ...(nmCol ? [nmCol] : []),
       ...uniqueOnly,
       ...otherFiltered,
@@ -751,7 +751,7 @@ export default function CodingTablesPage() {
     }
 
     const fields = [
-      ...(idCol ? [idCol] : []),
+      ...(idCol && idIdx !== -1 ? [idCol] : []),
       ...(nmCol ? [nmCol] : []),
       ...uniqueOnly,
       ...otherFiltered,


### PR DESCRIPTION
## Summary
- avoid inserting auto-generated IDs when no ID column is present

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686115fd8ef88331b206546d7b6cae08