### PR TITLE
Fix zoomed form popups

### DIFF
--- a/src/erp.mgt.mn/components/Modal.jsx
+++ b/src/erp.mgt.mn/components/Modal.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 export default function Modal({ visible, title, onClose, children, width = 'auto' }) {
   const [closing, setClosing] = useState(false);
@@ -76,15 +77,25 @@ export default function Modal({ visible, title, onClose, children, width = 'auto
     alignItems: 'center',
   };
 
-  return (
-    <div style={overlayStyle} onClick={(e) => e.target === e.currentTarget && handleClose()}>
+  const content = (
+    <div
+      style={overlayStyle}
+      onClick={(e) => e.target === e.currentTarget && handleClose()}
+    >
       <div ref={modalRef} style={modalStyle}>
         <div style={headerStyle} onMouseDown={startDrag}>
           <span>{title}</span>
-          <button onClick={handleClose} style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '1rem' }}>×</button>
+          <button
+            onClick={handleClose}
+            style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '1rem' }}
+          >
+            ×
+          </button>
         </div>
         <div style={{ padding: '1rem' }}>{children}</div>
       </div>
     </div>
   );
+  return createPortal(content, document.body);
 }
+

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -107,17 +107,27 @@ const RowFormModal = function RowFormModal({
 
   useEffect(() => {
     if (!fitted) return;
+    if (!wrapRef.current) return;
+    const el = wrapRef.current;
     function updateZoom() {
-      if (!wrapRef.current) return;
-      const { scrollWidth, scrollHeight } = wrapRef.current;
-      const wRatio = scrollWidth ? window.innerWidth / scrollWidth : 1;
-      const hRatio = scrollHeight ? window.innerHeight / scrollHeight : 1;
+      const parent = el.parentElement;
+      const parentW = parent?.clientWidth ?? window.innerWidth;
+      const parentH = parent?.clientHeight ?? window.innerHeight;
+      const { scrollWidth, scrollHeight } = el;
+      const wRatio = scrollWidth ? parentW / scrollWidth : 1;
+      const hRatio = scrollHeight ? parentH / scrollHeight : 1;
       const s = Math.min(1, wRatio, hRatio);
       setZoom(s);
     }
+    const ro = new ResizeObserver(updateZoom);
+    ro.observe(el);
+    if (el.parentElement) ro.observe(el.parentElement);
     updateZoom();
     window.addEventListener('resize', updateZoom);
-    return () => window.removeEventListener('resize', updateZoom);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener('resize', updateZoom);
+    };
   }, [fitted, visible]);
   const placeholders = React.useMemo(() => {
     const map = {};


### PR DESCRIPTION
## Summary
- portal Modal component to body so it isn't clipped
- render AsyncSearchSelect dropdown in a portal and track position
- revert overflow style so fitted subwindows remain resizable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877dc92891c8331bf11adfcc0184990