### PR TITLE
Improve POS transaction session records

### DIFF
--- a/api-server/routes/pos_txn_pending.js
+++ b/api-server/routes/pos_txn_pending.js
@@ -9,9 +9,12 @@ router.get('/', requireAuth, async (req, res, next) => {
     const { id, name } = req.query;
     if (id) {
       const rec = await getPending(id);
+      if (!rec || (rec.userId && rec.userId !== req.user.id)) {
+        return res.status(404).json({ message: 'Not found' });
+      }
       res.json(rec || {});
     } else {
-      const list = await listPending(name);
+      const list = await listPending(name, req.user.id);
       res.json(list);
     }
   } catch (err) {
@@ -23,7 +26,7 @@ router.post('/', requireAuth, async (req, res, next) => {
   try {
     const { id, name, data, masterId } = req.body;
     if (!name) return res.status(400).json({ message: 'name is required' });
-    const result = await savePending(id, { name, data, masterId });
+    const result = await savePending(id, { name, data, masterId }, req.user.id);
     res.json({ id: result.id });
   } catch (err) {
     next(err);

--- a/api-server/routes/pos_txn_post.js
+++ b/api-server/routes/pos_txn_post.js
@@ -6,9 +6,10 @@ const router = express.Router();
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {
-    const { name, data } = req.body;
+    const { name, data, session } = req.body;
     if (!name || !data) return res.status(400).json({ message: 'invalid data' });
-    const rec = await addTransaction(name, data);
+    const info = { ...(session || {}), userId: req.user.id };
+    const rec = await addTransaction(name, data, info);
     res.json({ id: rec.id });
   } catch (err) {
     next(err);

--- a/api-server/services/posTransactionPending.js
+++ b/api-server/services/posTransactionPending.js
@@ -16,12 +16,13 @@ async function writeData(data) {
   await fs.writeFile(filePath, JSON.stringify(data, null, 2));
 }
 
-export async function listPending(name) {
+export async function listPending(name, userId) {
   const all = await readData();
-  if (!name) return all;
   const filtered = {};
   for (const [id, rec] of Object.entries(all)) {
-    if (rec.name === name) filtered[id] = rec;
+    if (name && rec.name !== name) continue;
+    if (userId && rec.userId !== userId) continue;
+    filtered[id] = rec;
   }
   return filtered;
 }
@@ -31,13 +32,13 @@ export async function getPending(id) {
   return all[id] || null;
 }
 
-export async function savePending(id, record) {
+export async function savePending(id, record, userId) {
   const all = await readData();
   if (!id) {
     id = 'txn_' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
   }
   const key = String(id);
-  all[key] = { ...record, savedAt: new Date().toISOString() };
+  all[key] = { ...record, userId, savedAt: new Date().toISOString() };
   await writeData(all);
   return { id: key, record: all[key] };
 }

--- a/api-server/services/posTransactions.js
+++ b/api-server/services/posTransactions.js
@@ -16,9 +16,15 @@ async function writeData(arr) {
   await fs.writeFile(filePath, JSON.stringify(arr, null, 2));
 }
 
-export async function addTransaction(name, data) {
+export async function addTransaction(name, data, sessionInfo = {}) {
   const list = await readData();
-  const rec = { id: 'post_' + Date.now().toString(36), name, data, postedAt: new Date().toISOString() };
+  const rec = {
+    id: 'post_' + Date.now().toString(36),
+    name,
+    data,
+    ...sessionInfo,
+    postedAt: new Date().toISOString(),
+  };
   list.push(rec);
   await writeData(list);
   return rec;

--- a/docs/unified-pos-transaction-buttons.md
+++ b/docs/unified-pos-transaction-buttons.md
@@ -32,3 +32,6 @@ This module includes a single set of buttons used by every POS transaction confi
 - On success, deletes the pending entry, updates the `statusField` to `posted`, and leaves the master record intact.
 - Hidden forms are included in the submission automatically.
 - Error messages report the problematic field and value whenever possible.
+
+Posted transactions are recorded in `config/posTransactions.json` together with
+the company, branch and employee that created them and the posting date.

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useContext } from 'react';
 import RowFormModal from '../components/RowFormModal.jsx';
 import Modal from '../components/Modal.jsx';
 import { useToast } from '../context/ToastContext.jsx';
+import { AuthContext } from '../context/AuthContext.jsx';
 
 function parseErrorField(msg) {
   if (!msg) return null;
@@ -112,6 +113,7 @@ async function putRow(addToast, table, id, row) {
 
 export default function PosTransactionsPage() {
   const { addToast } = useToast();
+  const { user, company } = useContext(AuthContext);
   const [configs, setConfigs] = useState({});
   const [name, setName] = useState('');
   const [config, setConfig] = useState(null);
@@ -537,12 +539,18 @@ export default function PosTransactionsPage() {
       else single[t.table] = payload[t.table];
     });
     const postData = { masterId: masterIdRef.current, single, multi };
+    const session = {
+      employeeId: user?.empid,
+      companyId: company?.company_id,
+      branchId: company?.branch_id,
+      date: new Date().toISOString(),
+    };
     try {
       const res = await fetch('/api/pos_txn_post', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ name, data: postData }),
+        body: JSON.stringify({ name, data: postData, session }),
       });
       if (res.ok) {
         if (pendingId) {
@@ -633,7 +641,18 @@ export default function PosTransactionsPage() {
       <h2>{config?.label || 'POS Transactions'}</h2>
       {configNames.length > 0 && (
         <div style={{ marginBottom: '0.5rem' }}>
-          <select value={name} onChange={e => setName(e.target.value)}>
+          <select
+            value={name}
+            onChange={e => {
+              const newName = e.target.value;
+              if (newName === name) {
+                handleNew();
+              } else {
+                setName(newName);
+                initRef.current = '';
+              }
+            }}
+          >
             <option value="">-- select config --</option>
             {configNames.map(n => (
               <option key={n} value={n}>{n}</option>


### PR DESCRIPTION
## Summary
- filter pending transactions by the requesting user
- attach session info when posting transactions
- allow reselecting a transaction to reinitialize forms
- persist posted session metadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878b24d545c8331aebec924a1df40f9