### PR TITLE
Implement view lookup in dynamic forms

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -805,6 +805,25 @@ export default forwardRef(function InlineTransactionTable({
         );
       }
     }
+    if (viewSource[f]) {
+      const view = viewSource[f];
+      const inputVal = typeof val === 'object' ? val.value : val;
+      return (
+        <AsyncSearchSelect
+          table={view}
+          searchColumn={f}
+          value={inputVal}
+          onChange={(v, label) =>
+            handleChange(idx, f, label ? { value: v, label } : v)
+          }
+          inputRef={(el) => (inputRefs.current[`${idx}-${colIdx}`] = el)}
+          onKeyDown={(e) => handleKeyDown(e, idx, colIdx)}
+          onFocus={() => handleFocusField(f)}
+          className={invalid ? 'border-red-500 bg-red-100' : ''}
+          inputStyle={inputStyle}
+        />
+      );
+    }
     return (
       <textarea
         rows={1}

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -306,6 +306,8 @@ const RowFormModal = function RowFormModal({
     height: `${boxHeight}px`,
     maxHeight: `${boxMaxHeight}px`,
     overflow: 'hidden',
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
   };
 
   async function handleKeyDown(e, col) {
@@ -688,6 +690,26 @@ const RowFormModal = function RowFormModal({
         table={relationConfigs[c].table}
         searchColumn={relationConfigs[c].column}
         labelFields={relationConfigs[c].displayFields || []}
+        value={formVals[c]}
+        onChange={(val) => {
+          setFormVals((v) => ({ ...v, [c]: val }));
+          setErrors((er) => ({ ...er, [c]: undefined }));
+          onChange({ [c]: val });
+        }}
+        disabled={disabled}
+        onKeyDown={(e) => handleKeyDown(e, c)}
+        onFocus={(e) => {
+          e.target.select();
+          handleFocusField(c);
+        }}
+        inputRef={(el) => (inputRefs.current[c] = el)}
+        inputStyle={inputStyle}
+      />
+    ) : viewSource[c] && !Array.isArray(relations[c]) ? (
+      <AsyncSearchSelect
+        title={labels[c] || c}
+        table={viewSource[c]}
+        searchColumn={c}
         value={formVals[c]}
         onChange={(val) => {
           setFormVals((v) => ({ ...v, [c]: val }));


### PR DESCRIPTION
## Summary
- allow textarea/grid styles to wrap text when content grows
- support view lookups in `RowFormModal` using `AsyncSearchSelect`
- add view lookup to `InlineTransactionTable` cells

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883b4ae9d688331b6b64afe566bc079