### PR TITLE
Fix editable field fallback and apply config sizes

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -180,7 +180,7 @@ export default forwardRef(function InlineTransactionTable({
   const inputStyle = {
     fontSize: `${inputFontSize}px`,
     padding: '0.25rem 0.5rem',
-    width: 'auto',
+    width: `${boxWidth}px`,
     minWidth: `${boxWidth}px`,
     maxWidth: `${boxMaxWidth}px`,
     height: `${boxHeight}px`,
@@ -188,7 +188,7 @@ export default forwardRef(function InlineTransactionTable({
     overflow: 'hidden',
   };
   const colStyle = {
-    width: 'auto',
+    width: `${boxWidth}px`,
     minWidth: `${boxWidth}px`,
     maxWidth: `${boxMaxWidth}px`,
     wordBreak: 'break-word',

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -306,7 +306,7 @@ const RowFormModal = function RowFormModal({
   const inputStyle = {
     fontSize: `${inputFontSize}px`,
     padding: '0.25rem 0.5rem',
-    width: 'auto',
+    width: `${boxWidth}px`,
     minWidth: `${boxWidth}px`,
     maxWidth: `${boxMaxWidth}px`,
     height: `${boxHeight}px`,

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1217,12 +1217,14 @@ const TableManager = forwardRef(function TableManager({
     if (!formColumns.includes(f) && allColumns.includes(f)) formColumns.push(f);
   });
 
-  const hasEdit =
-    formConfig && Object.prototype.hasOwnProperty.call(formConfig, 'editableFields');
-  const editVals = Array.isArray(formConfig?.editableFields)
+  const provided = Array.isArray(formConfig?.editableFields)
     ? formConfig.editableFields
     : [];
-  const editSet = hasEdit ? new Set(editVals.map((f) => f.toLowerCase())) : null;
+  const defaults = Array.isArray(formConfig?.editableDefaultFields)
+    ? formConfig.editableDefaultFields
+    : [];
+  const editVals = provided.length > 0 ? provided : defaults;
+  const editSet = editVals.length > 0 ? new Set(editVals.map((f) => f.toLowerCase())) : null;
   let disabledFields = editSet
     ? formColumns.filter((c) => !editSet.has(c.toLowerCase()))
     : [];

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -874,14 +874,17 @@ export default function PosTransactionsPage() {
                   fc.footerFields && fc.footerFields.length > 0
                     ? fc.footerFields
                     : [];
-                const hasEdit =
-                  fc && Object.prototype.hasOwnProperty.call(fc, 'editableFields');
-                const editVals = Array.isArray(fc.editableFields)
+                const provided = Array.isArray(fc.editableFields)
                   ? fc.editableFields
                   : [];
-                const editSet = hasEdit
-                  ? new Set(editVals.map((f) => f.toLowerCase()))
-                  : null;
+                const defaults = Array.isArray(fc.editableDefaultFields)
+                  ? fc.editableDefaultFields
+                  : [];
+                const editVals = provided.length > 0 ? provided : defaults;
+                const editSet =
+                  editVals.length > 0
+                    ? new Set(editVals.map((f) => f.toLowerCase()))
+                    : null;
                 const allFields = Array.from(
                   new Set([...visible, ...headerFields, ...mainFields, ...footerFields]),
                 );
@@ -958,12 +961,14 @@ export default function PosTransactionsPage() {
                         let next = idx + 1;
                         while (next < formList.length) {
                           const nf = formConfigs[formList[next].table];
-                          const hasEd =
-                            nf && Object.prototype.hasOwnProperty.call(nf, 'editableFields');
-                          const ed = Array.isArray(nf?.editableFields)
+                          const provided = Array.isArray(nf?.editableFields)
                             ? nf.editableFields
                             : [];
-                          if (hasEd && ed.length > 0) break;
+                          const defaults = Array.isArray(nf?.editableDefaultFields)
+                            ? nf.editableDefaultFields
+                            : [];
+                          const ed = provided.length > 0 ? provided : defaults;
+                          if (ed.length > 0) break;
                           next += 1;
                         }
                         if (next < formList.length) focusFirst(formList[next].table);


### PR DESCRIPTION
## Summary
- fix editable field fallback logic so empty arrays don't disable everything
- fallback to editableDefaultFields when no editableFields provided
- apply box width/height from generalConfig in RowFormModal and InlineTransactionTable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688653acc84c8331b62ab12a62a64c52