### PR TITLE
Improve debug logging and sanitize table cells

### DIFF
--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -1,10 +1,11 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { HashRouter, Routes, Route, Navigate, Outlet } from 'react-router-dom';
 import AuthContextProvider, { AuthContext } from './context/AuthContext.jsx';
 import { TabProvider } from './context/TabContext.jsx';
 import { TxnSessionProvider } from './context/TxnSessionContext.jsx';
 import { ToastProvider } from './context/ToastContext.jsx';
 import { LoadingProvider } from './context/LoadingContext.jsx';
+import { debugLog } from './utils/debug.js';
 import RequireAuth from './components/RequireAuth.jsx';
 import ERPLayout from './components/ERPLayout.jsx';
 import AppLayout from './components/AppLayout.jsx';
@@ -32,6 +33,10 @@ import { useTxnModules } from './hooks/useTxnModules.js';
 export default function App() {
   const modules = useModules();
   const txnModules = useTxnModules();
+
+  useEffect(() => {
+    debugLog('Component mounted: App');
+  }, []);
 
   const moduleMap = {};
   modules.forEach((m) => {

--- a/src/erp.mgt.mn/context/AuthContext.jsx
+++ b/src/erp.mgt.mn/context/AuthContext.jsx
@@ -1,5 +1,6 @@
 // src/erp.mgt.mn/context/AuthContext.jsx
 import React, { createContext, useState, useEffect, useContext } from 'react';
+import { debugLog } from '../utils/debug.js';
 
 // Create the AuthContext
 export const AuthContext = createContext({
@@ -15,6 +16,7 @@ export default function AuthContextProvider({ children }) {
 
   // Persist selected company across reloads
   useEffect(() => {
+    debugLog('AuthContext: load stored company');
     const stored = localStorage.getItem('erp_selected_company');
     if (stored) {
       try {
@@ -26,6 +28,7 @@ export default function AuthContextProvider({ children }) {
   }, []);
 
   useEffect(() => {
+    debugLog('AuthContext: persist company');
     if (company) {
       localStorage.setItem('erp_selected_company', JSON.stringify(company));
     } else {
@@ -35,6 +38,7 @@ export default function AuthContextProvider({ children }) {
 
   // On mount, attempt to load the current profile (if a cookie is present)
   useEffect(() => {
+    debugLog('AuthContext: load profile');
     async function loadProfile() {
       try {
         const res = await fetch('/api/auth/me', {

--- a/src/erp.mgt.mn/hooks/useModules.js
+++ b/src/erp.mgt.mn/hooks/useModules.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { debugLog } from '../utils/debug.js';
 
 const cache = { data: null };
 const emitter = new EventTarget();
@@ -24,12 +25,14 @@ export function useModules() {
   }
 
   useEffect(() => {
+    debugLog('useModules effect: initial fetch');
     if (!cache.data) {
       fetchModules();
     }
   }, []);
 
   useEffect(() => {
+    debugLog('useModules effect: refresh listener');
     const handler = () => fetchModules();
     emitter.addEventListener('refresh', handler);
     return () => emitter.removeEventListener('refresh', handler);

--- a/src/erp.mgt.mn/hooks/useRolePermissions.js
+++ b/src/erp.mgt.mn/hooks/useRolePermissions.js
@@ -1,4 +1,5 @@
 import { useContext, useEffect, useState } from 'react';
+import { debugLog } from '../utils/debug.js';
 import { AuthContext } from '../context/AuthContext.jsx';
 
 // Cache permissions by role so switching users does not refetch unnecessarily
@@ -39,6 +40,7 @@ export function useRolePermissions() {
   }
 
   useEffect(() => {
+    debugLog('useRolePermissions effect: load perms');
     if (!user) {
       setPerms(null);
       return;
@@ -58,6 +60,7 @@ export function useRolePermissions() {
 
   // Listen for refresh events
   useEffect(() => {
+    debugLog('useRolePermissions effect: refresh listener');
     if (!user) return;
     const roleId =
       company?.role_id || user.role_id || (user.role === 'admin' ? 1 : 2);

--- a/src/erp.mgt.mn/hooks/useTxnModules.js
+++ b/src/erp.mgt.mn/hooks/useTxnModules.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { debugLog } from '../utils/debug.js';
 
 const cache = { keys: null };
 const emitter = new EventTarget();
@@ -28,10 +29,12 @@ export function useTxnModules() {
   }
 
   useEffect(() => {
+    debugLog('useTxnModules effect: initial fetch');
     if (!cache.keys) fetchKeys();
   }, []);
 
   useEffect(() => {
+    debugLog('useTxnModules effect: refresh listener');
     const handler = () => fetchKeys();
     emitter.addEventListener('refresh', handler);
     return () => emitter.removeEventListener('refresh', handler);

--- a/src/erp.mgt.mn/main.jsx
+++ b/src/erp.mgt.mn/main.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './utils/csrfFetch.js';
+import './utils/debug.js';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useModules } from '../hooks/useModules.js';
 import { refreshTxnModules } from '../hooks/useTxnModules.js';
+import { debugLog } from '../utils/debug.js';
 
 export default function FormsManagement() {
   const [tables, setTables] = useState([]);
@@ -14,6 +15,9 @@ export default function FormsManagement() {
   const [txnTypes, setTxnTypes] = useState([]);
   const [columns, setColumns] = useState([]);
   const modules = useModules();
+  useEffect(() => {
+    debugLog('Component mounted: FormsManagement');
+  }, []);
   const [config, setConfig] = useState({
     visibleFields: [],
     requiredFields: [],
@@ -503,7 +507,9 @@ export default function FormsManagement() {
             <tbody>
               {columns.map((col) => (
                 <tr key={col}>
-                  <td style={{ border: '1px solid #ccc', padding: '4px' }}>{col}</td>
+                  <td style={{ border: '1px solid #ccc', padding: '4px' }}>
+                    {col != null ? col : ''}
+                  </td>
                   <td style={{ border: '1px solid #ccc', padding: '4px', textAlign: 'center' }}>
                     <input
                       type="checkbox"

--- a/src/erp.mgt.mn/pages/UserCompanies.jsx
+++ b/src/erp.mgt.mn/pages/UserCompanies.jsx
@@ -1,6 +1,7 @@
 // src/erp.mgt.mn/pages/UserCompanies.jsx
 import React, { useEffect, useState, useContext } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
+import { debugLog } from '../utils/debug.js';
 
 export default function UserCompanies() {
   const [assignments, setAssignments] = useState([]);
@@ -11,6 +12,10 @@ export default function UserCompanies() {
   const [branchesList, setBranchesList] = useState([]);
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState(null);
+
+  useEffect(() => {
+    debugLog('Component mounted: UserCompanies');
+  }, []);
 
   function loadAssignments(empid) {
     const params = [];
@@ -134,10 +139,18 @@ export default function UserCompanies() {
           <tbody>
             {assignments.map(a => (
               <tr key={a.empid + '-' + a.company_id}>
-                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{a.empid}</td>
-                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{a.company_name}</td>
-                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{a.branch_name || ''}</td>
-                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{a.role}</td>
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
+                  {a.empid != null ? a.empid : ''}
+                </td>
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
+                  {a.company_name != null ? a.company_name : ''}
+                </td>
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
+                  {a.branch_name != null ? a.branch_name : ''}
+                </td>
+                <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
+                  {a.role != null ? a.role : ''}
+                </td>
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
                   <button onClick={() => handleEdit(a)}>Засах</button>
                   <button onClick={() => handleDelete(a)} style={{ marginLeft: '0.5rem' }}>

--- a/src/erp.mgt.mn/pages/Users.jsx
+++ b/src/erp.mgt.mn/pages/Users.jsx
@@ -1,11 +1,16 @@
 // src/erp.mgt.mn/pages/Users.jsx
 import React, { useEffect, useState, useContext } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
+import { debugLog } from '../utils/debug.js';
 
 export default function Users() {
   const [usersList, setUsersList] = useState([]);
   const [filter, setFilter] = useState('');
   const { company } = useContext(AuthContext);
+
+  useEffect(() => {
+    debugLog('Component mounted: Users');
+  }, []);
 
   function loadUsers() {
     const params = company ? `?companyId=${encodeURIComponent(company.company_id)}` : '';
@@ -132,10 +137,10 @@ export default function Users() {
               .map((u) => (
               <tr key={u.id}>
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
-                  {u.empid}
+                  {u.empid != null ? u.empid : ''}
                 </td>
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
-                  {u.role}
+                  {u.role != null ? u.role : ''}
                 </td>
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
                   <button onClick={() => handleEdit(u)}>Засах</button>

--- a/src/erp.mgt.mn/utils/debug.js
+++ b/src/erp.mgt.mn/utils/debug.js
@@ -1,0 +1,9 @@
+if (typeof window !== 'undefined') {
+  window.erpDebug = true;
+}
+
+export function debugLog(...args) {
+  if (typeof window !== 'undefined' && window.erpDebug) {
+    console.log(...args);
+  }
+}


### PR DESCRIPTION
## Summary
- add a small debug utility and enable it in the main entry
- log when major components or hooks mount
- sanitize table cell values to avoid invalid render output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686162fc69888331b93d8dd74614c806