### PR TITLE
Implement viewSource auto-fill

### DIFF
--- a/docs/transaction-form-config.md
+++ b/docs/transaction-form-config.md
@@ -26,6 +26,11 @@ Each **transaction** entry allows you to specify:
 - **mainFields** – fields shown in the main section
 - **footerFields** – fields shown in the footer section
 - **viewSource** – map of field names to SQL view names
+- When a field is mapped to a view, entering a value in that field triggers
+  a lookup against the specified view. The first matching row is fetched and any
+  columns that exist in the current table are automatically populated with the
+  returned values. Display field mappings from `tableDisplayFields.json` are
+  respected when assigning data.
 - **transactionTypeField** – column used to store the transaction type code
 - **transactionTypeValue** – default transaction type code value
 - **moduleKey** – module slug used to group the form under a module. If omitted,

--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -47,6 +47,8 @@ export default forwardRef(function InlineTransactionTable({
   defaultValues = {},
   onNextForm = null,
   rows: initRows = [],
+  columnCaseMap = {},
+  viewSource = {},
 }, ref) {
   const mounted = useRef(false);
   const renderCount = useRef(0);
@@ -247,8 +249,9 @@ export default forwardRef(function InlineTransactionTable({
         if (conf && conf.displayFields && relationData[field]?.[val]) {
           const ref = relationData[field][val];
           conf.displayFields.forEach((df) => {
-            if (ref[df] !== undefined) {
-              updated[df] = ref[df];
+            const key = columnCaseMap[df.toLowerCase()];
+            if (key && ref[df] !== undefined) {
+              updated[key] = ref[df];
             }
           });
         }
@@ -260,6 +263,34 @@ export default forwardRef(function InlineTransactionTable({
     if (invalidCell && invalidCell.row === rowIdx && invalidCell.field === field) {
       setInvalidCell(null);
       setErrorMsg('');
+    }
+
+    const view = viewSource[field];
+    if (view && value !== '') {
+      const params = new URLSearchParams({ perPage: 1 });
+      params.set(field, typeof value === 'object' && 'value' in value ? value.value : value);
+      fetch(`/api/tables/${encodeURIComponent(view)}?${params.toString()}`, {
+        credentials: 'include',
+      })
+        .then((res) => (res.ok ? res.json() : null))
+        .then((data) => {
+          if (!data || !Array.isArray(data.rows) || data.rows.length === 0) return;
+          const rowData = data.rows[0];
+          setRows((r) => {
+            const next = r.map((row, i) => {
+              if (i !== rowIdx) return row;
+              const updated = { ...row };
+              Object.entries(rowData).forEach(([k, v]) => {
+                const key = columnCaseMap[k.toLowerCase()];
+                if (key) updated[key] = v;
+              });
+              return updated;
+            });
+            onRowsChange(next);
+            return next;
+          });
+        })
+        .catch(() => {});
     }
   }
 
@@ -312,12 +343,14 @@ export default forwardRef(function InlineTransactionTable({
     const cleaned = {};
     Object.entries(row).forEach(([k, v]) => {
       if (k === '_saved') return;
+      const key = columnCaseMap[k.toLowerCase()];
+      if (!key) return;
       let val = typeof v === 'object' && v !== null && 'value' in v ? v.value : v;
-      if (placeholders[k]) val = normalizeDateInput(val, placeholders[k]);
-      if (totalAmountSet.has(k) || totalCurrencySet.has(k)) {
+      if (placeholders[key]) val = normalizeDateInput(val, placeholders[key]);
+      if (totalAmountSet.has(key) || totalCurrencySet.has(key)) {
         val = normalizeNumberInput(val);
       }
-      cleaned[k] = val;
+      cleaned[key] = val;
     });
     const ok = await Promise.resolve(onRowSubmit(cleaned));
     if (ok !== false) {

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -36,6 +36,8 @@ const RowFormModal = function RowFormModal({
   boxWidth = 60,
   boxHeight = 30,
   onNextForm = null,
+  columnCaseMap = {},
+  viewSource = {},
 }) {
   const mounted = useRef(false);
   const renderCount = useRef(0);
@@ -553,6 +555,8 @@ const RowFormModal = function RowFormModal({
             labels={labels}
             totalAmountFields={totalAmountFields}
             totalCurrencyFields={totalCurrencyFields}
+            viewSource={viewSource}
+            columnCaseMap={columnCaseMap}
             collectRows={useGrid}
             minRows={1}
             onRowSubmit={onSubmit}


### PR DESCRIPTION
## Summary
- extend transaction forms to populate fields using SQL views
- fetch matching rows from configured views when a mapped field changes
- apply matching values to current form via case-insensitive mapping
- document new viewSource behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bafaa9cec8331a1021400b9fb972a