### PR TITLE
Fix config path

### DIFF
--- a/api-server/services/codingTableConfig.js
+++ b/api-server/services/codingTableConfig.js
@@ -1,7 +1,10 @@
 import fs from 'fs/promises';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
-const filePath = path.join(process.cwd(), 'config', 'codingTableConfigs.json');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..', '..');
+const filePath = path.join(rootDir, 'config', 'codingTableConfigs.json');
 
 async function ensureDir() {
   await fs.mkdir(path.dirname(filePath), { recursive: true });


### PR DESCRIPTION
## Summary
- fix configuration path resolution so config files load correctly regardless of working directory

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864386308608331a07e843e413018b1