### PR TITLE
Fix procedure cache for preview

### DIFF
--- a/README_MIGRATION.md
+++ b/README_MIGRATION.md
@@ -35,6 +35,8 @@ Two SQL utilities assist with default module permissions:
 * `db/migrations/2025-06-12_role_default_modules.sql` – defines `role_default_modules` and seeds defaults.
 * `db/scripts/populate_role_module_permissions.sql` – copies those defaults into `role_module_permissions` for admin review.
 * `db/migrations/2025-06-14_role_module_permissions_company_id.sql` – adds a `company_id` column so permissions are scoped per company.
+* `db/migrations/2025-07-24_proc_fix.sql` – recreates `resolve_inventory_metadata` and `calculate_stock_per_branch` as read‑only procedures so triggers no longer attempt to update their source tables.
+* `db/migrations/2025-07-25_inventory_triggers.sql` – recreates inventory and expense triggers so they call the read‑only procedures without modifying their own tables.
 
 Run the script after applying the migration to initialize permissions for all roles.
 

--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -75,6 +75,9 @@ export async function updateRow(req, res, next) {
     await updateTableRow(req.params.table, req.params.id, updates);
     res.sendStatus(204);
   } catch (err) {
+    if (/Can't update table .* in stored function\/trigger/i.test(err.message)) {
+      return res.status(400).json({ message: err.message });
+    }
     next(err);
   }
 }
@@ -93,6 +96,9 @@ export async function addRow(req, res, next) {
     const result = await insertTableRow(req.params.table, row);
     res.status(201).json(result);
   } catch (err) {
+    if (/Can't update table .* in stored function\/trigger/i.test(err.message)) {
+      return res.status(400).json({ message: err.message });
+    }
     next(err);
   }
 }

--- a/api-server/routes/proc_triggers.js
+++ b/api-server/routes/proc_triggers.js
@@ -1,0 +1,18 @@
+import express from 'express';
+import { requireAuth } from '../middlewares/auth.js';
+import { getProcTriggers } from '../services/procTriggers.js';
+
+const router = express.Router();
+
+router.get('/', requireAuth, async (req, res, next) => {
+  try {
+    const { table } = req.query;
+    if (!table) return res.status(400).json({ message: 'table required' });
+    const triggers = await getProcTriggers(table);
+    res.json(triggers);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/api-server/routes/procedures.js
+++ b/api-server/routes/procedures.js
@@ -6,10 +6,14 @@ const router = express.Router();
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {
-    const { name, params } = req.body || {};
+    const { name, params, aliases } = req.body || {};
     if (!name) return res.status(400).json({ message: 'name required' });
-    const rows = await callStoredProcedure(name, Array.isArray(params) ? params : []);
-    res.json({ rows });
+    const row = await callStoredProcedure(
+      name,
+      Array.isArray(params) ? params : [],
+      Array.isArray(aliases) ? aliases : [],
+    );
+    res.json({ row });
   } catch (err) {
     next(err);
   }

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -29,6 +29,7 @@ import posTxnPostRoutes from "./routes/pos_txn_post.js";
 import viewsRoutes from "./routes/views.js";
 import transactionRoutes from "./routes/transactions.js";
 import procedureRoutes from "./routes/procedures.js";
+import procTriggerRoutes from "./routes/proc_triggers.js";
 import { requireAuth } from "./middlewares/auth.js";
 
 // Polyfill for __dirname in ES modules
@@ -74,6 +75,7 @@ app.use("/api/pos_txn_pending", posTxnPendingRoutes);
 app.use("/api/pos_txn_post", posTxnPostRoutes);
 app.use("/api/views", viewsRoutes);
 app.use("/api/procedures", requireAuth, procedureRoutes);
+app.use("/api/proc_triggers", requireAuth, procTriggerRoutes);
 app.use("/api/inventory_transactions", requireAuth, transactionRoutes);
 app.use("/api/tables", requireAuth, tableRoutes);
 

--- a/api-server/services/procTriggers.js
+++ b/api-server/services/procTriggers.js
@@ -1,0 +1,44 @@
+import { pool } from '../../db/index.js';
+
+export async function getProcTriggers(table) {
+  const [rows] = await pool.query('SHOW TRIGGERS WHERE `Table` = ?', [table]);
+  const result = {};
+  for (const row of rows || []) {
+    const stmt = row.Statement || '';
+    const varToCol = {};
+    stmt.replace(/SET\s+NEW\.([A-Za-z0-9_]+)\s*=\s*([A-Za-z0-9_]+)/gi, (_, col, v) => {
+      varToCol[v.toLowerCase()] = col;
+      return '';
+    });
+    const calls = [...stmt.matchAll(/CALL\s+([A-Za-z0-9_]+)\s*\(([^)]*)\)/gi)];
+    for (const c of calls) {
+      const [, proc, paramStr] = c;
+      const params = paramStr
+        .split(',')
+        .map((p) => p.trim())
+        .map((p) => {
+          if (/^NEW\./i.test(p)) return p.replace(/^NEW\./i, '');
+          if (/CURDATE\(\)/i.test(p)) return '$date';
+          return p.replace(/['`]/g, '');
+        })
+        .map((p) => p.toLowerCase());
+      const outMap = {};
+      params.forEach((p) => {
+        if (varToCol[p]) outMap[p] = varToCol[p];
+      });
+      params.forEach((p) => {
+        if (!p) return;
+        const key = (varToCol[p] || p).toLowerCase();
+        if (!result[key]) result[key] = [];
+        const exists = result[key].some(
+          (cfg) =>
+            cfg.name === proc &&
+            JSON.stringify(cfg.params) === JSON.stringify(params) &&
+            JSON.stringify(cfg.outMap) === JSON.stringify(outMap),
+        );
+        if (!exists) result[key].push({ name: proc, params, outMap });
+      });
+    }
+  }
+  return result;
+}

--- a/db/index.js
+++ b/db/index.js
@@ -973,10 +973,47 @@ export async function listInventoryTransactions({
   return { rows, count };
 }
 
-export async function callStoredProcedure(name, params = []) {
-  const placeholders = params.map(() => '?').join(', ');
-  const sql = `CALL ${name}(${placeholders})`;
-  const [rows] = await pool.query(sql, params);
-  if (Array.isArray(rows)) return rows[0] || [];
-  return rows || [];
+export async function callStoredProcedure(name, params = [], aliases = []) {
+  const conn = await pool.getConnection();
+  try {
+    const callParts = [];
+    const callArgs = [];
+    const outVars = [];
+
+    for (let i = 0; i < params.length; i++) {
+      const alias = aliases[i];
+      const value = params[i];
+      const cleanVal = value === '' || value === undefined ? null : value;
+      if (alias) {
+        const varName = `@_${name}_${i}`;
+        await conn.query(`SET ${varName} = ?`, [cleanVal]);
+        callParts.push(varName);
+        outVars.push([alias, varName]);
+      } else {
+        callParts.push('?');
+        callArgs.push(cleanVal);
+      }
+    }
+
+    const sql = `CALL ${name}(${callParts.join(', ')})`;
+    const [rows] = await conn.query(sql, callArgs);
+    let first = Array.isArray(rows) ? rows[0] || {} : rows || {};
+
+    if (outVars.length > 0) {
+      const selectSql =
+        'SELECT ' + outVars.map(([n, v]) => `${v} AS \`${n}\``).join(', ');
+      const [outRows] = await conn.query(selectSql);
+      if (Array.isArray(outRows) && outRows[0]) {
+        first = { ...first, ...outRows[0] };
+      }
+    }
+
+    aliases.forEach((alias) => {
+      if (alias && !(alias in first)) first[alias] = null;
+    });
+
+    return first;
+  } finally {
+    conn.release();
+  }
 }

--- a/db/migrations/2025-07-24_proc_fix.sql
+++ b/db/migrations/2025-07-24_proc_fix.sql
@@ -1,0 +1,70 @@
+-- Recreate stored procedures without modifying transactions table
+DROP PROCEDURE IF EXISTS resolve_inventory_metadata;
+DELIMITER $$
+CREATE PROCEDURE resolve_inventory_metadata(
+  IN p_inventory_id INT,
+  OUT sp_primary_code VARCHAR(50),
+  OUT sp_selling_code VARCHAR(50),
+  OUT sp_pm_name VARCHAR(255),
+  OUT sp_pm_unit_id INT,
+  OUT sp_categories INT,
+  OUT sp_manufacturer_id INT,
+  OUT sp_cost DECIMAL(18,4),
+  OUT sp_cost_date DATE,
+  OUT sp_source_table VARCHAR(50)
+)
+BEGIN
+  SELECT primary_code,
+         selling_code,
+         pm_name,
+         pm_unit_id,
+         categories,
+         manufacturer_id,
+         cost,
+         cost_date,
+         'product_cost'
+    INTO sp_primary_code,
+         sp_selling_code,
+         sp_pm_name,
+         sp_pm_unit_id,
+         sp_categories,
+         sp_manufacturer_id,
+         sp_cost,
+         sp_cost_date,
+         sp_source_table
+    FROM product_cost
+   WHERE id = p_inventory_id
+   LIMIT 1;
+
+  IF ROW_COUNT() = 0 THEN
+    SET sp_primary_code = NULL;
+    SET sp_selling_code = NULL;
+    SET sp_pm_name = NULL;
+    SET sp_pm_unit_id = NULL;
+    SET sp_categories = NULL;
+    SET sp_manufacturer_id = NULL;
+    SET sp_cost = NULL;
+    SET sp_cost_date = NULL;
+    SET sp_source_table = NULL;
+  END IF;
+END $$
+DELIMITER ;
+
+DROP PROCEDURE IF EXISTS calculate_stock_per_branch;
+DELIMITER $$
+CREATE PROCEDURE calculate_stock_per_branch(
+  IN p_branch_id INT,
+  IN p_inventory_id INT,
+  IN p_as_of_date DATE,
+  OUT sp_current_stock DECIMAL(18,4)
+)
+BEGIN
+  SELECT IFNULL(SUM(qty), 0)
+    INTO sp_current_stock
+    FROM inventory_transactions
+   WHERE branch_id = p_branch_id
+     AND inventory_id = p_inventory_id
+     AND transaction_date <= IFNULL(p_as_of_date, NOW());
+END $$
+DELIMITER ;
+

--- a/db/migrations/2025-07-25_inventory_triggers.sql
+++ b/db/migrations/2025-07-25_inventory_triggers.sql
@@ -1,0 +1,181 @@
+-- Ensure inventory transaction triggers call read-only procedures
+-- and avoid modifying the table within the trigger context.
+
+DROP TRIGGER IF EXISTS `transactions_inventory_bi`;
+DELIMITER $$
+CREATE TRIGGER `transactions_inventory_bi` BEFORE INSERT ON `transactions_inventory`
+FOR EACH ROW
+BEGIN
+  DECLARE v_primary_code VARCHAR(50);
+  DECLARE v_selling_code VARCHAR(50);
+  DECLARE v_pm_name VARCHAR(255);
+  DECLARE v_pm_unit_id INT;
+  DECLARE v_categories INT;
+  DECLARE v_manufacturer_id INT;
+  DECLARE v_cost DECIMAL(18,4);
+  DECLARE v_cost_date DATE;
+  DECLARE v_source_table VARCHAR(50);
+  DECLARE v_stock DECIMAL(18,4);
+
+  CALL resolve_inventory_metadata(
+    NEW.bmtr_pmid,
+    v_primary_code,
+    v_selling_code,
+    v_pm_name,
+    v_pm_unit_id,
+    v_categories,
+    v_manufacturer_id,
+    v_cost,
+    v_cost_date,
+    v_source_table
+  );
+
+  CALL calculate_stock_per_branch(
+    NEW.bmtr_transbranch,
+    NEW.bmtr_pmid,
+    NEW.bmtr_date,
+    v_stock
+  );
+
+  SET NEW.sp_primary_code = v_primary_code;
+  SET NEW.sp_selling_code = v_selling_code;
+  SET NEW.sp_pm_name = v_pm_name;
+  SET NEW.sp_pm_unit_id = v_pm_unit_id;
+  SET NEW.sp_categories = v_categories;
+  SET NEW.sp_manufacturer_id = v_manufacturer_id;
+  SET NEW.sp_cost = v_cost;
+  SET NEW.sp_cost_date = v_cost_date;
+  SET NEW.sp_source_table = v_source_table;
+  SET NEW.sp_current_stock = v_stock;
+END $$
+DELIMITER ;
+
+DROP TRIGGER IF EXISTS `transactions_inventory_bu`;
+DELIMITER $$
+CREATE TRIGGER `transactions_inventory_bu` BEFORE UPDATE ON `transactions_inventory`
+FOR EACH ROW
+BEGIN
+  DECLARE v_primary_code VARCHAR(50);
+  DECLARE v_selling_code VARCHAR(50);
+  DECLARE v_pm_name VARCHAR(255);
+  DECLARE v_pm_unit_id INT;
+  DECLARE v_categories INT;
+  DECLARE v_manufacturer_id INT;
+  DECLARE v_cost DECIMAL(18,4);
+  DECLARE v_cost_date DATE;
+  DECLARE v_source_table VARCHAR(50);
+  DECLARE v_stock DECIMAL(18,4);
+
+  CALL resolve_inventory_metadata(
+    NEW.bmtr_pmid,
+    v_primary_code,
+    v_selling_code,
+    v_pm_name,
+    v_pm_unit_id,
+    v_categories,
+    v_manufacturer_id,
+    v_cost,
+    v_cost_date,
+    v_source_table
+  );
+
+  CALL calculate_stock_per_branch(
+    NEW.bmtr_transbranch,
+    NEW.bmtr_pmid,
+    NEW.bmtr_date,
+    v_stock
+  );
+
+  SET NEW.sp_primary_code = v_primary_code;
+  SET NEW.sp_selling_code = v_selling_code;
+  SET NEW.sp_pm_name = v_pm_name;
+  SET NEW.sp_pm_unit_id = v_pm_unit_id;
+  SET NEW.sp_categories = v_categories;
+  SET NEW.sp_manufacturer_id = v_manufacturer_id;
+  SET NEW.sp_cost = v_cost;
+  SET NEW.sp_cost_date = v_cost_date;
+  SET NEW.sp_source_table = v_source_table;
+  SET NEW.sp_current_stock = v_stock;
+END $$
+DELIMITER ;
+
+-- Repeat for expense transactions
+DROP TRIGGER IF EXISTS `transactions_expense_bi`;
+DELIMITER $$
+CREATE TRIGGER `transactions_expense_bi` BEFORE INSERT ON `transactions_expense`
+FOR EACH ROW
+BEGIN
+  DECLARE v_primary_code VARCHAR(50);
+  DECLARE v_selling_code VARCHAR(50);
+  DECLARE v_pm_name VARCHAR(255);
+  DECLARE v_pm_unit_id INT;
+  DECLARE v_categories INT;
+  DECLARE v_manufacturer_id INT;
+  DECLARE v_cost DECIMAL(18,4);
+  DECLARE v_cost_date DATE;
+  DECLARE v_source_table VARCHAR(50);
+
+  CALL resolve_inventory_metadata(
+    NEW.bmte_pmid,
+    v_primary_code,
+    v_selling_code,
+    v_pm_name,
+    v_pm_unit_id,
+    v_categories,
+    v_manufacturer_id,
+    v_cost,
+    v_cost_date,
+    v_source_table
+  );
+
+  SET NEW.sp_primary_code = v_primary_code;
+  SET NEW.sp_selling_code = v_selling_code;
+  SET NEW.sp_pm_name = v_pm_name;
+  SET NEW.sp_pm_unit_id = v_pm_unit_id;
+  SET NEW.sp_categories = v_categories;
+  SET NEW.sp_manufacturer_id = v_manufacturer_id;
+  SET NEW.sp_cost = v_cost;
+  SET NEW.sp_cost_date = v_cost_date;
+  SET NEW.sp_source_table = v_source_table;
+END $$
+DELIMITER ;
+
+DROP TRIGGER IF EXISTS `transactions_expense_bu`;
+DELIMITER $$
+CREATE TRIGGER `transactions_expense_bu` BEFORE UPDATE ON `transactions_expense`
+FOR EACH ROW
+BEGIN
+  DECLARE v_primary_code VARCHAR(50);
+  DECLARE v_selling_code VARCHAR(50);
+  DECLARE v_pm_name VARCHAR(255);
+  DECLARE v_pm_unit_id INT;
+  DECLARE v_categories INT;
+  DECLARE v_manufacturer_id INT;
+  DECLARE v_cost DECIMAL(18,4);
+  DECLARE v_cost_date DATE;
+  DECLARE v_source_table VARCHAR(50);
+
+  CALL resolve_inventory_metadata(
+    NEW.bmte_pmid,
+    v_primary_code,
+    v_selling_code,
+    v_pm_name,
+    v_pm_unit_id,
+    v_categories,
+    v_manufacturer_id,
+    v_cost,
+    v_cost_date,
+    v_source_table
+  );
+
+  SET NEW.sp_primary_code = v_primary_code;
+  SET NEW.sp_selling_code = v_selling_code;
+  SET NEW.sp_pm_name = v_pm_name;
+  SET NEW.sp_pm_unit_id = v_pm_unit_id;
+  SET NEW.sp_categories = v_categories;
+  SET NEW.sp_manufacturer_id = v_manufacturer_id;
+  SET NEW.sp_cost = v_cost;
+  SET NEW.sp_cost_date = v_cost_date;
+  SET NEW.sp_source_table = v_source_table;
+END $$
+DELIMITER ;

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -43,6 +43,7 @@ const RowFormModal = function RowFormModal({
   const mounted = useRef(false);
   const renderCount = useRef(0);
   const warned = useRef(false);
+  const procCache = useRef({});
 
   renderCount.current++;
   if (renderCount.current > 10 && !warned.current) {
@@ -263,7 +264,7 @@ const RowFormModal = function RowFormModal({
       }
     : undefined;
 
-  function handleKeyDown(e, col) {
+  async function handleKeyDown(e, col) {
     if (e.key !== 'Enter') return;
     e.preventDefault();
     let val = normalizeDateInput(e.target.value, placeholders[col]);
@@ -291,6 +292,10 @@ const RowFormModal = function RowFormModal({
       setErrors((er) => ({ ...er, [col]: 'Буруу тоон утга' }));
       return;
     }
+    if (hasTrigger(col)) {
+      await runProcTrigger(col);
+    }
+
     const enabled = columns.filter((c) => !disabledFields.includes(c));
     const idx = enabled.indexOf(col);
     const next = enabled[idx + 1];
@@ -306,29 +311,119 @@ const RowFormModal = function RowFormModal({
     }
   }
 
-  async function handleFocusField(col) {
-    const cfg = procTriggers[col];
-    if (!cfg || !cfg.name) return;
-    const { name: procName, params = [] } = cfg;
-    const getParam = (p) => {
-      if (p === '$current') return formVals[col];
-      if (p === '$branchId') return company?.branch_id;
-      if (p === '$companyId') return company?.company_id;
-      if (p === '$employeeId') return user?.empid;
-      if (p === '$date') return new Date().toISOString().slice(0, 10);
-      return formVals[p] ?? extraVals[p];
-    };
-    const paramValues = params.map(getParam);
-    try {
-      const res = await fetch('/api/procedures', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ name: procName, params: paramValues }),
+  function getDirectTriggers(col) {
+    const val = procTriggers[col.toLowerCase()];
+    if (!val) return [];
+    return Array.isArray(val) ? val : [val];
+  }
+
+  function getParamTriggers(col) {
+    const res = [];
+    const colLower = col.toLowerCase();
+    Object.entries(procTriggers).forEach(([tCol, cfgList]) => {
+      const list = Array.isArray(cfgList) ? cfgList : [cfgList];
+      list.forEach((cfg) => {
+        if (Array.isArray(cfg.params) && cfg.params.includes(colLower)) {
+          res.push([tCol, cfg]);
+        }
       });
-      const js = await res.json();
-      const row = Array.isArray(js.rows) && js.rows.length > 0 ? js.rows[0] : {};
-      if (row && typeof row === 'object') {
+    });
+    return res;
+  }
+
+  function hasTrigger(col) {
+    return getDirectTriggers(col).length > 0 || getParamTriggers(col).length > 0;
+  }
+
+  function showTriggerInfo(col) {
+    const direct = getDirectTriggers(col);
+    const paramTrigs = getParamTriggers(col);
+
+    if (direct.length === 0 && paramTrigs.length === 0) {
+      window.dispatchEvent(
+        new CustomEvent('toast', {
+          detail: { message: `${col} талбар триггер ашигладаггүй`, type: 'info' },
+        }),
+      );
+      return;
+    }
+
+    const directNames = [...new Set(direct.map((d) => d.name))];
+    directNames.forEach((name) => {
+      window.dispatchEvent(
+        new CustomEvent('toast', {
+          detail: { message: `${col} -> ${name}`, type: 'info' },
+        }),
+      );
+    });
+
+    if (paramTrigs.length > 0) {
+      const names = [...new Set(paramTrigs.map(([, cfg]) => cfg.name))].join(', ');
+      window.dispatchEvent(
+        new CustomEvent('toast', {
+          detail: {
+            message: `${col} талбар параметр болгож дараах процедуруудад ашиглана: ${names}`,
+            type: 'info',
+          },
+        }),
+      );
+    }
+  }
+
+  async function runProcTrigger(col) {
+    const direct = getDirectTriggers(col);
+    const paramTrigs = getParamTriggers(col);
+
+    const map = new Map();
+    const keyFor = (cfg) => {
+      const out = Object.keys(cfg.outMap || {})
+        .sort()
+        .reduce((m, k) => {
+          m[k] = cfg.outMap[k];
+          return m;
+        }, {});
+      return JSON.stringify([cfg.name, cfg.params, out]);
+    };
+    direct.forEach((cfg) => {
+      if (!cfg || !cfg.name) return;
+      const key = keyFor(cfg);
+      const rec = map.get(key) || { cfg, cols: new Set() };
+      rec.cols.add(col.toLowerCase());
+      map.set(key, rec);
+    });
+    paramTrigs.forEach(([tCol, cfg]) => {
+      if (!cfg || !cfg.name) return;
+      const key = keyFor(cfg);
+      const rec = map.get(key) || { cfg, cols: new Set() };
+      rec.cols.add(tCol.toLowerCase());
+      map.set(key, rec);
+    });
+
+    for (const { cfg, cols } of map.values()) {
+      const tCol = [...cols][0];
+      const { name: procName, params = [], outMap = {} } = cfg;
+      const targetCols = Object.values(outMap || {}).map((c) =>
+        columnCaseMap[c.toLowerCase()] || c,
+      );
+      const hasTarget = targetCols.some((c) => columns.includes(c));
+      if (!hasTarget) continue;
+      const getVal = (name) => {
+        const key = columnCaseMap[name.toLowerCase()] || name;
+        return formVals[key] ?? extraVals[key];
+      };
+      const getParam = (p) => {
+        if (p === '$current') return getVal(tCol);
+        if (p === '$branchId') return company?.branch_id;
+        if (p === '$companyId') return company?.company_id;
+        if (p === '$employeeId') return user?.empid;
+        if (p === '$date') return new Date().toISOString().slice(0, 10);
+        return getVal(p);
+      };
+      const paramValues = params.map(getParam);
+      const aliases = params.map((p) => outMap[p] || null);
+      const cacheKey = `${procName}|${JSON.stringify(paramValues)}`;
+      if (procCache.current[cacheKey]) {
+        const row = procCache.current[cacheKey];
         setExtraVals((v) => ({ ...v, ...row }));
         setFormVals((vals) => {
           const updated = { ...vals };
@@ -338,10 +433,60 @@ const RowFormModal = function RowFormModal({
           return updated;
         });
         onChange(row);
+        window.dispatchEvent(
+          new CustomEvent('toast', {
+            detail: { message: `Returned: ${JSON.stringify(row)}`, type: 'info' },
+          }),
+        );
+        continue;
+      }
+      window.dispatchEvent(
+        new CustomEvent('toast', {
+          detail: {
+            message: `${tCol} -> ${procName}(${paramValues.join(', ')})`,
+            type: 'info',
+        },
+      }),
+    );
+    try {
+      const res = await fetch('/api/procedures', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ name: procName, params: paramValues, aliases }),
+      });
+      const js = await res.json();
+      const row = js.row || {};
+      if (row && typeof row === 'object') {
+        procCache.current[cacheKey] = row;
+        setExtraVals((v) => ({ ...v, ...row }));
+        setFormVals((vals) => {
+          const updated = { ...vals };
+          Object.entries(row).forEach(([k, v]) => {
+            if (updated[k] !== undefined) updated[k] = v;
+          });
+          return updated;
+        });
+        onChange(row);
+        window.dispatchEvent(
+          new CustomEvent('toast', {
+            detail: { message: `Returned: ${JSON.stringify(row)}`, type: 'info' },
+          }),
+        );
       }
     } catch (err) {
       console.error('Procedure call failed', err);
+      window.dispatchEvent(
+        new CustomEvent('toast', {
+          detail: { message: `Procedure failed: ${err.message}`, type: 'error' },
+        }),
+      );
     }
+    }
+  }
+
+  async function handleFocusField(col) {
+    showTriggerInfo(col);
   }
 
   async function submitForm() {
@@ -428,6 +573,7 @@ const RowFormModal = function RowFormModal({
           tableRef.current.replaceRows(failedRows);
         }
       }
+      procCache.current = {};
       setSubmitLocked(false);
       return;
     }
@@ -456,6 +602,7 @@ const RowFormModal = function RowFormModal({
           setSubmitLocked(false);
           return;
         }
+        procCache.current = {};
       } catch (err) {
         console.error('Submit failed', err);
         setSubmitLocked(false);
@@ -609,6 +756,9 @@ const RowFormModal = function RowFormModal({
             totalAmountFields={totalAmountFields}
             totalCurrencyFields={totalCurrencyFields}
             viewSource={viewSource}
+            procTriggers={procTriggers}
+            user={user}
+            company={company}
             columnCaseMap={columnCaseMap}
             collectRows={useGrid}
             minRows={1}

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -132,6 +132,7 @@ const TableManager = forwardRef(function TableManager({
   const [gridRows, setGridRows] = useState([]);
   const [selectedRows, setSelectedRows] = useState(new Set());
   const [localRefresh, setLocalRefresh] = useState(0);
+  const [procTriggers, setProcTriggers] = useState({});
   const [deleteInfo, setDeleteInfo] = useState(null); // { id, refs }
   const [showCascade, setShowCascade] = useState(false);
   const [showDetail, setShowDetail] = useState(false);
@@ -237,6 +238,24 @@ const TableManager = forwardRef(function TableManager({
       })
       .catch(() => {
         addToast('Failed to load table columns', 'error');
+      });
+    return () => {
+      canceled = true;
+    };
+  }, [table]);
+
+  useEffect(() => {
+    if (!table) return;
+    let canceled = false;
+    fetch(`/api/proc_triggers?table=${encodeURIComponent(table)}`, {
+      credentials: 'include',
+    })
+      .then((res) => (res.ok ? res.json() : {}))
+      .then((data) => {
+        if (!canceled) setProcTriggers(data || {});
+      })
+      .catch(() => {
+        if (!canceled) setProcTriggers({});
       });
     return () => {
       canceled = true;
@@ -1805,6 +1824,7 @@ const TableManager = forwardRef(function TableManager({
         printCustField={formConfig?.printCustField || []}
         totalAmountFields={formConfig?.totalAmountFields || []}
         totalCurrencyFields={formConfig?.totalCurrencyFields || []}
+        procTriggers={procTriggers}
         columnCaseMap={columnCaseMap}
         viewSource={viewSourceMap}
         onRowsChange={setGridRows}

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -124,6 +124,7 @@ export default function PosTransactionsPage() {
   const [relationsMap, setRelationsMap] = useState({});
   const [relationConfigs, setRelationConfigs] = useState({});
   const [relationData, setRelationData] = useState({});
+  const [procTriggersMap, setProcTriggersMap] = useState({});
   const [pendingId, setPendingId] = useState(null);
   const [sessionFields, setSessionFields] = useState([]);
   const [masterId, setMasterId] = useState(null);
@@ -266,6 +267,10 @@ export default function PosTransactionsPage() {
           setColumnMeta(m => ({ ...m, [tbl]: cols || [] }));
           loadRelations(tbl);
         })
+        .catch(() => {});
+      fetch(`/api/proc_triggers?table=${encodeURIComponent(tbl)}`, { credentials: 'include' })
+        .then(res => res.ok ? res.json() : {})
+        .then(data => setProcTriggersMap(m => ({ ...m, [tbl]: data || {} })))
         .catch(() => {});
     });
   }, [config]);
@@ -843,11 +848,15 @@ export default function PosTransactionsPage() {
                       rows={t.type === 'multi' ? values[t.table] : undefined}
                       headerFields={headerFields}
                       defaultValues={fc.defaultValues || {}}
-                      relations={relationsMap[t.table] || {}}
-                      relationConfigs={relationConfigs[t.table] || {}}
-                      relationData={relationData[t.table] || {}}
-                      onChange={(changes) => handleChange(t.table, changes)}
-                      onRowsChange={(rows) => handleRowsChange(t.table, rows)}
+                    relations={relationsMap[t.table] || {}}
+                    relationConfigs={relationConfigs[t.table] || {}}
+                    relationData={relationData[t.table] || {}}
+                    procTriggers={procTriggersMap[t.table] || {}}
+                    user={user}
+                    company={company}
+                    columnCaseMap={(columnMeta[t.table] || []).reduce((m,c)=>{m[c.name.toLowerCase()] = c.name;return m;}, {})}
+                    onChange={(changes) => handleChange(t.table, changes)}
+                    onRowsChange={(rows) => handleRowsChange(t.table, rows)}
                       onSubmit={() => true}
                       useGrid={t.view === 'table' || t.type === 'multi'}
                       fitted={t.view === 'fitted'}

--- a/tests/api/procTriggers.test.js
+++ b/tests/api/procTriggers.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getProcTriggers } from '../../api-server/services/procTriggers.js';
+import { pool } from '../../db/index.js';
+
+const origQuery = pool.query;
+
+pool.query = async () => [[{ Statement: `CALL foo(NEW.a, v_b); SET NEW.c = v_b;` }]];
+
+await test('getProcTriggers maps keys to output columns', async () => {
+  const trig = await getProcTriggers('t');
+  assert.deepEqual(trig, {
+    a: [
+      {
+        name: 'foo',
+        params: ['a', 'v_b'],
+        outMap: { v_b: 'c' },
+      },
+    ],
+    c: [
+      {
+        name: 'foo',
+        params: ['a', 'v_b'],
+        outMap: { v_b: 'c' },
+      },
+    ],
+  });
+});
+
+pool.query = origQuery;


### PR DESCRIPTION
## Summary
- clear stored procedure cache after submitting rows so caching only affects preview
- keep database triggers active when posting
- recreate inventory transaction triggers so read-only procedures populate the fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6880b5d0515c8331979d1c121de1fa4b