### PR TITLE
Fix editable field detection

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -34,6 +34,9 @@ function parseEntry(raw = {}) {
     editableDefaultFields: Array.isArray(raw.editableDefaultFields)
       ? raw.editableDefaultFields.map(String)
       : [],
+    editableFields: Array.isArray(raw.editableFields)
+      ? raw.editableFields.map(String)
+      : [],
     userIdFields: arrify(
       raw.userIdFields || (raw.userIdField ? [raw.userIdField] : []),
     ),
@@ -118,6 +121,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     requiredFields = [],
     defaultValues = {},
     editableDefaultFields = [],
+    editableFields = [],
     userIdFields = [],
     branchIdFields = [],
     companyIdFields = [],
@@ -163,6 +167,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     requiredFields: arrify(requiredFields),
     defaultValues,
     editableDefaultFields: arrify(editableDefaultFields),
+    editableFields: arrify(editableFields),
     userIdFields: uid,
     branchIdFields: bid,
     companyIdFields: cid,

--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -74,6 +74,10 @@ export default forwardRef(function InlineTransactionTable({
   const branchIdSet = new Set(branchIdFields);
   const departmentIdSet = new Set(departmentIdFields);
   const companyIdSet = new Set(companyIdFields);
+  const disabledSet = React.useMemo(
+    () => new Set(disabledFields.map((f) => f.toLowerCase())),
+    [disabledFields],
+  );
 
   function fillSessionDefaults(obj) {
     const row = { ...obj };
@@ -189,7 +193,7 @@ export default forwardRef(function InlineTransactionTable({
     maxWidth: `${boxMaxWidth}px`,
     wordBreak: 'break-word',
   };
-  const enabledFields = fields.filter((f) => !disabledFields.includes(f));
+  const enabledFields = fields.filter((f) => !disabledSet.has(f.toLowerCase()));
 
   function isValidDate(value, format) {
     if (!value) return true;
@@ -808,7 +812,7 @@ export default forwardRef(function InlineTransactionTable({
     const val = rows[idx]?.[f] ?? '';
     const isRel = relationConfigs[f] || Array.isArray(relations[f]);
     const invalid = invalidCell && invalidCell.row === idx && invalidCell.field === f;
-    if (disabledFields.includes(f)) {
+    if (disabledSet.has(f.toLowerCase())) {
       return (
         <div className="px-1" style={inputStyle} title={typeof val === 'object' ? val.label || val.value : val}>
           {typeof val === 'object' ? val.label || val.value : val}

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -83,6 +83,10 @@ const RowFormModal = function RowFormModal({
   const branchIdSet = new Set(branchIdFields);
   const departmentIdSet = new Set(departmentIdFields);
   const companyIdSet = new Set(companyIdFields);
+  const disabledSet = React.useMemo(
+    () => new Set(disabledFields.map((f) => f.toLowerCase())),
+    [disabledFields],
+  );
   const { user, company } = useContext(AuthContext);
   const [formVals, setFormVals] = useState(() => {
     const init = {};
@@ -349,7 +353,7 @@ const RowFormModal = function RowFormModal({
       await runProcTrigger(col, override);
     }
 
-    const enabled = columns.filter((c) => !disabledFields.includes(c));
+    const enabled = columns.filter((c) => !disabledSet.has(c.toLowerCase()));
     const idx = enabled.indexOf(col);
     const next = enabled[idx + 1];
     if (next && inputRefs.current[next]) {
@@ -673,7 +677,7 @@ const RowFormModal = function RowFormModal({
   function renderField(c, withLabel = true) {
     const err = errors[c];
     const inputClass = `w-full border rounded ${err ? 'border-red-500' : 'border-gray-300'}`;
-    const disabled = disabledFields.includes(c);
+    const disabled = disabledSet.has(c.toLowerCase());
 
     if (disabled) {
       const val = formVals[c];
@@ -969,88 +973,7 @@ const RowFormModal = function RowFormModal({
 
   function renderHeaderTable(cols) {
     if (cols.length === 0) return null;
-    const grid = (
-      <div className={formGridClass} style={formGridStyle}>
-        {cols.map((c) => {
-          let val = formVals[c];
-          if (val === '' || val === undefined) {
-            if (userIdSet.has(c) && user?.empid) val = user.empid;
-            else if (branchIdSet.has(c) && company?.branch_id !== undefined)
-              val = company.branch_id;
-            else if (departmentIdSet.has(c) && company?.department_id !== undefined)
-              val = company.department_id;
-            else if (companyIdSet.has(c) && company?.company_id !== undefined)
-              val = company.company_id;
-          }
-          return (
-            <div key={c} className={fitted ? 'mb-1' : 'mb-3'}>
-              <label className="block mb-1 font-medium" style={labelStyle}>{labels[c] || c}</label>
-              <div className="w-full border rounded bg-gray-100 px-2 py-1" style={inputStyle} title={val}>
-                {val}
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    );
-    if (fitted) {
-      return (
-        <div className="mb-1">
-          <h3 className="mt-0 mb-1 font-semibold">Header</h3>
-          {grid}
-        </div>
-      );
-    }
-    return (
-      <div className="mb-4">
-        <h3 className="mt-0 mb-1 font-semibold">Header</h3>
-        <table className="min-w-full border border-gray-300 text-sm" style={{tableLayout:'fixed',width:'100%'}}>
-          <tbody>
-            {cols.map((c) => {
-              let val = formVals[c];
-              if (val === '' || val === undefined) {
-                if (userIdSet.has(c) && user?.empid) val = user.empid;
-                else if (branchIdSet.has(c) && company?.branch_id !== undefined)
-                  val = company.branch_id;
-                else if (
-                  departmentIdSet.has(c) && company?.department_id !== undefined
-                )
-                  val = company.department_id;
-                else if (companyIdSet.has(c) && company?.company_id !== undefined)
-                  val = company.company_id;
-              }
-              return (
-                <tr key={c}>
-                  <th
-                    className="border px-2 py-1 text-left"
-                  style={{
-                    maxWidth: `${boxMaxWidth}px`,
-                    wordBreak: 'break-word',
-                    fontSize: labelStyle.fontSize,
-                    width: `${boxWidth}px`,
-                    minWidth: `${boxWidth}px`,
-                  }}
-                >
-                  {labels[c] || c}
-                </th>
-                <td
-                  className="border px-2 py-1"
-                  style={{
-                    maxWidth: `${boxMaxWidth}px`,
-                    wordBreak: 'break-word',
-                    width: `${boxWidth}px`,
-                    minWidth: `${boxWidth}px`,
-                  }}
-                >
-                  {val}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-    );
+    return renderSection('Header', cols);
   }
 
   function renderSection(title, cols) {

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1206,15 +1206,6 @@ const TableManager = forwardRef(function TableManager({
     )
     .map(([k]) => k);
 
-  let disabledFields = [];
-  if (formConfig?.editableFields?.length) {
-    const set = new Set(formConfig.editableFields);
-    disabledFields = formColumns.filter((c) => !set.has(c));
-  }
-  disabledFields = editing
-    ? Array.from(new Set([...disabledFields, ...getKeyFields(), ...lockedDefaults]))
-    : Array.from(new Set([...disabledFields, ...lockedDefaults]));
-
   const headerFields = formConfig?.headerFields || [];
 
   const mainFields = formConfig?.mainFields || [];
@@ -1225,6 +1216,14 @@ const TableManager = forwardRef(function TableManager({
   sectionFields.forEach((f) => {
     if (!formColumns.includes(f) && allColumns.includes(f)) formColumns.push(f);
   });
+
+  const editSet = new Set(
+    (formConfig?.editableFields || []).map((f) => f.toLowerCase()),
+  );
+  let disabledFields = formColumns.filter((c) => !editSet.has(c.toLowerCase()));
+  disabledFields = editing
+    ? Array.from(new Set([...disabledFields, ...getKeyFields(), ...lockedDefaults]))
+    : Array.from(new Set([...disabledFields, ...lockedDefaults]));
 
   const totalAmountSet = useMemo(
     () => new Set(formConfig?.totalAmountFields || []),

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -866,12 +866,24 @@ export default function PosTransactionsPage() {
                   fc.headerFields && fc.headerFields.length > 0
                     ? fc.headerFields
                     : [];
+                const mainFields =
+                  fc.mainFields && fc.mainFields.length > 0
+                    ? fc.mainFields
+                    : [];
+                const footerFields =
+                  fc.footerFields && fc.footerFields.length > 0
+                    ? fc.footerFields
+                    : [];
                 const editable = Array.isArray(fc.editableFields)
                   ? fc.editableFields
                   : [];
-                const disabled = editable.length
-                  ? visible.filter((c) => !editable.includes(c))
-                  : [];
+                const editSet = new Set(editable.map((f) => f.toLowerCase()));
+                const allFields = Array.from(
+                  new Set([...visible, ...headerFields, ...mainFields, ...footerFields]),
+                );
+                const disabled = allFields.filter(
+                  (c) => !editSet.has(c.toLowerCase()),
+                );
                 const posStyle = {
                   top_row: { gridColumn: '1 / span 3', gridRow: '1' },
                   upper_left: { gridColumn: '1', gridRow: '2' },
@@ -911,13 +923,15 @@ export default function PosTransactionsPage() {
                       key={`rf-${t.table}-${generalConfig.pos.boxWidth}`}
                       inline
                       visible
-                      columns={visible}
+                      columns={allFields}
                       disabledFields={disabled}
                       requiredFields={fc.requiredFields || []}
                       labels={labels}
                       row={values[t.table]}
                       rows={t.type === 'multi' ? values[t.table] : undefined}
                       headerFields={headerFields}
+                      mainFields={mainFields}
+                      footerFields={footerFields}
                       defaultValues={fc.defaultValues || {}}
                     relations={relationsMap[t.table] || {}}
                     relationConfigs={relationConfigs[t.table] || {}}


### PR DESCRIPTION
## Summary
- handle editableFields case-insensitively when deriving disabled columns
- compute disabled fields after injecting header/main/footer so all sections respect configuration
- pass all configured columns to POS forms so non-editable fields display correctly
- disable fields not listed in editableFields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688614fb1b8883319c4d3b9125d895a6