### PR TITLE
Enable display field autofill

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -35,6 +35,7 @@ export default forwardRef(function InlineTransactionTable({
   fields = [],
   relations = {},
   relationConfigs = {},
+  relationData = {},
   labels = {},
   totalAmountFields = [],
   totalCurrencyFields = [],
@@ -222,7 +223,24 @@ export default forwardRef(function InlineTransactionTable({
 
   function handleChange(rowIdx, field, value) {
     setRows((r) => {
-      const next = r.map((row, i) => (i === rowIdx ? { ...row, [field]: value } : row));
+      const next = r.map((row, i) => {
+        if (i !== rowIdx) return row;
+        const updated = { ...row, [field]: value };
+        const conf = relationConfigs[field];
+        let val = value;
+        if (val && typeof val === 'object' && 'value' in val) {
+          val = val.value;
+        }
+        if (conf && conf.displayFields && relationData[field]?.[val]) {
+          const ref = relationData[field][val];
+          conf.displayFields.forEach((df) => {
+            if (ref[df] !== undefined) {
+              updated[df] = ref[df];
+            }
+          });
+        }
+        return updated;
+      });
       onRowsChange(next);
       return next;
     });

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -13,6 +13,7 @@ const RowFormModal = function RowFormModal({
   row,
   relations = {},
   relationConfigs = {},
+  relationData = {},
   disabledFields = [],
   labels = {},
   requiredFields = [],
@@ -449,6 +450,7 @@ const RowFormModal = function RowFormModal({
             fields={cols}
             relations={relations}
             relationConfigs={relationConfigs}
+            relationData={relationData}
             labels={labels}
             totalAmountFields={totalAmountFields}
             totalCurrencyFields={totalCurrencyFields}


### PR DESCRIPTION
## Summary
- add refRows cache to track full reference rows
- update relation loading to store reference rows
- autopopulate display fields when editing single rows
- propagate reference row info to grid forms and handle change events
- fix relation display fields not filled when hidden

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867c07b7a208331abddb356a3791b9d