### PR TITLE
Update POS config handling

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -30,6 +30,7 @@ const RowFormModal = function RowFormModal({
   inline = false,
   useGrid = false,
   hideAddButton = false,
+  formView = 'cells',
 }) {
   const mounted = useRef(false);
   const renderCount = useRef(0);
@@ -189,7 +190,11 @@ const RowFormModal = function RowFormModal({
       ? columns.filter((c) => mainSet.has(c))
       : columns.filter((c) => !headerSet.has(c) && !footerSet.has(c));
 
-  const formGrid = 'grid grid-cols-1 md:grid-cols-2 gap-0';
+  const formGrid = React.useMemo(() => {
+    if (formView === 'row') return 'flex flex-row flex-wrap items-end gap-2';
+    if (formView === 'column') return 'flex flex-col gap-2';
+    return 'grid grid-cols-1 md:grid-cols-2 gap-0';
+  }, [formView]);
 
   function handleKeyDown(e, col) {
     if (e.key !== 'Enter') return;

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -27,7 +27,15 @@ export default function PosTransactionsPage() {
       .then((cfg) => {
         if (cfg && Array.isArray(cfg.tables) && cfg.tables.length > 0 && !cfg.masterTable) {
           const [master, ...rest] = cfg.tables;
-          cfg = { ...cfg, masterTable: master.table || '', masterForm: master.form || '', masterType: master.type || 'single', masterPosition: master.position || 'upper_left', tables: rest };
+          cfg = {
+            ...cfg,
+            masterTable: master.table || '',
+            masterForm: master.form || '',
+            masterType: master.type || 'single',
+            masterPosition: master.position || 'upper_left',
+            masterView: master.view || 'cells',
+            tables: rest,
+          };
         }
         setConfig(cfg);
         setFormConfigs({});
@@ -134,7 +142,15 @@ export default function PosTransactionsPage() {
               gridTemplateRows: 'auto auto auto auto auto',
             }}
           >
-            {[{ table: config.masterTable, type: config.masterType, position: config.masterPosition }, ...config.tables]
+            {[
+              {
+                table: config.masterTable,
+                type: config.masterType,
+                position: config.masterPosition,
+                view: config.masterView,
+              },
+              ...config.tables,
+            ]
               .filter((t) => t.position !== 'hidden')
               .map((t, idx) => {
                 const fc = formConfigs[t.table];
@@ -175,6 +191,7 @@ export default function PosTransactionsPage() {
                       onSubmit={(row) => handleSubmit(t.table, row)}
                       useGrid={t.type === 'multi'}
                       hideAddButton
+                      formView={t.view || 'cells'}
                     />
                   </div>
                 );

--- a/src/erp.mgt.mn/pages/PosTxnConfig.jsx
+++ b/src/erp.mgt.mn/pages/PosTxnConfig.jsx
@@ -118,6 +118,7 @@ export default function PosTxnConfig() {
             form: loaded.masterForm,
             type: loaded.masterType || 'single',
             position: loaded.masterPosition || 'upper_left',
+            view: loaded.masterView || 'cells',
           },
           ...(loaded.tables || []),
         ];
@@ -125,7 +126,15 @@ export default function PosTxnConfig() {
         delete loaded.masterForm;
         delete loaded.masterType;
         delete loaded.masterPosition;
+        delete loaded.masterView;
       }
+      loaded.tables = (loaded.tables || []).map((t) => ({
+        table: t.table || '',
+        form: t.form || '',
+        type: t.type || 'single',
+        position: t.position || 'upper_left',
+        view: t.view || 'cells',
+      }));
       if (Array.isArray(loaded.calcFields)) {
         loaded.calcFields = loaded.calcFields.map((row, rIdx) => {
           const cells = Array.isArray(row.cells)
@@ -173,7 +182,7 @@ export default function PosTxnConfig() {
       ...c,
       tables: [
         ...c.tables,
-        { table: '', form: '', type: 'single', position: 'upper_left' },
+        { table: '', form: '', type: 'single', position: 'upper_left', view: 'cells' },
       ],
       calcFields: c.calcFields.map((row) => ({
         ...row,
@@ -192,6 +201,9 @@ export default function PosTxnConfig() {
         }
         if (key === 'table') {
           return { ...t, table: value };
+        }
+        if (key === 'view') {
+          return { ...t, view: value };
         }
         return { ...t, [key]: value };
       });
@@ -232,7 +244,17 @@ export default function PosTxnConfig() {
       addToast('Name required', 'error');
       return;
     }
-    const saveCfg = { ...config };
+    const { tables = [], ...rest } = config;
+    const [master, ...others] = tables;
+    const saveCfg = {
+      ...rest,
+      masterTable: master?.table || '',
+      masterForm: master?.form || '',
+      masterType: master?.type || 'single',
+      masterPosition: master?.position || 'upper_left',
+      masterView: master?.view || 'cells',
+      tables: others,
+    };
     await fetch('/api/pos_txn_config', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -439,6 +461,22 @@ export default function PosTxnConfig() {
                     <option value="lower_right">lower_right</option>
                     <option value="bottom_row">bottom_row</option>
                     <option value="hidden">hidden</option>
+                  </select>
+                </td>
+              ))}
+            </tr>
+            <tr>
+              <td>View</td>
+              {config.tables.map((t, idx) => (
+                <td key={idx} style={{ padding: '4px' }}>
+                  <select
+                    value={t.view}
+                    onChange={(e) => updateColumn(idx, 'view', e.target.value)}
+                  >
+                    <option value="cells">Cells</option>
+                    <option value="row">Row</option>
+                    <option value="column">Column</option>
+                    <option value="table">Table</option>
                   </select>
                 </td>
               ))}


### PR DESCRIPTION
## Summary
- preserve master table when saving POS transactions config
- allow choosing view layout per table
- show forms with custom view layouts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ed126265c8331a47a24e58032fe1b