### PR TITLE
Fix coding table insert logic

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -703,7 +703,9 @@ const TableManager = forwardRef(function TableManager({
     }
 
     const cleaned = {};
+    const skipFields = new Set([...autoCols, 'id']);
     Object.entries(merged).forEach(([k, v]) => {
+      if (skipFields.has(k)) return;
       if (v !== '') {
         cleaned[k] =
           typeof v === 'string' ? normalizeDateInput(v, placeholders[k]) : v;


### PR DESCRIPTION
## Summary
- avoid sending autoincrement `id` when saving table rows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864072ba49c8331af8a64d2ac2aaff1