### PR TITLE
Fix form preview styles and async dropdown searches

### DIFF
--- a/src/erp.mgt.mn/components/AsyncSearchSelect.jsx
+++ b/src/erp.mgt.mn/components/AsyncSearchSelect.jsx
@@ -23,6 +23,7 @@ export default function AsyncSearchSelect({
   const [input, setInput] = useState(initialVal);
   const [label, setLabel] = useState(initialLabel);
   const [options, setOptions] = useState([]);
+  const [loading, setLoading] = useState(false);
   const [show, setShow] = useState(false);
   const [highlight, setHighlight] = useState(-1);
   const containerRef = useRef(null);
@@ -52,67 +53,43 @@ export default function AsyncSearchSelect({
       ? [searchColumn]
       : [];
     if (!table || cols.length === 0) return;
+    const term = String(input || '').trim();
+    if (!term) { setOptions([]); return; }
     const controller = new AbortController();
-    async function load() {
+    const t = setTimeout(async () => {
+      setLoading(true);
       try {
-        let page = 1;
-        const perPage = 500;
-        let rows = [];
-        while (true) {
-          const params = new URLSearchParams({ page, perPage });
-          if (input) {
-            cols.forEach((c) => params.set(c, input));
-          }
-          const res = await fetch(
-            `/api/tables/${encodeURIComponent(table)}?${params.toString()}`,
-            { credentials: 'include', signal: controller.signal },
-          );
-          const json = await res.json();
-          if (Array.isArray(json.rows)) {
-            rows = rows.concat(json.rows);
-            if (
-              rows.length >= (json.count || rows.length) ||
-              json.rows.length < perPage
-            )
-              break;
+        const params = new URLSearchParams({ page: 1, perPage: 100 });
+        cols.forEach((c) => params.set(c, term));
+        const res = await fetch(
+          `/api/tables/${encodeURIComponent(table)}?${params.toString()}`,
+          { credentials: 'include', signal: controller.signal },
+        );
+        const json = await res.json();
+        const rows = Array.isArray(json.rows) ? json.rows : [];
+        const opts = rows.map((r) => {
+          const val = r[idField || searchColumn];
+          const parts = [];
+          if (val !== undefined) parts.push(val);
+          if (labelFields.length === 0) {
+            Object.entries(r).forEach(([k, v]) => {
+              if (k === idField || k === searchColumn) return;
+              if (v !== undefined && parts.length < 3) parts.push(v);
+            });
           } else {
-            break;
+            labelFields.forEach((f) => {
+              if (r[f] !== undefined) parts.push(r[f]);
+            });
           }
-          page += 1;
-        }
-        if (rows.length > 0) {
-          const opts = rows.map((r) => {
-            const val = r[idField || searchColumn];
-            const parts = [];
-            if (val !== undefined) parts.push(val);
-            if (labelFields.length === 0) {
-              Object.entries(r).forEach(([k, v]) => {
-                if (k === idField || k === searchColumn) return;
-                if (v !== undefined && parts.length < 3) parts.push(v);
-              });
-            } else {
-              labelFields.forEach((f) => {
-                if (r[f] !== undefined) parts.push(r[f]);
-              });
-            }
-            return { value: val, label: parts.join(' - ') };
-          });
-          const q = String(input || '').toLowerCase();
-          const filtered = opts.filter(
-            (o) =>
-              String(o.value).toLowerCase().includes(q) ||
-              String(o.label).toLowerCase().includes(q),
-          );
-          setOptions(filtered);
-        } else {
-          setOptions([]);
-        }
+          return { value: val, label: parts.join(' - ') };
+        });
+        setOptions(opts);
       } catch (err) {
         if (err.name !== 'AbortError') setOptions([]);
       }
-    }
-    load();
-    return () => controller.abort();
+      setLoading(false);
+    }, 300);
+    return () => { clearTimeout(t); controller.abort(); };
   }, [table, searchColumn, searchColumns, labelFields, idField, input]);
 
   function handleSelectKeyDown(e) {
@@ -182,7 +159,7 @@ export default function AsyncSearchSelect({
         title={input}
         {...rest}
       />
-      {show && options.length > 0 && (
+      {show && (options.length > 0 || loading) && (
         <ul
           style={{
             position: 'absolute',
@@ -197,28 +174,30 @@ export default function AsyncSearchSelect({
             overflowY: 'auto',
           }}
         >
-          {options.map((opt, idx) => (
-            <li
-              key={opt.value}
-              onMouseDown={() => {
-                onChange(opt.value, opt.label);
-                if (onSelect) onSelect(opt);
-                setInput(String(opt.value));
-                setLabel(opt.label || '');
-                if (internalRef.current) internalRef.current.value = String(opt.value);
-                chosenRef.current = opt;
-                setShow(false);
-              }}
-              onMouseEnter={() => setHighlight(idx)}
-              style={{
-                padding: '0.25rem',
-                background: highlight === idx ? '#eee' : '#fff',
-                cursor: 'pointer',
-              }}
-            >
-              {opt.label || opt.value}
-            </li>
-          ))}
+          {loading && <li style={{ padding: '0.25rem' }}>Loading...</li>}
+          {!loading &&
+            options.map((opt, idx) => (
+              <li
+                key={opt.value}
+                onMouseDown={() => {
+                  onChange(opt.value, opt.label);
+                  if (onSelect) onSelect(opt);
+                  setInput(String(opt.value));
+                  setLabel(opt.label || '');
+                  if (internalRef.current) internalRef.current.value = String(opt.value);
+                  chosenRef.current = opt;
+                  setShow(false);
+                }}
+                onMouseEnter={() => setHighlight(idx)}
+                style={{
+                  padding: '0.25rem',
+                  background: highlight === idx ? '#eee' : '#fff',
+                  cursor: 'pointer',
+                }}
+              >
+                {opt.label || opt.value}
+              </li>
+            ))}
         </ul>
       )}
       {displayLabel && (

--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -9,6 +9,7 @@ import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import AsyncSearchSelect from './AsyncSearchSelect.jsx';
 import formatTimestamp from '../utils/formatTimestamp.js';
 import callProcedure from '../utils/callProcedure.js';
+import RowDetailModal from './RowDetailModal.jsx';
 
 const currencyFmt = new Intl.NumberFormat('en-US', {
   minimumFractionDigits: 2,
@@ -170,6 +171,7 @@ export default forwardRef(function InlineTransactionTable({
   const addBtnRef = useRef(null);
   const [errorMsg, setErrorMsg] = useState('');
   const [invalidCell, setInvalidCell] = useState(null);
+  const [detailRow, setDetailRow] = useState(null);
   const procCache = useRef({});
 
   const totalAmountSet = new Set(totalAmountFields);
@@ -808,14 +810,35 @@ export default forwardRef(function InlineTransactionTable({
     }
   }
 
+  function openDetail(rowIdx, field) {
+    let val = rows[rowIdx]?.[field];
+    if (val && typeof val === 'object' && 'value' in val) val = val.value;
+    const conf = relationConfigs[field];
+    const dataMap = conf ? relationData[field] : relationData[viewSource[field]];
+    if (dataMap && val !== undefined && dataMap[val]) {
+      setDetailRow(dataMap[val]);
+    }
+  }
+
   function renderCell(idx, f, colIdx) {
     const val = rows[idx]?.[f] ?? '';
     const isRel = relationConfigs[f] || Array.isArray(relations[f]);
     const invalid = invalidCell && invalidCell.row === idx && invalidCell.field === f;
     if (disabledSet.has(f.toLowerCase())) {
+      const divStyle = { ...inputStyle, width: 'fit-content', maxWidth: `${boxMaxWidth}px` };
+      const showBtn =
+        (relationConfigs[f] && relationData[f]?.[typeof val === 'object' ? val.value : val]) ||
+        (viewSource[f] && relationData[viewSource[f]]?.[typeof val === 'object' ? val.value : val]);
       return (
-        <div className="px-1" style={inputStyle} title={typeof val === 'object' ? val.label || val.value : val}>
-          {typeof val === 'object' ? val.label || val.value : val}
+        <div className="flex items-center space-x-1">
+          <div className="px-1 border rounded bg-gray-100" style={divStyle} title={typeof val === 'object' ? val.label || val.value : val}>
+            {typeof val === 'object' ? val.label || val.value : val}
+          </div>
+          {showBtn && (
+            <button type="button" onClick={() => openDetail(idx, f)} style={{ lineHeight: 1 }} title="View details">
+              🔍
+            </button>
+          )}
         </div>
       );
     }
@@ -830,6 +853,7 @@ export default forwardRef(function InlineTransactionTable({
           <AsyncSearchSelect
             table={conf.table}
             searchColumn={conf.column}
+            searchColumns={[conf.column, ...(conf.displayFields || [])]}
             labelFields={conf.displayFields || []}
             value={inputVal}
             onChange={(v, label) =>
@@ -1018,6 +1042,12 @@ export default forwardRef(function InlineTransactionTable({
           + Мөр нэмэх
         </button>
       )}
+      <RowDetailModal
+        visible={!!detailRow}
+        onClose={() => setDetailRow(null)}
+        row={detailRow || {}}
+        columns={detailRow ? Object.keys(detailRow) : []}
+      />
     </div>
   );
 });


### PR DESCRIPTION
## Summary
- adjust read-only divs to fit content and open detail modal
- add relation detail view to InlineTransactionTable and RowFormModal
- debounce AsyncSearchSelect queries and show loading
- search dropdowns across display fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68866375b68c8331bd0a59c3a04e2a00