### PR TITLE
Fix grid width usage for POS and regular forms

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useEffect,
 } from 'react';
+import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import AsyncSearchSelect from './AsyncSearchSelect.jsx';
 import formatTimestamp from '../utils/formatTimestamp.js';
 import callProcedure from '../utils/callProcedure.js';
@@ -50,16 +51,24 @@ export default forwardRef(function InlineTransactionTable({
   procTriggers = {},
   user = {},
   company = {},
-  labelFontSize = 14,
-  boxWidth = 60,
-  boxHeight = 30,
-  boxMaxWidth = 150,
-  boxMaxHeight = 150,
+  scope = 'forms',
+  labelFontSize,
+  boxWidth,
+  boxHeight,
+  boxMaxWidth,
+  boxMaxHeight,
   disabledFields = [],
   dateField = [],
 }, ref) {
   const mounted = useRef(false);
   const renderCount = useRef(0);
+  const generalConfig = useGeneralConfig();
+  const cfg = generalConfig[scope] || {};
+  labelFontSize = labelFontSize ?? cfg.labelFontSize ?? 14;
+  boxWidth = boxWidth ?? cfg.boxWidth ?? 60;
+  boxHeight = boxHeight ?? cfg.boxHeight ?? 30;
+  boxMaxWidth = boxMaxWidth ?? cfg.boxMaxWidth ?? 150;
+  boxMaxHeight = boxMaxHeight ?? cfg.boxMaxHeight ?? 150;
   renderCount.current++;
   if (renderCount.current > 10) {
     console.warn('Excessive renders: InlineTransactionTable', renderCount.current);

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -5,6 +5,7 @@ import InlineTransactionTable from './InlineTransactionTable.jsx';
 import { AuthContext } from '../context/AuthContext.jsx';
 import formatTimestamp from '../utils/formatTimestamp.js';
 import callProcedure from '../utils/callProcedure.js';
+import useGeneralConfig from '../hooks/useGeneralConfig.js';
 
 const RowFormModal = function RowFormModal({
   visible,
@@ -33,11 +34,12 @@ const RowFormModal = function RowFormModal({
   inline = false,
   useGrid = false,
   fitted = false,
-  labelFontSize = 14,
-  boxWidth = 60,
-  boxHeight = 30,
-  boxMaxWidth = 150,
-  boxMaxHeight = 150,
+  scope = 'forms',
+  labelFontSize,
+  boxWidth,
+  boxHeight,
+  boxMaxWidth,
+  boxMaxHeight,
   onNextForm = null,
   columnCaseMap = {},
   viewSource = {},
@@ -47,6 +49,13 @@ const RowFormModal = function RowFormModal({
   const renderCount = useRef(0);
   const warned = useRef(false);
   const procCache = useRef({});
+  const generalConfig = useGeneralConfig();
+  const cfg = generalConfig[scope] || {};
+  labelFontSize = labelFontSize ?? cfg.labelFontSize ?? 14;
+  boxWidth = boxWidth ?? cfg.boxWidth ?? 60;
+  boxHeight = boxHeight ?? cfg.boxHeight ?? 30;
+  boxMaxWidth = boxMaxWidth ?? cfg.boxMaxWidth ?? 150;
+  boxMaxHeight = boxMaxHeight ?? cfg.boxMaxHeight ?? 150;
 
   renderCount.current++;
   if (renderCount.current > 10 && !warned.current) {
@@ -818,6 +827,7 @@ const RowFormModal = function RowFormModal({
             boxWidth={boxWidth}
             boxHeight={boxHeight}
             boxMaxWidth={boxMaxWidth}
+            scope={scope}
           />
         </div>
       );

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -870,6 +870,7 @@ export default function PosTransactionsPage() {
                       onSubmit={() => true}
                       useGrid={t.view === 'table' || t.type === 'multi'}
                       fitted={t.view === 'fitted'}
+                      scope="pos"
                       labelFontSize={generalConfig.pos.labelFontSize}
                       boxWidth={generalConfig.pos.boxWidth}
                       boxHeight={generalConfig.pos.boxHeight}


### PR DESCRIPTION
## Summary
- load general configuration within transaction form components
- default grid sizing based on `forms` or `pos` scope
- pass `scope="pos"` for POS transaction forms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883a038711883319d71d899fa9879f0