### PR TITLE
Fix fitted form resizing

### DIFF
--- a/config/posTransactionConfig.json
+++ b/config/posTransactionConfig.json
@@ -1,1 +1,7 @@
-{}
+{
+  "example": {
+    "labelSize": 100,
+    "boxSize": 180,
+    "tables": []
+  }
+}

--- a/docs/pos-transaction-layout.md
+++ b/docs/pos-transaction-layout.md
@@ -1,0 +1,29 @@
+# POS Transaction Layout Settings
+
+Forms used by POS transactions support a special **fitted** view. In this mode
+all padding and borders are removed so the contents fill the parent window.
+The layout can be tuned globally per transaction configuration by adding the
+following optional properties to each entry inside `config/posTransactionConfig.json`:
+
+```json
+{
+  "labelSize": 100,
+  "boxSize": 180
+}
+```
+
+`labelSize` controls the pixel width of each label while `boxSize` defines the
+width of the input element. When omitted, the defaults are `100` and `180`
+respectively. Only fitted forms apply these settings.
+
+Example configuration snippet:
+
+```json
+{
+  "sales": {
+    "labelSize": 120,
+    "boxSize": 200,
+    "tables": []
+  }
+}
+```

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -32,6 +32,8 @@ const RowFormModal = function RowFormModal({
   inline = false,
   useGrid = false,
   fitted = false,
+  labelSize = 100,
+  boxSize = 180,
   onNextForm = null,
 }) {
   const mounted = useRef(false);
@@ -107,17 +109,27 @@ const RowFormModal = function RowFormModal({
 
   useEffect(() => {
     if (!fitted) return;
+    const wrap = wrapRef.current;
+    const parent = wrap?.parentElement || null;
+
     function updateZoom() {
-      if (!wrapRef.current) return;
-      const { scrollWidth, scrollHeight } = wrapRef.current;
-      const wRatio = scrollWidth ? window.innerWidth / scrollWidth : 1;
-      const hRatio = scrollHeight ? window.innerHeight / scrollHeight : 1;
+      if (!wrap || !parent) return;
+      const { scrollWidth, scrollHeight } = wrap;
+      const wRatio = scrollWidth ? parent.clientWidth / scrollWidth : 1;
+      const hRatio = scrollHeight ? parent.clientHeight / scrollHeight : 1;
       const s = Math.min(1, wRatio, hRatio);
       setZoom(s);
     }
+
     updateZoom();
+    const ro = parent ? new ResizeObserver(updateZoom) : null;
+    if (ro && parent) ro.observe(parent);
     window.addEventListener('resize', updateZoom);
-    return () => window.removeEventListener('resize', updateZoom);
+
+    return () => {
+      if (ro && parent) ro.disconnect();
+      window.removeEventListener('resize', updateZoom);
+    };
   }, [fitted, visible]);
   const placeholders = React.useMemo(() => {
     const map = {};
@@ -215,7 +227,7 @@ const RowFormModal = function RowFormModal({
       ? columns.filter((c) => mainSet.has(c))
       : columns.filter((c) => !headerSet.has(c) && !footerSet.has(c));
 
-  const formGridClass = 'grid gap-2';
+  const formGridClass = fitted ? 'grid gap-1' : 'grid gap-2';
   const formGridStyle = fitted
     ? {
         gridTemplateColumns: 'repeat(auto-fit, minmax(min(20rem, 40vw), 1fr))',
@@ -223,8 +235,11 @@ const RowFormModal = function RowFormModal({
         fontSize: 'calc(0.65rem + 0.35vw + 0.35vh)',
       }
     : { gridTemplateColumns: 'repeat(2, minmax(0, 1fr))' };
+  const labelStyle = fitted
+    ? { display: 'inline-block', width: `${labelSize}px`, minWidth: `${labelSize}px` }
+    : undefined;
   const inputStyle = fitted
-    ? { fontSize: 'inherit', padding: '0.25rem 0.5rem' }
+    ? { fontSize: 'inherit', padding: '0.25rem 0.5rem', width: `${boxSize}px`, minWidth: `${boxSize}px` }
     : undefined;
 
   function handleKeyDown(e, col) {
@@ -467,8 +482,8 @@ const RowFormModal = function RowFormModal({
     if (!withLabel) return <>{control}</>;
 
     return (
-      <div key={c} className="mb-3">
-        <label className="block mb-1 font-medium">
+      <div key={c} className={fitted ? 'mb-1' : 'mb-3'}>
+        <label className="block mb-1 font-medium" style={labelStyle}>
           {labels[c] || c}
           {requiredFields.includes(c) && (
             <span className="text-red-500">*</span>
@@ -484,7 +499,7 @@ const RowFormModal = function RowFormModal({
     if (cols.length === 0) return null;
     if (fitted) {
       return (
-        <div className="mb-4">
+        <div className="mb-1">
           <h3 className="mt-0 mb-1 font-semibold">Main</h3>
           <div className={formGridClass} style={formGridStyle}>
             {cols.map((c) => renderField(c))}
@@ -592,8 +607,8 @@ const RowFormModal = function RowFormModal({
             }
           }
           return (
-            <div key={c} className="mb-3">
-              <label className="block mb-1 font-medium">{labels[c] || c}</label>
+            <div key={c} className={fitted ? 'mb-1' : 'mb-3'}>
+              <label className="block mb-1 font-medium" style={labelStyle}>{labels[c] || c}</label>
               <input
                 type="text"
                 value={val}
@@ -608,7 +623,7 @@ const RowFormModal = function RowFormModal({
     );
     if (fitted) {
       return (
-        <div className="mb-4">
+        <div className="mb-1">
           <h3 className="mt-0 mb-1 font-semibold">Header</h3>
           {grid}
         </div>
@@ -649,7 +664,7 @@ const RowFormModal = function RowFormModal({
   function renderSection(title, cols) {
     if (cols.length === 0) return null;
     return (
-      <div className="mb-2">
+      <div className={fitted ? 'mb-1' : 'mb-2'}>
         <h3 className="mt-0 mb-1 font-semibold">{title}</h3>
         <div className={formGridClass} style={formGridStyle}>
           {cols.map((c) => renderField(c))}
@@ -724,7 +739,11 @@ const RowFormModal = function RowFormModal({
 
   if (inline) {
     return (
-      <div className="p-4 space-y-4" ref={wrapRef} style={{ transform: `scale(${zoom})`, transformOrigin: '0 0' }}>
+      <div
+        className={fitted ? 'space-y-2' : 'p-4 space-y-4'}
+        ref={wrapRef}
+        style={{ transform: `scale(${zoom})`, transformOrigin: '0 0', padding: fitted ? 0 : undefined }}
+      >
         {renderHeaderTable(headerCols)}
         {renderMainTable(mainCols)}
         {renderSection('Footer', footerCols)}
@@ -740,12 +759,12 @@ const RowFormModal = function RowFormModal({
     >
       <form
         ref={wrapRef}
-        style={{ transform: `scale(${zoom})`, transformOrigin: '0 0' }}
+        style={{ transform: `scale(${zoom})`, transformOrigin: '0 0', padding: fitted ? 0 : undefined }}
         onSubmit={(e) => {
           e.preventDefault();
           submitForm();
         }}
-        className="p-4 space-y-4"
+        className={fitted ? 'space-y-2' : 'p-4 space-y-4'}
       >
         {renderHeaderTable(headerCols)}
         {renderMainTable(mainCols)}

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -676,6 +676,8 @@ export default function PosTransactionsPage() {
                       onSubmit={(row) => handleSubmit(t.table, row)}
                       useGrid={t.view === 'table' || t.type === 'multi'}
                       fitted={t.view === 'fitted'}
+                      labelSize={config.labelSize}
+                      boxSize={config.boxSize}
                       onNextForm={() => focusFirst(formList[idx + 1]?.table)}
                     />
                   </div>


### PR DESCRIPTION
## Summary
- adjust RowFormModal scaling based on its container size
- tighten fitted forms and make label/input sizes configurable
- pass layout sizing via POS transaction config
- document fitted form settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687877a96e948331a4c76fe2864a1f1a