### PR TITLE
Add debug helpers to diagnose render loops

### DIFF
--- a/src/erp.mgt.mn/components/AppLayout.jsx
+++ b/src/erp.mgt.mn/components/AppLayout.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { logout } from '../hooks/useAuth.jsx';
@@ -6,6 +6,10 @@ import { logout } from '../hooks/useAuth.jsx';
 export default function AppLayout({ children, title }) {
   const { user, company } = useContext(AuthContext);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (window.erpDebug) console.warn('Mounted: AppLayout');
+  }, []);
 
   async function handleLogout() {
     await logout();

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -23,6 +23,9 @@ import Spinner from "./Spinner.jsx";
  */
 export default function ERPLayout() {
   const { user, setUser, company } = useContext(AuthContext);
+  useEffect(() => {
+    if (window.erpDebug) console.warn('Mounted: ERPLayout');
+  }, []);
   const navigate = useNavigate();
   const location = useLocation();
 

--- a/src/erp.mgt.mn/components/Layout.jsx
+++ b/src/erp.mgt.mn/components/Layout.jsx
@@ -1,5 +1,5 @@
 // src/erp.mgt.mn/components/ERPLayout.jsx
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { Outlet, NavLink, useNavigate, useLocation } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { logout } from '../hooks/useAuth.jsx';
@@ -14,6 +14,10 @@ export default function ERPLayout() {
   const { user, setUser } = useContext(AuthContext);
   const navigate = useNavigate();
   const location = useLocation();
+
+  useEffect(() => {
+    if (window.erpDebug) console.warn('Mounted: Layout');
+  }, []);
 
   const titleMap = {
     '/': 'Dashboard',

--- a/src/erp.mgt.mn/context/AuthContext.jsx
+++ b/src/erp.mgt.mn/context/AuthContext.jsx
@@ -1,6 +1,6 @@
 // src/erp.mgt.mn/context/AuthContext.jsx
-import React, { createContext, useState, useEffect, useContext } from 'react';
-import { debugLog } from '../utils/debug.js';
+import React, { createContext, useState, useEffect, useContext, useMemo } from 'react';
+import { debugLog, trackSetState } from '../utils/debug.js';
 
 // Create the AuthContext
 export const AuthContext = createContext({
@@ -20,6 +20,7 @@ export default function AuthContextProvider({ children }) {
     const stored = localStorage.getItem('erp_selected_company');
     if (stored) {
       try {
+        trackSetState('AuthContext.setCompany');
         setCompany(JSON.parse(stored));
       } catch {
         // ignore parse errors
@@ -47,6 +48,7 @@ export default function AuthContextProvider({ children }) {
 
         if (res.ok) {
           const data = await res.json();
+          trackSetState('AuthContext.setUser');
           setUser(data);
         } else {
           // Not logged in or token expired → ignore
@@ -59,8 +61,10 @@ export default function AuthContextProvider({ children }) {
     loadProfile();
   }, []);
 
+  const value = useMemo(() => ({ user, setUser, company, setCompany }), [user, company]);
+
   return (
-    <AuthContext.Provider value={{ user, setUser, company, setCompany }}>
+    <AuthContext.Provider value={value}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/erp.mgt.mn/context/LoadingContext.jsx
+++ b/src/erp.mgt.mn/context/LoadingContext.jsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState, useMemo } from 'react';
+import { trackSetState } from '../utils/debug.js';
 
 const LoadingContext = createContext({ loaders: {} });
 
@@ -8,10 +9,12 @@ export function LoadingProvider({ children }) {
   useEffect(() => {
     function start(e) {
       const key = (e.detail && e.detail.key) || 'global';
+      trackSetState('LoadingProvider.setLoaders');
       setLoaders((l) => ({ ...l, [key]: (l[key] || 0) + 1 }));
     }
     function end(e) {
       const key = (e.detail && e.detail.key) || 'global';
+      trackSetState('LoadingProvider.setLoaders');
       setLoaders((l) => ({ ...l, [key]: Math.max(0, (l[key] || 0) - 1) }));
     }
     window.addEventListener('loading:start', start);
@@ -22,8 +25,10 @@ export function LoadingProvider({ children }) {
     };
   }, []);
 
+  const value = useMemo(() => ({ loaders }), [loaders]);
+
   return (
-    <LoadingContext.Provider value={{ loaders }}>
+    <LoadingContext.Provider value={value}>
       {children}
     </LoadingContext.Provider>
   );

--- a/src/erp.mgt.mn/context/TabContext.jsx
+++ b/src/erp.mgt.mn/context/TabContext.jsx
@@ -4,7 +4,9 @@ import React, {
   useState,
   useCallback,
   useEffect,
+  useMemo,
 } from 'react';
+import { trackSetState } from '../utils/debug.js';
 
 const TabContext = createContext();
 
@@ -18,27 +20,33 @@ export function TabProvider({ children }) {
   }, [activeKey]);
 
   const openTab = useCallback(({ key, label, content }) => {
+    trackSetState('TabProvider.setTabs');
     setTabs((t) => {
       if (t.some((tab) => tab.key === key)) return t;
       return [...t, { key, label }];
     });
     if (content) setCache((c) => ({ ...c, [key]: content }));
+    trackSetState('TabProvider.setActiveKey');
     setActiveKey(key);
     window.__activeTabKey = key;
   }, []);
 
   const switchTab = useCallback((key) => {
+    trackSetState('TabProvider.setActiveKey');
     setActiveKey(key);
     window.__activeTabKey = key;
   }, []);
 
   const closeTab = useCallback((key) => {
+    trackSetState('TabProvider.setTabs');
     setTabs((t) => t.filter((tab) => tab.key !== key));
+    trackSetState('TabProvider.setCache');
     setCache((c) => {
       const n = { ...c };
       delete n[key];
       return n;
     });
+    trackSetState('TabProvider.setActiveKey');
     setActiveKey((k) => {
       if (k !== key) return k;
       const remaining = tabs.filter((t) => t.key !== key);
@@ -47,11 +55,17 @@ export function TabProvider({ children }) {
   }, [tabs]);
 
   const setTabContent = useCallback((key, content) => {
+    trackSetState('TabProvider.setCache');
     setCache((c) => ({ ...c, [key]: content }));
   }, []);
 
+  const value = useMemo(
+    () => ({ tabs, activeKey, openTab, closeTab, switchTab, setTabContent, cache }),
+    [tabs, activeKey, openTab, closeTab, switchTab, setTabContent, cache]
+  );
+
   return (
-    <TabContext.Provider value={{ tabs, activeKey, openTab, closeTab, switchTab, setTabContent, cache }}>
+    <TabContext.Provider value={value}>
       {children}
     </TabContext.Provider>
   );

--- a/src/erp.mgt.mn/context/ToastContext.jsx
+++ b/src/erp.mgt.mn/context/ToastContext.jsx
@@ -1,4 +1,5 @@
-import React, { createContext, useCallback, useContext, useState, useEffect } from 'react';
+import React, { createContext, useCallback, useContext, useState, useEffect, useMemo } from 'react';
+import { trackSetState } from '../utils/debug.js';
 
 const ToastContext = createContext({ addToast: () => {} });
 
@@ -7,8 +8,10 @@ export function ToastProvider({ children }) {
 
   const addToast = useCallback((message, type = 'info') => {
     const id = Date.now() + Math.random();
+    trackSetState('ToastProvider.setToasts');
     setToasts((t) => [...t, { id, message, type }]);
     setTimeout(() => {
+      trackSetState('ToastProvider.setToasts');
       setToasts((t) => t.filter((toast) => toast.id !== id));
     }, 5000);
   }, []);
@@ -22,8 +25,10 @@ export function ToastProvider({ children }) {
     return () => window.removeEventListener('toast', handle);
   }, [addToast]);
 
+  const value = useMemo(() => ({ addToast }), [addToast]);
+
   return (
-    <ToastContext.Provider value={{ addToast }}>
+    <ToastContext.Provider value={value}>
       {children}
       <div className="toast-container">
         {toasts.map((t) => (

--- a/src/erp.mgt.mn/context/TxnSessionContext.jsx
+++ b/src/erp.mgt.mn/context/TxnSessionContext.jsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useState, useMemo } from 'react';
+import { trackSetState } from '../utils/debug.js';
 
 const TxnSessionContext = createContext();
 
@@ -7,6 +8,7 @@ export function TxnSessionProvider({ children }) {
 
   const getSession = (key) => {
     if (!sessions[key]) {
+      trackSetState('TxnSessionProvider.setSessions');
       setSessions((s) => ({ ...s, [key]: {} }));
       return {};
     }
@@ -14,10 +16,12 @@ export function TxnSessionProvider({ children }) {
   };
 
   const setSession = (key, state) => {
+    trackSetState('TxnSessionProvider.setSessions');
     setSessions((s) => ({ ...s, [key]: { ...s[key], ...state } }));
   };
 
   const clearSession = (key) => {
+    trackSetState('TxnSessionProvider.setSessions');
     setSessions((s) => {
       const copy = { ...s };
       delete copy[key];
@@ -25,8 +29,13 @@ export function TxnSessionProvider({ children }) {
     });
   };
 
+  const value = useMemo(
+    () => ({ getSession, setSession, clearSession }),
+    [getSession, setSession, clearSession]
+  );
+
   return (
-    <TxnSessionContext.Provider value={{ getSession, setSession, clearSession }}>
+    <TxnSessionContext.Provider value={value}>
       {children}
     </TxnSessionContext.Provider>
   );

--- a/src/erp.mgt.mn/main.jsx
+++ b/src/erp.mgt.mn/main.jsx
@@ -3,7 +3,10 @@ import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './utils/csrfFetch.js';
 import './utils/debug.js';
+import { setupDebugHooks } from './utils/debugHooks.js';
 import './index.css';
+
+setupDebugHooks();
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/src/erp.mgt.mn/pages/BlueLinkPage.jsx
+++ b/src/erp.mgt.mn/pages/BlueLinkPage.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import MosaicLayout from '../components/MosaicLayout.jsx';
 import { AuthContext } from '../context/AuthContext.jsx';
 
@@ -16,6 +16,10 @@ const initialLayout = {
 
 export default function BlueLinkPage() {
   const { user, company } = useContext(AuthContext);
+
+  useEffect(() => {
+    if (window.erpDebug) console.warn('Mounted: BlueLinkPage');
+  }, []);
 
   const cardStyle = {
     background: '#f0f4ff',

--- a/src/erp.mgt.mn/pages/Dashboard.jsx
+++ b/src/erp.mgt.mn/pages/Dashboard.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import MosaicLayout from '../components/MosaicLayout.jsx';
 
 const initialLayout = {
@@ -19,6 +19,9 @@ const initialLayout = {
 };
 
 export default function Dashboard() {
+  useEffect(() => {
+    if (window.erpDebug) console.warn('Mounted: Dashboard');
+  }, []);
   return (
     <div>
       <h2>Самбар</h2>

--- a/src/erp.mgt.mn/pages/InventoryPage.jsx
+++ b/src/erp.mgt.mn/pages/InventoryPage.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 const data = [
   { id: 1, name: 'Бараа 1', qty: 10, price: 1000 },
@@ -7,6 +7,9 @@ const data = [
 ];
 
 export default function InventoryPage() {
+  useEffect(() => {
+    if (window.erpDebug) console.warn('Mounted: InventoryPage');
+  }, []);
   return (
     <div className="overflow-x-auto">
       <table className="min-w-full border text-sm bg-white max-h-[70vh] overflow-auto">

--- a/src/erp.mgt.mn/utils/debug.js
+++ b/src/erp.mgt.mn/utils/debug.js
@@ -1,9 +1,18 @@
 if (typeof window !== 'undefined') {
   window.erpDebug = true;
+  window.__stateCount = {};
 }
 
 export function debugLog(...args) {
   if (typeof window !== 'undefined' && window.erpDebug) {
     console.log(...args);
+  }
+}
+
+export function trackSetState(name) {
+  if (typeof window === 'undefined') return;
+  const counts = (window.__stateCount ||= {});
+  if (++counts[name] > 10) {
+    console.error('Excessive setState:', name);
   }
 }

--- a/src/erp.mgt.mn/utils/debugHooks.js
+++ b/src/erp.mgt.mn/utils/debugHooks.js
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { debugLog } from './debug.js';
+
+export function setupDebugHooks() {
+  if (typeof window === 'undefined' || !window.erpDebug) return;
+  if (React.__erpDebugPatched) return;
+  React.__erpDebugPatched = true;
+
+  function patchEffect(name) {
+    const orig = React[name];
+    React[name] = (cb, deps) => {
+      if (deps === undefined) {
+        console.warn(`${name} without dependency array`);
+      }
+      return orig(() => {
+        debugLog(`${name} run`, deps);
+        return cb();
+      }, deps);
+    };
+  }
+
+  ['useEffect', 'useLayoutEffect'].forEach(patchEffect);
+
+  function patchMemo(name) {
+    const orig = React[name];
+    React[name] = (cb, deps) => {
+      if (deps === undefined) {
+        console.warn(`${name} without dependency array`);
+      }
+      debugLog(`${name} evaluate`, deps);
+      return orig(cb, deps);
+    };
+  }
+
+  ['useMemo', 'useCallback'].forEach(patchMemo);
+}


### PR DESCRIPTION
## Summary
- add `setupDebugHooks` to log hook usage
- warn for excessive state updates with `trackSetState`
- memoize context provider values
- log when key layouts and pages mount

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68616580de3c83319c3547296f0bdcff