### PR TITLE
Handle triggers with nested blocks

### DIFF
--- a/api-server/services/codingTableConfig.js
+++ b/api-server/services/codingTableConfig.js
@@ -73,6 +73,8 @@ function parseConfig(raw = {}) {
     startYear: raw.startYear ? String(raw.startYear) : '',
     endYear: raw.endYear ? String(raw.endYear) : '',
     autoIncStart: raw.autoIncStart ? String(raw.autoIncStart) : '1',
+    triggers: typeof raw.triggers === 'string' ? raw.triggers : '',
+    foreignKeys: typeof raw.foreignKeys === 'string' ? raw.foreignKeys : '',
   };
 }
 

--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -34,6 +34,8 @@ export default function CodingTablesPage() {
   const [structSqlOther, setStructSqlOther] = useState('');
   const [recordsSql, setRecordsSql] = useState('');
   const [recordsSqlOther, setRecordsSqlOther] = useState('');
+  const [triggerSql, setTriggerSql] = useState('');
+  const [foreignKeySql, setForeignKeySql] = useState('');
   const [sqlMove, setSqlMove] = useState('');
   const [uploading, setUploading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState({ done: 0, total: 0 });
@@ -604,6 +606,16 @@ export default function CodingTablesPage() {
           .forEach((c) => uniq.push(c));
       }
     }
+
+    const foreigns = lines.filter((l) => /^(KEY|CONSTRAINT|FOREIGN KEY)/i.test(l));
+
+    const trigMatches = [];
+    const trgRe = /CREATE\s+TRIGGER[\s\S]*?END;/gi;
+    let mTrg;
+    while ((mTrg = trgRe.exec(sqlText))) {
+      trigMatches.push(mTrg[0].trim());
+    }
+
     return {
       table,
       idColumn: idCol,
@@ -618,6 +630,8 @@ export default function CodingTablesPage() {
       ),
       defaultValues: defaults,
       autoIncStart: autoInc,
+      foreignKeys: foreigns.join('\n'),
+      triggers: trigMatches.join('\n'),
     };
   }
 
@@ -638,6 +652,8 @@ export default function CodingTablesPage() {
     setAllowZeroMap((prev) => ({ ...prev, ...cfg.allowZeroMap }));
     setDefaultValues((prev) => ({ ...prev, ...cfg.defaultValues }));
     setAutoIncStart(cfg.autoIncStart || '1');
+    setForeignKeySql(cfg.foreignKeys || '');
+    setTriggerSql(cfg.triggers || '');
   }
 
   async function loadTableStructure() {
@@ -670,6 +686,8 @@ export default function CodingTablesPage() {
           setAllowZeroMap((prev) => ({ ...prev, ...cfg.allowZeroMap }));
           setDefaultValues((prev) => ({ ...prev, ...cfg.defaultValues }));
           setAutoIncStart(cfg.autoIncStart || '1');
+          setForeignKeySql(cfg.foreignKeys || '');
+          setTriggerSql(cfg.triggers || '');
         }
       }
     } catch {
@@ -887,7 +905,12 @@ export default function CodingTablesPage() {
     setDuplicateRecords(dupRows.map((r) => r.join(',')).join('\n'));
 
     let extras = [];
-    if (sql) {
+    if (foreignKeySql) {
+      extras = foreignKeySql
+        .split(/\r?\n/)
+        .map((l) => l.trim())
+        .filter((l) => l);
+    } else if (sql) {
       const m = sql.match(/CREATE TABLE[^\(]*\([^]*?\)/m);
       if (m) {
         const body = m[0].replace(/^[^\(]*\(|\)[^\)]*$/g, '');
@@ -940,6 +963,46 @@ export default function CodingTablesPage() {
     }
     const defsNoUnique = defs.filter((d) => !d.trim().startsWith('UNIQUE KEY'));
 
+    function buildTriggerScripts(text, tbl) {
+      const trimmed = text.trim();
+      if (!trimmed) return '';
+      const statements = splitSqlStatements(trimmed);
+      const counts = {};
+      const results = [];
+      for (let i = 0; i < statements.length; i++) {
+        const piece = statements[i].trim();
+        if (/^(CREATE|DROP)\s+TRIGGER/i.test(piece)) {
+          results.push(piece.endsWith(';') ? piece : piece + ';');
+          continue;
+        }
+        const colMatch = piece.match(/SET\s+NEW\.\`?([A-Za-z0-9_]+)\`?\s*=/i);
+        const col = colMatch ? cleanIdentifier(colMatch[1]) : `col${i + 1}`;
+        counts[col] = (counts[col] || 0) + 1;
+        const suffix = counts[col] > 1 ? `_bi${counts[col]}` : '_bi';
+        const trgName = `${tbl}_${col}${suffix}`;
+
+        let inner = piece;
+        if (/^BEGIN/i.test(inner)) {
+          inner = inner.replace(/^BEGIN/i, '').replace(/END;?$/i, '').trim();
+        }
+
+        const startsWithCheck = new RegExp(`^IF\\s+NEW\\.${col}\\b`, 'i').test(inner);
+        if (startsWithCheck) {
+          const body = `BEGIN\n  ${inner.replace(/;?\s*$/, ';')}\nEND;`;
+          results.push(
+            `DROP TRIGGER IF EXISTS \`${trgName}\`;\nCREATE TRIGGER \`${trgName}\` BEFORE INSERT ON \`${tbl}\` FOR EACH ROW\n${body}`
+          );
+        } else {
+          inner = inner.replace(/;?\s*$/, ';');
+          const body = `BEGIN\n  IF NEW.${col} IS NULL OR NEW.${col} = '' THEN\n    ${inner}\n  END IF;\nEND;`;
+          results.push(
+            `DROP TRIGGER IF EXISTS \`${trgName}\`;\nCREATE TRIGGER \`${trgName}\` BEFORE INSERT ON \`${tbl}\` FOR EACH ROW\n${body}`
+          );
+        }
+      }
+      return results.join('\n');
+    }
+
     function buildOtherStructure(tableNameForSql) {
       const defArr = defsNoUnique.map((d) =>
         /AUTO_INCREMENT/i.test(d) ? d : d.replace(/\s+NOT NULL\b/gi, '')
@@ -957,18 +1020,9 @@ export default function CodingTablesPage() {
       if (includeError) defArr.push('`error_description` VARCHAR(255)');
       const base = `CREATE TABLE IF NOT EXISTS \`${tableNameForSql}\` (\n  ${defArr.join(',\n  ')}\n)${idCol ? ` AUTO_INCREMENT=${autoIncStart}` : ''};`;
 
-      const trgParts = [];
-      Object.values(dbCols).forEach((col) => {
-        if (col.includes('num')) {
-          const trgName = `${tableNameForSql}_${col}_bi`;
-          trgParts.push(`DROP TRIGGER IF EXISTS \`${trgName}\`;`);
-          trgParts.push(
-            `CREATE TRIGGER \`${trgName}\` BEFORE INSERT ON \`${tableNameForSql}\` FOR EACH ROW\nBEGIN\n  SET NEW.\`${col}\` = CONCAT(\n    UPPER(CONCAT(\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26))\n    )),\n    '-',\n    UPPER(CONCAT(\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26))\n    )),\n    '-',\n    UPPER(CONCAT(\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26))\n    )),\n    '-',\n    UPPER(CONCAT(\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26)),\n      CHAR(FLOOR(65 + RAND() * 26))\n    ))\n  );\nEND;`
-          );
-        }
-      });
-      const trgSql = trgParts.length ? `\n${trgParts.join('\n')}` : '';
-      return `${base}\n${trgSql}\n`;
+      const trgSql = buildTriggerScripts(triggerSql, tableNameForSql);
+      const trgPart = trgSql ? `\n${trgSql}` : '';
+      return `${base}${trgPart}\n`;
     }
 
     function buildInsert(rows, tableNameForSql, fields, chunkLimit = 100, relaxed = false) {
@@ -1185,16 +1239,32 @@ export default function CodingTablesPage() {
     const statements = [];
     let current = [];
     let inTrigger = false;
+    let depth = 0;
+    const beginRe = /\bBEGIN\b/i;
+    const endRe = /\bEND\b\s*;?\s*$/i;
+    const endBlockRe = /\bEND\s+(IF|WHILE|LOOP|REPEAT|CASE)\b/i;
     for (const line of lines) {
       current.push(line);
       if (inTrigger) {
-        if (/END;\s*$/.test(line)) {
-          statements.push(current.join('\n').trim());
-          current = [];
-          inTrigger = false;
+        if (beginRe.test(line)) depth++;
+        if (endRe.test(line) && !endBlockRe.test(line)) {
+          if (depth === 0) {
+            statements.push(current.join('\n').trim());
+            current = [];
+            inTrigger = false;
+            continue;
+          }
+          depth--;
+          if (depth === 0) {
+            statements.push(current.join('\n').trim());
+            current = [];
+            inTrigger = false;
+          }
         }
       } else if (/^CREATE\s+TRIGGER/i.test(line)) {
         inTrigger = true;
+        if (beginRe.test(line)) depth = 1;
+        else depth = 0;
       } else if (/;\s*$/.test(line)) {
         statements.push(current.join('\n').trim());
         current = [];
@@ -1631,6 +1701,12 @@ export default function CodingTablesPage() {
         if (typeof v !== 'boolean') return `${k} allowZero must be true/false`;
       }
     }
+    if (cfg.triggers && typeof cfg.triggers !== 'string') {
+      return 'triggers must be a string';
+    }
+    if (cfg.foreignKeys && typeof cfg.foreignKeys !== 'string') {
+      return 'foreignKeys must be a string';
+    }
     return null;
   }
 
@@ -1668,6 +1744,8 @@ export default function CodingTablesPage() {
       startYear,
       endYear,
       autoIncStart,
+      triggers: triggerSql,
+      foreignKeys: foreignKeySql,
     };
     const validationError = validateConfig(config);
     if (validationError) {
@@ -1814,6 +1892,8 @@ export default function CodingTablesPage() {
           if (workbook && headers.length > 0) {
             extractHeaders(workbook, sheet, headerRow, mnHeaderRow);
           }
+          setForeignKeySql('');
+          setTriggerSql('');
           return;
         }
         setSheet(cfg.sheet ?? '');
@@ -1880,6 +1960,8 @@ export default function CodingTablesPage() {
         setStartYear(cfg.startYear ?? '');
         setEndYear(cfg.endYear ?? '');
         setAutoIncStart(cfg.autoIncStart ?? '1');
+        setForeignKeySql(cfg.foreignKeys ?? '');
+        setTriggerSql(cfg.triggers ?? '');
       })
       .catch(() => {});
   }, [tableName, configNames]);
@@ -2269,6 +2351,24 @@ export default function CodingTablesPage() {
                   onChange={(e) =>
                     setGroupSize(parseInt(e.target.value, 10) || 1)
                   }
+                />
+              </div>
+              <div>
+                Foreign Keys / Indexes:
+                <textarea
+                  rows={3}
+                  cols={40}
+                  value={foreignKeySql}
+                  onChange={(e) => setForeignKeySql(e.target.value)}
+                />
+              </div>
+              <div>
+                Triggers:
+                <textarea
+                  rows={5}
+                  cols={80}
+                  value={triggerSql}
+                  onChange={(e) => setTriggerSql(e.target.value)}
                 />
               </div>
             <div>

--- a/tests/api/buildTriggerScripts.test.js
+++ b/tests/api/buildTriggerScripts.test.js
@@ -1,0 +1,103 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+function cleanIdentifier(name) {
+  return String(name).replace(/[^A-Za-z0-9_]+/g, '');
+}
+
+function splitSqlStatements(sqlText) {
+  const lines = sqlText.split(/\r?\n/);
+  const statements = [];
+  let current = [];
+  let inTrigger = false;
+  let depth = 0;
+  const beginRe = /\bBEGIN\b/i;
+  const endRe = /\bEND\b\s*;?\s*$/i;
+  const endBlockRe = /\bEND\s+(IF|WHILE|LOOP|REPEAT|CASE)\b/i;
+  for (const line of lines) {
+    current.push(line);
+    if (inTrigger) {
+      if (beginRe.test(line)) depth++;
+      if (endRe.test(line) && !endBlockRe.test(line)) {
+        if (depth === 0) {
+          statements.push(current.join('\n').trim());
+          current = [];
+          inTrigger = false;
+          continue;
+        }
+        depth--;
+        if (depth === 0) {
+          statements.push(current.join('\n').trim());
+          current = [];
+          inTrigger = false;
+        }
+      }
+    } else if (/^CREATE\s+TRIGGER/i.test(line)) {
+      inTrigger = true;
+      if (beginRe.test(line)) depth = 1;
+      else depth = 0;
+    } else if (/;\s*$/.test(line)) {
+      statements.push(current.join('\n').trim());
+      current = [];
+    }
+  }
+  if (current.length) {
+    const stmt = current.join('\n').trim();
+    if (stmt) statements.push(stmt.endsWith(';') ? stmt : stmt + ';');
+  }
+  return statements;
+}
+
+function buildTriggerScripts(text, tbl) {
+  const trimmed = text.trim();
+  if (!trimmed) return '';
+  const statements = splitSqlStatements(trimmed);
+  const counts = {};
+  const results = [];
+  for (let i = 0; i < statements.length; i++) {
+    const piece = statements[i].trim();
+    if (/^(CREATE|DROP)\s+TRIGGER/i.test(piece)) {
+      results.push(piece.endsWith(';') ? piece : piece + ';');
+      continue;
+    }
+    const colMatch = piece.match(/SET\s+NEW\.\`?([A-Za-z0-9_]+)\`?\s*=/i);
+    const col = colMatch ? cleanIdentifier(colMatch[1]) : `col${i + 1}`;
+    counts[col] = (counts[col] || 0) + 1;
+    const suffix = counts[col] > 1 ? `_bi${counts[col]}` : '_bi';
+    const trgName = `${tbl}_${col}${suffix}`;
+
+    let inner = piece;
+    if (/^BEGIN/i.test(inner)) {
+      inner = inner.replace(/^BEGIN/i, '').replace(/END;?$/i, '').trim();
+    }
+
+    const startsWithCheck = new RegExp(`^IF\\s+NEW\\.${col}\\b`, 'i').test(inner);
+    if (startsWithCheck) {
+      const body = `BEGIN\n  ${inner.replace(/;?\s*$/, ';')}\nEND;`;
+      results.push(
+        `DROP TRIGGER IF EXISTS \`${trgName}\`;\nCREATE TRIGGER \`${trgName}\` BEFORE INSERT ON \`${tbl}\` FOR EACH ROW\n${body}`
+      );
+    } else {
+      inner = inner.replace(/;?\s*$/, ';');
+      const body = `BEGIN\n  IF NEW.${col} IS NULL OR NEW.${col} = '' THEN\n    ${inner}\n  END IF;\nEND;`;
+      results.push(
+        `DROP TRIGGER IF EXISTS \`${trgName}\`;\nCREATE TRIGGER \`${trgName}\` BEFORE INSERT ON \`${tbl}\` FOR EACH ROW\n${body}`
+      );
+    }
+  }
+  return results.join('\n');
+}
+
+test('buildTriggerScripts avoids duplicate IF clause', () => {
+  const snippet = `BEGIN\n  IF NEW.pid IS NULL OR NEW.pid = '' THEN\n    SET NEW.pid = 'x';\n  END IF;\nEND`;
+  const sql = buildTriggerScripts(snippet, 't');
+  const occurrences = sql.match(/IF NEW\.pid/gi) || [];
+  assert.equal(occurrences.length, 1);
+});
+
+test('buildTriggerScripts keeps full CREATE TRIGGER intact', () => {
+  const snippet = `CREATE TRIGGER t_pid_bi BEFORE INSERT ON t FOR EACH ROW\nBEGIN\n  IF NEW.pid IS NULL OR NEW.pid = '' THEN\n    IF NEW.branch = 1 THEN\n      SET NEW.pid = 'A';\n    ELSE\n      SET NEW.pid = 'B';\n    END IF;\n  END IF;\nEND;`;
+  const sql = buildTriggerScripts(snippet, 't');
+  assert.ok(sql.trim().endsWith('END;'));
+  assert.ok(/CREATE TRIGGER/.test(sql));
+});

--- a/tests/api/splitSqlStatements.test.js
+++ b/tests/api/splitSqlStatements.test.js
@@ -9,3 +9,17 @@ test('splitSqlStatements keeps CREATE TRIGGER intact', () => {
   assert.equal(stmts.length, 2);
   assert.ok(stmts[0].startsWith('CREATE TRIGGER'));
 });
+
+test('splitSqlStatements handles trigger without ending semicolon', () => {
+  const noSemi = triggerSQL.replace('END;', 'END');
+  const stmts = splitSqlStatements(noSemi);
+  assert.equal(stmts.length, 2);
+  assert.ok(stmts[0].startsWith('CREATE TRIGGER'));
+});
+
+test('splitSqlStatements handles nested BEGIN blocks', () => {
+  const nested = `CREATE TRIGGER t_bi BEFORE INSERT ON t FOR EACH ROW\nBEGIN\n  IF NEW.x IS NULL THEN\n    BEGIN\n      SET NEW.x = 1;\n    END;\n  END IF;\nEND;\nINSERT INTO t VALUES (1);`;
+  const stmts = splitSqlStatements(nested);
+  assert.equal(stmts.length, 2);
+  assert.ok(stmts[0].includes('SET NEW.x = 1;'));
+});


### PR DESCRIPTION
## Summary
- improve splitSqlStatements to track BEGIN/END depth so nested trigger blocks are parsed correctly
- apply same splitting logic in CodingTables frontend
- adjust tests for new splitting behavior and add regression for nested BEGIN blocks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68691fe5f52c8331bd328bd45225d9c0