### PR TITLE
Add auto-trigger for num fields

### DIFF
--- a/api-server/services/generatedSql.js
+++ b/api-server/services/generatedSql.js
@@ -32,11 +32,35 @@ export async function saveSql(table, sql) {
   await writeFiles(map);
 }
 
+export function splitSqlStatements(sqlText) {
+  const lines = sqlText.split(/\r?\n/);
+  const statements = [];
+  let current = [];
+  let inTrigger = false;
+  for (const line of lines) {
+    current.push(line);
+    if (inTrigger) {
+      if (/END;\s*$/.test(line)) {
+        statements.push(current.join('\n').trim());
+        current = [];
+        inTrigger = false;
+      }
+    } else if (/^CREATE\s+TRIGGER/i.test(line)) {
+      inTrigger = true;
+    } else if (/;\s*$/.test(line)) {
+      statements.push(current.join('\n').trim());
+      current = [];
+    }
+  }
+  if (current.length) {
+    const stmt = current.join('\n').trim();
+    if (stmt) statements.push(stmt.endsWith(';') ? stmt : stmt + ';');
+  }
+  return statements;
+}
+
 export async function runSql(sql) {
-  const statements = sql
-    .split(/;\s*\n/)
-    .map((s) => s.trim())
-    .filter(Boolean);
+  const statements = splitSqlStatements(sql);
   let inserted = 0;
   const failed = [];
   for (const stmt of statements) {
@@ -57,5 +81,30 @@ export async function getTableStructure(table) {
   const [rows] = await pool.query(`SHOW CREATE TABLE \`${table}\``);
   if (!rows || rows.length === 0) return '';
   const key = Object.keys(rows[0]).find((k) => /create table/i.test(k));
-  return rows[0][key] + ';';
+  let sql = rows[0][key] + ';';
+  try {
+    const [cols] = await pool.query(`SHOW COLUMNS FROM \`${table}\``);
+    const numCols = cols.filter((c) => c.Field && c.Field.includes('num'));
+    for (const col of numCols) {
+      const trgName = `${table}_${col.Field}_bi`; // before insert
+      sql += `\nDROP TRIGGER IF EXISTS \`${trgName}\`;`;
+      let createSql;
+      try {
+        const [trg] = await pool.query(`SHOW CREATE TRIGGER \`${trgName}\``);
+        if (trg && trg.length) {
+          const k = Object.keys(trg[0]).find((x) => /create trigger/i.test(x));
+          createSql = trg[0][k] + ';';
+        }
+      } catch {
+        createSql = '';
+      }
+      if (!createSql) {
+        createSql = `CREATE TRIGGER \`${trgName}\` BEFORE INSERT ON \`${table}\` FOR EACH ROW\nBEGIN\n  SET NEW.\`${col.Field}\` = CONCAT(\n    UPPER(CONCAT(\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26))\n    )),\n    '-',\n    UPPER(CONCAT(\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26))\n    )),\n    '-',\n    UPPER(CONCAT(\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26))\n    )),\n    '-',\n    UPPER(CONCAT(\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26))\n    ))\n  );\nEND;`;
+      }
+      sql += `\n${createSql}`;
+    }
+  } catch {
+    // ignore trigger generation errors
+  }
+  return sql;
 }

--- a/tests/api/splitSqlStatements.test.js
+++ b/tests/api/splitSqlStatements.test.js
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { splitSqlStatements } from '../../api-server/services/generatedSql.js';
+
+const triggerSQL = `CREATE TRIGGER t_bi BEFORE INSERT ON t FOR EACH ROW\nBEGIN\n  SET NEW.num = 1;\nEND;\nINSERT INTO t VALUES (1);`;
+
+test('splitSqlStatements keeps CREATE TRIGGER intact', () => {
+  const stmts = splitSqlStatements(triggerSQL);
+  assert.equal(stmts.length, 2);
+  assert.ok(stmts[0].startsWith('CREATE TRIGGER'));
+});


### PR DESCRIPTION
## Summary
- generate SQL triggers for any table columns containing `num`
- keep existing triggers when exporting table structure
- avoid splitting CREATE TRIGGER statements when executing SQL
- add test for SQL splitting with triggers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868ed8bc4488331b14de0e31343ecd7