### PR TITLE
Fix relation preview and dropdown search

### DIFF
--- a/src/erp.mgt.mn/components/AsyncSearchSelect.jsx
+++ b/src/erp.mgt.mn/components/AsyncSearchSelect.jsx
@@ -25,6 +25,8 @@ export default function AsyncSearchSelect({
   const [options, setOptions] = useState([]);
   const [show, setShow] = useState(false);
   const [highlight, setHighlight] = useState(-1);
+  const [loading, setLoading] = useState(false);
+  const timeoutRef = useRef(null);
   const containerRef = useRef(null);
   const match = options.find((o) => String(o.value) === String(input));
   const displayLabel = match ? match.label : label;
@@ -46,73 +48,63 @@ export default function AsyncSearchSelect({
   }, [options, show]);
 
   useEffect(() => {
-    const cols = searchColumns && searchColumns.length > 0
-      ? searchColumns
-      : searchColumn
-      ? [searchColumn]
-      : [];
+    const cols =
+      searchColumns && searchColumns.length > 0
+        ? searchColumns
+        : searchColumn
+        ? [searchColumn]
+        : [];
     if (!table || cols.length === 0) return;
+    if (!input) {
+      setOptions([]);
+      return;
+    }
     const controller = new AbortController();
-    async function load() {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(async () => {
+      setLoading(true);
       try {
-        let page = 1;
-        const perPage = 500;
-        let rows = [];
-        while (true) {
-          const params = new URLSearchParams({ page, perPage });
-          if (input) {
-            cols.forEach((c) => params.set(c, input));
-          }
-          const res = await fetch(
-            `/api/tables/${encodeURIComponent(table)}?${params.toString()}`,
-            { credentials: 'include', signal: controller.signal },
-          );
-          const json = await res.json();
-          if (Array.isArray(json.rows)) {
-            rows = rows.concat(json.rows);
-            if (
-              rows.length >= (json.count || rows.length) ||
-              json.rows.length < perPage
-            )
-              break;
+        const params = new URLSearchParams({ page: 1, perPage: 50 });
+        cols.forEach((c) => params.append(c, input));
+        const res = await fetch(
+          `/api/tables/${encodeURIComponent(table)}?${params.toString()}`,
+          { credentials: 'include', signal: controller.signal },
+        );
+        const json = await res.json();
+        const rows = Array.isArray(json.rows) ? json.rows : [];
+        const opts = rows.map((r) => {
+          const val = r[idField || searchColumn];
+          const parts = [];
+          if (val !== undefined) parts.push(val);
+          if (labelFields.length === 0) {
+            Object.entries(r).forEach(([k, v]) => {
+              if (k === idField || k === searchColumn) return;
+              if (v !== undefined && parts.length < 3) parts.push(v);
+            });
           } else {
-            break;
+            labelFields.forEach((f) => {
+              if (r[f] !== undefined) parts.push(r[f]);
+            });
           }
-          page += 1;
-        }
-        if (rows.length > 0) {
-          const opts = rows.map((r) => {
-            const val = r[idField || searchColumn];
-            const parts = [];
-            if (val !== undefined) parts.push(val);
-            if (labelFields.length === 0) {
-              Object.entries(r).forEach(([k, v]) => {
-                if (k === idField || k === searchColumn) return;
-                if (v !== undefined && parts.length < 3) parts.push(v);
-              });
-            } else {
-              labelFields.forEach((f) => {
-                if (r[f] !== undefined) parts.push(r[f]);
-              });
-            }
-            return { value: val, label: parts.join(' - ') };
-          });
-          const q = String(input || '').toLowerCase();
-          const filtered = opts.filter(
-            (o) =>
-              String(o.value).toLowerCase().includes(q) ||
-              String(o.label).toLowerCase().includes(q),
-          );
-          setOptions(filtered);
-        } else {
-          setOptions([]);
-        }
+          return { value: val, label: parts.join(' - ') };
+        });
+        const q = String(input).toLowerCase();
+        const filtered = opts.filter(
+          (o) =>
+            String(o.value).toLowerCase().includes(q) ||
+            String(o.label).toLowerCase().includes(q),
+        );
+        setOptions(filtered);
       } catch (err) {
         if (err.name !== 'AbortError') setOptions([]);
+      } finally {
+        setLoading(false);
       }
-    }
-    load();
-    return () => controller.abort();
+    }, 300);
+    return () => {
+      clearTimeout(timeoutRef.current);
+      controller.abort();
+    };
   }, [table, searchColumn, searchColumns, labelFields, idField, input]);
 
   function handleSelectKeyDown(e) {
@@ -182,7 +174,7 @@ export default function AsyncSearchSelect({
         title={input}
         {...rest}
       />
-      {show && options.length > 0 && (
+      {show && (
         <ul
           style={{
             position: 'absolute',
@@ -197,28 +189,32 @@ export default function AsyncSearchSelect({
             overflowY: 'auto',
           }}
         >
-          {options.map((opt, idx) => (
-            <li
-              key={opt.value}
-              onMouseDown={() => {
-                onChange(opt.value, opt.label);
-                if (onSelect) onSelect(opt);
-                setInput(String(opt.value));
-                setLabel(opt.label || '');
-                if (internalRef.current) internalRef.current.value = String(opt.value);
-                chosenRef.current = opt;
-                setShow(false);
-              }}
-              onMouseEnter={() => setHighlight(idx)}
-              style={{
-                padding: '0.25rem',
-                background: highlight === idx ? '#eee' : '#fff',
-                cursor: 'pointer',
-              }}
-            >
-              {opt.label || opt.value}
-            </li>
-          ))}
+          {loading ? (
+            <li style={{ padding: '0.25rem' }}>Loading...</li>
+          ) : (
+            options.map((opt, idx) => (
+              <li
+                key={opt.value}
+                onMouseDown={() => {
+                  onChange(opt.value, opt.label);
+                  if (onSelect) onSelect(opt);
+                  setInput(String(opt.value));
+                  setLabel(opt.label || '');
+                  if (internalRef.current) internalRef.current.value = String(opt.value);
+                  chosenRef.current = opt;
+                  setShow(false);
+                }}
+                onMouseEnter={() => setHighlight(idx)}
+                style={{
+                  padding: '0.25rem',
+                  background: highlight === idx ? '#eee' : '#fff',
+                  cursor: 'pointer',
+                }}
+              >
+                {opt.label || opt.value}
+              </li>
+            ))
+          )}
         </ul>
       )}
       {displayLabel && (

--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -9,6 +9,7 @@ import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import AsyncSearchSelect from './AsyncSearchSelect.jsx';
 import formatTimestamp from '../utils/formatTimestamp.js';
 import callProcedure from '../utils/callProcedure.js';
+import RowDetailModal from './RowDetailModal.jsx';
 
 const currencyFmt = new Intl.NumberFormat('en-US', {
   minimumFractionDigits: 2,
@@ -170,6 +171,8 @@ export default forwardRef(function InlineTransactionTable({
   const addBtnRef = useRef(null);
   const [errorMsg, setErrorMsg] = useState('');
   const [invalidCell, setInvalidCell] = useState(null);
+  const [previewRow, setPreviewRow] = useState(null);
+  const [showPreview, setShowPreview] = useState(false);
   const procCache = useRef({});
 
   const totalAmountSet = new Set(totalAmountFields);
@@ -467,6 +470,23 @@ export default forwardRef(function InlineTransactionTable({
 
   function handleFocusField(col) {
     showTriggerInfo(col);
+  }
+
+  async function openPreview(field, val, rowIdx) {
+    const tableName = relationConfigs[field]?.table || viewSource[field];
+    const id = val && typeof val === 'object' ? val.value : val;
+    if (!tableName || !id) return;
+    try {
+      const res = await fetch(
+        `/api/tables/${encodeURIComponent(tableName)}/${encodeURIComponent(id)}`,
+        { credentials: 'include' },
+      );
+      if (res.ok) {
+        const rowData = await res.json();
+        setPreviewRow(rowData);
+        setShowPreview(true);
+      }
+    } catch {}
   }
 
   function addRow() {
@@ -813,9 +833,25 @@ export default forwardRef(function InlineTransactionTable({
     const isRel = relationConfigs[f] || Array.isArray(relations[f]);
     const invalid = invalidCell && invalidCell.row === idx && invalidCell.field === f;
     if (disabledSet.has(f.toLowerCase())) {
+      const previewable = relationConfigs[f] || viewSource[f];
       return (
-        <div className="px-1" style={inputStyle} title={typeof val === 'object' ? val.label || val.value : val}>
-          {typeof val === 'object' ? val.label || val.value : val}
+        <div
+          className="px-1 flex items-center"
+          style={{ ...inputStyle, width: 'fit-content', maxWidth: `${boxMaxWidth}px` }}
+          title={typeof val === 'object' ? val.label || val.value : val}
+        >
+          <div className="flex-1">
+            {typeof val === 'object' ? val.label || val.value : val}
+          </div>
+          {previewable && val !== '' && (
+            <button
+              type="button"
+              onClick={() => openPreview(f, val, idx)}
+              style={{ marginLeft: '0.25rem' }}
+            >
+              🔍
+            </button>
+          )}
         </div>
       );
     }
@@ -830,6 +866,7 @@ export default forwardRef(function InlineTransactionTable({
           <AsyncSearchSelect
             table={conf.table}
             searchColumn={conf.column}
+            searchColumns={[conf.column, ...(conf.displayFields || [])]}
             labelFields={conf.displayFields || []}
             value={inputVal}
             onChange={(v, label) =>
@@ -1018,6 +1055,12 @@ export default forwardRef(function InlineTransactionTable({
           + Мөр нэмэх
         </button>
       )}
+      <RowDetailModal
+        visible={showPreview}
+        onClose={() => setShowPreview(false)}
+        row={previewRow || {}}
+        columns={previewRow ? Object.keys(previewRow) : []}
+      />
     </div>
   );
 });

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useContext, memo } from 'react';
 import AsyncSearchSelect from './AsyncSearchSelect.jsx';
 import Modal from './Modal.jsx';
 import InlineTransactionTable from './InlineTransactionTable.jsx';
+import RowDetailModal from './RowDetailModal.jsx';
 import { AuthContext } from '../context/AuthContext.jsx';
 import formatTimestamp from '../utils/formatTimestamp.js';
 import callProcedure from '../utils/callProcedure.js';
@@ -143,6 +144,8 @@ const RowFormModal = function RowFormModal({
   const [gridRows, setGridRows] = useState(() => (Array.isArray(rows) ? rows : []));
   const wrapRef = useRef(null);
   const [zoom, setZoom] = useState(1);
+  const [previewRow, setPreviewRow] = useState(null);
+  const [showPreview, setShowPreview] = useState(false);
 
   useEffect(() => {
     if (useGrid) {
@@ -552,6 +555,25 @@ const RowFormModal = function RowFormModal({
     showTriggerInfo(col);
   }
 
+  async function handlePreview(col) {
+    const val = formVals[col];
+    const id = val && typeof val === 'object' ? val.value : val;
+    if (!id) return;
+    const tableName = relationConfigs[col]?.table || viewSource[col];
+    if (!tableName) return;
+    try {
+      const res = await fetch(
+        `/api/tables/${encodeURIComponent(tableName)}/${encodeURIComponent(id)}`,
+        { credentials: 'include' },
+      );
+      if (res.ok) {
+        const rowData = await res.json();
+        setPreviewRow(rowData);
+        setShowPreview(true);
+      }
+    } catch {}
+  }
+
   async function submitForm() {
     if (submitLocked) return;
     setSubmitLocked(true);
@@ -681,10 +703,32 @@ const RowFormModal = function RowFormModal({
 
     if (disabled) {
       const val = formVals[c];
+      const previewable = relationConfigs[c] || viewSource[c];
+      const boxStyle = {
+        ...inputStyle,
+        width: 'fit-content',
+        maxWidth: `${boxMaxWidth}px`,
+      };
+      const content = (
+        <div className="flex items-center">
+          <div className="flex-1" title={val}>
+            {val}
+          </div>
+          {previewable && val !== '' && (
+            <button
+              type="button"
+              onClick={() => handlePreview(c)}
+              style={{ marginLeft: '0.25rem' }}
+            >
+              🔍
+            </button>
+          )}
+        </div>
+      );
       if (!withLabel) {
         return (
-          <div className="w-full border rounded bg-gray-100 px-2 py-1" style={inputStyle} title={val}>
-            {val}
+          <div className="w-full border rounded bg-gray-100 px-2 py-1" style={boxStyle}>
+            {content}
           </div>
         );
       }
@@ -693,8 +737,8 @@ const RowFormModal = function RowFormModal({
           <label className="block mb-1 font-medium" style={labelStyle}>
             {labels[c] || c}
           </label>
-          <div className="w-full border rounded bg-gray-100 px-2 py-1" style={inputStyle} title={val}>
-            {val}
+          <div className="w-full border rounded bg-gray-100 px-2 py-1" style={boxStyle}>
+            {content}
           </div>
         </div>
       );
@@ -705,6 +749,10 @@ const RowFormModal = function RowFormModal({
         title={labels[c] || c}
         table={relationConfigs[c].table}
         searchColumn={relationConfigs[c].column}
+        searchColumns={[
+          relationConfigs[c].column,
+          ...(relationConfigs[c].displayFields || []),
+        ]}
         labelFields={relationConfigs[c].displayFields || []}
         value={typeof formVals[c] === 'object' ? formVals[c].value : formVals[c]}
         onChange={(val) => {
@@ -1115,6 +1163,12 @@ const RowFormModal = function RowFormModal({
         </div>
       </form>
     </Modal>
+    <RowDetailModal
+      visible={showPreview}
+      onClose={() => setShowPreview(false)}
+      row={previewRow || {}}
+      columns={previewRow ? Object.keys(previewRow) : []}
+    />
   );
 }
 


### PR DESCRIPTION
## Summary
- update AsyncSearchSelect to debounce fetch and show loading state
- let readonly div fields expand to fit content and show preview button
- add relation preview for InlineTransactionTable and RowFormModal
- allow relation search across label fields
- remove stray closing form tag

## Testing
- `npm test`
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68865a773dec8331ab7db5dcd214dd1d