### PR TITLE
Fix coding table record SQL generation

### DIFF
--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -806,10 +806,6 @@ export default function CodingTablesPage() {
       const idxMap = fields.map((f) => allHdrs.indexOf(f));
       let out = '';
       for (const r of rows) {
-        if (nmCol) {
-          const nameVal = r[nameIdx];
-          if (nameVal === undefined || nameVal === null || nameVal === '') continue;
-        }
         let hasData = false;
         const vals = idxMap.map((idx, i) => {
           const f = fields[i];
@@ -827,7 +823,15 @@ export default function CodingTablesPage() {
               v = defaultValForType(colTypes[f]);
             }
           }
-          if (v !== undefined && v !== null && v !== '' && (allowZeroMap[f] ? true : v !== 0)) {
+          if (
+            v !== undefined &&
+            v !== null &&
+            v !== '' &&
+            (allowZeroMap[f] ? true : v !== 0)
+          ) {
+            hasData = true;
+          }
+          if (localNotNull[f]) {
             hasData = true;
           }
           return formatVal(v, colTypes[f]);
@@ -857,7 +861,12 @@ export default function CodingTablesPage() {
     const insertMainStr = buildInsert(mainRows, tbl, fields);
     const otherCombined = [...otherRows, ...dupRows];
     const structOtherStr = buildStructure(`${tbl}_other`, false);
-    const insertOtherStr = buildInsert(otherCombined, `${tbl}_other`, fields);
+    const fieldsWithoutId = fields.filter((f) => f !== idCol);
+    const insertOtherStr = buildInsert(
+      otherCombined,
+      `${tbl}_other`,
+      fieldsWithoutId
+    );
     if (structure) {
       const sqlStr = structMainStr + insertMainStr;
       const sqlOtherStr =


### PR DESCRIPTION
## Summary
- allow inserting records even when name values are missing
- ensure `_other` table record SQL doesn't include auto id column
- ensure rows with required columns aren't skipped when their defaults are inserted

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68640cea466c8331b34bcafe5009fd1d