### PR TITLE
Add custom SQL hooks for coding tables

### DIFF
--- a/api-server/services/codingTableConfig.js
+++ b/api-server/services/codingTableConfig.js
@@ -73,6 +73,8 @@ function parseConfig(raw = {}) {
     startYear: raw.startYear ? String(raw.startYear) : '',
     endYear: raw.endYear ? String(raw.endYear) : '',
     autoIncStart: raw.autoIncStart ? String(raw.autoIncStart) : '1',
+    triggers: typeof raw.triggers === 'string' ? raw.triggers : '',
+    foreignKeys: typeof raw.foreignKeys === 'string' ? raw.foreignKeys : '',
   };
 }
 


### PR DESCRIPTION
## Summary
- allow storing triggers and foreign keys in coding table configs
- parse triggers and foreign key lines from SQL
- include user SQL when generating table structures
- expose input boxes on Coding Tables page
- stop auto-generating triggers when fetching table structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68691fe5f52c8331bd328bd45225d9c0