### PR TITLE
Normalize trigger lookup

### DIFF
--- a/api-server/routes/proc_triggers.js
+++ b/api-server/routes/proc_triggers.js
@@ -1,0 +1,18 @@
+import express from 'express';
+import { requireAuth } from '../middlewares/auth.js';
+import { getProcTriggers } from '../services/procTriggers.js';
+
+const router = express.Router();
+
+router.get('/', requireAuth, async (req, res, next) => {
+  try {
+    const { table } = req.query;
+    if (!table) return res.status(400).json({ message: 'table required' });
+    const triggers = await getProcTriggers(table);
+    res.json(triggers);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/api-server/routes/procedures.js
+++ b/api-server/routes/procedures.js
@@ -6,10 +6,14 @@ const router = express.Router();
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {
-    const { name, params } = req.body || {};
+    const { name, params, aliases } = req.body || {};
     if (!name) return res.status(400).json({ message: 'name required' });
-    const rows = await callStoredProcedure(name, Array.isArray(params) ? params : []);
-    res.json({ rows });
+    const row = await callStoredProcedure(
+      name,
+      Array.isArray(params) ? params : [],
+      Array.isArray(aliases) ? aliases : [],
+    );
+    res.json({ row });
   } catch (err) {
     next(err);
   }

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -29,6 +29,7 @@ import posTxnPostRoutes from "./routes/pos_txn_post.js";
 import viewsRoutes from "./routes/views.js";
 import transactionRoutes from "./routes/transactions.js";
 import procedureRoutes from "./routes/procedures.js";
+import procTriggerRoutes from "./routes/proc_triggers.js";
 import { requireAuth } from "./middlewares/auth.js";
 
 // Polyfill for __dirname in ES modules
@@ -74,6 +75,7 @@ app.use("/api/pos_txn_pending", posTxnPendingRoutes);
 app.use("/api/pos_txn_post", posTxnPostRoutes);
 app.use("/api/views", viewsRoutes);
 app.use("/api/procedures", requireAuth, procedureRoutes);
+app.use("/api/proc_triggers", requireAuth, procTriggerRoutes);
 app.use("/api/inventory_transactions", requireAuth, transactionRoutes);
 app.use("/api/tables", requireAuth, tableRoutes);
 

--- a/api-server/services/procTriggers.js
+++ b/api-server/services/procTriggers.js
@@ -1,0 +1,43 @@
+import { pool } from '../../db/index.js';
+
+export async function getProcTriggers(table) {
+  const [rows] = await pool.query('SHOW TRIGGERS WHERE `Table` = ?', [table]);
+  const result = {};
+  for (const row of rows || []) {
+    const stmt = row.Statement || '';
+    const varToCol = {};
+    stmt.replace(/SET\s+NEW\.([A-Za-z0-9_]+)\s*=\s*([A-Za-z0-9_]+)/gi, (_, col, v) => {
+      varToCol[v.toLowerCase()] = col;
+      return '';
+    });
+    const calls = [...stmt.matchAll(/CALL\s+([A-Za-z0-9_]+)\s*\(([^)]*)\)/gi)];
+    for (const c of calls) {
+      const [, proc, paramStr] = c;
+      const params = paramStr
+        .split(',')
+        .map((p) => p.trim())
+        .map((p) => {
+          if (/^NEW\./i.test(p)) return p.replace(/^NEW\./i, '');
+          if (/CURDATE\(\)/i.test(p)) return '$date';
+          return p.replace(/['`]/g, '');
+        })
+        .map((p) => p.toLowerCase());
+      const outMap = {};
+      params.forEach((p) => {
+        if (varToCol[p]) outMap[p] = varToCol[p];
+      });
+      params.forEach((p) => {
+        if (!p) return;
+        if (!result[p]) result[p] = [];
+        const exists = result[p].some(
+          (cfg) =>
+            cfg.name === proc &&
+            JSON.stringify(cfg.params) === JSON.stringify(params) &&
+            JSON.stringify(cfg.outMap) === JSON.stringify(outMap),
+        );
+        if (!exists) result[p].push({ name: proc, params, outMap });
+      });
+    }
+  }
+  return result;
+}

--- a/db/index.js
+++ b/db/index.js
@@ -973,10 +973,47 @@ export async function listInventoryTransactions({
   return { rows, count };
 }
 
-export async function callStoredProcedure(name, params = []) {
-  const placeholders = params.map(() => '?').join(', ');
-  const sql = `CALL ${name}(${placeholders})`;
-  const [rows] = await pool.query(sql, params);
-  if (Array.isArray(rows)) return rows[0] || [];
-  return rows || [];
+export async function callStoredProcedure(name, params = [], aliases = []) {
+  const conn = await pool.getConnection();
+  try {
+    const callParts = [];
+    const callArgs = [];
+    const outVars = [];
+
+    for (let i = 0; i < params.length; i++) {
+      const alias = aliases[i];
+      const value = params[i];
+      const cleanVal = value === '' || value === undefined ? null : value;
+      if (alias) {
+        const varName = `@_${name}_${i}`;
+        await conn.query(`SET ${varName} = ?`, [cleanVal]);
+        callParts.push(varName);
+        outVars.push([alias, varName]);
+      } else {
+        callParts.push('?');
+        callArgs.push(cleanVal);
+      }
+    }
+
+    const sql = `CALL ${name}(${callParts.join(', ')})`;
+    const [rows] = await conn.query(sql, callArgs);
+    let first = Array.isArray(rows) ? rows[0] || {} : rows || {};
+
+    if (outVars.length > 0) {
+      const selectSql =
+        'SELECT ' + outVars.map(([n, v]) => `${v} AS \`${n}\``).join(', ');
+      const [outRows] = await conn.query(selectSql);
+      if (Array.isArray(outRows) && outRows[0]) {
+        first = { ...first, ...outRows[0] };
+      }
+    }
+
+    aliases.forEach((alias) => {
+      if (alias && !(alias in first)) first[alias] = null;
+    });
+
+    return first;
+  } finally {
+    conn.release();
+  }
 }

--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -49,6 +49,9 @@ export default forwardRef(function InlineTransactionTable({
   rows: initRows = [],
   columnCaseMap = {},
   viewSource = {},
+  procTriggers = {},
+  user = {},
+  company = {},
 }, ref) {
   const mounted = useRef(false);
   const renderCount = useRef(0);
@@ -85,6 +88,7 @@ export default forwardRef(function InlineTransactionTable({
   const addBtnRef = useRef(null);
   const [errorMsg, setErrorMsg] = useState('');
   const [invalidCell, setInvalidCell] = useState(null);
+  const procCache = useRef({});
 
   const totalAmountSet = new Set(totalAmountFields);
   const totalCurrencySet = new Set(totalCurrencyFields);
@@ -169,6 +173,182 @@ export default forwardRef(function InlineTransactionTable({
       }),
     hasInvalid: () => invalidCell !== null,
   }));
+
+  function getDirectTriggers(col) {
+    const val = procTriggers[col.toLowerCase()];
+    if (!val) return [];
+    return Array.isArray(val) ? val : [val];
+  }
+
+  function getParamTriggers(col) {
+    const res = [];
+    const colLower = col.toLowerCase();
+    Object.entries(procTriggers).forEach(([tCol, cfgList]) => {
+      const list = Array.isArray(cfgList) ? cfgList : [cfgList];
+      list.forEach((cfg) => {
+        if (Array.isArray(cfg.params) && cfg.params.includes(colLower)) {
+          res.push([tCol, cfg]);
+        }
+      });
+    });
+    return res;
+  }
+
+  function hasTrigger(col) {
+    return getDirectTriggers(col).length > 0 || getParamTriggers(col).length > 0;
+  }
+
+  function showTriggerInfo(col) {
+    const direct = getDirectTriggers(col);
+    const paramTrigs = getParamTriggers(col);
+
+    if (direct.length === 0 && paramTrigs.length === 0) {
+      window.dispatchEvent(
+        new CustomEvent('toast', {
+          detail: { message: `${col} талбар триггер ашигладаггүй`, type: 'info' },
+        }),
+      );
+      return;
+    }
+
+    const directNames = [...new Set(direct.map((d) => d.name))];
+    directNames.forEach((name) => {
+      window.dispatchEvent(
+        new CustomEvent('toast', {
+          detail: { message: `${col} -> ${name}`, type: 'info' },
+        }),
+      );
+    });
+
+    if (paramTrigs.length > 0) {
+      const names = [...new Set(paramTrigs.map(([, cfg]) => cfg.name))].join(', ');
+      window.dispatchEvent(
+        new CustomEvent('toast', {
+          detail: {
+            message: `${col} талбар параметр болгож дараах процедуруудад ашиглана: ${names}`,
+            type: 'info',
+          },
+        }),
+      );
+    }
+  }
+
+  async function runProcTrigger(rowIdx, col) {
+    const direct = getDirectTriggers(col);
+    const paramTrigs = getParamTriggers(col);
+
+    const map = new Map();
+    direct.forEach((cfg) => {
+      if (!cfg || !cfg.name) return;
+      const key = JSON.stringify([cfg.name, cfg.params, cfg.outMap]);
+      const rec = map.get(key) || { cfg, cols: new Set() };
+      rec.cols.add(col.toLowerCase());
+      map.set(key, rec);
+    });
+    paramTrigs.forEach(([tCol, cfg]) => {
+      if (!cfg || !cfg.name) return;
+      const key = JSON.stringify([cfg.name, cfg.params, cfg.outMap]);
+      const rec = map.get(key) || { cfg, cols: new Set() };
+      rec.cols.add(tCol.toLowerCase());
+      map.set(key, rec);
+    });
+    for (const { cfg, cols } of map.values()) {
+      const tCol = [...cols][0];
+      const { name: procName, params = [], outMap = {} } = cfg;
+      const targetCols = Object.values(outMap || {}).map((c) =>
+        columnCaseMap[c.toLowerCase()] || c,
+      );
+      const hasTarget = targetCols.some((c) => fields.includes(c));
+      if (!hasTarget) continue;
+      const getVal = (name) => {
+        const key = columnCaseMap[name.toLowerCase()] || name;
+        return rows[rowIdx]?.[key];
+      };
+      const getParam = (p) => {
+        if (p === '$current') return getVal(tCol);
+        if (p === '$branchId') return company?.branch_id;
+        if (p === '$companyId') return company?.company_id;
+        if (p === '$employeeId') return user?.empid;
+        if (p === '$date') return new Date().toISOString().slice(0, 10);
+        return getVal(p);
+      };
+      const paramValues = params.map(getParam);
+      const aliases = params.map((p) => outMap[p] || null);
+      const cacheKey = `${procName}|${JSON.stringify(paramValues)}`;
+      if (procCache.current[cacheKey]) {
+        const rowData = procCache.current[cacheKey];
+        setRows((r) => {
+          const next = r.map((row, i) => {
+            if (i !== rowIdx) return row;
+            const updated = { ...row };
+            Object.entries(rowData).forEach(([k, v]) => {
+              const key = columnCaseMap[k.toLowerCase()];
+              if (key) updated[key] = v;
+            });
+            return updated;
+          });
+          onRowsChange(next);
+          return next;
+        });
+        window.dispatchEvent(
+          new CustomEvent('toast', {
+            detail: { message: `Returned: ${JSON.stringify(rowData)}`, type: 'info' },
+          }),
+        );
+        continue;
+      }
+      window.dispatchEvent(
+        new CustomEvent('toast', {
+          detail: {
+            message: `${tCol} -> ${procName}(${paramValues.join(', ')})`,
+            type: 'info',
+          },
+        }),
+      );
+      try {
+        const res = await fetch('/api/procedures', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ name: procName, params: paramValues, aliases }),
+        });
+      const js = await res.json();
+      const rowData = js.row || {};
+      if (rowData && typeof rowData === 'object') {
+        procCache.current[cacheKey] = rowData;
+        setRows((r) => {
+          const next = r.map((row, i) => {
+            if (i !== rowIdx) return row;
+            const updated = { ...row };
+              Object.entries(rowData).forEach(([k, v]) => {
+                const key = columnCaseMap[k.toLowerCase()];
+                if (key) updated[key] = v;
+              });
+              return updated;
+            });
+            onRowsChange(next);
+            return next;
+          });
+          window.dispatchEvent(
+            new CustomEvent('toast', {
+              detail: { message: `Returned: ${JSON.stringify(rowData)}`, type: 'info' },
+            }),
+          );
+        }
+      } catch (err) {
+        console.error('Procedure call failed', err);
+        window.dispatchEvent(
+          new CustomEvent('toast', {
+            detail: { message: `Procedure failed: ${err.message}`, type: 'error' },
+          }),
+        );
+      }
+    }
+  }
+
+  function handleFocusField(col) {
+    showTriggerInfo(col);
+  }
 
   function addRow() {
     if (requiredFields.length > 0 && rows.length > 0) {
@@ -414,7 +594,7 @@ export default forwardRef(function InlineTransactionTable({
     return { sums, count };
   }, [rows, fields, totalAmountSet, totalCurrencySet, totalAmountFields]);
 
-  function handleKeyDown(e, rowIdx, colIdx) {
+  async function handleKeyDown(e, rowIdx, colIdx) {
     const isEnter = e.key === 'Enter';
     const isForwardTab = e.key === 'Tab' && !e.shiftKey;
     if (!isEnter && !isForwardTab) return;
@@ -458,6 +638,9 @@ export default forwardRef(function InlineTransactionTable({
       e.target.focus();
       if (e.target.select) e.target.select();
       return;
+    }
+    if (hasTrigger(field)) {
+      await runProcTrigger(rowIdx, field);
     }
     const nextCol = colIdx + 1;
     if (nextCol < fields.length) {
@@ -506,6 +689,7 @@ export default forwardRef(function InlineTransactionTable({
             }
             inputRef={(el) => (inputRefs.current[`${idx}-${colIdx}`] = el)}
             onKeyDown={(e) => handleKeyDown(e, idx, colIdx)}
+            onFocus={() => handleFocusField(f)}
             className={invalid ? 'border-red-500 bg-red-100' : ''}
           />
         );
@@ -519,6 +703,7 @@ export default forwardRef(function InlineTransactionTable({
             onChange={(e) => handleChange(idx, f, e.target.value)}
             ref={(el) => (inputRefs.current[`${idx}-${colIdx}`] = el)}
             onKeyDown={(e) => handleKeyDown(e, idx, colIdx)}
+            onFocus={() => handleFocusField(f)}
           >
             <option value="">-- select --</option>
             {relations[f].map((opt) => (
@@ -539,6 +724,7 @@ export default forwardRef(function InlineTransactionTable({
         onChange={(e) => handleChange(idx, f, e.target.value)}
         ref={(el) => (inputRefs.current[`${idx}-${colIdx}`] = el)}
         onKeyDown={(e) => handleKeyDown(e, idx, colIdx)}
+        onFocus={() => handleFocusField(f)}
         onInput={(e) => {
           e.target.style.height = 'auto';
           e.target.style.height = `${e.target.scrollHeight}px`;

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -43,6 +43,7 @@ const RowFormModal = function RowFormModal({
   const mounted = useRef(false);
   const renderCount = useRef(0);
   const warned = useRef(false);
+  const procCache = useRef({});
 
   renderCount.current++;
   if (renderCount.current > 10 && !warned.current) {
@@ -263,7 +264,7 @@ const RowFormModal = function RowFormModal({
       }
     : undefined;
 
-  function handleKeyDown(e, col) {
+  async function handleKeyDown(e, col) {
     if (e.key !== 'Enter') return;
     e.preventDefault();
     let val = normalizeDateInput(e.target.value, placeholders[col]);
@@ -291,6 +292,10 @@ const RowFormModal = function RowFormModal({
       setErrors((er) => ({ ...er, [col]: 'Буруу тоон утга' }));
       return;
     }
+    if (hasTrigger(col)) {
+      await runProcTrigger(col);
+    }
+
     const enabled = columns.filter((c) => !disabledFields.includes(c));
     const idx = enabled.indexOf(col);
     const next = enabled[idx + 1];
@@ -306,29 +311,110 @@ const RowFormModal = function RowFormModal({
     }
   }
 
-  async function handleFocusField(col) {
-    const cfg = procTriggers[col];
-    if (!cfg || !cfg.name) return;
-    const { name: procName, params = [] } = cfg;
-    const getParam = (p) => {
-      if (p === '$current') return formVals[col];
-      if (p === '$branchId') return company?.branch_id;
-      if (p === '$companyId') return company?.company_id;
-      if (p === '$employeeId') return user?.empid;
-      if (p === '$date') return new Date().toISOString().slice(0, 10);
-      return formVals[p] ?? extraVals[p];
-    };
-    const paramValues = params.map(getParam);
-    try {
-      const res = await fetch('/api/procedures', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ name: procName, params: paramValues }),
+  function getDirectTriggers(col) {
+    const val = procTriggers[col.toLowerCase()];
+    if (!val) return [];
+    return Array.isArray(val) ? val : [val];
+  }
+
+  function getParamTriggers(col) {
+    const res = [];
+    const colLower = col.toLowerCase();
+    Object.entries(procTriggers).forEach(([tCol, cfgList]) => {
+      const list = Array.isArray(cfgList) ? cfgList : [cfgList];
+      list.forEach((cfg) => {
+        if (Array.isArray(cfg.params) && cfg.params.includes(colLower)) {
+          res.push([tCol, cfg]);
+        }
       });
-      const js = await res.json();
-      const row = Array.isArray(js.rows) && js.rows.length > 0 ? js.rows[0] : {};
-      if (row && typeof row === 'object') {
+    });
+    return res;
+  }
+
+  function hasTrigger(col) {
+    return getDirectTriggers(col).length > 0 || getParamTriggers(col).length > 0;
+  }
+
+  function showTriggerInfo(col) {
+    const direct = getDirectTriggers(col);
+    const paramTrigs = getParamTriggers(col);
+
+    if (direct.length === 0 && paramTrigs.length === 0) {
+      window.dispatchEvent(
+        new CustomEvent('toast', {
+          detail: { message: `${col} талбар триггер ашигладаггүй`, type: 'info' },
+        }),
+      );
+      return;
+    }
+
+    const directNames = [...new Set(direct.map((d) => d.name))];
+    directNames.forEach((name) => {
+      window.dispatchEvent(
+        new CustomEvent('toast', {
+          detail: { message: `${col} -> ${name}`, type: 'info' },
+        }),
+      );
+    });
+
+    if (paramTrigs.length > 0) {
+      const names = [...new Set(paramTrigs.map(([, cfg]) => cfg.name))].join(', ');
+      window.dispatchEvent(
+        new CustomEvent('toast', {
+          detail: {
+            message: `${col} талбар параметр болгож дараах процедуруудад ашиглана: ${names}`,
+            type: 'info',
+          },
+        }),
+      );
+    }
+  }
+
+  async function runProcTrigger(col) {
+    const direct = getDirectTriggers(col);
+    const paramTrigs = getParamTriggers(col);
+
+    const map = new Map();
+    direct.forEach((cfg) => {
+      if (!cfg || !cfg.name) return;
+      const key = JSON.stringify([cfg.name, cfg.params, cfg.outMap]);
+      const rec = map.get(key) || { cfg, cols: new Set() };
+      rec.cols.add(col.toLowerCase());
+      map.set(key, rec);
+    });
+    paramTrigs.forEach(([tCol, cfg]) => {
+      if (!cfg || !cfg.name) return;
+      const key = JSON.stringify([cfg.name, cfg.params, cfg.outMap]);
+      const rec = map.get(key) || { cfg, cols: new Set() };
+      rec.cols.add(tCol.toLowerCase());
+      map.set(key, rec);
+    });
+
+    for (const { cfg, cols } of map.values()) {
+      const tCol = [...cols][0];
+      const { name: procName, params = [], outMap = {} } = cfg;
+      const targetCols = Object.values(outMap || {}).map((c) =>
+        columnCaseMap[c.toLowerCase()] || c,
+      );
+      const hasTarget = targetCols.some((c) => columns.includes(c));
+      if (!hasTarget) continue;
+      const getVal = (name) => {
+        const key = columnCaseMap[name.toLowerCase()] || name;
+        return formVals[key] ?? extraVals[key];
+      };
+      const getParam = (p) => {
+        if (p === '$current') return getVal(tCol);
+        if (p === '$branchId') return company?.branch_id;
+        if (p === '$companyId') return company?.company_id;
+        if (p === '$employeeId') return user?.empid;
+        if (p === '$date') return new Date().toISOString().slice(0, 10);
+        return getVal(p);
+      };
+      const paramValues = params.map(getParam);
+      const aliases = params.map((p) => outMap[p] || null);
+      const cacheKey = `${procName}|${JSON.stringify(paramValues)}`;
+      if (procCache.current[cacheKey]) {
+        const row = procCache.current[cacheKey];
         setExtraVals((v) => ({ ...v, ...row }));
         setFormVals((vals) => {
           const updated = { ...vals };
@@ -338,10 +424,60 @@ const RowFormModal = function RowFormModal({
           return updated;
         });
         onChange(row);
+        window.dispatchEvent(
+          new CustomEvent('toast', {
+            detail: { message: `Returned: ${JSON.stringify(row)}`, type: 'info' },
+          }),
+        );
+        continue;
+      }
+      window.dispatchEvent(
+        new CustomEvent('toast', {
+          detail: {
+            message: `${tCol} -> ${procName}(${paramValues.join(', ')})`,
+            type: 'info',
+        },
+      }),
+    );
+    try {
+      const res = await fetch('/api/procedures', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ name: procName, params: paramValues, aliases }),
+      });
+      const js = await res.json();
+      const row = js.row || {};
+      if (row && typeof row === 'object') {
+        procCache.current[cacheKey] = row;
+        setExtraVals((v) => ({ ...v, ...row }));
+        setFormVals((vals) => {
+          const updated = { ...vals };
+          Object.entries(row).forEach(([k, v]) => {
+            if (updated[k] !== undefined) updated[k] = v;
+          });
+          return updated;
+        });
+        onChange(row);
+        window.dispatchEvent(
+          new CustomEvent('toast', {
+            detail: { message: `Returned: ${JSON.stringify(row)}`, type: 'info' },
+          }),
+        );
       }
     } catch (err) {
       console.error('Procedure call failed', err);
+      window.dispatchEvent(
+        new CustomEvent('toast', {
+          detail: { message: `Procedure failed: ${err.message}`, type: 'error' },
+        }),
+      );
     }
+    }
+  }
+
+  async function handleFocusField(col) {
+    showTriggerInfo(col);
   }
 
   async function submitForm() {
@@ -609,6 +745,9 @@ const RowFormModal = function RowFormModal({
             totalAmountFields={totalAmountFields}
             totalCurrencyFields={totalCurrencyFields}
             viewSource={viewSource}
+            procTriggers={procTriggers}
+            user={user}
+            company={company}
             columnCaseMap={columnCaseMap}
             collectRows={useGrid}
             minRows={1}

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -132,6 +132,7 @@ const TableManager = forwardRef(function TableManager({
   const [gridRows, setGridRows] = useState([]);
   const [selectedRows, setSelectedRows] = useState(new Set());
   const [localRefresh, setLocalRefresh] = useState(0);
+  const [procTriggers, setProcTriggers] = useState({});
   const [deleteInfo, setDeleteInfo] = useState(null); // { id, refs }
   const [showCascade, setShowCascade] = useState(false);
   const [showDetail, setShowDetail] = useState(false);
@@ -237,6 +238,24 @@ const TableManager = forwardRef(function TableManager({
       })
       .catch(() => {
         addToast('Failed to load table columns', 'error');
+      });
+    return () => {
+      canceled = true;
+    };
+  }, [table]);
+
+  useEffect(() => {
+    if (!table) return;
+    let canceled = false;
+    fetch(`/api/proc_triggers?table=${encodeURIComponent(table)}`, {
+      credentials: 'include',
+    })
+      .then((res) => (res.ok ? res.json() : {}))
+      .then((data) => {
+        if (!canceled) setProcTriggers(data || {});
+      })
+      .catch(() => {
+        if (!canceled) setProcTriggers({});
       });
     return () => {
       canceled = true;
@@ -1805,6 +1824,7 @@ const TableManager = forwardRef(function TableManager({
         printCustField={formConfig?.printCustField || []}
         totalAmountFields={formConfig?.totalAmountFields || []}
         totalCurrencyFields={formConfig?.totalCurrencyFields || []}
+        procTriggers={procTriggers}
         columnCaseMap={columnCaseMap}
         viewSource={viewSourceMap}
         onRowsChange={setGridRows}


### PR DESCRIPTION
## Summary
- parse stored procedure triggers using lowercase keys
- normalize trigger lookups in forms and grid
- map parameter names to actual column case when calling procedures
- simplify stored procedure calls
- return a single row object from stored procedures
- cache stored procedure results per params to avoid duplicate calls
- deduplicate procedure trigger execution

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6880b5d0515c8331979d1c121de1fa4b