### PR TITLE
Improve POS form usability

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -342,7 +342,9 @@ export default forwardRef(function InlineTransactionTable({
   }, [rows, fields, totalAmountSet, totalCurrencySet, totalAmountFields]);
 
   function handleKeyDown(e, rowIdx, colIdx) {
-    if (e.key !== 'Enter') return;
+    const isEnter = e.key === 'Enter';
+    const isForwardTab = e.key === 'Tab' && !e.shiftKey;
+    if (!isEnter && !isForwardTab) return;
     e.preventDefault();
     const field = fields[colIdx];
     let val = e.target.value;

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -125,7 +125,7 @@ export default function PosTransactionsPage() {
           <div
             style={{
               display: 'grid',
-              gap: '1rem',
+              gap: '0',
               gridTemplateColumns: '1fr 1fr 1fr',
               gridTemplateRows: 'auto auto auto auto auto',
             }}


### PR DESCRIPTION
## Summary
- allow Tab key to act like Enter to trigger navigation and add rows in multi-row transaction tables
- set POS forms grid gap to zero for tight alignment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68776c2163b08331a740b52d4b348d82