### PR TITLE
Track filtering reasons in _other table

### DIFF
--- a/tests/api/detectType.test.js
+++ b/tests/api/detectType.test.js
@@ -15,3 +15,8 @@ test('detectType limits VARCHAR length to max data length', () => {
   const vals = ['a', 'abcd', 'abc'];
   assert.equal(detectType('name', vals), 'VARCHAR(4)');
 });
+
+test('detectType ignores Excel error values', () => {
+  const vals = ['#N/A', '#VALUE!', '123'];
+  assert.equal(detectType('amount', vals), 'INT');
+});


### PR DESCRIPTION
## Summary
- add `error_description` column when creating `_other` table
- record reason for each filtered row and include it in insert statements
- mention column names in `error_description` for duplicates and invalid data
- treat whitespace-only fields as zero values in both client and server
- normalize Excel error cells to zeroes compatible with their field type

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68666d3185c0833185b4491e09475a6f