### PR TITLE
Clarify boxWidth in docs

### DIFF
--- a/docs/general-configuration.md
+++ b/docs/general-configuration.md
@@ -21,11 +21,13 @@
 }
 ```
 
-The **Forms** section controls default sizing for all transaction forms except POS.
-`boxWidth` is the starting width for each grid cell. Cells expand up to
-`boxMaxWidth`/`boxMaxHeight` as text is entered and wrap when necessary. The
-**POS** section provides the same options specifically for POS transaction
-windows.
+The **Forms** section controls default sizing for all non‑POS transaction windows.
+`boxWidth` sets the initial grid cell width when a form first loads. Cells expand
+up to `boxMaxWidth`/`boxMaxHeight` as text is entered and wrap when necessary.
+
+The **POS** section provides the same options specifically for POS transaction
+windows. Here `boxWidth` defines the initial grid box width of a POS
+transaction window.
 
 The settings can be edited in the **General Configuration** screen
 (module key `general_configuration`) under the Settings menu.

--- a/docs/pos-transaction-layout.md
+++ b/docs/pos-transaction-layout.md
@@ -15,5 +15,6 @@ Forms used by POS transactions support a special **fitted** view. In this mode a
 ```
 
 `labelFontSize` sets the text size used by both labels and values in the grid.
-`boxWidth` gives the default width for cells while `boxMaxWidth` and
-`boxMaxHeight` limit how far a cell can stretch when the content is larger.
+`boxWidth` gives the initial width for grid cells in the POS transaction window
+while `boxMaxWidth` and `boxMaxHeight` limit how far a cell can stretch when the
+content is larger.


### PR DESCRIPTION
## Summary
- clarify that boxWidth sets the initial grid width for forms
- mention POS boxWidth as initial grid width in POS docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688391337fc08331a5f4e9ba57133de2