### PR TITLE
Fix session autofill for new transactions

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1935,7 +1935,7 @@ const TableManager = forwardRef(function TableManager({
         scope="forms"
         table={table}
         imagenameField={formConfig?.imagenameField || []}
-        fillSession={!isAdding}
+        fillSession={isAdding}
       />
       <CascadeDeleteModal
         visible={showCascade}


### PR DESCRIPTION
## Summary
- autofill session-based fields when adding new rows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888f63e8e1c8331b2647246a30810ba