### PR TITLE
Improve dynamic form field handling

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -33,7 +33,7 @@ const RowFormModal = function RowFormModal({
   useGrid = false,
   fitted = false,
   labelFontSize = 14,
-  boxWidth = 180,
+  boxWidth = 60,
   boxHeight = 30,
   onNextForm = null,
 }) {
@@ -223,17 +223,17 @@ const RowFormModal = function RowFormModal({
   const totalCurrencySet = new Set(totalCurrencyFields);
   const headerCols = columns.filter((c) => headerSet.has(c));
   const footerCols = columns.filter((c) => footerSet.has(c));
-  const mainCols =
-    mainFields.length > 0
-      ? columns.filter((c) => mainSet.has(c))
-      : columns.filter((c) => !headerSet.has(c) && !footerSet.has(c));
+  const mainCols = mainFields.length > 0
+    ? columns.filter((c) => mainSet.has(c))
+    : [];
 
   const formGridClass = fitted ? 'grid' : 'grid gap-2';
   const inputFontSize = Math.max(10, Math.round(boxHeight * 0.6));
+  const maxWidth = 150;
   const formGridStyle = fitted
     ? {
         gap: '2px',
-        gridTemplateColumns: `repeat(auto-fill, minmax(${boxWidth}px, 1fr))`,
+        gridTemplateColumns: `repeat(auto-fill, minmax(${boxWidth}px, ${maxWidth}px))`,
         fontSize: `${inputFontSize}px`,
       }
     : { gridTemplateColumns: 'repeat(2, minmax(0, 1fr))' };
@@ -242,9 +242,10 @@ const RowFormModal = function RowFormModal({
     ? {
         fontSize: `${inputFontSize}px`,
         padding: '0.25rem 0.5rem',
-        width: `${boxWidth}px`,
+        width: '100%',
+        minWidth: `${boxWidth}px`,
+        maxWidth: `${maxWidth}px`,
         height: `${boxHeight}px`,
-        maxWidth: '100%',
       }
     : undefined;
 

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1002,6 +1002,21 @@ const TableManager = forwardRef(function TableManager({
   const ordered = formConfig?.visibleFields?.length
     ? allColumns.filter((c) => formConfig.visibleFields.includes(c))
     : allColumns;
+
+  const selectedForForm = new Set([
+    ...(formConfig?.headerFields || []),
+    ...(formConfig?.mainFields || []),
+    ...(formConfig?.footerFields || []),
+  ]);
+
+  let formColumns = [];
+  if (selectedForForm.size > 0) {
+    formColumns = allColumns.filter((c) => selectedForForm.has(c));
+  } else if (formConfig?.visibleFields?.length) {
+    formColumns = ordered.slice();
+  } else {
+    formColumns = allColumns.slice();
+  }
   const labels = {};
   columnMeta.forEach((c) => {
     labels[c.name] = c.label || c.name;
@@ -1079,10 +1094,14 @@ const TableManager = forwardRef(function TableManager({
     )
     .map(([k]) => k);
 
+  const editableSet = new Set(formConfig?.editableDefaultFields || []);
+  const nonEditable = formColumns.filter((c) => !editableSet.has(c));
+
   const disabledFields = editing
-    ? [...getKeyFields(), ...lockedDefaults]
-    : lockedDefaults;
-  let formColumns = ordered.filter(
+    ? [...getKeyFields(), ...lockedDefaults, ...nonEditable]
+    : [...lockedDefaults, ...nonEditable];
+
+  formColumns = formColumns.filter(
     (c) => !autoCols.has(c) && c !== 'created_at' && c !== 'created_by'
   );
 


### PR DESCRIPTION
## Summary
- always show header, main and footer fields if configured
- honor `editableDefaultFields` for all fields
- shrink fitted form grid size and allow stretch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687909f471608331af342d7ed7ad2527