### PR TITLE
Implement server-side transaction listing

### DIFF
--- a/src/erp.mgt.mn/components/TransactionsTable.jsx
+++ b/src/erp.mgt.mn/components/TransactionsTable.jsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from 'react';
+import Spinner from './Spinner.jsx';
+
+export default function TransactionsTable({ branchId, type = '', date = '', perPage = 10 }) {
+  const [rows, setRows] = useState([]);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setPage(1);
+  }, [branchId, type, date, perPage]);
+
+  useEffect(() => {
+    let canceled = false;
+    async function load() {
+      setLoading(true);
+      const params = new URLSearchParams();
+      if (branchId !== undefined) params.set('branch', branchId);
+      if (type) params.set('type', type);
+      if (date) params.set('date', date);
+      params.set('page', page);
+      params.set('perPage', perPage);
+      try {
+        const res = await fetch(`/api/transactions?${params.toString()}`, {
+          credentials: 'include',
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!canceled) {
+          setRows(Array.isArray(data.rows) ? data.rows : []);
+          setTotal(data.totalCount || 0);
+        }
+      } catch {
+        if (!canceled) {
+          setRows([]);
+          setTotal(0);
+        }
+      } finally {
+        if (!canceled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      canceled = true;
+    };
+  }, [branchId, type, date, page, perPage]);
+
+  const totalPages = Math.max(1, Math.ceil(total / perPage));
+
+  return (
+    <div style={{ position: 'relative' }}>
+      {loading && <Spinner />}
+      <div className="overflow-x-auto">
+        <table className="min-w-full border text-sm bg-white">
+          <thead className="sticky top-0 bg-white z-10">
+            <tr>
+              {rows[0] &&
+                Object.keys(rows[0]).map((col) => (
+                  <th key={col} className="px-4 py-2 border-b whitespace-nowrap">
+                    {col}
+                  </th>
+                ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, idx) => (
+              <tr key={idx} className="odd:bg-gray-50">
+                {Object.keys(row).map((col) => (
+                  <td key={col} className="px-4 py-2 border-b whitespace-nowrap">
+                    {row[col]}
+                  </td>
+                ))}
+              </tr>
+            ))}
+            {rows.length === 0 && !loading && (
+              <tr>
+                <td
+                  className="px-4 py-2 border-b text-center"
+                  colSpan={rows[0] ? Object.keys(rows[0]).length : 1}
+                >
+                  No data
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+      <div className="flex justify-center items-center space-x-2 mt-2">
+        <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page <= 1}>
+          Prev
+        </button>
+        <span>
+          {page}/{totalPages}
+        </span>
+        <button
+          onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+          disabled={page >= totalPages}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useContext, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import TableManager from '../components/TableManager.jsx';
+import TransactionsTable from '../components/TransactionsTable.jsx';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { useRolePermissions } from '../hooks/useRolePermissions.js';
 import { useCompanyModules } from '../hooks/useCompanyModules.js';
@@ -15,14 +16,13 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
   const [name, setName] = useState(() => sessionState.name || searchParams.get(paramKey) || '');
   const [table, setTable] = useState(() => sessionState.table || '');
   const [config, setConfig] = useState(() => sessionState.config || null);
-  const [refreshId, setRefreshId] = useState(() => sessionState.refreshId || 0);
-  const [showTable, setShowTable] = useState(() => sessionState.showTable || false);
   const { company } = useContext(AuthContext);
   const perms = useRolePermissions();
   const licensed = useCompanyModules(company?.company_id);
-  const tableRef = useRef(null);
   const prevModuleKey = useRef(moduleKey);
   const { addToast } = useToast();
+  const [dateFilter, setDateFilter] = useState('');
+  const [typeFilter, setTypeFilter] = useState('');
 
   
   useEffect(() => {
@@ -41,14 +41,12 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
     setName(sessionState.name || '');
     setTable(sessionState.table || '');
     setConfig(sessionState.config || null);
-    setRefreshId(sessionState.refreshId || 0);
-    setShowTable(sessionState.showTable || false);
   }, [moduleKey]);
 
   // persist state to session
   useEffect(() => {
-    setSessionState({ name, table, config, refreshId, showTable });
-  }, [name, table, config, refreshId, showTable, setSessionState]);
+    setSessionState({ name, table, config });
+  }, [name, table, config, setSessionState]);
 
   useEffect(() => {
     setSearchParams((prev) => {
@@ -220,23 +218,32 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
         )}
       {table && config && (
         <div style={{ marginBottom: '0.5rem' }}>
-          <button onClick={() => tableRef.current?.openAdd()} style={{ marginRight: '0.5rem' }}>
-            Add Transaction
-          </button>
-          <button onClick={() => setShowTable((v) => !v)}>
-            {showTable ? 'Hide Table' : 'View Table'}
-          </button>
+          <label style={{ marginRight: '0.5rem' }}>
+            Date:
+            <input
+              type="date"
+              value={dateFilter}
+              onChange={(e) => setDateFilter(e.target.value)}
+              style={{ marginLeft: '0.25rem' }}
+            />
+          </label>
+          <label style={{ marginRight: '0.5rem' }}>
+            Type:
+            <input
+              type="text"
+              value={typeFilter}
+              onChange={(e) => setTypeFilter(e.target.value)}
+              style={{ marginLeft: '0.25rem' }}
+            />
+          </label>
         </div>
       )}
       {table && config && (
-        <TableManager
-          ref={tableRef}
-          table={table}
-          refreshId={refreshId}
-          formConfig={config}
-          initialPerPage={10}
-          addLabel="Add Transaction"
-          showTable={showTable}
+        <TransactionsTable
+          branchId={company?.branch_id}
+          type={typeFilter}
+          date={dateFilter}
+          perPage={10}
         />
       )}
       {transactionNames.length === 0 && (


### PR DESCRIPTION
## Summary
- create `TransactionsTable` to fetch `/api/transactions`
- update `FinanceTransactions` to show server-filtered list with date and type filters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686159a8b6048331806a99a3ffb3d98d