### PR TITLE
Handle image actions when rows unsaved

### DIFF
--- a/src/erp.mgt.mn/components/RowImageUploadModal.jsx
+++ b/src/erp.mgt.mn/components/RowImageUploadModal.jsx
@@ -19,6 +19,7 @@ export default function RowImageUploadModal({
   function buildName() {
     return buildImageName(row, imagenameFields, columnCaseMap);
   }
+  const { name: previewName, missing: missingFields } = buildName();
 
   async function handleUpload() {
     const { name: safeName, missing } = buildName();
@@ -53,6 +54,14 @@ export default function RowImageUploadModal({
 
   return (
     <Modal visible={visible} title="Upload Images" onClose={onClose} width="auto">
+      {missingFields.length > 0 && (
+        <div style={{ color: 'red', marginBottom: '0.5rem' }}>
+          Missing fields: {missingFields.join(', ')}
+        </div>
+      )}
+      {previewName && (
+        <div style={{ marginBottom: '0.5rem' }}>Image name: {previewName}</div>
+      )}
       <input type="file" multiple onChange={(e) => setFiles(Array.from(e.target.files))} />
       <button onClick={handleUpload} disabled={!files.length || loading} style={{ marginLeft: '0.5rem' }}>
         {loading ? 'Uploading...' : 'Upload'}


### PR DESCRIPTION
## Summary
- warn users when attempting to add/view images before saving rows
- update InlineTransactionTable button logic and tooltips
- show missing fields and preview name in RowImageUploadModal
- mark rows saved after image upload when possible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889031c01248331b0d5866e7eea1a12