### PR TITLE
Add procedure preview utilities

### DIFF
--- a/docs/procedure-preview.md
+++ b/docs/procedure-preview.md
@@ -1,0 +1,25 @@
+# Dynamic Transaction Preview Logic
+
+This snippet demonstrates how to call a stored procedure once and map the
+returned values to preview fields without updating the database.
+
+```javascript
+import previewTransaction from '../src/erp.mgt.mn/utils/previewTransaction.js';
+
+// Example usage inside a React component
+async function handlePreview() {
+  const proc = 'sp_preview_transaction';
+  const params = [masterId, branchId];
+  const fieldMap = {
+    total_amt: 'previewTotalAmount',
+    total_qty: 'previewTotalQuantity',
+  };
+
+  const preview = await previewTransaction(proc, params, fieldMap);
+  setPreviewValues(preview); // update local state only
+}
+```
+
+The `previewTransaction` helper parses the stored procedure result into a field
+map so any returned field can be dynamically assigned to a matching form value.
+No database writes occur during this process.

--- a/src/erp.mgt.mn/utils/callProcedure.js
+++ b/src/erp.mgt.mn/utils/callProcedure.js
@@ -1,0 +1,13 @@
+export default async function callProcedure(name, params = [], aliases = []) {
+  const res = await fetch('/api/procedures', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ name, params, aliases }),
+  });
+  if (!res.ok) {
+    return {};
+  }
+  const js = await res.json().catch(() => ({}));
+  return js.row || {};
+}

--- a/src/erp.mgt.mn/utils/previewTransaction.js
+++ b/src/erp.mgt.mn/utils/previewTransaction.js
@@ -1,0 +1,19 @@
+import callProcedure from './callProcedure.js';
+
+/**
+ * Fetch preview data by calling a stored procedure once.
+ * @param {string} procName        Stored procedure name
+ * @param {Array}  params          Procedure parameters
+ * @param {Object} fieldMap        Map of returned fields -> preview field keys
+ * @returns {Object}               Mapped preview values
+ */
+export default async function previewTransaction(procName, params = [], fieldMap = {}) {
+  const row = await callProcedure(procName, params, Object.keys(fieldMap));
+  const preview = {};
+  Object.entries(fieldMap).forEach(([resultField, previewField]) => {
+    if (row[resultField] !== undefined) {
+      preview[previewField] = row[resultField];
+    }
+  });
+  return preview;
+}


### PR DESCRIPTION
## Summary
- add `callProcedure` helper for calling /api/procedures
- add `previewTransaction` helper to map stored procedure results for preview
- document how to use preview utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882171d4ffc83318fb634aa8b800546