### PR TITLE
Fill session fields everywhere

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -25,6 +25,10 @@ const RowFormModal = function RowFormModal({
   headerFields = [],
   footerFields = [],
   mainFields = [],
+  userIdFields = [],
+  branchIdFields = [],
+  departmentIdFields = [],
+  companyIdFields = [],
   printEmpField = [],
   printCustField = [],
   totalAmountFields = [],
@@ -75,6 +79,10 @@ const RowFormModal = function RowFormModal({
   }, []);
   const headerSet = new Set(headerFields);
   const footerSet = new Set(footerFields);
+  const userIdSet = new Set(userIdFields);
+  const branchIdSet = new Set(branchIdFields);
+  const departmentIdSet = new Set(departmentIdFields);
+  const companyIdSet = new Set(companyIdFields);
   const { user, company } = useContext(AuthContext);
   const [formVals, setFormVals] = useState(() => {
     const init = {};
@@ -95,19 +103,14 @@ const RowFormModal = function RowFormModal({
         else if (placeholder === 'HH:MM:SS') val = formatTimestamp(now).slice(11, 19);
         else val = formatTimestamp(now);
       }
-      if (missing && !val && headerSet.has(c)) {
-        if (
-          ['created_by', 'employee_id', 'emp_id', 'empid', 'user_id'].includes(c) &&
-          user?.empid
-        ) {
-          val = user.empid;
-        } else if (c === 'branch_id' && company?.branch_id !== undefined) {
+      if (missing && !val) {
+        if (userIdSet.has(c) && user?.empid) val = user.empid;
+        else if (branchIdSet.has(c) && company?.branch_id !== undefined)
           val = company.branch_id;
-        } else if (c === 'department_id' && company?.department_id !== undefined) {
+        else if (departmentIdSet.has(c) && company?.department_id !== undefined)
           val = company.department_id;
-        } else if (c === 'company_id' && company?.company_id !== undefined) {
+        else if (companyIdSet.has(c) && company?.company_id !== undefined)
           val = company.company_id;
-        }
       }
       init[c] = val;
     });
@@ -240,19 +243,14 @@ const RowFormModal = function RowFormModal({
         else if (placeholders[c] === 'HH:MM:SS') v = formatTimestamp(now).slice(11, 19);
         else v = formatTimestamp(now);
       }
-      if (missing && !v && headerSet.has(c)) {
-        if (
-          ['created_by', 'employee_id', 'emp_id', 'empid', 'user_id'].includes(c) &&
-          user?.empid
-        ) {
-          v = user.empid;
-        } else if (c === 'branch_id' && company?.branch_id !== undefined) {
+      if (missing && !v) {
+        if (userIdSet.has(c) && user?.empid) v = user.empid;
+        else if (branchIdSet.has(c) && company?.branch_id !== undefined)
           v = company.branch_id;
-        } else if (c === 'department_id' && company?.department_id !== undefined) {
+        else if (departmentIdSet.has(c) && company?.department_id !== undefined)
           v = company.department_id;
-        } else if (c === 'company_id' && company?.company_id !== undefined) {
+        else if (companyIdSet.has(c) && company?.company_id !== undefined)
           v = company.company_id;
-        }
       }
       vals[c] = v;
     });
@@ -972,18 +970,13 @@ const RowFormModal = function RowFormModal({
         {cols.map((c) => {
           let val = formVals[c];
           if (val === '' || val === undefined) {
-            if (
-              ['created_by', 'employee_id', 'emp_id', 'empid', 'user_id'].includes(c) &&
-              user?.empid
-            ) {
-              val = user.empid;
-            } else if (c === 'branch_id' && company?.branch_id !== undefined) {
+            if (userIdSet.has(c) && user?.empid) val = user.empid;
+            else if (branchIdSet.has(c) && company?.branch_id !== undefined)
               val = company.branch_id;
-            } else if (c === 'department_id' && company?.department_id !== undefined) {
+            else if (departmentIdSet.has(c) && company?.department_id !== undefined)
               val = company.department_id;
-            } else if (c === 'company_id' && company?.company_id !== undefined) {
+            else if (companyIdSet.has(c) && company?.company_id !== undefined)
               val = company.company_id;
-            }
           }
           return (
             <div key={c} className={fitted ? 'mb-1' : 'mb-3'}>
@@ -1012,18 +1005,15 @@ const RowFormModal = function RowFormModal({
             {cols.map((c) => {
               let val = formVals[c];
               if (val === '' || val === undefined) {
-                if (
-                  ['created_by', 'employee_id', 'emp_id', 'empid', 'user_id'].includes(c) &&
-                  user?.empid
-                ) {
-                  val = user.empid;
-                } else if (c === 'branch_id' && company?.branch_id !== undefined) {
+                if (userIdSet.has(c) && user?.empid) val = user.empid;
+                else if (branchIdSet.has(c) && company?.branch_id !== undefined)
                   val = company.branch_id;
-                } else if (c === 'department_id' && company?.department_id !== undefined) {
+                else if (
+                  departmentIdSet.has(c) && company?.department_id !== undefined
+                )
                   val = company.department_id;
-                } else if (c === 'company_id' && company?.company_id !== undefined) {
+                else if (companyIdSet.has(c) && company?.company_id !== undefined)
                   val = company.company_id;
-                }
               }
               return (
                 <tr key={c}>

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -172,6 +172,12 @@ const TableManager = forwardRef(function TableManager({
     return ['department_id'].filter(f => validCols.has(f));
   }, [formConfig, validCols]);
 
+  const companyIdFields = useMemo(() => {
+    if (formConfig?.companyIdFields?.length)
+      return formConfig.companyIdFields.filter(f => validCols.has(f));
+    return ['company_id'].filter(f => validCols.has(f));
+  }, [formConfig, validCols]);
+
   const userIdFields = useMemo(() => {
     if (formConfig?.userIdFields?.length)
       return formConfig.userIdFields.filter(f => validCols.has(f));
@@ -654,7 +660,7 @@ const TableManager = forwardRef(function TableManager({
       if (userIdFields.includes(c) && user?.empid) v = user.empid;
       if (branchIdFields.includes(c) && company?.branch_id !== undefined) v = company.branch_id;
       if (departmentIdFields.includes(c) && company?.department_id !== undefined) v = company.department_id;
-      if (formConfig?.companyIdFields?.includes(c) && company?.company_id !== undefined) v = company.company_id;
+      if (companyIdFields.includes(c) && company?.company_id !== undefined) v = company.company_id;
       vals[c] = v;
       defaults[c] = v;
       if (!v && formConfig?.dateField?.includes(c)) {
@@ -850,7 +856,7 @@ const TableManager = forwardRef(function TableManager({
         if (columns.has(f) && company?.department_id !== undefined)
           merged[f] = company.department_id;
       });
-      formConfig?.companyIdFields?.forEach((f) => {
+      companyIdFields.forEach((f) => {
         if (columns.has(f) && company?.company_id !== undefined)
           merged[f] = company.company_id;
       });
@@ -1853,6 +1859,10 @@ const TableManager = forwardRef(function TableManager({
         headerFields={headerFields}
         mainFields={mainFields}
         footerFields={footerFields}
+        userIdFields={userIdFields}
+        branchIdFields={branchIdFields}
+        departmentIdFields={departmentIdFields}
+        companyIdFields={companyIdFields}
         printEmpField={formConfig?.printEmpField || []}
         printCustField={formConfig?.printCustField || []}
         totalAmountFields={formConfig?.totalAmountFields || []}


### PR DESCRIPTION
## Summary
- pass session field lists to `RowFormModal`
- auto-fill session values regardless of section placement
- include company ID fields in TableManager configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885ebbff2bc8331a22a7a2cc5da74b0