### PR TITLE
Improve upload warning and viewing messages

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -1139,10 +1139,14 @@ const RowFormModal = function RowFormModal({
     const { name, missing } = buildImageName(formVals, imagenameField, columnCaseMap);
     const finalName = formVals._imageName || name;
     if (!finalName || !table) {
-      const msg = missing.length
-        ? `Image name is missing fields: ${missing.join(', ')}`
-        : 'Image name is missing';
-      addToast(msg, 'error');
+      if (missing.length) {
+        addToast(
+          `Please complete these fields before viewing images: ${missing.join(', ')}`,
+          'error',
+        );
+      } else {
+        addToast('Cannot generate image name. Required data is missing.', 'error');
+      }
       return;
     }
     try {

--- a/src/erp.mgt.mn/components/RowImageUploadModal.jsx
+++ b/src/erp.mgt.mn/components/RowImageUploadModal.jsx
@@ -25,10 +25,14 @@ export default function RowImageUploadModal({
     const { name: safeName, missing } = buildName();
     const uploadUrl = safeName && table ? `/api/transaction_images/${table}/${encodeURIComponent(safeName)}` : '';
     if (!uploadUrl) {
-      const msg = missing.length
-        ? `Image name is missing fields: ${missing.join(', ')}`
-        : 'Image name is missing';
-      addToast(msg, 'error');
+      if (missing.length) {
+        addToast(
+          `Please complete these fields before uploading: ${missing.join(', ')}`,
+          'error',
+        );
+      } else {
+        addToast('Cannot generate image name. Required data is missing.', 'error');
+      }
       return;
     }
     if (!files.length) return;

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -778,10 +778,14 @@ const TableManager = forwardRef(function TableManager({
       columnCaseMap,
     );
     if (!name) {
-      const msg = missing.length
-        ? `Please save the row first. Missing fields: ${missing.join(', ')}`
-        : 'Please save the row before viewing images';
-      addToast(msg, 'warning');
+      if (missing.length) {
+        addToast(
+          `Please complete these fields before viewing images: ${missing.join(', ')}`,
+          'warning',
+        );
+      } else {
+        addToast('Cannot generate image name. Required data is missing.', 'warning');
+      }
       return;
     }
     try {


### PR DESCRIPTION
## Summary
- clarify missing field warnings when uploading images
- improve error reporting when viewing images in TableManager
- adjust image view modal message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889053d26008331867fef4f90124bc5