### PR TITLE
Add viewSource config to transaction forms

### DIFF
--- a/api-server/routes/views.js
+++ b/api-server/routes/views.js
@@ -1,0 +1,16 @@
+import express from 'express';
+import { listDatabaseViews } from '../../db/index.js';
+import { requireAuth } from '../middlewares/auth.js';
+
+const router = express.Router();
+
+router.get('/', requireAuth, async (req, res, next) => {
+  try {
+    const views = await listDatabaseViews();
+    res.json(views);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -22,6 +22,7 @@ import displayFieldRoutes from "./routes/display_fields.js";
 import codingTableConfigRoutes from "./routes/coding_table_configs.js";
 import generatedSqlRoutes from "./routes/generated_sql.js";
 import transactionFormRoutes from "./routes/transaction_forms.js";
+import viewsRoutes from "./routes/views.js";
 import transactionRoutes from "./routes/transactions.js";
 import { requireAuth } from "./middlewares/auth.js";
 
@@ -62,6 +63,7 @@ app.use("/api/display_fields", displayFieldRoutes);
 app.use("/api/coding_table_configs", codingTableConfigRoutes);
 app.use("/api/generated_sql", generatedSqlRoutes);
 app.use("/api/transaction_forms", transactionFormRoutes);
+app.use("/api/views", viewsRoutes);
 app.use("/api/inventory_transactions", requireAuth, transactionRoutes);
 app.use("/api/tables", requireAuth, tableRoutes);
 

--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -54,6 +54,10 @@ function parseEntry(raw = {}) {
     headerFields: arrify(raw.headerFields),
     mainFields: arrify(raw.mainFields),
     footerFields: arrify(raw.footerFields),
+    viewSource:
+      raw && typeof raw.viewSource === 'object' && raw.viewSource !== null
+        ? raw.viewSource
+        : {},
     transactionTypeField:
       typeof raw.transactionTypeField === 'string'
         ? raw.transactionTypeField
@@ -135,6 +139,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     headerFields = [],
     mainFields = [],
     footerFields = [],
+    viewSource = {},
     transactionTypeField = '',
     transactionTypeValue = '',
   } = config || {};
@@ -172,6 +177,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     headerFields: arrify(headerFields),
     mainFields: arrify(mainFields),
     footerFields: arrify(footerFields),
+    viewSource: viewSource && typeof viewSource === 'object' ? viewSource : {},
     transactionTypeField: transactionTypeField || '',
     transactionTypeValue: transactionTypeValue || '',
     moduleKey: parentModuleKey,

--- a/db/index.js
+++ b/db/index.js
@@ -523,6 +523,13 @@ export async function listDatabaseTables() {
   return rows.map((r) => Object.values(r)[0]);
 }
 
+export async function listDatabaseViews() {
+  const [rows] = await pool.query(
+    "SHOW FULL TABLES WHERE TABLE_TYPE = 'VIEW'",
+  );
+  return rows.map((r) => Object.values(r)[0]);
+}
+
 export async function listTableColumns(tableName) {
   const [rows] = await pool.query(
     `SELECT COLUMN_NAME

--- a/docs/transaction-form-config.md
+++ b/docs/transaction-form-config.md
@@ -23,6 +23,7 @@ Each **transaction** entry allows you to specify:
 - **headerFields** – fields shown in the header section
 - **mainFields** – fields shown in the main section
 - **footerFields** – fields shown in the footer section
+- **viewSource** – map of field names to SQL view names
 - **transactionTypeField** – column used to store the transaction type code
 - **transactionTypeValue** – default transaction type code value
 - **moduleKey** – module slug used to group the form under a module. If omitted,
@@ -49,6 +50,7 @@ Example snippet:
       "userIdFields": ["created_by"],
       "branchIdFields": ["branch_id"],
       "companyIdFields": ["company_id"],
+      "viewSource": { "branch_id": "v_branch" },
       "moduleKey": "finance_transactions",
       "moduleLabel": "Finance",
       "allowedBranches": [1, 2],

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -14,6 +14,7 @@ export default function FormsManagement() {
   const [departments, setDepartments] = useState([]);
   const [txnTypes, setTxnTypes] = useState([]);
   const [columns, setColumns] = useState([]);
+  const [views, setViews] = useState([]);
   const modules = useModules();
   useEffect(() => {
     debugLog('Component mounted: FormsManagement');
@@ -37,6 +38,7 @@ export default function FormsManagement() {
     headerFields: [],
     mainFields: [],
     footerFields: [],
+    viewSource: {},
     transactionTypeField: '',
     transactionTypeValue: '',
     allowedBranches: [],
@@ -48,6 +50,11 @@ export default function FormsManagement() {
       .then((res) => (res.ok ? res.json() : []))
       .then((data) => setTables(data))
       .catch(() => setTables([]));
+
+    fetch('/api/views', { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => setViews(data))
+      .catch(() => setViews([]));
 
     fetch('/api/tables/code_branches?perPage=500', { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : { rows: [] }))
@@ -103,6 +110,7 @@ export default function FormsManagement() {
             headerFields: filtered[name].headerFields || [],
             mainFields: filtered[name].mainFields || [],
             footerFields: filtered[name].footerFields || [],
+            viewSource: filtered[name].viewSource || {},
             transactionTypeField: filtered[name].transactionTypeField || '',
             transactionTypeValue: filtered[name].transactionTypeValue || '',
             allowedBranches: (filtered[name].allowedBranches || []).map(String),
@@ -129,6 +137,7 @@ export default function FormsManagement() {
             headerFields: [],
             mainFields: [],
             footerFields: [],
+            viewSource: {},
             transactionTypeField: '',
             transactionTypeValue: '',
             allowedBranches: [],
@@ -158,6 +167,7 @@ export default function FormsManagement() {
           headerFields: [],
           mainFields: [],
           footerFields: [],
+          viewSource: {},
           transactionTypeField: '',
           transactionTypeValue: '',
           allowedBranches: [],
@@ -192,6 +202,7 @@ export default function FormsManagement() {
           headerFields: cfg.headerFields || [],
           mainFields: cfg.mainFields || [],
           footerFields: cfg.footerFields || [],
+          viewSource: cfg.viewSource || {},
           transactionTypeField: cfg.transactionTypeField || '',
           transactionTypeValue: cfg.transactionTypeValue || '',
           allowedBranches: (cfg.allowedBranches || []).map(String),
@@ -218,6 +229,7 @@ export default function FormsManagement() {
           headerFields: [],
           mainFields: [],
           footerFields: [],
+          viewSource: {},
           transactionTypeField: '',
           transactionTypeValue: '',
           allowedBranches: [],
@@ -336,6 +348,7 @@ export default function FormsManagement() {
       headerFields: [],
       mainFields: [],
       footerFields: [],
+      viewSource: {},
       transactionTypeField: '',
       transactionTypeValue: '',
       allowedBranches: [],
@@ -366,6 +379,7 @@ export default function FormsManagement() {
       headerFields: cfg.headerFields || [],
       mainFields: cfg.mainFields || [],
       footerFields: cfg.footerFields || [],
+      viewSource: cfg.viewSource || {},
       transactionTypeField: cfg.transactionTypeField || '',
       transactionTypeValue: cfg.transactionTypeValue || '',
       allowedBranches: (cfg.allowedBranches || []).map(String),
@@ -502,6 +516,7 @@ export default function FormsManagement() {
                 <th style={{ border: '1px solid #ccc', padding: '4px' }}>Header</th>
                 <th style={{ border: '1px solid #ccc', padding: '4px' }}>Main</th>
                 <th style={{ border: '1px solid #ccc', padding: '4px' }}>Footer</th>
+                <th style={{ border: '1px solid #ccc', padding: '4px' }}>View</th>
               </tr>
             </thead>
             <tbody>
@@ -635,6 +650,24 @@ export default function FormsManagement() {
                       checked={config.footerFields.includes(col)}
                       onChange={() => toggleFieldList(col, 'footerFields')}
                     />
+                  </td>
+                  <td style={{ border: '1px solid #ccc', padding: '4px' }}>
+                    <select
+                      value={config.viewSource[col] || ''}
+                      onChange={(e) =>
+                        setConfig((c) => ({
+                          ...c,
+                          viewSource: { ...c.viewSource, [col]: e.target.value },
+                        }))
+                      }
+                    >
+                      <option value="">-- none --</option>
+                      {views.map((v) => (
+                        <option key={v} value={v}>
+                          {v}
+                        </option>
+                      ))}
+                    </select>
                   </td>
                 </tr>
               ))}

--- a/tests/db/transactionFormConfig.test.js
+++ b/tests/db/transactionFormConfig.test.js
@@ -42,6 +42,18 @@ await test('setFormConfig writes moduleKey without touching modules', async () =
   await restore();
 });
 
+await test('setFormConfig stores viewSource map', async () => {
+  const { orig, restore } = await withTempFile();
+  await fs.writeFile(filePath, '{}');
+  await setFormConfig('tbl', 'ViewTest', {
+    moduleKey: 'parent_mod',
+    viewSource: { branch_id: 'v_branch' },
+  });
+  const data = JSON.parse(await fs.readFile(filePath, 'utf8'));
+  assert.deepEqual(data.tbl.ViewTest.viewSource, { branch_id: 'v_branch' });
+  await restore();
+});
+
 await test('setFormConfig stores moduleLabel when provided', async () => {
   const { orig, restore } = await withTempFile();
   await fs.writeFile(filePath, '{}');


### PR DESCRIPTION
## Summary
- allow listing database views via `/api/views`
- support viewSource in transactionFormConfig service
- fetch views in FormsManagement and render dropdown per column
- document viewSource option in docs
- test viewSource persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686642e069188331af78354658522e15