### PR TITLE
Add separate form/POS sizing config

### DIFF
--- a/api-server/services/generalConfig.js
+++ b/api-server/services/generalConfig.js
@@ -4,16 +4,34 @@ import path from 'path';
 const filePath = path.join(process.cwd(), 'config', 'generalConfig.json');
 
 const defaults = {
-  labelFontSize: 14,
-  boxWidth: 60,
-  boxHeight: 30,
-  boxMaxWidth: 150,
+  forms: {
+    labelFontSize: 14,
+    boxWidth: 60,
+    boxHeight: 30,
+    boxMaxWidth: 150,
+    boxMaxHeight: 150,
+  },
+  pos: {
+    labelFontSize: 14,
+    boxWidth: 60,
+    boxHeight: 30,
+    boxMaxWidth: 150,
+    boxMaxHeight: 150,
+  },
 };
 
 async function readConfig() {
   try {
     const data = await fs.readFile(filePath, 'utf8');
-    return { ...defaults, ...JSON.parse(data) };
+    const parsed = JSON.parse(data);
+    if (parsed.forms || parsed.pos) {
+      return { ...defaults, ...parsed };
+    }
+    // migrate older flat structure to new nested layout
+    return {
+      forms: { ...defaults.forms, ...parsed },
+      pos: { ...defaults.pos },
+    };
   } catch {
     return { ...defaults };
   }
@@ -29,7 +47,8 @@ export async function getGeneralConfig() {
 
 export async function updateGeneralConfig(updates = {}) {
   const cfg = await readConfig();
-  Object.assign(cfg, updates);
+  if (updates.forms) Object.assign(cfg.forms, updates.forms);
+  if (updates.pos) Object.assign(cfg.pos, updates.pos);
   await writeConfig(cfg);
   return cfg;
 }

--- a/config/generalConfig.json
+++ b/config/generalConfig.json
@@ -1,6 +1,16 @@
 {
-  "labelFontSize": 14,
-  "boxWidth": 60,
-  "boxHeight": 30,
-  "boxMaxWidth": 150
+  "forms": {
+    "labelFontSize": 14,
+    "boxWidth": 60,
+    "boxHeight": 30,
+    "boxMaxWidth": 150,
+    "boxMaxHeight": 150
+  },
+  "pos": {
+    "labelFontSize": 14,
+    "boxWidth": 60,
+    "boxHeight": 30,
+    "boxMaxWidth": 150,
+    "boxMaxHeight": 150
+  }
 }

--- a/docs/general-configuration.md
+++ b/docs/general-configuration.md
@@ -1,20 +1,31 @@
 # General Configuration
 
-`config/generalConfig.json` holds global UI settings used by dynamic forms.
+`config/generalConfig.json` now groups settings under `forms` and `pos`.
 
 ```json
 {
-  "labelFontSize": 14,
-  "boxWidth": 60,
-  "boxHeight": 30,
-  "boxMaxWidth": 150
+  "forms": {
+    "labelFontSize": 14,
+    "boxWidth": 60,
+    "boxHeight": 30,
+    "boxMaxWidth": 150,
+    "boxMaxHeight": 150
+  },
+  "pos": {
+    "labelFontSize": 14,
+    "boxWidth": 60,
+    "boxHeight": 30,
+    "boxMaxWidth": 150,
+    "boxMaxHeight": 150
+  }
 }
 ```
 
-These values control label text size and input box dimensions across all forms.
-Transaction grids start with `boxWidth` for each cell but stretch up to
-`boxMaxWidth` when the content is longer. Changing `labelFontSize` automatically
-adjusts the label text and the grid's input font size.
+The **Forms** section controls default sizing for all transaction forms except POS.
+`boxWidth` is the starting width for each grid cell. Cells expand up to
+`boxMaxWidth`/`boxMaxHeight` as text is entered and wrap when necessary. The
+**POS** section provides the same options specifically for POS transaction
+windows.
 
 The settings can be edited in the **General Configuration** screen
 (module key `general_configuration`) under the Settings menu.

--- a/docs/pos-transaction-layout.md
+++ b/docs/pos-transaction-layout.md
@@ -1,24 +1,19 @@
 # POS Transaction Layout Settings
 
-Forms used by POS transactions support a special **fitted** view. In this mode all padding and borders are removed so the contents fill the parent window. Input sizing is now controlled globally from `config/generalConfig.json` instead of the transaction configuration. The file can specify:
+Forms used by POS transactions support a special **fitted** view. In this mode all padding and borders are removed so the contents fill the parent window. The layout now reads its sizing from the `pos` section of `config/generalConfig.json`:
 
 ```json
 {
-  "labelFontSize": 14,
-  "boxWidth": 60,
-  "boxHeight": 30,
-  "boxMaxWidth": 150
+  "pos": {
+    "labelFontSize": 14,
+    "boxWidth": 60,
+    "boxHeight": 30,
+    "boxMaxWidth": 150,
+    "boxMaxHeight": 150
+  }
 }
 ```
 
 `labelFontSize` sets the text size used by both labels and values in the grid.
-`boxWidth` gives the default width for cells while `boxMaxWidth` is the maximum
-size a cell can stretch to when the content is wider. `boxHeight` controls input
-height.
-
-
-
-`labelFontSize` sets the text size used by both labels and values in the grid.
-`boxWidth` gives the default width for cells while `boxMaxWidth` is the maximum
-size a cell can stretch to when the content is wider. `boxHeight` controls input
-height.
+`boxWidth` gives the default width for cells while `boxMaxWidth` and
+`boxMaxHeight` limit how far a cell can stretch when the content is larger.

--- a/src/erp.mgt.mn/components/AsyncSearchSelect.jsx
+++ b/src/erp.mgt.mn/components/AsyncSearchSelect.jsx
@@ -108,6 +108,7 @@ export default function AsyncSearchSelect({
         }}
         disabled={disabled}
         style={{ width: '100%', padding: '0.5rem', ...inputStyle }}
+        title={input}
         {...rest}
       />
       {show && options.length > 0 && (

--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -54,6 +54,7 @@ export default forwardRef(function InlineTransactionTable({
   boxWidth = 60,
   boxHeight = 30,
   boxMaxWidth = 150,
+  boxMaxHeight = 150,
   disabledFields = [],
   dateField = [],
 }, ref) {
@@ -127,13 +128,15 @@ export default forwardRef(function InlineTransactionTable({
   const inputStyle = {
     fontSize: `${inputFontSize}px`,
     padding: '0.25rem 0.5rem',
-    width: `${boxWidth}px`,
+    width: 'auto',
     minWidth: `${boxWidth}px`,
     maxWidth: `${boxMaxWidth}px`,
     height: `${boxHeight}px`,
+    maxHeight: `${boxMaxHeight}px`,
+    overflow: 'hidden',
   };
   const colStyle = {
-    width: `${boxWidth}px`,
+    width: 'auto',
     minWidth: `${boxWidth}px`,
     maxWidth: `${boxMaxWidth}px`,
     wordBreak: 'break-word',
@@ -724,7 +727,11 @@ export default forwardRef(function InlineTransactionTable({
     const isRel = relationConfigs[f] || Array.isArray(relations[f]);
     const invalid = invalidCell && invalidCell.row === idx && invalidCell.field === f;
     if (disabledFields.includes(f)) {
-      return <div className="px-1" style={inputStyle}>{typeof val === 'object' ? val.label || val.value : val}</div>;
+      return (
+        <div className="px-1" style={inputStyle} title={typeof val === 'object' ? val.label || val.value : val}>
+          {typeof val === 'object' ? val.label || val.value : val}
+        </div>
+      );
     }
     if (rows[idx]?._saved && !collectRows) {
       return typeof val === 'object' ? val.label : val;
@@ -761,6 +768,7 @@ export default forwardRef(function InlineTransactionTable({
             ref={(el) => (inputRefs.current[`${idx}-${colIdx}`] = el)}
             onKeyDown={(e) => handleKeyDown(e, idx, colIdx)}
             onFocus={() => handleFocusField(f)}
+            title={typeof val === 'object' ? val.label || val.value : val}
           >
             <option value="">-- select --</option>
             {relations[f].map((opt) => (
@@ -778,13 +786,16 @@ export default forwardRef(function InlineTransactionTable({
         className={`w-full border px-1 resize-none whitespace-pre-wrap ${invalid ? 'border-red-500 bg-red-100' : ''}`}
         style={{ overflow: 'hidden', ...inputStyle }}
         value={typeof val === 'object' ? val.value : val}
+        title={typeof val === 'object' ? val.value : val}
         onChange={(e) => handleChange(idx, f, e.target.value)}
         ref={(el) => (inputRefs.current[`${idx}-${colIdx}`] = el)}
         onKeyDown={(e) => handleKeyDown(e, idx, colIdx)}
         onFocus={() => handleFocusField(f)}
         onInput={(e) => {
           e.target.style.height = 'auto';
-          e.target.style.height = `${e.target.scrollHeight}px`;
+          const h = Math.min(e.target.scrollHeight, boxMaxHeight);
+          e.target.style.height = `${h}px`;
+          e.target.style.overflowY = e.target.scrollHeight > h ? 'auto' : 'hidden';
         }}
       />
     );

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -37,6 +37,7 @@ const RowFormModal = function RowFormModal({
   boxWidth = 60,
   boxHeight = 30,
   boxMaxWidth = 150,
+  boxMaxHeight = 150,
   onNextForm = null,
   columnCaseMap = {},
   viewSource = {},
@@ -274,10 +275,12 @@ const RowFormModal = function RowFormModal({
   const inputStyle = {
     fontSize: `${inputFontSize}px`,
     padding: '0.25rem 0.5rem',
-    width: `${boxWidth}px`,
+    width: 'auto',
     minWidth: `${boxWidth}px`,
     maxWidth: `${boxMaxWidth}px`,
     height: `${boxHeight}px`,
+    maxHeight: `${boxMaxHeight}px`,
+    overflow: 'hidden',
   };
 
   async function handleKeyDown(e, col) {
@@ -637,7 +640,7 @@ const RowFormModal = function RowFormModal({
       const val = formVals[c];
       if (!withLabel) {
         return (
-          <div className="w-full border rounded bg-gray-100 px-2 py-1" style={inputStyle}>
+          <div className="w-full border rounded bg-gray-100 px-2 py-1" style={inputStyle} title={val}>
             {val}
           </div>
         );
@@ -647,7 +650,7 @@ const RowFormModal = function RowFormModal({
           <label className="block mb-1 font-medium" style={labelStyle}>
             {labels[c] || c}
           </label>
-          <div className="w-full border rounded bg-gray-100 px-2 py-1" style={inputStyle}>
+          <div className="w-full border rounded bg-gray-100 px-2 py-1" style={inputStyle} title={val}>
             {val}
           </div>
         </div>
@@ -677,7 +680,7 @@ const RowFormModal = function RowFormModal({
       />
     ) : Array.isArray(relations[c]) ? (
       <select
-        title={labels[c] || c}
+        title={formVals[c]}
         ref={(el) => (inputRefs.current[c] = el)}
         value={formVals[c]}
         onFocus={() => handleFocusField(c)}
@@ -705,7 +708,7 @@ const RowFormModal = function RowFormModal({
       </select>
     ) : (
       <input
-        title={labels[c] || c}
+        title={formVals[c]}
         ref={(el) => (inputRefs.current[c] = el)}
         type="text"
         placeholder={placeholders[c] || ''}
@@ -728,6 +731,11 @@ const RowFormModal = function RowFormModal({
         disabled={disabled}
         className={inputClass}
         style={inputStyle}
+        onInput={(e) => {
+          e.target.style.width = 'auto';
+          const w = Math.min(e.target.scrollWidth + 2, boxMaxWidth);
+          e.target.style.width = `${w}px`;
+        }}
       />
     );
 
@@ -893,7 +901,7 @@ const RowFormModal = function RowFormModal({
           return (
             <div key={c} className={fitted ? 'mb-1' : 'mb-3'}>
               <label className="block mb-1 font-medium" style={labelStyle}>{labels[c] || c}</label>
-              <div className="w-full border rounded bg-gray-100 px-2 py-1" style={inputStyle}>
+              <div className="w-full border rounded bg-gray-100 px-2 py-1" style={inputStyle} title={val}>
                 {val}
               </div>
             </div>

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1824,10 +1824,11 @@ const TableManager = forwardRef(function TableManager({
         columnCaseMap={columnCaseMap}
         viewSource={viewSourceMap}
         onRowsChange={setGridRows}
-        labelFontSize={generalConfig.labelFontSize}
-        boxWidth={generalConfig.boxWidth}
-        boxHeight={generalConfig.boxHeight}
-        boxMaxWidth={generalConfig.boxMaxWidth}
+        labelFontSize={generalConfig.forms.labelFontSize}
+        boxWidth={generalConfig.forms.boxWidth}
+        boxHeight={generalConfig.forms.boxHeight}
+        boxMaxWidth={generalConfig.forms.boxMaxWidth}
+        boxMaxHeight={generalConfig.forms.boxMaxHeight}
       />
       <CascadeDeleteModal
         visible={showCascade}

--- a/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
+++ b/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
@@ -5,6 +5,7 @@ export default function GeneralConfiguration() {
   const initial = useGeneralConfig();
   const [cfg, setCfg] = useState(null);
   const [saving, setSaving] = useState(false);
+  const [tab, setTab] = useState('forms');
 
   useEffect(() => {
     if (initial && Object.keys(initial).length) setCfg(initial);
@@ -16,7 +17,10 @@ export default function GeneralConfiguration() {
 
   function handleChange(e) {
     const { name, value } = e.target;
-    setCfg(c => ({ ...c, [name]: Number(value) }));
+    setCfg(c => ({
+      ...c,
+      [tab]: { ...(c?.[tab] || {}), [name]: Number(value) },
+    }));
   }
 
   async function handleSave() {
@@ -40,16 +44,26 @@ export default function GeneralConfiguration() {
 
   if (!cfg) return <p>Loading…</p>;
 
+  const active = cfg?.[tab] || {};
+
   return (
     <div>
       <h2>General Configuration</h2>
+      <div style={{ marginBottom: '0.5rem' }}>
+        <button onClick={() => setTab('forms')} disabled={tab === 'forms'}>
+          Forms
+        </button>
+        <button onClick={() => setTab('pos')} disabled={tab === 'pos'} style={{ marginLeft: '0.5rem' }}>
+          POS
+        </button>
+      </div>
       <div style={{ marginBottom: '0.5rem' }}>
         <label>
           Label Font Size{' '}
           <input
             name="labelFontSize"
             type="number"
-            value={cfg.labelFontSize ?? ''}
+            value={active.labelFontSize ?? ''}
             onChange={handleChange}
           />
         </label>
@@ -60,7 +74,7 @@ export default function GeneralConfiguration() {
           <input
             name="boxWidth"
             type="number"
-            value={cfg.boxWidth ?? ''}
+            value={active.boxWidth ?? ''}
             onChange={handleChange}
           />
         </label>
@@ -71,7 +85,7 @@ export default function GeneralConfiguration() {
           <input
             name="boxHeight"
             type="number"
-            value={cfg.boxHeight ?? ''}
+            value={active.boxHeight ?? ''}
             onChange={handleChange}
           />
         </label>
@@ -82,7 +96,18 @@ export default function GeneralConfiguration() {
           <input
             name="boxMaxWidth"
             type="number"
-            value={cfg.boxMaxWidth ?? ''}
+            value={active.boxMaxWidth ?? ''}
+            onChange={handleChange}
+          />
+        </label>
+      </div>
+      <div style={{ marginBottom: '0.5rem' }}>
+        <label>
+          Box Max Height{' '}
+          <input
+            name="boxMaxHeight"
+            type="number"
+            value={active.boxMaxHeight ?? ''}
             onChange={handleChange}
           />
         </label>

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -870,10 +870,11 @@ export default function PosTransactionsPage() {
                       onSubmit={() => true}
                       useGrid={t.view === 'table' || t.type === 'multi'}
                       fitted={t.view === 'fitted'}
-                      labelFontSize={generalConfig.labelFontSize}
-                      boxWidth={generalConfig.boxWidth}
-                      boxHeight={generalConfig.boxHeight}
-                      boxMaxWidth={generalConfig.boxMaxWidth}
+                      labelFontSize={generalConfig.pos.labelFontSize}
+                      boxWidth={generalConfig.pos.boxWidth}
+                      boxHeight={generalConfig.pos.boxHeight}
+                      boxMaxWidth={generalConfig.pos.boxMaxWidth}
+                      boxMaxHeight={generalConfig.pos.boxMaxHeight}
                       dateField={fc.dateField || []}
                       onNextForm={() => {
                         let next = idx + 1;


### PR DESCRIPTION
## Summary
- support nested `forms` and `pos` objects in `generalConfig.json`
- migrate server side config service for new structure
- add tabbed UI for configuration screen with new boxMaxHeight option
- apply form and POS settings to transaction windows
- auto-resize text areas and inputs up to configured max sizes
- show full cell contents via title hints
- update docs for new configuration layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68837c0e012c8331b09c24a9f0cb629c