### PR TITLE
Fix transaction images and session defaults

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -76,6 +76,7 @@ export default forwardRef(function InlineTransactionTable({
   branchIdFields = [],
   departmentIdFields = [],
   companyIdFields = [],
+  fillSession = true,
 }, ref) {
   const mounted = useRef(false);
   const renderCount = useRef(0);
@@ -92,25 +93,28 @@ export default forwardRef(function InlineTransactionTable({
 
   function fillSessionDefaults(obj) {
     const row = { ...obj };
-    if (user?.empid !== undefined) {
-      userIdSet.forEach((f) => {
-        if (row[f] === undefined || row[f] === '') row[f] = user.empid;
-      });
-    }
-    if (company?.branch_id !== undefined) {
-      branchIdSet.forEach((f) => {
-        if (row[f] === undefined || row[f] === '') row[f] = company.branch_id;
-      });
-    }
-    if (company?.department_id !== undefined) {
-      departmentIdSet.forEach((f) => {
-        if (row[f] === undefined || row[f] === '') row[f] = company.department_id;
-      });
-    }
-    if (company?.company_id !== undefined) {
-      companyIdSet.forEach((f) => {
-        if (row[f] === undefined || row[f] === '') row[f] = company.company_id;
-      });
+    if (fillSession) {
+      if (user?.empid !== undefined) {
+        userIdSet.forEach((f) => {
+          if (row[f] === undefined || row[f] === '') row[f] = user.empid;
+        });
+      }
+      if (company?.branch_id !== undefined) {
+        branchIdSet.forEach((f) => {
+          if (row[f] === undefined || row[f] === '') row[f] = company.branch_id;
+        });
+      }
+      if (company?.department_id !== undefined) {
+        departmentIdSet.forEach((f) => {
+          if (row[f] === undefined || row[f] === '')
+            row[f] = company.department_id;
+        });
+      }
+      if (company?.company_id !== undefined) {
+        companyIdSet.forEach((f) => {
+          if (row[f] === undefined || row[f] === '') row[f] = company.company_id;
+        });
+      }
     }
     const now = formatTimestamp(new Date()).slice(0, 10);
     dateField.forEach((f) => {
@@ -763,6 +767,8 @@ export default forwardRef(function InlineTransactionTable({
       row.image_name ||
       row[columnCaseMap['imagename']] ||
       safeName;
+    if (!name) name = safeName;
+    name = sanitizeName(name);
     if (!name || !table) {
       addToast('Image name is missing', 'error');
       return;

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -55,6 +55,7 @@ const RowFormModal = function RowFormModal({
   procTriggers = {},
   table = '',
   imagenameField = [],
+  fillSession = true,
 }) {
   const mounted = useRef(false);
   const renderCount = useRef(0);
@@ -113,7 +114,7 @@ const RowFormModal = function RowFormModal({
         else if (placeholder === 'HH:MM:SS') val = formatTimestamp(now).slice(11, 19);
         else val = formatTimestamp(now);
       }
-      if (missing && !val) {
+      if (fillSession && missing && !val) {
         if (userIdSet.has(c) && user?.empid) val = user.empid;
         else if (branchIdSet.has(c) && company?.branch_id !== undefined)
           val = company.branch_id;
@@ -262,7 +263,7 @@ const RowFormModal = function RowFormModal({
         else if (placeholders[c] === 'HH:MM:SS') v = formatTimestamp(now).slice(11, 19);
         else v = formatTimestamp(now);
       }
-      if (missing && !v) {
+      if (fillSession && missing && !v) {
         if (userIdSet.has(c) && user?.empid) v = user.empid;
         else if (branchIdSet.has(c) && company?.branch_id !== undefined)
           v = company.branch_id;
@@ -278,7 +279,7 @@ const RowFormModal = function RowFormModal({
     if (!same) setFormVals(vals);
     inputRefs.current = {};
     setErrors({});
-  }, [row, visible, user, company]);
+  }, [row, visible, user, company, fillSession]);
 
   useEffect(() => {
     Object.values(inputRefs.current).forEach((el) => {
@@ -955,6 +956,7 @@ const RowFormModal = function RowFormModal({
             boxMaxWidth={boxMaxWidth}
             table={table}
             imagenameFields={imagenameField}
+            fillSession={fillSession}
             scope={scope}
           />
         </div>

--- a/src/erp.mgt.mn/components/RowImageUploadModal.jsx
+++ b/src/erp.mgt.mn/components/RowImageUploadModal.jsx
@@ -39,7 +39,14 @@ export default function RowImageUploadModal({
       })
       .filter((v) => v !== undefined && v !== null && v !== '')
       .join('_');
-    return sanitizeName(base);
+    const safe = sanitizeName(base);
+    if (safe) return safe;
+    const fallback =
+      row._imageName ||
+      row.ImageName ||
+      row.image_name ||
+      row[columnCaseMap['imagename']];
+    return sanitizeName(fallback || '');
   }
 
   async function handleUpload() {

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -773,6 +773,8 @@ const TableManager = forwardRef(function TableManager({
       cur.image_name ||
       cur[columnCaseMap['imagename']] ||
       safeName;
+    if (!name) name = safeName;
+    name = sanitizeName(name);
     if (!name) {
       addToast('Image name is missing', 'error');
       return;
@@ -1747,7 +1749,6 @@ const TableManager = forwardRef(function TableManager({
                       </button>
                       <button
                         onClick={() => openEdit(r)}
-                        disabled={rid === undefined}
                         style={actionBtnStyle}
                       >
                         🖉 Edit
@@ -1951,6 +1952,7 @@ const TableManager = forwardRef(function TableManager({
         scope="forms"
         table={table}
         imagenameField={formConfig?.imagenameField || []}
+        fillSession={!isAdding}
       />
       <CascadeDeleteModal
         visible={showCascade}


### PR DESCRIPTION
## Summary
- improve naming fallback for image upload
- sanitize names when viewing images
- allow editing rows without a primary key
- add `fillSession` option to avoid filling session defaults when adding
- skip session defaults in TableManager when creating new records

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888ed357ba48331bfe0107e9fd10b5e