### PR TITLE
Add POS module form entry

### DIFF
--- a/api-server/services/posTransactionConfig.js
+++ b/api-server/services/posTransactionConfig.js
@@ -1,0 +1,90 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+const filePath = path.join(process.cwd(), 'config', 'posTransactionConfigs.json');
+
+async function readConfig() {
+  try {
+    const data = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(data);
+  } catch {
+    return {};
+  }
+}
+
+async function writeConfig(cfg) {
+  await fs.writeFile(filePath, JSON.stringify(cfg, null, 2));
+}
+
+function parseTable(raw = {}) {
+  return {
+    table: typeof raw.table === 'string' ? raw.table : '',
+    transaction: typeof raw.transaction === 'string' ? raw.transaction : '',
+    position: typeof raw.position === 'string' ? raw.position : 'hidden',
+    multiRow: !!raw.multiRow,
+  };
+}
+
+function parseEntry(raw = {}) {
+  return {
+    moduleKey: typeof raw.moduleKey === 'string' ? raw.moduleKey : '',
+    masterTable: typeof raw.masterTable === 'string' ? raw.masterTable : '',
+    tables: Array.isArray(raw.tables) ? raw.tables.map(parseTable) : [],
+    calculatedFields: Array.isArray(raw.calculatedFields)
+      ? raw.calculatedFields.map((c) => ({
+          target: c.target || '',
+          expression: c.expression || '',
+        }))
+      : [],
+    status: raw.status && typeof raw.status === 'object'
+      ? {
+          beforePost: raw.status.beforePost ?? null,
+          afterPost: raw.status.afterPost ?? null,
+        }
+      : { beforePost: null, afterPost: null },
+  };
+}
+
+export async function getPosConfig(name) {
+  const cfg = await readConfig();
+  return parseEntry(cfg[name]);
+}
+
+export async function getAllPosConfigs() {
+  const cfg = await readConfig();
+  const result = {};
+  for (const [name, info] of Object.entries(cfg)) {
+    result[name] = parseEntry(info);
+  }
+  return result;
+}
+
+export async function setPosConfig(name, config = {}) {
+  const cfg = await readConfig();
+  cfg[name] = {
+    moduleKey: config.moduleKey || '',
+    masterTable: config.masterTable || '',
+    tables: Array.isArray(config.tables) ? config.tables.map(parseTable) : [],
+    calculatedFields: Array.isArray(config.calculatedFields)
+      ? config.calculatedFields.map((c) => ({
+          target: c.target || '',
+          expression: c.expression || '',
+        }))
+      : [],
+    status: config.status && typeof config.status === 'object'
+      ? {
+          beforePost: config.status.beforePost ?? null,
+          afterPost: config.status.afterPost ?? null,
+        }
+      : { beforePost: null, afterPost: null },
+  };
+  await writeConfig(cfg);
+  return cfg[name];
+}
+
+export async function deletePosConfig(name) {
+  const cfg = await readConfig();
+  if (!cfg[name]) return;
+  delete cfg[name];
+  await writeConfig(cfg);
+}

--- a/config/posTransactionConfigs.json
+++ b/config/posTransactionConfigs.json
@@ -1,0 +1,49 @@
+{
+  "Default POS": {
+    "moduleKey": "pos_transaction_management",
+    "masterTable": "transactions_pos",
+    "tables": [
+      {
+        "table": "transactions_posorder",
+        "transaction": "Order Entry",
+        "position": "upper_left",
+        "multiRow": true
+      },
+      {
+        "table": "transactions_inventory",
+        "transaction": "Inventory",
+        "position": "upper_right",
+        "multiRow": true
+      },
+      {
+        "table": "transactions_income",
+        "transaction": "Income",
+        "position": "lower_left",
+        "multiRow": false
+      },
+      {
+        "table": "transactions_expense",
+        "transaction": "Expense",
+        "position": "lower_right",
+        "multiRow": false
+      },
+      {
+        "table": "transactions_planning",
+        "transaction": "Planning",
+        "position": "bottom_row",
+        "multiRow": false
+      }
+    ],
+    "calculatedFields": [
+      {
+        "target": "transactions_pos.total_amount",
+        "expression": "SUM(transactions_posorder.inventory_price)"
+      },
+      {
+        "target": "transactions_pos.payable_amount",
+        "expression": "total_amount - total_discount - cashback"
+      }
+    ],
+    "status": { "beforePost": 0, "afterPost": 1 }
+  }
+}

--- a/config/transactionForms.json
+++ b/config/transactionForms.json
@@ -64,4 +64,19 @@
       "moduleKey": "finance_transactions"
     }
   }
+  ,
+  "transactions_pos": {
+    "Simple POS": {
+      "visibleFields": [],
+      "requiredFields": [],
+      "defaultValues": {},
+      "editableDefaultFields": [],
+      "userIdFields": [],
+      "branchIdFields": [],
+      "companyIdFields": [],
+      "allowedBranches": [],
+      "allowedDepartments": [],
+      "moduleKey": "pos_transaction_management"
+    }
+  }
 }

--- a/docs/pos-transaction-config.md
+++ b/docs/pos-transaction-config.md
@@ -1,0 +1,53 @@
+# POS Transaction Configuration
+
+The file `config/posTransactionConfigs.json` defines how a POS transaction is
+composed from multiple table transactions. Each entry uses the following
+structure:
+
+```json
+{
+  "Transaction Name": {
+    "moduleKey": "pos_transaction_management",
+    "masterTable": "transactions_pos",
+    "tables": [
+      {
+        "table": "transactions_posorder",
+        "transaction": "Order Entry",
+        "position": "upper_left",
+        "multiRow": true
+      }
+    ],
+    "calculatedFields": [
+      {
+        "target": "transactions_pos.total_amount",
+        "expression": "SUM(transactions_posorder.inventory_price)"
+      }
+    ],
+    "status": { "beforePost": 0, "afterPost": 1 }
+  }
+}
+```
+
+`moduleKey` links the configuration to the `pos_transaction_management` module.
+`masterTable` specifies the table that stores the primary POS record.  Each
+entry in `tables` chooses a transaction form from `forms_management` and assigns
+it to a window position. The `multiRow` flag indicates whether the table will
+hold multiple rows per POS transaction.
+
+To display the module in the application sidebar you must also create a
+transaction form entry with `moduleKey` set to `pos_transaction_management` in
+`config/transactionForms.json`.  A minimal configuration is:
+
+```json
+{
+  "transactions_pos": {
+    "Simple POS": {
+      "moduleKey": "pos_transaction_management"
+    }
+  }
+}
+```
+
+`calculatedFields` define expressions that sync fields across the selected
+tables. The `status` block specifies the value of `transactions_pos.status`
+before and after posting the transaction.

--- a/tests/db/posTransactionConfig.test.js
+++ b/tests/db/posTransactionConfig.test.js
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import path from 'path';
+import {
+  getPosConfig,
+  getAllPosConfigs,
+  setPosConfig,
+  deletePosConfig,
+} from '../../api-server/services/posTransactionConfig.js';
+
+const filePath = path.join(process.cwd(), 'config', 'posTransactionConfigs.json');
+
+function withTempFile() {
+  return fs.readFile(filePath, 'utf8')
+    .catch(() => '{}')
+    .then((orig) => ({
+      orig,
+      restore: () => fs.writeFile(filePath, orig),
+    }));
+}
+
+await test('set and get POS config', async () => {
+  const { orig, restore } = await withTempFile();
+  await fs.writeFile(filePath, '{}');
+  await setPosConfig('Sale', {
+    moduleKey: 'pos_transaction_management',
+    masterTable: 'transactions_pos',
+    tables: [{ table: 't1', transaction: 'A', position: 'upper_left', multiRow: true }],
+    calculatedFields: [{ target: 't.total', expression: 'SUM(x)' }],
+    status: { beforePost: 0, afterPost: 1 },
+  });
+  const cfg = await getPosConfig('Sale');
+  assert.equal(cfg.moduleKey, 'pos_transaction_management');
+  assert.equal(cfg.masterTable, 'transactions_pos');
+  assert.equal(cfg.tables[0].table, 't1');
+  assert.equal(cfg.calculatedFields[0].expression, 'SUM(x)');
+  assert.equal(cfg.status.afterPost, 1);
+  await restore();
+});
+
+await test('deletePosConfig removes entry', async () => {
+  const { orig, restore } = await withTempFile();
+  await fs.writeFile(filePath, '{}');
+  await setPosConfig('Sale', { moduleKey: 'm' });
+  await deletePosConfig('Sale');
+  const all = await getAllPosConfigs();
+  assert.deepEqual(all, {});
+  await restore();
+});


### PR DESCRIPTION
## Summary
- register a basic `transactions_pos` form under the `pos_transaction_management` module so the sidebar displays the module
- document that the module requires a matching entry in `transactionForms.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e50151c608331b1677295839c5ceb