### PR TITLE
Improve transaction forms

### DIFF
--- a/src/erp.mgt.mn/components/AsyncSearchSelect.jsx
+++ b/src/erp.mgt.mn/components/AsyncSearchSelect.jsx
@@ -47,6 +47,7 @@ export default function AsyncSearchSelect({
   }, [options, show]);
 
   useEffect(() => {
+    if (disabled) return;
     const cols = searchColumns && searchColumns.length > 0
       ? searchColumns
       : searchColumn
@@ -97,7 +98,7 @@ export default function AsyncSearchSelect({
       clearTimeout(handler);
       controller.abort();
     };
-  }, [table, searchColumn, searchColumns, labelFields, idField, input, show]);
+  }, [table, searchColumn, searchColumns, labelFields, idField, input, show, disabled]);
 
   function handleSelectKeyDown(e) {
     if (e.key === 'ArrowDown') {

--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -870,6 +870,7 @@ export default forwardRef(function InlineTransactionTable({
           <AsyncSearchSelect
             table={conf.table}
             searchColumn={conf.column}
+            searchColumns={[conf.column, ...(conf.displayFields || [])]}
             labelFields={conf.displayFields || []}
             value={inputVal}
             onChange={(v, label) =>

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -746,6 +746,10 @@ const RowFormModal = function RowFormModal({
         title={labels[c] || c}
         table={relationConfigs[c].table}
         searchColumn={relationConfigs[c].column}
+        searchColumns={[
+          relationConfigs[c].column,
+          ...(relationConfigs[c].displayFields || []),
+        ]}
         labelFields={relationConfigs[c].displayFields || []}
         value={typeof formVals[c] === 'object' ? formVals[c].value : formVals[c]}
         onChange={(val) => {

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1223,7 +1223,7 @@ const TableManager = forwardRef(function TableManager({
   const defaults = Array.isArray(formConfig?.editableDefaultFields)
     ? formConfig.editableDefaultFields
     : [];
-  const editVals = provided.length > 0 ? provided : defaults;
+  const editVals = Array.from(new Set([...defaults, ...provided]));
   const editSet = editVals.length > 0 ? new Set(editVals.map((f) => f.toLowerCase())) : null;
   let disabledFields = editSet
     ? formColumns.filter((c) => !editSet.has(c.toLowerCase()))

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -880,7 +880,7 @@ export default function PosTransactionsPage() {
                 const defaults = Array.isArray(fc.editableDefaultFields)
                   ? fc.editableDefaultFields
                   : [];
-                const editVals = provided.length > 0 ? provided : defaults;
+                const editVals = Array.from(new Set([...defaults, ...provided]));
                 const editSet =
                   editVals.length > 0
                     ? new Set(editVals.map((f) => f.toLowerCase()))
@@ -967,7 +967,7 @@ export default function PosTransactionsPage() {
                           const defaults = Array.isArray(nf?.editableDefaultFields)
                             ? nf.editableDefaultFields
                             : [];
-                          const ed = provided.length > 0 ? provided : defaults;
+                          const ed = Array.from(new Set([...defaults, ...provided]));
                           if (ed.length > 0) break;
                           next += 1;
                         }


### PR DESCRIPTION
## Summary
- use union of editable fields and editableDefaultFields
- avoid lookups when AsyncSearchSelect is disabled
- include displayFields in relation search
- update POS page form logic
- respect editableDefaultFields in table manager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688673655a788331b2f51cd3ac724975