### PR TITLE
Fix image upload validations

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -742,6 +742,19 @@ export default forwardRef(function InlineTransactionTable({
   }
 
   function openUpload(idx) {
+    const row = rows[idx] || {};
+    const { name, missing } = buildImageName(
+      row,
+      imagenameFields,
+      columnCaseMap,
+    );
+    if (!name) {
+      const msg = missing.length
+        ? `Image name is missing fields: ${missing.join(', ')}`
+        : 'Image name is missing';
+      addToast(msg, 'error');
+      return;
+    }
     setUploadRowIdx(idx);
   }
 

--- a/src/erp.mgt.mn/components/RowImageUploadModal.jsx
+++ b/src/erp.mgt.mn/components/RowImageUploadModal.jsx
@@ -54,7 +54,7 @@ export default function RowImageUploadModal({
   return (
     <Modal visible={visible} title="Upload Images" onClose={onClose} width="auto">
       <input type="file" multiple onChange={(e) => setFiles(Array.from(e.target.files))} />
-      <button onClick={handleUpload} disabled={!files.length || loading} style={{ marginLeft: '0.5rem' }}>
+      <button type="button" onClick={handleUpload} disabled={!files.length || loading} style={{ marginLeft: '0.5rem' }}>
         {loading ? 'Uploading...' : 'Upload'}
       </button>
       <div style={{ textAlign: 'right', marginTop: '1rem' }}>

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -735,6 +735,18 @@ const TableManager = forwardRef(function TableManager({
   }
 
   function openUpload(row, idx) {
+    const { name, missing } = buildImageName(
+      row,
+      formConfig?.imagenameField || [],
+      columnCaseMap,
+    );
+    if (!name) {
+      const msg = missing.length
+        ? `Image name is missing fields: ${missing.join(', ')}`
+        : 'Image name is missing';
+      addToast(msg, 'error');
+      return;
+    }
     setUploadRow({ row, idx });
   }
 


### PR DESCRIPTION
## Summary
- validate image name fields before opening upload dialogs
- avoid form submission from upload button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68890010a4248331a4b962dea1c5303b