### PR TITLE
Apply pos layout to transaction tables

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -50,6 +50,9 @@ export default forwardRef(function InlineTransactionTable({
   procTriggers = {},
   user = {},
   company = {},
+  labelFontSize = 14,
+  boxWidth = 60,
+  boxHeight = 30,
 }, ref) {
   const mounted = useRef(false);
   const renderCount = useRef(0);
@@ -115,6 +118,17 @@ export default forwardRef(function InlineTransactionTable({
 
   const totalAmountSet = new Set(totalAmountFields);
   const totalCurrencySet = new Set(totalCurrencyFields);
+
+  const inputFontSize = Math.max(10, Math.round(boxHeight * 0.6));
+  const labelStyle = { fontSize: `${labelFontSize}px` };
+  const inputStyle = {
+    fontSize: `${inputFontSize}px`,
+    padding: '0.25rem 0.5rem',
+    minWidth: `${boxWidth}px`,
+    maxWidth: '150px',
+    width: '100%',
+    height: `${boxHeight}px`,
+  };
 
   function isValidDate(value, format) {
     if (!value) return true;
@@ -711,6 +725,7 @@ export default forwardRef(function InlineTransactionTable({
             onKeyDown={(e) => handleKeyDown(e, idx, colIdx)}
             onFocus={() => handleFocusField(f)}
             className={invalid ? 'border-red-500 bg-red-100' : ''}
+            inputStyle={inputStyle}
           />
         );
       }
@@ -719,6 +734,7 @@ export default forwardRef(function InlineTransactionTable({
         return (
           <select
             className={`w-full border px-1 ${invalid ? 'border-red-500 bg-red-100' : ''}`}
+            style={inputStyle}
             value={inputVal}
             onChange={(e) => handleChange(idx, f, e.target.value)}
             ref={(el) => (inputRefs.current[`${idx}-${colIdx}`] = el)}
@@ -739,7 +755,7 @@ export default forwardRef(function InlineTransactionTable({
       <textarea
         rows={1}
         className={`w-full border px-1 resize-none whitespace-pre-wrap ${invalid ? 'border-red-500 bg-red-100' : ''}`}
-        style={{ overflow: 'hidden' }}
+        style={{ overflow: 'hidden', ...inputStyle }}
         value={typeof val === 'object' ? val.value : val}
         onChange={(e) => handleChange(idx, f, e.target.value)}
         ref={(el) => (inputRefs.current[`${idx}-${colIdx}`] = el)}
@@ -755,7 +771,10 @@ export default forwardRef(function InlineTransactionTable({
 
   return (
     <div className="overflow-x-auto overflow-y-visible relative">
-      <table className="min-w-max border border-gray-300 text-xs">
+      <table
+        className="min-w-max border border-gray-300"
+        style={{ fontSize: `${inputFontSize}px` }}
+      >
         <thead className="bg-gray-50">
           <tr>
             {fields.map((f) => {
@@ -769,8 +788,9 @@ export default forwardRef(function InlineTransactionTable({
                     whiteSpace: 'normal',
                     wordBreak: 'break-word',
                     lineHeight: '1.1',
-                    fontSize: '0.75rem',
+                    fontSize: labelStyle.fontSize,
                     maxHeight: '3em',
+                    minWidth: `${boxWidth}px`,
                     ...(vertical
                       ? { writingMode: 'vertical-rl', transform: 'rotate(180deg)' }
                       : {}),
@@ -787,7 +807,11 @@ export default forwardRef(function InlineTransactionTable({
           {rows.map((r, idx) => (
             <tr key={idx}>
               {fields.map((f, cIdx) => (
-                <td key={f} className="border px-1 py-1 align-top">
+                <td
+                  key={f}
+                  className="border px-1 py-1 align-top"
+                  style={{ minWidth: `${boxWidth}px`, maxWidth: '150px' }}
+                >
                   {renderCell(idx, f, cIdx)}
                 </td>
               ))}
@@ -818,7 +842,11 @@ export default forwardRef(function InlineTransactionTable({
                   val = totals.sums[f];
                 }
                 return (
-                  <td key={f} className="border px-1 py-1 font-semibold">
+                  <td
+                    key={f}
+                    className="border px-1 py-1 font-semibold"
+                    style={{ minWidth: `${boxWidth}px`, maxWidth: '150px' }}
+                  >
                     {val}
                   </td>
                 );
@@ -827,7 +855,11 @@ export default forwardRef(function InlineTransactionTable({
             </tr>
             <tr>
               {fields.map((f, idx) => (
-                <td key={f} className="border px-1 py-1 font-semibold">
+                <td
+                  key={f}
+                  className="border px-1 py-1 font-semibold"
+                  style={{ minWidth: `${boxWidth}px`, maxWidth: '150px' }}
+                >
                   {idx === 0 ? totals.count : ''}
                 </td>
               ))}

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -789,6 +789,9 @@ const RowFormModal = function RowFormModal({
             defaultValues={defaultValues}
             rows={rows}
             onNextForm={onNextForm}
+            labelFontSize={labelFontSize}
+            boxWidth={boxWidth}
+            boxHeight={boxHeight}
           />
         </div>
       );


### PR DESCRIPTION
## Summary
- allow setting label and box sizes in `InlineTransactionTable`
- forward POS configuration values from `RowFormModal`
- size grid table cells and inputs based on POS config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68833071a4688331b951f29fef23e12f