### PR TITLE
Fix coding table configuration parsing

### DIFF
--- a/api-server/services/codingTableConfig.js
+++ b/api-server/services/codingTableConfig.js
@@ -1,7 +1,10 @@
 import fs from 'fs/promises';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
-const filePath = path.join(process.cwd(), 'config', 'codingTableConfigs.json');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..', '..');
+const filePath = path.join(rootDir, 'config', 'codingTableConfigs.json');
 
 async function ensureDir() {
   await fs.mkdir(path.dirname(filePath), { recursive: true });

--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -1260,10 +1260,7 @@ export default function CodingTablesPage() {
       return;
     }
     const usedFields = new Set([
-      idColumn,
-      nameColumn,
-      ...otherColumns,
-      ...uniqueFields,
+      ...headers,
       ...extraFields.filter((f) => f.trim() !== ''),
     ]);
     const filterMap = (obj) =>
@@ -1434,19 +1431,19 @@ export default function CodingTablesPage() {
       .then((res) => (res.ok ? res.json() : null))
       .then((cfg) => {
         if (!cfg) return;
-        setSheet(cfg.sheet || sheet);
-        setHeaderRow(cfg.headerRow || 1);
-        setMnHeaderRow(cfg.mnHeaderRow || '');
-        setIdFilterMode(cfg.idFilterMode || 'contains');
-        setIdColumn(cfg.idColumn || '');
-        setNameColumn(cfg.nameColumn || '');
+        setSheet(cfg.sheet ?? '');
+        setHeaderRow(cfg.headerRow ?? 1);
+        setMnHeaderRow(cfg.mnHeaderRow ?? '');
+        setIdFilterMode(cfg.idFilterMode ?? 'contains');
+        setIdColumn(cfg.idColumn ?? '');
+        setNameColumn(cfg.nameColumn ?? '');
         const extras =
           cfg.extraFields && cfg.extraFields.length > 0 ? cfg.extraFields : [''];
         setExtraFields(extras);
-        setOtherColumns(cfg.otherColumns || []);
-        setUniqueFields(cfg.uniqueFields || []);
-        setCalcText(cfg.calcText || '');
-        setColumnTypes(cfg.columnTypes || {});
+        setOtherColumns(cfg.otherColumns ?? []);
+        setUniqueFields(cfg.uniqueFields ?? []);
+        setCalcText(cfg.calcText ?? '');
+        setColumnTypes(cfg.columnTypes ?? {});
         if (cfg.columnTypes) {
           const baseHeaders = Object.keys(cfg.columnTypes || {});
           const merged = Array.from(
@@ -1457,6 +1454,7 @@ export default function CodingTablesPage() {
               ...extras.filter((f) => f.trim() !== ''),
               ...(cfg.idColumn ? [cfg.idColumn] : []),
               ...(cfg.nameColumn ? [cfg.nameColumn] : []),
+              ...Object.keys(cfg.renameMap || {}),
             ])
           );
           setHeaders(merged);
@@ -1494,10 +1492,10 @@ export default function CodingTablesPage() {
         setDefaultValues(dv);
         setDefaultFrom(df);
         setRenameMap(rm);
-        setPopulateRange(cfg.populateRange || false);
-        setStartYear(cfg.startYear || '');
-        setEndYear(cfg.endYear || '');
-        setAutoIncStart(cfg.autoIncStart || '1');
+        setPopulateRange(cfg.populateRange ?? false);
+        setStartYear(cfg.startYear ?? '');
+        setEndYear(cfg.endYear ?? '');
+        setAutoIncStart(cfg.autoIncStart ?? '1');
       })
       .catch(() => {});
   }, [tableName]);


### PR DESCRIPTION
## Summary
- ensure service resolves coding table JSON path relative to repo root
- when saving configs, consider all extracted headers
- keep renamed headers when restoring config
- use nullish coalescing to apply defaults correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864407d716c8331908520cf262bfd84