### PR TITLE
Fix add-row validation and retain grid rows on errors

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -163,31 +163,6 @@ export default forwardRef(function InlineTransactionTable({
           }
           return;
         }
-        if (
-          totalCurrencySet.has(f) &&
-          val !== '' &&
-          isNaN(Number(normalizeNumberInput(val)))
-        ) {
-          setErrorMsg('Invalid number in ' + (labels[f] || f));
-          setInvalidCell({ row: rows.length - 1, field: f });
-          const el = inputRefs.current[`${rows.length - 1}-${fields.indexOf(f)}`];
-          if (el) {
-            el.focus();
-            if (el.select) el.select();
-          }
-          return;
-        }
-        const ph = placeholders[f];
-        if (ph && !isValidDate(val, ph)) {
-          setErrorMsg('Invalid date in ' + (labels[f] || f));
-          setInvalidCell({ row: rows.length - 1, field: f });
-          const el = inputRefs.current[`${rows.length - 1}-${fields.indexOf(f)}`];
-          if (el) {
-            el.focus();
-            if (el.select) el.select();
-          }
-          return;
-        }
       }
     }
     setRows((r) => {
@@ -436,7 +411,7 @@ export default forwardRef(function InlineTransactionTable({
   }
 
   return (
-    <div className="overflow-x-auto">
+    <div className="overflow-x-auto overflow-y-visible relative">
       <table className="min-w-max border border-gray-300 text-xs">
         <thead className="bg-gray-50">
           <tr>

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -291,10 +291,19 @@ const RowFormModal = function RowFormModal({
         'Post these transactions? Have you checked all data and accept responsibility?'
       );
       if (ok) {
+        let allOk = true;
         for (const r of cleanedRows) {
-          await Promise.resolve(onSubmit(r));
+          try {
+            const res = await Promise.resolve(onSubmit(r));
+            if (res === false) allOk = false;
+          } catch (err) {
+            console.error('Submit failed', err);
+            allOk = false;
+          }
         }
-        tableRef.current.clearRows();
+        if (allOk) {
+          tableRef.current.clearRows();
+        }
       }
       setSubmitLocked(false);
       return;
@@ -319,7 +328,17 @@ const RowFormModal = function RowFormModal({
           }
           normalized[k] = val;
         });
-        await Promise.resolve(onSubmit(normalized));
+        try {
+          const res = await Promise.resolve(onSubmit(normalized));
+          if (res === false) {
+            setSubmitLocked(false);
+            return;
+          }
+        } catch (err) {
+          console.error('Submit failed', err);
+          setSubmitLocked(false);
+          return;
+        }
       } else {
         setSubmitLocked(false);
         return;

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -759,6 +759,7 @@ const TableManager = forwardRef(function TableManager({
             setTimeout(() => openAdd(), 0);
           }
         }
+        return true;
       } else {
         let message = 'Save failed';
         try {
@@ -768,9 +769,11 @@ const TableManager = forwardRef(function TableManager({
           // ignore
         }
         addToast(message, 'error');
+        return false;
       }
     } catch (err) {
       console.error('Save failed', err);
+      return false;
     }
   }
 


### PR DESCRIPTION
## Summary
- relax add-row validation to only check required fields
- ensure dropdowns aren't clipped in transaction grid
- retain grid rows if posting fails and respect onSubmit return value
- return boolean from TableManager submit handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68654274af90833199d60165f6da85b6