### PR TITLE
Fix foreign keys in _other tables

### DIFF
--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -1016,9 +1016,11 @@ export default function CodingTablesPage() {
     }
 
     function buildOtherStructure(tableNameForSql) {
-      const defArr = defsNoUnique.map((d) =>
-        /AUTO_INCREMENT/i.test(d) ? d : d.replace(/\s+NOT NULL\b/gi, '')
-      );
+      const defArr = defsNoUnique
+        .filter((d) => !/\bFOREIGN KEY\b/i.test(d))
+        .map((d) =>
+          /AUTO_INCREMENT/i.test(d) ? d : d.replace(/\s+NOT NULL\b/gi, '')
+        );
       defArr.push('`error_description` VARCHAR(255)');
       return `CREATE TABLE IF NOT EXISTS \`${tableNameForSql}\` (\n  ${defArr.join(',\n  ')}\n);`;
     }


### PR DESCRIPTION
## Summary
- avoid adding foreign key constraints when creating `_other` tables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686cb33ff5348331b0741a00c4ebd127