### PR TITLE
Fix config parsing

### DIFF
--- a/api-server/services/codingTableConfig.js
+++ b/api-server/services/codingTableConfig.js
@@ -1,7 +1,10 @@
 import fs from 'fs/promises';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
-const filePath = path.join(process.cwd(), 'config', 'codingTableConfigs.json');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..', '..');
+const filePath = path.join(rootDir, 'config', 'codingTableConfigs.json');
 
 async function ensureDir() {
   await fs.mkdir(path.dirname(filePath), { recursive: true });

--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -1260,10 +1260,7 @@ export default function CodingTablesPage() {
       return;
     }
     const usedFields = new Set([
-      idColumn,
-      nameColumn,
-      ...otherColumns,
-      ...uniqueFields,
+      ...headers,
       ...extraFields.filter((f) => f.trim() !== ''),
     ]);
     const filterMap = (obj) =>
@@ -1457,6 +1454,7 @@ export default function CodingTablesPage() {
               ...extras.filter((f) => f.trim() !== ''),
               ...(cfg.idColumn ? [cfg.idColumn] : []),
               ...(cfg.nameColumn ? [cfg.nameColumn] : []),
+              ...Object.keys(cfg.renameMap || {}),
             ])
           );
           setHeaders(merged);


### PR DESCRIPTION
## Summary
- include renamed fields when restoring headers from saved config
- keep rename mappings for all headers when saving config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6864386308608331a07e843e413018b1