### PR TITLE
Implement dynamic master form selection

### DIFF
--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -26,7 +26,7 @@ export default function PosTransactionsPage() {
       .then((cfg) => {
         if (cfg && Array.isArray(cfg.tables) && cfg.tables.length > 0 && !cfg.masterTable) {
           const [master, ...rest] = cfg.tables;
-          cfg = { ...cfg, masterTable: master.table || '', masterType: master.type || 'single', masterPosition: master.position || 'upper_left', tables: rest };
+          cfg = { ...cfg, masterTable: master.table || '', masterForm: master.form || '', masterType: master.type || 'single', masterPosition: master.position || 'upper_left', tables: rest };
         }
         setConfig(cfg);
         setFormConfigs({});
@@ -42,7 +42,7 @@ export default function PosTransactionsPage() {
   useEffect(() => {
     if (!config) return;
     const tables = [config.masterTable, ...config.tables.map(t => t.table)];
-    const forms = ['', ...config.tables.map(t => t.form)];
+    const forms = [config.masterForm || '', ...config.tables.map(t => t.form)];
     tables.forEach((tbl, idx) => {
       const form = forms[idx];
       if (!tbl || !form) return;


### PR DESCRIPTION
## Summary
- support selecting a form for the master table in POS transaction configuration
- allow choosing the master table only from tables configured in the form list
- propagate selected master form to transaction rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ebe8513548331a3dc1e88c18451e2