### PR TITLE
Fill session info fields in POS forms

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -89,12 +89,13 @@ const RowFormModal = function RowFormModal({
       }
       const raw = row ? String(row[c] ?? '') : String(defaultValues[c] ?? '');
       let val = normalizeDateInput(raw, placeholder);
-      if (!row && !val && dateField.includes(c)) {
+      const missing = !row || row[c] === undefined || row[c] === '';
+      if (missing && !val && dateField.includes(c)) {
         if (placeholder === 'YYYY-MM-DD') val = formatTimestamp(now).slice(0, 10);
         else if (placeholder === 'HH:MM:SS') val = formatTimestamp(now).slice(11, 19);
         else val = formatTimestamp(now);
       }
-      if (!row && !val && headerSet.has(c)) {
+      if (missing && !val && headerSet.has(c)) {
         if (
           ['created_by', 'employee_id', 'emp_id', 'empid', 'user_id'].includes(c) &&
           user?.empid
@@ -232,13 +233,14 @@ const RowFormModal = function RowFormModal({
     columns.forEach((c) => {
       const raw = row ? String(row[c] ?? '') : String(defaultValues[c] ?? '');
       let v = normalizeDateInput(raw, placeholders[c]);
-        if (!row && !v && dateField.includes(c)) {
-          const now = new Date();
-          if (placeholders[c] === 'YYYY-MM-DD') v = formatTimestamp(now).slice(0, 10);
-          else if (placeholders[c] === 'HH:MM:SS') v = formatTimestamp(now).slice(11, 19);
-          else v = formatTimestamp(now);
-        }
-      if (!row && !v && headerSet.has(c)) {
+      const missing = !row || row[c] === undefined || row[c] === '';
+      if (missing && !v && dateField.includes(c)) {
+        const now = new Date();
+        if (placeholders[c] === 'YYYY-MM-DD') v = formatTimestamp(now).slice(0, 10);
+        else if (placeholders[c] === 'HH:MM:SS') v = formatTimestamp(now).slice(11, 19);
+        else v = formatTimestamp(now);
+      }
+      if (missing && !v && headerSet.has(c)) {
         if (
           ['created_by', 'employee_id', 'emp_id', 'empid', 'user_id'].includes(c) &&
           user?.empid
@@ -969,7 +971,7 @@ const RowFormModal = function RowFormModal({
       <div className={formGridClass} style={formGridStyle}>
         {cols.map((c) => {
           let val = formVals[c];
-          if ((val === '' || val === undefined) && headerSet.has(c)) {
+          if (val === '' || val === undefined) {
             if (
               ['created_by', 'employee_id', 'emp_id', 'empid', 'user_id'].includes(c) &&
               user?.empid
@@ -1009,7 +1011,7 @@ const RowFormModal = function RowFormModal({
           <tbody>
             {cols.map((c) => {
               let val = formVals[c];
-              if ((val === '' || val === undefined) && headerSet.has(c)) {
+              if (val === '' || val === undefined) {
                 if (
                   ['created_by', 'employee_id', 'emp_id', 'empid', 'user_id'].includes(c) &&
                   user?.empid

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -481,6 +481,34 @@ export default function PosTransactionsPage() {
       Object.entries(defs).forEach(([k, v]) => {
         if (next[tbl][k] === undefined) next[tbl][k] = v;
       });
+      if (fc.userIdFields && user?.empid !== undefined) {
+        fc.userIdFields.forEach((f) => {
+          if (next[tbl][f] === undefined) next[tbl][f] = user.empid;
+        });
+      }
+      if (fc.branchIdFields && company?.branch_id !== undefined) {
+        fc.branchIdFields.forEach((f) => {
+          if (next[tbl][f] === undefined) next[tbl][f] = company.branch_id;
+        });
+      }
+      if (fc.companyIdFields && company?.company_id !== undefined) {
+        fc.companyIdFields.forEach((f) => {
+          if (next[tbl][f] === undefined) next[tbl][f] = company.company_id;
+        });
+      }
+      if (fc.transactionTypeField && fc.transactionTypeValue) {
+        if (next[tbl][fc.transactionTypeField] === undefined) {
+          next[tbl][fc.transactionTypeField] = fc.transactionTypeValue;
+        }
+      }
+      if (fc.dateField && Array.isArray(fc.dateField)) {
+        const now = formatTimestamp(new Date()).slice(0, 10);
+        fc.dateField.forEach((f) => {
+          if (next[tbl][f] === undefined || next[tbl][f] === '') {
+            next[tbl][f] = now;
+          }
+        });
+      }
     });
     setValues(next);
     setMasterId(null);


### PR DESCRIPTION
## Summary
- auto-fill session info fields even when not in header section
- when starting new POS transaction, prefill user/company/date fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883d508098c8331a04287256c39d06e