### PR TITLE
Improve POS transaction lifecycle

### DIFF
--- a/api-server/routes/pos_txn_pending.js
+++ b/api-server/routes/pos_txn_pending.js
@@ -21,9 +21,9 @@ router.get('/', requireAuth, async (req, res, next) => {
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {
-    const { id, name, data } = req.body;
+    const { id, name, data, masterId } = req.body;
     if (!name) return res.status(400).json({ message: 'name is required' });
-    const result = await savePending(id, { name, data });
+    const result = await savePending(id, { name, data, masterId });
     res.json({ id: result.id });
   } catch (err) {
     next(err);

--- a/docs/unified-pos-transaction-buttons.md
+++ b/docs/unified-pos-transaction-buttons.md
@@ -1,0 +1,36 @@
+# Unified POS Transaction Buttons
+
+This module includes a single set of buttons used by every POS transaction configuration. Each button drives multiple tables using the mapping rules from `posTransactionConfig.json`.
+
+## New
+- Creates a fresh master record in the configured master table and stores its returned ID.
+- Generates a session ID (also saved on the server) and applies it to every field mapped via `calcFields` or `posFields`.
+- Fills default values for **all** forms including hidden ones so every table is ready for input.
+- Sets the configured `statusField` to the `created` value if defined.
+- Clears any previously loaded or pending transaction IDs.
+
+## Save
+- Creates the master record if it does not yet exist and ensures child tables reference the master ID.
+- Writes the current values to the pending transactions store together with the master ID.
+- Auto-fills any missing default values for each form before saving.
+- Updates the `statusField` to the `beforePost` value so the transaction can be resumed later.
+- Returns an ID for the pending transaction which is required for Delete or POST.
+
+## Load
+- Lists pending transaction IDs saved for the chosen configuration.
+- Loads the master and all child tables for the selected ID with session-based field mapping and restores the master ID.
+- The Load button is enabled whenever a configuration is selected.
+
+## Delete
+- Removes the currently loaded pending transaction and all related child tables.
+- Clears the session ID, master ID and pending ID from the UI.
+- Disabled when no pending transaction is loaded.
+
+## POST
+- Validates required fields for all forms before submission.
+- Merges default values so each payload contains the latest defaults.
+- Verifies `calcFields` mapping rules to ensure all tables contain the same session ID or other linked values.
+- Splits the payload into `single` and `multi` collections before sending to `/api/pos_txn_post`.
+- On success, deletes the pending entry, updates the `statusField` to `posted`, and leaves the master record intact.
+- Hidden forms are included in the submission automatically.
+- Error messages report the problematic field and value whenever possible.


### PR DESCRIPTION
## Summary
- save pending transactions with masterId and reload correctly
- keep forms in sync with loaded values
- update master record instead of duplicating on save

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877a3f1a5f4833186a947a33725a67b