### PR TITLE
Improve dynamic form editability

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -86,7 +86,14 @@ export default forwardRef(function InlineTransactionTable({
     if (Array.isArray(initRows) && initRows.length > 0) {
       return initRows;
     }
-    return Array.from({ length: minRows }, () => ({ ...defaultValues }));
+    const now = formatTimestamp(new Date()).slice(0, 10);
+    return Array.from({ length: minRows }, () => {
+      const row = { ...defaultValues };
+      dateField.forEach((f) => {
+        if (row[f] === undefined || row[f] === '') row[f] = now;
+      });
+      return row;
+    });
   });
 
   const placeholders = React.useMemo(() => {
@@ -110,7 +117,14 @@ export default forwardRef(function InlineTransactionTable({
         ? base
         : [
             ...base,
-            ...Array.from({ length: minRows - base.length }, () => ({ ...defaultValues })),
+            ...Array.from({ length: minRows - base.length }, () => {
+              const row = { ...defaultValues };
+              const now = formatTimestamp(new Date()).slice(0, 10);
+              dateField.forEach((f) => {
+                if (row[f] === undefined || row[f] === '') row[f] = now;
+              });
+              return row;
+            }),
           ];
     const normalized = next.map((row) => {
       if (!row || typeof row !== 'object') return row;
@@ -123,7 +137,7 @@ export default forwardRef(function InlineTransactionTable({
       return updated;
     });
     setRows(normalized);
-  }, [initRows, minRows, defaultValues, placeholders]);
+  }, [initRows, minRows, defaultValues, placeholders, dateField]);
   const inputRefs = useRef({});
   const focusRow = useRef(0);
   const addBtnRef = useRef(null);

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1201,7 +1201,7 @@ const TableManager = forwardRef(function TableManager({
     .map(([k]) => k);
 
   let disabledFields = [];
-  if (formConfig?.editableFields?.length) {
+  if (Array.isArray(formConfig?.editableFields)) {
     const set = new Set(formConfig.editableFields);
     disabledFields = formColumns.filter((c) => !set.has(c));
   }

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -841,9 +841,7 @@ export default function PosTransactionsPage() {
                 const editable = Array.isArray(fc.editableFields)
                   ? fc.editableFields
                   : [];
-                const disabled = editable.length
-                  ? visible.filter((c) => !editable.includes(c))
-                  : [];
+                const disabled = visible.filter((c) => !editable.includes(c));
                 const posStyle = {
                   top_row: { gridColumn: '1 / span 3', gridRow: '1' },
                   upper_left: { gridColumn: '1', gridRow: '2' },


### PR DESCRIPTION
## Summary
- enforce `editableFields` lists for transaction forms so fields without the flag become read-only
- auto-fill date columns with today's date when new grid rows are created

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883cf03041c8331bdab6b2b7e1584b7