### PR TITLE
Fix date display in detail modal

### DIFF
--- a/src/erp.mgt.mn/components/RowDetailModal.jsx
+++ b/src/erp.mgt.mn/components/RowDetailModal.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Modal from './Modal.jsx';
+import formatTimestamp from '../utils/formatTimestamp.js';
 
 export default function RowDetailModal({ visible, onClose, row = {}, columns = [], relations = {}, references = [], labels = {} }) {
   if (!visible) return null;
@@ -13,6 +14,33 @@ export default function RowDetailModal({ visible, onClose, row = {}, columns = [
   });
 
   const cols = columns.length > 0 ? columns : Object.keys(row);
+  const placeholders = React.useMemo(() => {
+    const map = {};
+    cols.forEach((c) => {
+      const lower = c.toLowerCase();
+      if (lower.includes('timestamp') || (lower.includes('date') && lower.includes('time'))) {
+        map[c] = 'YYYY-MM-DD HH:MM:SS';
+      } else if (lower.includes('date')) {
+        map[c] = 'YYYY-MM-DD';
+      } else if (lower.includes('time')) {
+        map[c] = 'HH:MM:SS';
+      }
+    });
+    return map;
+  }, [cols]);
+
+  function normalizeDateInput(value, format) {
+    if (typeof value !== 'string') return value;
+    let v = value.replace(/^(\d{4})[.,](\d{2})[.,](\d{2})/, '$1-$2-$3');
+    const isoRe = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+    if (isoRe.test(v)) {
+      const local = formatTimestamp(new Date(v));
+      if (format === 'YYYY-MM-DD') return local.slice(0, 10);
+      if (format === 'HH:MM:SS') return local.slice(11, 19);
+      return local;
+    }
+    return v;
+  }
 
   return (
     <Modal visible={visible} title="Row Details" onClose={onClose}>
@@ -38,7 +66,12 @@ export default function RowDetailModal({ visible, onClose, row = {}, columns = [
                     wordBreak: 'break-word',
                   }}
                 >
-                  {relations[c] ? labelMap[c][row[c]] || String(row[c]) : String(row[c])}
+                  {(() => {
+                    const raw = relations[c] ? labelMap[c][row[c]] || row[c] : row[c];
+                    const str = String(raw ?? '');
+                    const display = placeholders[c] ? normalizeDateInput(str, placeholders[c]) : str;
+                    return display;
+                  })()}
                 </td>
               </tr>
             ))}


### PR DESCRIPTION
## Summary
- format date values in `RowDetailModal`
- normalize ISO strings to `YYYY-MM-DD` or `YYYY-MM-DD HH:MM:SS`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68822876adb48331979ac4aa1aa2faa4