### PR TITLE
Fix RowFormModal update loop

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -266,9 +266,12 @@ function MainWindow({ title }) {
   const navigate = useNavigate();
   const { tabs, activeKey, switchTab, closeTab, setTabContent, cache } = useTabs();
 
+  // Store rendered outlet by path once the route changes. Avoid tracking
+  // the `outlet` object itself to prevent endless updates caused by React
+  // creating a new element on every render.
   useEffect(() => {
     setTabContent(location.pathname, outlet);
-  }, [location.pathname, outlet, setTabContent]);
+  }, [location.pathname, setTabContent]);
 
   function handleSwitch(key) {
     switchTab(key);

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -150,7 +150,7 @@ export default function RowFormModal({
     setFormVals(vals);
     inputRefs.current = {};
     setErrors({});
-  }, [row, columns, visible, placeholders, user, company]);
+  }, [row, visible, user, company]);
 
   if (!visible) return null;
 


### PR DESCRIPTION
## Summary
- avoid including placeholders array in RowFormModal state effect
- prevent MainWindow from updating on every render

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68616a53fcf4833195525837b2bb78e1