### PR TITLE
Clarify boxWidth description

### DIFF
--- a/docs/general-configuration.md
+++ b/docs/general-configuration.md
@@ -21,11 +21,12 @@
 }
 ```
 
-The **Forms** section controls default sizing for all transaction forms except POS.
-`boxWidth` is the starting width for each grid cell. Cells expand up to
-`boxMaxWidth`/`boxMaxHeight` as text is entered and wrap when necessary. The
-**POS** section provides the same options specifically for POS transaction
-windows.
+The **Forms** section controls default sizing for all non‑POS transaction windows.
+`boxWidth` sets the initial grid box width for these forms. Cells expand
+up to `boxMaxWidth`/`boxMaxHeight` as text is entered and wrap when necessary.
+
+The **POS** section provides the same options specifically for POS transactions.
+Here `boxWidth` defines the initial grid box width of a POS transaction.
 
 The settings can be edited in the **General Configuration** screen
 (module key `general_configuration`) under the Settings menu.

--- a/docs/pos-transaction-layout.md
+++ b/docs/pos-transaction-layout.md
@@ -15,5 +15,6 @@ Forms used by POS transactions support a special **fitted** view. In this mode a
 ```
 
 `labelFontSize` sets the text size used by both labels and values in the grid.
-`boxWidth` gives the default width for cells while `boxMaxWidth` and
-`boxMaxHeight` limit how far a cell can stretch when the content is larger.
+`boxWidth` defines the initial grid box width for POS transactions, while
+`boxMaxWidth` and `boxMaxHeight` limit how far a cell can stretch when the
+content is larger.

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -28,7 +28,9 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
   const [table, setTable] = useState(() => sessionState.table || '');
   const [config, setConfig] = useState(() => sessionState.config || null);
   const [refreshId, setRefreshId] = useState(() => sessionState.refreshId || 0);
-  const [showTable, setShowTable] = useState(() => sessionState.showTable || false);
+  const [showTable, setShowTable] = useState(() =>
+    sessionState.showTable || !!sessionState.config,
+  );
   const { company } = useContext(AuthContext);
   const perms = useRolePermissions();
   const licensed = useCompanyModules(company?.company_id);
@@ -79,7 +81,7 @@ useEffect(() => {
     table: sessionState.table || '',
     config: sessionState.config || null,
     refreshId: sessionState.refreshId || 0,
-    showTable: sessionState.showTable || false,
+    showTable: sessionState.showTable || !!sessionState.config,
   };
 
   if (!isEqual(prevSessionRef.current, next)) {
@@ -219,16 +221,17 @@ useEffect(() => {
           setConfig(cfg);
           prevConfigRef.current = cfg;
         }
+        setShowTable(true);
       } else {
         if (config !== null) setConfig(null);
-        if (showTable) setShowTable(false);
+        setShowTable(false);
         addToast('Transaction configuration not found', 'error');
       }
     })
     .catch(() => {
       if (!canceled) {
         if (config !== null) setConfig(null);
-        if (showTable) setShowTable(false);
+        setShowTable(false);
         addToast('Failed to load transaction configuration', 'error');
       }
     });
@@ -257,7 +260,7 @@ useEffect(() => {
                 if (newName === name) return;
                 setName(newName);
                 setRefreshId((r) => r + 1);
-                setShowTable(false);
+                setShowTable(true);
                 if (!newName) {
                   if (table !== '') setTable('');
                   if (config !== null) setConfig(null);


### PR DESCRIPTION
## Summary
- refine wording around `boxWidth` in General Configuration docs
- specify that POS `boxWidth` defines initial grid box width
- show selected transaction form instead of blank window

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688391337fc08331a5f4e9ba57133de2