### PR TITLE
Improve POS transaction lifecycle

### DIFF
--- a/docs/unified-pos-transaction-buttons.md
+++ b/docs/unified-pos-transaction-buttons.md
@@ -1,0 +1,35 @@
+# Unified POS Transaction Buttons
+
+This module includes a single set of buttons used by every POS transaction configuration. Each button drives multiple tables using the mapping rules from `posTransactionConfig.json`.
+
+## New
+- Creates a fresh master record in the configured master table and stores its returned ID.
+- Generates a session ID (also saved on the server) and applies it to every field mapped via `calcFields` or `posFields`.
+- Fills default values for **all** forms including hidden ones so every table is ready for input.
+- Sets the configured `statusField` to the `created` value if defined.
+- Clears any previously loaded or pending transaction IDs.
+
+## Save
+- Creates the master record if it does not yet exist and ensures child tables reference the master ID.
+- Writes the current values to the pending transactions store together with the master ID.
+- Auto-fills any missing default values for each form before saving.
+- Updates the `statusField` to the `beforePost` value so the transaction can be resumed later.
+- Returns an ID for the pending transaction which is required for Delete or POST.
+
+## Load
+- Lists pending transaction IDs saved for the chosen configuration.
+- Loads the master and all child tables for the selected ID with session-based field mapping and restores the master ID.
+- The Load button is enabled whenever a configuration is selected.
+
+## Delete
+- Removes the currently loaded pending transaction and all related child tables.
+- Clears the session ID, master ID and pending ID from the UI.
+- Disabled when no pending transaction is loaded.
+
+## POST
+- Validates required fields for all forms before submission.
+- Merges default values so each payload contains the latest defaults.
+- Verifies `calcFields` mapping rules to ensure all tables contain the same session ID or other linked values.
+- Splits the payload into `single` and `multi` collections before sending to `/api/pos_txn_post`.
+- On success, deletes the pending entry, updates the `statusField` to `posted`, and leaves the master record intact.
+- Hidden forms are included in the submission automatically.

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -13,6 +13,7 @@ export default function PosTransactionsPage() {
   const [layout, setLayout] = useState({});
   const [pendingId, setPendingId] = useState(null);
   const [sessionFields, setSessionFields] = useState([]);
+  const [masterId, setMasterId] = useState(null);
   const refs = useRef({});
   const dragInfo = useRef(null);
 
@@ -87,6 +88,25 @@ export default function PosTransactionsPage() {
     setSessionFields(fields);
   }, [config]);
 
+  useEffect(() => {
+    if (!config) return;
+    const masterSf = sessionFields.find((f) => f.table === config.masterTable);
+    if (!masterSf) return;
+    const sid = values[config.masterTable]?.[masterSf.field];
+    if (sid === undefined) return;
+    sessionFields.forEach((sf) => {
+      if (sf.table === config.masterTable) return;
+      setValues((v) => {
+        const cur = v[sf.table]?.[sf.field];
+        if (cur === sid || sid === undefined) return v;
+        return {
+          ...v,
+          [sf.table]: { ...(v[sf.table] || {}), [sf.field]: sid },
+        };
+      });
+    });
+  }, [values, config, sessionFields]);
+
   function handleChange(tbl, changes) {
     setValues(v => ({ ...v, [tbl]: { ...v[tbl], ...changes } }));
   }
@@ -133,18 +153,52 @@ export default function PosTransactionsPage() {
     addToast('Layout saved', 'success');
   }
 
-  function handleNew() {
+  async function handleNew() {
     if (!config) return;
     const sid = 'sess_' + Date.now().toString(36);
     const next = {};
-    sessionFields.forEach(sf => {
+    sessionFields.forEach((sf) => {
       if (!next[sf.table]) next[sf.table] = {};
       next[sf.table][sf.field] = sid;
     });
-    if (config.statusField?.table && config.statusField.field && config.statusField.created) {
+    if (
+      config.statusField?.table &&
+      config.statusField.field &&
+      config.statusField.created
+    ) {
       const tbl = config.statusField.table;
       if (!next[tbl]) next[tbl] = {};
       next[tbl][config.statusField.field] = config.statusField.created;
+    }
+    Object.entries(formConfigs).forEach(([tbl, fc]) => {
+      const defs = fc.defaultValues || {};
+      if (!next[tbl]) next[tbl] = {};
+      Object.entries(defs).forEach(([k, v]) => {
+        if (next[tbl][k] === undefined) next[tbl][k] = v;
+      });
+    });
+    try {
+      const res = await fetch(
+        `/api/tables/${encodeURIComponent(config.masterTable)}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify(next[config.masterTable] || {}),
+        },
+      );
+      const js = await res.json().catch(() => null);
+      if (js && js.id) {
+        const pk =
+          (columnMeta[config.masterTable] || []).find((c) => c.key === 'PRI')?.name ||
+          'id';
+        next[config.masterTable][pk] = js.id;
+        setMasterId(js.id);
+      } else {
+        setMasterId(null);
+      }
+    } catch {
+      setMasterId(null);
     }
     setValues(next);
     setPendingId(null);
@@ -152,16 +206,60 @@ export default function PosTransactionsPage() {
 
   async function handleSavePending() {
     if (!name) return;
+    const next = { ...values };
+    if (
+      config?.statusField?.table &&
+      config.statusField.field &&
+      config.statusField.beforePost
+    ) {
+      const tbl = config.statusField.table;
+      if (!next[tbl]) next[tbl] = {};
+      next[tbl][config.statusField.field] = config.statusField.beforePost;
+    }
+    // fill defaults when missing
+    Object.entries(formConfigs).forEach(([tbl, fc]) => {
+      const defs = fc.defaultValues || {};
+      if (!next[tbl]) next[tbl] = {};
+      Object.entries(defs).forEach(([k, v]) => {
+        if (next[tbl][k] === undefined) next[tbl][k] = v;
+      });
+    });
+
+    let mid = masterId;
+    if (!mid) {
+      try {
+        const res = await fetch(
+          `/api/tables/${encodeURIComponent(config.masterTable)}`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify(next[config.masterTable] || {}),
+          },
+        );
+        const js = await res.json().catch(() => null);
+        if (js && js.id) {
+          const pk =
+            (columnMeta[config.masterTable] || []).find((c) => c.key === 'PRI')?.name ||
+            'id';
+          next[config.masterTable][pk] = js.id;
+          mid = js.id;
+          setMasterId(js.id);
+        }
+      } catch {}
+    }
+
     try {
       const res = await fetch('/api/pos_txn_pending', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ id: pendingId, name, data: values }),
+        body: JSON.stringify({ id: pendingId, name, data: next, masterId: mid }),
       });
       const js = await res.json().catch(() => ({}));
       if (js.id) {
         setPendingId(js.id);
+        setValues(next);
         addToast('Saved', 'success');
       } else {
         addToast('Save failed', 'error');
@@ -186,6 +284,7 @@ export default function PosTransactionsPage() {
     if (rec && rec.data) {
       setValues(rec.data);
       setPendingId(sel);
+      setMasterId(rec.masterId || null);
     }
   }
 
@@ -197,6 +296,7 @@ export default function PosTransactionsPage() {
     });
     setPendingId(null);
     setValues({});
+    setMasterId(null);
   }
 
   async function handlePostAll() {
@@ -214,14 +314,46 @@ export default function PosTransactionsPage() {
         }
       }
     }
+    const payload = { ...values };
+    Object.entries(formConfigs).forEach(([tbl, fc]) => {
+      const defs = fc.defaultValues || {};
+      if (!payload[tbl]) payload[tbl] = {};
+      Object.entries(defs).forEach(([k, v]) => {
+        if (payload[tbl][k] === undefined) payload[tbl][k] = v;
+      });
+    });
+    for (const map of config.calcFields || []) {
+      if (!Array.isArray(map.cells) || map.cells.length < 2) continue;
+      const [first, ...rest] = map.cells;
+      const base = payload[first.table]?.[first.field];
+      for (const c of rest) {
+        if (payload[c.table]?.[c.field] !== base) {
+          addToast('Mapping mismatch', 'error');
+          return;
+        }
+      }
+    }
+    const single = {};
+    const multi = {};
+    formList.forEach((t) => {
+      if (t.type === 'multi') multi[t.table] = payload[t.table];
+      else single[t.table] = payload[t.table];
+    });
+    const postData = { masterId, single, multi };
     try {
       const res = await fetch('/api/pos_txn_post', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ name, data: values }),
+        body: JSON.stringify({ name, data: postData }),
       });
       if (res.ok) {
+        if (pendingId) {
+          await fetch(`/api/pos_txn_pending?id=${encodeURIComponent(pendingId)}`, {
+            method: 'DELETE',
+            credentials: 'include',
+          });
+        }
         setPendingId(null);
         if (config.statusField?.table && config.statusField.field && config.statusField.posted) {
           setValues(v => ({
@@ -269,14 +401,31 @@ export default function PosTransactionsPage() {
 
   const formList = React.useMemo(() => {
     if (!config) return [];
-    const arr = [{ table: config.masterTable, type: config.masterType, position: config.masterPosition, view: config.masterView }, ...config.tables];
+    const arr = [
+      { table: config.masterTable, type: config.masterType, position: config.masterPosition, view: config.masterView },
+      ...config.tables,
+    ];
     const seen = new Set();
-    return arr.filter(t => {
+    const filtered = arr.filter((t) => {
       if (!t.table) return false;
       if (seen.has(t.table)) return false;
       seen.add(t.table);
       return true;
     });
+    const order = [
+      'top_row',
+      'upper_left',
+      'upper_right',
+      'left',
+      'right',
+      'lower_left',
+      'lower_right',
+      'bottom_row',
+      'hidden',
+    ];
+    return filtered.sort(
+      (a, b) => order.indexOf(a.position) - order.indexOf(b.position),
+    );
   }, [config]);
 
   return (
@@ -301,8 +450,8 @@ export default function PosTransactionsPage() {
             <button onClick={handleNew} style={{ marginRight: '0.5rem' }}>New</button>
             <button onClick={handleSavePending} style={{ marginRight: '0.5rem' }}>Save</button>
             <button onClick={handleLoadPending} style={{ marginRight: '0.5rem' }}>Load</button>
-            <button onClick={handleDeletePending} style={{ marginRight: '0.5rem' }}>Delete</button>
-            <button onClick={handlePostAll}>POST</button>
+            <button onClick={handleDeletePending} style={{ marginRight: '0.5rem' }} disabled={!pendingId}>Delete</button>
+            <button onClick={handlePostAll} disabled={!pendingId}>POST</button>
           </div>
           <div
             style={{


### PR DESCRIPTION
## Summary
- enhance session sync across tables
- add default values when creating or saving transactions
- validate mapping rules and defaults before POST
- sort forms by layout position and disable actions until saved
- document unified transaction button functions
- create master record on new/save
- split POST payload for single vs multi forms
- purge pending file on post
- load button always available once config selected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877a3f1a5f4833186a947a33725a67b