### PR TITLE
Fix RowFormModal update loop

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -63,7 +63,7 @@ export default function ERPLayout() {
   useEffect(() => {
     const title = titleForPath(location.pathname);
     openTab({ key: location.pathname, label: title });
-  }, [location.pathname, modules, openTab]);
+  }, [location.pathname, openTab]);
 
   function handleOpen(path, label, key) {
     if (txnModuleKeys && txnModuleKeys.has(key)) {
@@ -266,9 +266,12 @@ function MainWindow({ title }) {
   const navigate = useNavigate();
   const { tabs, activeKey, switchTab, closeTab, setTabContent, cache } = useTabs();
 
+  // Store rendered outlet by path once the route changes. Avoid tracking
+  // the `outlet` object itself to prevent endless updates caused by React
+  // creating a new element on every render.
   useEffect(() => {
     setTabContent(location.pathname, outlet);
-  }, [location.pathname, outlet, setTabContent]);
+  }, [location.pathname, setTabContent]);
 
   function handleSwitch(key) {
     switchTab(key);

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -147,10 +147,12 @@ export default function RowFormModal({
       }
       vals[c] = v;
     });
-    setFormVals(vals);
+    // Avoid triggering a state update if the values haven't actually changed.
+    const same = Object.keys(vals).every((k) => formVals[k] === vals[k]);
+    if (!same) setFormVals(vals);
     inputRefs.current = {};
     setErrors({});
-  }, [row, columns, visible, placeholders, user, company]);
+  }, [row, visible, user, company]);
 
   if (!visible) return null;
 

--- a/src/erp.mgt.mn/context/TabContext.jsx
+++ b/src/erp.mgt.mn/context/TabContext.jsx
@@ -25,9 +25,14 @@ export function TabProvider({ children }) {
       if (t.some((tab) => tab.key === key)) return t;
       return [...t, { key, label }];
     });
-    if (content) setCache((c) => ({ ...c, [key]: content }));
+    if (content) {
+      setCache((c) => {
+        if (c[key] === content) return c;
+        return { ...c, [key]: content };
+      });
+    }
     trackSetState('TabProvider.setActiveKey');
-    setActiveKey(key);
+    setActiveKey((k) => (k === key ? k : key));
     window.__activeTabKey = key;
   }, []);
 
@@ -56,7 +61,10 @@ export function TabProvider({ children }) {
 
   const setTabContent = useCallback((key, content) => {
     trackSetState('TabProvider.setCache');
-    setCache((c) => ({ ...c, [key]: content }));
+    setCache((c) => {
+      if (c[key] === content) return c;
+      return { ...c, [key]: content };
+    });
   }, []);
 
   const value = useMemo(


### PR DESCRIPTION
## Summary
- avoid including placeholders array in RowFormModal state effect
- prevent MainWindow from updating on every render
- reduce unnecessary tab updates
- avoid redundant state reset in RowFormModal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68616a53fcf4833195525837b2bb78e1