### PR TITLE
Add inventory transaction query endpoint

### DIFF
--- a/api-server/controllers/transactionController.js
+++ b/api-server/controllers/transactionController.js
@@ -1,0 +1,17 @@
+import { listInventoryTransactions } from '../../db/index.js';
+
+export async function getInventoryTransactions(req, res, next) {
+  try {
+    const { startDate, endDate, branchId, page, perPage } = req.query;
+    const result = await listInventoryTransactions({
+      branchId,
+      startDate,
+      endDate,
+      page: Number(page) || 1,
+      perPage: Number(perPage) || 50,
+    });
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/api-server/routes/transactions.js
+++ b/api-server/routes/transactions.js
@@ -1,0 +1,9 @@
+import express from 'express';
+import { requireAuth } from '../middlewares/auth.js';
+import { getInventoryTransactions } from '../controllers/transactionController.js';
+
+const router = express.Router();
+
+router.get('/', requireAuth, getInventoryTransactions);
+
+export default router;

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -22,6 +22,7 @@ import displayFieldRoutes from "./routes/display_fields.js";
 import codingTableConfigRoutes from "./routes/coding_table_configs.js";
 import generatedSqlRoutes from "./routes/generated_sql.js";
 import transactionFormRoutes from "./routes/transaction_forms.js";
+import transactionRoutes from "./routes/transactions.js";
 import { requireAuth } from "./middlewares/auth.js";
 
 // Polyfill for __dirname in ES modules
@@ -61,6 +62,7 @@ app.use("/api/display_fields", displayFieldRoutes);
 app.use("/api/coding_table_configs", codingTableConfigRoutes);
 app.use("/api/generated_sql", generatedSqlRoutes);
 app.use("/api/transaction_forms", transactionFormRoutes);
+app.use("/api/inventory_transactions", requireAuth, transactionRoutes);
 app.use("/api/tables", requireAuth, tableRoutes);
 
 // Serve static React build and fallback to index.html


### PR DESCRIPTION
## Summary
- enable backend to query filtered inventory transactions
- expose `/api/inventory_transactions` route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68615c45b20c8331a8ad7b9d45f3d13e