### PR TITLE
Add viewSource configuration for transaction forms

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -22,6 +22,25 @@ function arrify(val) {
   return [String(val)];
 }
 
+function parseViewSource(raw) {
+  const result = {};
+  if (raw && typeof raw === 'object') {
+    for (const [field, info] of Object.entries(raw)) {
+      if (typeof info === 'string') {
+        result[field] = { view: info, fields: [] };
+      } else if (info && typeof info.view === 'string') {
+        result[field] = {
+          view: info.view,
+          fields: Array.isArray(info.fields)
+            ? info.fields.map(String)
+            : [],
+        };
+      }
+    }
+  }
+  return result;
+}
+
 function parseEntry(raw = {}) {
   return {
     visibleFields: Array.isArray(raw.visibleFields)
@@ -70,6 +89,7 @@ function parseEntry(raw = {}) {
       ? raw.allowedDepartments.map((v) => Number(v)).filter((v) => !Number.isNaN(v))
       : [],
     moduleLabel: typeof raw.moduleLabel === 'string' ? raw.moduleLabel : '',
+    viewSource: parseViewSource(raw.viewSource),
   };
 }
 
@@ -137,6 +157,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     footerFields = [],
     transactionTypeField = '',
     transactionTypeValue = '',
+    viewSource = {},
   } = config || {};
   const uid = arrify(userIdFields.length ? userIdFields : userIdField ? [userIdField] : []);
   const bid = arrify(
@@ -178,6 +199,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     moduleLabel: moduleLabel || undefined,
     allowedBranches: ab,
     allowedDepartments: ad,
+    viewSource: parseViewSource(viewSource),
   };
   await writeConfig(cfg);
   return cfg[table][name];

--- a/docs/transaction-form-config.md
+++ b/docs/transaction-form-config.md
@@ -31,6 +31,11 @@ Each **transaction** entry allows you to specify:
 - **moduleLabel** – optional label for the parent module
 - **allowedBranches** – restrict usage to these branch IDs
 - **allowedDepartments** – restrict usage to these department IDs
+- **viewSource** – optional mapping of a table field to a SQL view. Each entry
+  defines `{ "view": "VIEW_NAME", "fields": ["col1", ...] }` and allows the
+  listed `fields` to be fetched from the view using the field value as the `WHERE`
+  parameter. These fields are shown in the form but are not saved back to the
+  transaction table.
 
 The form displays header fields (system filled values) separately from other
 fields. When printing, the `printEmpField` and `printCustField` lists control

--- a/tests/db/transactionFormConfig.test.js
+++ b/tests/db/transactionFormConfig.test.js
@@ -98,6 +98,20 @@ await test('setFormConfig stores additional field lists', async () => {
   await restore();
 });
 
+await test('setFormConfig stores viewSource config', async () => {
+  const { orig, restore } = await withTempFile();
+  await fs.writeFile(filePath, '{}');
+  await setFormConfig('tbl', 'ViewCfg', {
+    moduleKey: 'parent_mod',
+    viewSource: { ref_id: { view: 'v_ref', fields: ['name'] } },
+  });
+  const data = JSON.parse(await fs.readFile(filePath, 'utf8'));
+  assert.deepEqual(data.tbl.ViewCfg.viewSource, {
+    ref_id: { view: 'v_ref', fields: ['name'] },
+  });
+  await restore();
+});
+
 await test('deleteFormConfig removes entry when unused', async () => {
   const { orig, restore } = await withTempFile();
   await fs.writeFile(


### PR DESCRIPTION
## Summary
- support `viewSource` mappings in transaction form configuration
- document the new option
- test that `viewSource` is written to config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68656f4274988331b98d8bf75a926447