### PR TITLE
Add viewSource editing in transaction form config UI

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -22,6 +22,25 @@ function arrify(val) {
   return [String(val)];
 }
 
+function parseViewSource(raw) {
+  const result = {};
+  if (raw && typeof raw === 'object') {
+    for (const [field, info] of Object.entries(raw)) {
+      if (typeof info === 'string') {
+        result[field] = { view: info, fields: [] };
+      } else if (info && typeof info.view === 'string') {
+        result[field] = {
+          view: info.view,
+          fields: Array.isArray(info.fields)
+            ? info.fields.map(String)
+            : [],
+        };
+      }
+    }
+  }
+  return result;
+}
+
 function parseEntry(raw = {}) {
   return {
     visibleFields: Array.isArray(raw.visibleFields)
@@ -70,6 +89,7 @@ function parseEntry(raw = {}) {
       ? raw.allowedDepartments.map((v) => Number(v)).filter((v) => !Number.isNaN(v))
       : [],
     moduleLabel: typeof raw.moduleLabel === 'string' ? raw.moduleLabel : '',
+    viewSource: parseViewSource(raw.viewSource),
   };
 }
 
@@ -137,6 +157,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     footerFields = [],
     transactionTypeField = '',
     transactionTypeValue = '',
+    viewSource = {},
   } = config || {};
   const uid = arrify(userIdFields.length ? userIdFields : userIdField ? [userIdField] : []);
   const bid = arrify(
@@ -178,6 +199,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     moduleLabel: moduleLabel || undefined,
     allowedBranches: ab,
     allowedDepartments: ad,
+    viewSource: parseViewSource(viewSource),
   };
   await writeConfig(cfg);
   return cfg[table][name];

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -42,6 +42,8 @@ This document outlines the roadmap, scope, architecture, milestones, and deliver
        exclude any chosen `id` or `name` column.
      - Any combination of these groups is valid (e.g. `id` + `unique`, or just
        `unique` + `other`).
+   - Config may map a column to a SQL view using `viewSource` so additional
+     fields can be fetched dynamically during form entry.
 
 ## 4. Architecture & Tech Stack
 - **Front-end**  

--- a/docs/transaction-form-config.md
+++ b/docs/transaction-form-config.md
@@ -31,6 +31,11 @@ Each **transaction** entry allows you to specify:
 - **moduleLabel** – optional label for the parent module
 - **allowedBranches** – restrict usage to these branch IDs
 - **allowedDepartments** – restrict usage to these department IDs
+- **viewSource** – optional mapping of a table field to a SQL view. Each entry
+  defines `{ "view": "VIEW_NAME", "fields": ["col1", ...] }` and allows the
+  listed `fields` to be fetched from the view using the field value as the `WHERE`
+  parameter. These fields are shown in the form but are not saved back to the
+  transaction table.
 
 The form displays header fields (system filled values) separately from other
 fields. When printing, the `printEmpField` and `printCustField` lists control

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -37,6 +37,7 @@ export default function FormsManagement() {
     headerFields: [],
     mainFields: [],
     footerFields: [],
+    viewSource: {},
     transactionTypeField: '',
     transactionTypeValue: '',
     allowedBranches: [],
@@ -103,6 +104,7 @@ export default function FormsManagement() {
             headerFields: filtered[name].headerFields || [],
             mainFields: filtered[name].mainFields || [],
             footerFields: filtered[name].footerFields || [],
+            viewSource: filtered[name].viewSource || {},
             transactionTypeField: filtered[name].transactionTypeField || '',
             transactionTypeValue: filtered[name].transactionTypeValue || '',
             allowedBranches: (filtered[name].allowedBranches || []).map(String),
@@ -129,6 +131,7 @@ export default function FormsManagement() {
             headerFields: [],
             mainFields: [],
             footerFields: [],
+            viewSource: {},
             transactionTypeField: '',
             transactionTypeValue: '',
             allowedBranches: [],
@@ -158,6 +161,7 @@ export default function FormsManagement() {
           headerFields: [],
           mainFields: [],
           footerFields: [],
+          viewSource: {},
           transactionTypeField: '',
           transactionTypeValue: '',
           allowedBranches: [],
@@ -218,6 +222,7 @@ export default function FormsManagement() {
           headerFields: [],
           mainFields: [],
           footerFields: [],
+          viewSource: {},
           transactionTypeField: '',
           transactionTypeValue: '',
           allowedBranches: [],
@@ -269,6 +274,17 @@ export default function FormsManagement() {
       const set = new Set(c[key]);
       set.has(field) ? set.delete(field) : set.add(field);
       return { ...c, [key]: Array.from(set) };
+    });
+  }
+
+  function changeViewSource(field, key, value) {
+    setConfig((c) => {
+      const entry = c.viewSource[field] || { view: '', fields: [] };
+      const next = { ...entry, [key]: value };
+      const vs = { ...c.viewSource };
+      if (!next.view && next.fields.length === 0) delete vs[field];
+      else vs[field] = next;
+      return { ...c, viewSource: vs };
     });
   }
 
@@ -336,6 +352,7 @@ export default function FormsManagement() {
       headerFields: [],
       mainFields: [],
       footerFields: [],
+      viewSource: {},
       transactionTypeField: '',
       transactionTypeValue: '',
       allowedBranches: [],
@@ -366,6 +383,7 @@ export default function FormsManagement() {
       headerFields: cfg.headerFields || [],
       mainFields: cfg.mainFields || [],
       footerFields: cfg.footerFields || [],
+      viewSource: cfg.viewSource || {},
       transactionTypeField: cfg.transactionTypeField || '',
       transactionTypeValue: cfg.transactionTypeValue || '',
       allowedBranches: (cfg.allowedBranches || []).map(String),
@@ -502,6 +520,8 @@ export default function FormsManagement() {
                 <th style={{ border: '1px solid #ccc', padding: '4px' }}>Header</th>
                 <th style={{ border: '1px solid #ccc', padding: '4px' }}>Main</th>
                 <th style={{ border: '1px solid #ccc', padding: '4px' }}>Footer</th>
+                <th style={{ border: '1px solid #ccc', padding: '4px' }}>View</th>
+                <th style={{ border: '1px solid #ccc', padding: '4px' }}>View Fields</th>
               </tr>
             </thead>
             <tbody>
@@ -634,6 +654,26 @@ export default function FormsManagement() {
                       type="checkbox"
                       checked={config.footerFields.includes(col)}
                       onChange={() => toggleFieldList(col, 'footerFields')}
+                    />
+                  </td>
+                  <td style={{ border: '1px solid #ccc', padding: '4px' }}>
+                    <input
+                      type="text"
+                      value={config.viewSource[col]?.view || ''}
+                      onChange={(e) => changeViewSource(col, 'view', e.target.value)}
+                    />
+                  </td>
+                  <td style={{ border: '1px solid #ccc', padding: '4px' }}>
+                    <input
+                      type="text"
+                      value={(config.viewSource[col]?.fields || []).join(',')}
+                      onChange={(e) =>
+                        changeViewSource(
+                          col,
+                          'fields',
+                          e.target.value.split(',').map((v) => v.trim()).filter(Boolean),
+                        )
+                      }
                     />
                   </td>
                 </tr>

--- a/tests/db/codingTableConfig.test.js
+++ b/tests/db/codingTableConfig.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import path from 'path';
+import { setConfig } from '../../api-server/services/codingTableConfig.js';
+
+const filePath = path.join(process.cwd(), 'config', 'codingTableConfigs.json');
+
+function withTempFile() {
+  return fs.readFile(filePath, 'utf8')
+    .catch(() => '{}')
+    .then((orig) => ({ orig, restore: () => fs.writeFile(filePath, orig) }));
+}
+
+await test('setConfig stores viewSource mapping', async () => {
+  const { orig, restore } = await withTempFile();
+  await fs.writeFile(filePath, '{}');
+  await setConfig('tbl', { viewSource: { code: { view: 'v_code', fields: ['name'] } } });
+  const data = JSON.parse(await fs.readFile(filePath, 'utf8'));
+  assert.deepEqual(data.tbl.viewSource, { code: { view: 'v_code', fields: ['name'] } });
+  await restore();
+});

--- a/tests/db/transactionFormConfig.test.js
+++ b/tests/db/transactionFormConfig.test.js
@@ -98,6 +98,20 @@ await test('setFormConfig stores additional field lists', async () => {
   await restore();
 });
 
+await test('setFormConfig stores viewSource config', async () => {
+  const { orig, restore } = await withTempFile();
+  await fs.writeFile(filePath, '{}');
+  await setFormConfig('tbl', 'ViewCfg', {
+    moduleKey: 'parent_mod',
+    viewSource: { ref_id: { view: 'v_ref', fields: ['name'] } },
+  });
+  const data = JSON.parse(await fs.readFile(filePath, 'utf8'));
+  assert.deepEqual(data.tbl.ViewCfg.viewSource, {
+    ref_id: { view: 'v_ref', fields: ['name'] },
+  });
+  await restore();
+});
+
 await test('deleteFormConfig removes entry when unused', async () => {
   const { orig, restore } = await withTempFile();
   await fs.writeFile(


### PR DESCRIPTION
## Summary
- expose `viewSource` mapping in the transaction form management page
- allow specifying SQL view and returned fields for each table column

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68656f4274988331b98d8bf75a926447