### PR TITLE
Handle duplicate fields better in coding tables

### DIFF
--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -7,6 +7,10 @@ function cleanIdentifier(name) {
   return String(name).replace(/[^A-Za-z0-9_]+/g, '');
 }
 
+function normalizeField(name) {
+  return cleanIdentifier(name).toLowerCase();
+}
+
 export default function CodingTablesPage() {
   const { addToast } = useToast();
   const [sheets, setSheets] = useState([]);
@@ -62,12 +66,13 @@ export default function CodingTablesPage() {
   }, []);
 
   const allFields = useMemo(() => {
-    return Array.from(
-      new Set([
-        ...headers,
-        ...extraFields.filter((f) => f.trim() !== ''),
-      ]),
-    );
+    // keep duplicates so user can easily spot them and clean extras the same way
+    return [
+      ...headers,
+      ...extraFields
+        .filter((f) => f.trim() !== '')
+        .map((f) => cleanIdentifier(f)),
+    ];
   }, [headers, extraFields]);
 
   const hasDateField = useMemo(
@@ -75,15 +80,38 @@ export default function CodingTablesPage() {
     [allFields]
   );
 
+  useEffect(() => {
+    if (workbook && headers.length > 0) {
+      extractHeaders(workbook, sheet, headerRow, mnHeaderRow);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [extraFields]);
+
   function computeIdCandidates(hdrs, extras, mode) {
     const strs = hdrs.filter((h) => typeof h === 'string');
-    const extraList = extras.filter((f) => typeof f === 'string' && f.trim() !== '');
+    const extraList = extras
+      .filter((f) => typeof f === 'string' && f.trim() !== '')
+      .map((f) => normalizeField(f));
     if (mode === 'contains') {
       const ids = strs.filter((h) => h.toLowerCase().includes('id'));
       const base = ids.length > 0 ? ids : strs;
       return Array.from(new Set([...base, ...extraList]));
     }
     return Array.from(new Set([...strs, ...extraList]));
+  }
+
+  function uniqueRenamedFields(fields = allFields, exclude) {
+    const seen = new Set();
+    const opts = [];
+    for (const f of fields) {
+      if (f === exclude) continue;
+      const label = renameMap[f] || f;
+      if (!seen.has(label)) {
+        seen.add(label);
+        opts.push({ value: f, label });
+      }
+    }
+    return opts;
   }
 
   async function applyHeaderMapping(hdrs, currentMap) {
@@ -229,28 +257,32 @@ export default function CodingTablesPage() {
     const seen = {};
     const extras = extraFields
       .filter((f) => f.trim() !== '')
-      .map((f) => cleanIdentifier(f));
-    extras.forEach((ex) => {
-      if (ex) seen[ex] = 1;
+      .map((f) => normalizeField(f));
+    extras.forEach((key) => {
+      if (key) {
+        seen[key] = (seen[key] || 0) + 1;
+      }
     });
     const dup = new Set();
     raw.forEach((h, i) => {
       if (String(h).trim().length > 0) {
-        let clean = cleanIdentifier(h);
-        if (seen[clean]) {
-          seen[clean] += 1;
-          const suffixed = `${clean}_${seen[clean]}`;
+        const clean = cleanIdentifier(h);
+        const key = normalizeField(h);
+        if (key in seen) {
+          const suffixNum = seen[key];
+          const suffixed = `${clean}_${suffixNum}`;
           dup.add(suffixed);
           hdrs.push(suffixed);
+          seen[key] = suffixNum + 1;
         } else {
-          seen[clean] = 1;
+          seen[key] = 1;
           hdrs.push(clean);
         }
         keepIdx.push(i);
         const mnVal = mnRaw[i];
-        const key = hdrs[hdrs.length - 1];
+        const hdrKey = hdrs[hdrs.length - 1];
         if (mnVal && String(mnVal).trim()) {
-          map[key] = String(mnVal).trim();
+          map[hdrKey] = String(mnVal).trim();
         }
       }
     });
@@ -555,13 +587,33 @@ export default function CodingTablesPage() {
     const raw = data[idx] || [];
     const hdrs = [];
     const keepIdx = [];
+    const seen = {};
+    const extrasNorm = extraFields
+      .filter((f) => f.trim() !== '')
+      .map((f) => normalizeField(f));
+    extrasNorm.forEach((key) => {
+      if (key) {
+        seen[key] = (seen[key] || 0) + 1;
+      }
+    });
     raw.forEach((h, i) => {
       if (String(h).trim().length > 0) {
-        hdrs.push(cleanIdentifier(h));
+        const clean = cleanIdentifier(h);
+        const key = normalizeField(h);
+        if (key in seen) {
+          const suffixNum = seen[key];
+          hdrs.push(`${clean}_${suffixNum}`);
+          seen[key] = suffixNum + 1;
+        } else {
+          seen[key] = 1;
+          hdrs.push(clean);
+        }
         keepIdx.push(i);
       }
     });
-    const extra = extraFields.filter((f) => f.trim() !== '').map(cleanIdentifier);
+    const extra = extraFields
+      .filter((f) => f.trim() !== '')
+      .map((f) => cleanIdentifier(f));
     const rows = data
       .slice(idx + 1)
       .map((r) => [...keepIdx.map((ci) => r[ci]), ...Array(extra.length).fill(undefined)]);
@@ -1626,9 +1678,9 @@ export default function CodingTablesPage() {
                 ID Column:
                 <select value={idColumn} onChange={(e) => setIdColumn(e.target.value)}>
                   <option value="">--none--</option>
-                  {idCandidates.map((h) => (
-                    <option key={h} value={h}>
-                      {h}
+                  {uniqueRenamedFields(idCandidates).map((o) => (
+                    <option key={o.value} value={o.value}>
+                      {o.label}
                     </option>
                   ))}
                 </select>
@@ -1648,9 +1700,9 @@ export default function CodingTablesPage() {
                 Name Column:
                 <select value={nameColumn} onChange={(e) => setNameColumn(e.target.value)}>
                   <option value="">--select--</option>
-                  {allFields.map((h) => (
-                    <option key={h} value={h}>
-                      {h}
+                  {uniqueRenamedFields().map((o) => (
+                    <option key={o.value} value={o.value}>
+                      {o.label}
                     </option>
                   ))}
                 </select>
@@ -1658,7 +1710,7 @@ export default function CodingTablesPage() {
               <div>
                 Unique Fields:
                 <div>
-                  {allFields.map((h) => (
+                  {uniqueRenamedFields().map(({ value: h, label }) => (
                     <label key={h} style={{ marginRight: '0.5rem' }}>
                       <input
                         type="checkbox"
@@ -1672,7 +1724,7 @@ export default function CodingTablesPage() {
                           }
                         }}
                       />
-                      {h}
+                      {label}
                     </label>
                   ))}
                 </div>
@@ -1680,7 +1732,7 @@ export default function CodingTablesPage() {
               <div>
                 Other Columns:
                 <div>
-                  {allFields.map((h) => (
+                  {uniqueRenamedFields().map(({ value: h, label }) => (
                     <label key={h} style={{ marginRight: '0.5rem' }}>
                       <input
                         type="checkbox"
@@ -1694,7 +1746,7 @@ export default function CodingTablesPage() {
                           }
                         }}
                       />
-                      {h}
+                      {label}
                     </label>
                   ))}
                 </div>
@@ -1702,9 +1754,9 @@ export default function CodingTablesPage() {
               <div>
                 Column Types:
                 <div>
-                  {allFields.map((h) => (
+                  {uniqueRenamedFields().map(({ value: h, label }) => (
                     <div key={h} style={{ marginBottom: '0.25rem' }}>
-                      {h}:{' '}
+                      {label}:{' '}
                       <input
                         value={columnTypes[h] || ''}
                         onChange={(e) =>
@@ -1762,13 +1814,11 @@ export default function CodingTablesPage() {
                         style={{ marginLeft: '0.25rem' }}
                       >
                         <option value="">from field...</option>
-                        {allFields
-                          .filter((x) => x !== h)
-                          .map((o) => (
-                            <option key={o} value={o}>
-                              {o}
-                            </option>
-                          ))}
+                        {uniqueRenamedFields(allFields, h).map((o) => (
+                          <option key={o.value} value={o.value}>
+                            {o.label}
+                          </option>
+                        ))}
                       </select>
                     </div>
                   ))}


### PR DESCRIPTION
## Summary
- keep duplicate fields in the list so users can see duplicates
- provide helper to list unique renamed options
- use the helper when choosing default-from fields
- append `_1` suffix when an Excel header duplicates an extra field and display all configuration lists using unique renamed labels
- handle case-insensitive duplicates so extra fields with the same name force `_1` suffix on Excel headers
- normalize extra field names when listing so duplicates show up correctly
- fix variable naming clash when copying Mongolian header text
- use `normalizeField` when comparing extras and headers so clashes get suffixed
- re-run header extraction when extra fields change to apply suffixes
- **ensure workbook generation uses the same duplicate-handling logic**

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6863dfa385a883318a01566b4264ca19