### PR TITLE
Fix zoom handling for fitted POS forms

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -107,17 +107,27 @@ const RowFormModal = function RowFormModal({
 
   useEffect(() => {
     if (!fitted) return;
+    if (!wrapRef.current) return;
+    const el = wrapRef.current;
     function updateZoom() {
-      if (!wrapRef.current) return;
-      const { scrollWidth, scrollHeight } = wrapRef.current;
-      const wRatio = scrollWidth ? window.innerWidth / scrollWidth : 1;
-      const hRatio = scrollHeight ? window.innerHeight / scrollHeight : 1;
+      const parent = el.parentElement;
+      const parentW = parent?.clientWidth ?? window.innerWidth;
+      const parentH = parent?.clientHeight ?? window.innerHeight;
+      const { scrollWidth, scrollHeight } = el;
+      const wRatio = scrollWidth ? parentW / scrollWidth : 1;
+      const hRatio = scrollHeight ? parentH / scrollHeight : 1;
       const s = Math.min(1, wRatio, hRatio);
       setZoom(s);
     }
+    const ro = new ResizeObserver(updateZoom);
+    ro.observe(el);
+    if (el.parentElement) ro.observe(el.parentElement);
     updateZoom();
     window.addEventListener('resize', updateZoom);
-    return () => window.removeEventListener('resize', updateZoom);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener('resize', updateZoom);
+    };
   }, [fitted, visible]);
   const placeholders = React.useMemo(() => {
     const map = {};

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -646,7 +646,7 @@ export default function PosTransactionsPage() {
                     style={{
                       border: '1px solid #ccc',
                       resize: 'both',
-                      overflow: 'auto',
+                      overflow: t.view === 'fitted' ? 'visible' : 'auto',
                       width: saved.width || 'auto',
                       height: saved.height || 'auto',
                       margin: '-1px',


### PR DESCRIPTION
## Summary
- update `RowFormModal` zoom logic to use parent size and observe resize
- avoid clipping popups in fitted view by disabling overflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877dc92891c8331bf11adfcc0184990