### PR TITLE
Improve coding table SQL insertion

### DIFF
--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -57,6 +57,7 @@ export default function CodingTablesPage() {
   const fileInputRef = useRef(null);
   const [selectedFile, setSelectedFile] = useState(null);
   const [configNames, setConfigNames] = useState([]);
+  const interruptRef = useRef(false);
 
   useEffect(() => {
     fetch('/api/coding_table_configs', { credentials: 'include' })
@@ -64,6 +65,18 @@ export default function CodingTablesPage() {
       .then((data) => setConfigNames(Object.keys(data)))
       .catch(() => setConfigNames([]));
   }, []);
+
+  useEffect(() => {
+    function onKey(e) {
+      if (e.key === 'Escape' && uploading) {
+        if (window.confirm('Interrupt insert process?')) {
+          interruptRef.current = true;
+        }
+      }
+    }
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [uploading]);
 
   const allFields = useMemo(() => {
     // keep duplicates so user can easily spot them and clean extras the same way
@@ -983,6 +996,43 @@ export default function CodingTablesPage() {
     generateFromWorkbook({ structure: false, records: true });
   }
 
+  async function runStatements(statements) {
+    setUploadProgress({ done: 0, total: statements.length });
+    setInsertedCount(0);
+    let totalInserted = 0;
+    const failedAll = [];
+    interruptRef.current = false;
+    for (let i = 0; i < statements.length; i++) {
+      if (interruptRef.current) break;
+      const stmt = statements[i];
+      const res = await fetch('/api/generated_sql/execute', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sql: stmt }),
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        alert(data.message || 'Execution failed');
+        return { inserted: totalInserted, failed: failedAll, aborted: true };
+      }
+      const data = await res.json().catch(() => ({}));
+      const inserted = data.inserted || 0;
+      if (Array.isArray(data.failed) && data.failed.length > 0) {
+        failedAll.push(
+          ...data.failed.map((f) =>
+            typeof f === 'string' ? f : `${f.sql} -- ${f.error}`
+          )
+        );
+      }
+      totalInserted += inserted;
+      setInsertedCount(totalInserted);
+      addToast(`Inserted ${totalInserted} records`, 'info');
+      setUploadProgress({ done: i + 1, total: statements.length });
+    }
+    return { inserted: totalInserted, failed: failedAll, aborted: interruptRef.current };
+  }
+
 
   async function executeGeneratedSql() {
     const combined = [sql, sqlOther].filter(Boolean).join('\n');
@@ -997,60 +1047,20 @@ export default function CodingTablesPage() {
         .map((s) => s.trim())
         .filter(Boolean)
         .map((s) => s + ';');
-      const chunks = [];
-      let current = [];
-      let size = 0;
-      const limit = 500000; // ~0.5MB per chunk
-      for (const stmt of statements) {
-        const len = stmt.length + 1; // include newline
-        if (size + len > limit && current.length) {
-          chunks.push(current.join('\n'));
-          current = [];
-          size = 0;
+      const { inserted, failed, aborted } = await runStatements(statements);
+      if (aborted) {
+        addToast('Insert interrupted', 'warning');
+      } else {
+        setSummaryInfo(
+          `Inserted ${inserted} rows. Duplicates: ${
+            duplicateInfo ? duplicateInfo.split('\n').length : 0
+          }`
+        );
+        if (failed.length > 0) {
+          setSqlMove(failed.join('\n'));
         }
-        current.push(stmt);
-        size += len;
+        addToast(`Table created with ${inserted} rows`, 'success');
       }
-      if (current.length) chunks.push(current.join('\n'));
-      setUploadProgress({ done: 0, total: chunks.length });
-      setInsertedCount(0);
-      let totalInserted = 0;
-      const failedAll = [];
-      for (const chunk of chunks) {
-        const res = await fetch('/api/generated_sql/execute', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ sql: chunk }),
-          credentials: 'include',
-        });
-        if (!res.ok) {
-          const data = await res.json().catch(() => ({}));
-          alert(data.message || 'Execution failed');
-          return;
-        }
-        const data = await res.json().catch(() => ({}));
-        const inserted = data.inserted || 0;
-        if (Array.isArray(data.failed) && data.failed.length > 0) {
-          failedAll.push(
-            ...data.failed.map((f) =>
-              typeof f === 'string' ? f : `${f.sql} -- ${f.error}`
-            )
-          );
-        }
-        totalInserted += inserted;
-        setInsertedCount(totalInserted);
-        addToast(`Inserted ${totalInserted} records`, 'info');
-        setUploadProgress((p) => ({ done: p.done + 1, total: chunks.length }));
-      }
-      setSummaryInfo(
-        `Inserted ${totalInserted} rows. Duplicates: ${
-          duplicateInfo ? duplicateInfo.split('\n').length : 0
-        }`
-      );
-      if (failedAll.length > 0) {
-        setSqlMove(failedAll.join('\n'));
-      }
-      addToast(`Table created with ${totalInserted} rows`, 'success');
     } catch (err) {
       console.error('SQL execution failed', err);
       alert('Execution failed');
@@ -1075,60 +1085,20 @@ export default function CodingTablesPage() {
         .map((s) => s.trim())
         .filter(Boolean)
         .map((s) => s + ';');
-      const chunks = [];
-      let current = [];
-      let size = 0;
-      const limit = 500000;
-      for (const stmt of statements) {
-        const len = stmt.length + 1;
-        if (size + len > limit && current.length) {
-          chunks.push(current.join('\n'));
-          current = [];
-          size = 0;
+      const { inserted, failed, aborted } = await runStatements(statements);
+      if (aborted) {
+        addToast('Insert interrupted', 'warning');
+      } else {
+        setSummaryInfo(
+          `Inserted ${inserted} rows. Duplicates: ${
+            duplicateInfo ? duplicateInfo.split('\n').length : 0
+          }`
+        );
+        if (failed.length > 0) {
+          setSqlMove(failed.join('\n'));
         }
-        current.push(stmt);
-        size += len;
+        addToast(`Table created with ${inserted} rows`, 'success');
       }
-      if (current.length) chunks.push(current.join('\n'));
-      setUploadProgress({ done: 0, total: chunks.length });
-      setInsertedCount(0);
-      let totalInserted = 0;
-      const failedAll = [];
-      for (const chunk of chunks) {
-        const res = await fetch('/api/generated_sql/execute', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ sql: chunk }),
-          credentials: 'include',
-        });
-        if (!res.ok) {
-          const data = await res.json().catch(() => ({}));
-          alert(data.message || 'Execution failed');
-          return;
-        }
-        const data = await res.json().catch(() => ({}));
-        const inserted = data.inserted || 0;
-        if (Array.isArray(data.failed) && data.failed.length > 0) {
-          failedAll.push(
-            ...data.failed.map((f) =>
-              typeof f === 'string' ? f : `${f.sql} -- ${f.error}`
-            )
-          );
-        }
-        totalInserted += inserted;
-        setInsertedCount(totalInserted);
-        addToast(`Inserted ${totalInserted} records`, 'info');
-        setUploadProgress((p) => ({ done: p.done + 1, total: chunks.length }));
-      }
-      setSummaryInfo(
-        `Inserted ${totalInserted} rows. Duplicates: ${
-          duplicateInfo ? duplicateInfo.split('\n').length : 0
-        }`
-      );
-      if (failedAll.length > 0) {
-        setSqlMove(failedAll.join('\n'));
-      }
-      addToast(`Table created with ${totalInserted} rows`, 'success');
     } catch (err) {
       console.error('SQL execution failed', err);
       alert('Execution failed');
@@ -1145,19 +1115,12 @@ export default function CodingTablesPage() {
     }
     setUploading(true);
     try {
-      const res = await fetch('/api/generated_sql/execute', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sql: structSqlOther }),
-        credentials: 'include',
-      });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        alert(data.message || 'Execution failed');
-        return;
+      const { inserted } = await runStatements([structSqlOther]);
+      if (!interruptRef.current) {
+        addToast(`Other table inserted ${inserted} rows`, 'success');
+      } else {
+        addToast('Insert interrupted', 'warning');
       }
-      const data = await res.json().catch(() => ({}));
-      addToast(`Other table inserted ${data.inserted || 0} rows`, 'success');
     } catch (err) {
       console.error('SQL execution failed', err);
       alert('Execution failed');
@@ -1173,42 +1136,19 @@ export default function CodingTablesPage() {
     }
     setUploading(true);
     try {
-      const failedAll = [];
-      if (recordsSql) {
-        const resMain = await fetch('/api/generated_sql/execute', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ sql: recordsSql }),
-          credentials: 'include',
-        });
-        if (!resMain.ok) throw new Error('main failed');
-        const dataMain = await resMain.json().catch(() => ({}));
-        if (Array.isArray(dataMain.failed))
-          failedAll.push(
-            ...dataMain.failed.map((f) =>
-              typeof f === 'string' ? f : `${f.sql} -- ${f.error}`
-            )
-          );
-      }
-      if (recordsSqlOther) {
-        const resOther = await fetch('/api/generated_sql/execute', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ sql: recordsSqlOther }),
-          credentials: 'include',
-        });
-        if (!resOther.ok) throw new Error('other failed');
-        const dataOther = await resOther.json().catch(() => ({}));
-        if (Array.isArray(dataOther.failed))
-          failedAll.push(
-            ...dataOther.failed.map((f) =>
-              typeof f === 'string' ? f : `${f.sql} -- ${f.error}`
-            )
-          );
-      }
-      if (failedAll.length > 0) {
+      const statements = [recordsSql, recordsSqlOther]
+        .filter(Boolean)
+        .flatMap((s) =>
+          s
+            .split(/;\s*\n/)
+            .map((st) => st.trim())
+            .filter(Boolean)
+            .map((st) => st + ';')
+        );
+      const { inserted, failed, aborted } = await runStatements(statements);
+      if (failed.length > 0) {
         const tbl = cleanIdentifier(tableName);
-        const moveSql = failedAll
+        const moveSql = failed
           .map((stmt) => {
             const re = new RegExp(`INSERT INTO\\s+\`${tbl}\``, 'i');
             if (re.test(stmt) && !/\_other`/i.test(stmt)) {
@@ -1238,7 +1178,11 @@ export default function CodingTablesPage() {
           }
         }
       }
-      addToast('Records inserted', 'success');
+      if (aborted) {
+        addToast('Insert interrupted', 'warning');
+      } else {
+        addToast('Records inserted', 'success');
+      }
     } catch (err) {
       console.error('SQL execution failed', err);
       alert('Execution failed');


### PR DESCRIPTION
## Summary
- support aborting insert process with Escape key
- process SQL statements sequentially with progress updates
- keep grouping SQL inserts by 5000 rows each

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686647590e6483318eb8f16cd5445086