### PR TITLE
Fix row form layout and search

### DIFF
--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -31,12 +31,15 @@ export async function getTables(req, res, next) {
 
 export async function getTableRows(req, res, next) {
   try {
-    const { page, perPage, sort, dir, debug, ...filters } = req.query;
+    const { page, perPage, sort, dir, debug, search, searchColumns, ...filters } =
+      req.query;
     const rowsPerPage = Math.min(Number(perPage) || 50, 500);
     const result = await listTableRows(req.params.table, {
       page: Number(page) || 1,
       perPage: rowsPerPage,
       filters,
+      search: search || '',
+      searchColumns: typeof searchColumns === 'string' ? searchColumns.split(',') : [],
       sort: { column: sort, dir },
       debug: debug === '1' || debug === 'true',
     });

--- a/src/erp.mgt.mn/components/AsyncSearchSelect.jsx
+++ b/src/erp.mgt.mn/components/AsyncSearchSelect.jsx
@@ -46,7 +46,10 @@ export default function AsyncSearchSelect({
     setLoading(true);
     try {
       const params = new URLSearchParams({ page: p, perPage: 50 });
-      if (q) cols.forEach((c) => params.set(c, q));
+      if (q) {
+        params.set('search', q);
+        params.set('searchColumns', cols.join(','));
+      }
       const res = await fetch(
         `/api/tables/${encodeURIComponent(table)}?${params.toString()}`,
         { credentials: 'include', signal },
@@ -163,6 +166,18 @@ export default function AsyncSearchSelect({
         onFocus={(e) => {
           setShow(true);
           if (onFocus) onFocus(e);
+          e.target.style.width = 'auto';
+          const max = parseFloat(inputStyle.maxWidth) || 150;
+          const min = parseFloat(inputStyle.minWidth) || 60;
+          const w = Math.min(e.target.scrollWidth + 2, max);
+          e.target.style.width = `${Math.max(min, w)}px`;
+        }}
+        onInput={(e) => {
+          e.target.style.width = 'auto';
+          const max = parseFloat(inputStyle.maxWidth) || 150;
+          const min = parseFloat(inputStyle.minWidth) || 60;
+          const w = Math.min(e.target.scrollWidth + 2, max);
+          e.target.style.width = `${Math.max(min, w)}px`;
         }}
         onBlur={handleBlur}
         onKeyDown={(e) => {
@@ -172,7 +187,7 @@ export default function AsyncSearchSelect({
           chosenRef.current = null;
         }}
         disabled={disabled}
-        style={{ width: '100%', padding: '0.5rem', ...inputStyle }}
+        style={{ padding: '0.5rem', ...inputStyle }}
         title={input}
         {...rest}
       />

--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -867,20 +867,9 @@ export default forwardRef(function InlineTransactionTable({
         display = parts.join(' - ');
       }
       const readonlyStyle = { ...inputStyle, width: 'fit-content', maxWidth: `${boxMaxWidth}px` };
-      const btn = relationConfigs[f] || viewSource[f] || Array.isArray(relations[f]) ? (
-        <button
-          type="button"
-          onClick={() => openRelationPreview(f, val)}
-          className="ml-1 text-blue-600"
-          title="View"
-        >
-          🔍
-        </button>
-      ) : null;
       return (
         <div className="flex items-center" title={display}>
           <div className="px-1 border rounded bg-gray-100" style={readonlyStyle}>{display}</div>
-          {btn}
         </div>
       );
     }

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -710,8 +710,9 @@ const RowFormModal = function RowFormModal({
     const disabled = disabledSet.has(c.toLowerCase());
 
     if (disabled) {
-      const val = formVals[c];
-      let display = val;
+      const raw = formVals[c];
+      const val = typeof raw === 'object' && raw !== null ? raw.value : raw;
+      let display = typeof raw === 'object' && raw !== null ? raw.label || val : val;
       if (
         relationConfigs[c] &&
         val !== undefined &&
@@ -736,32 +737,27 @@ const RowFormModal = function RowFormModal({
         });
         display = parts.join(' - ');
       }
-      const readonlyStyle = { ...inputStyle, width: 'fit-content', maxWidth: `${boxMaxWidth}px` };
-      const previewBtn = relationConfigs[c] || viewSource[c] || Array.isArray(relations[c]) ? (
-        <button
-          type="button"
-          onClick={() => openRelationPreview(c)}
-          className="ml-1 text-blue-600"
-          title="View"
-        >
-          🔍
-        </button>
-      ) : null;
+      const readonlyStyle = {
+        ...inputStyle,
+        width: 'fit-content',
+        maxWidth: `${boxMaxWidth}px`,
+      };
       const content = (
-        <div className="flex items-center">
-          <div className="border rounded bg-gray-100 px-2 py-1" style={readonlyStyle} title={display}>
+        <div className="flex items-center space-x-1" title={display}>
+          <div className="border rounded bg-gray-100 px-2 py-1" style={readonlyStyle}>
             {display}
           </div>
-          {previewBtn}
         </div>
       );
       if (!withLabel) return content;
       return (
         <div key={c} className={fitted ? 'mb-1' : 'mb-3'}>
-          <label className="block mb-1 font-medium" style={labelStyle}>
-            {labels[c] || c}
-          </label>
-          {content}
+          <div className="flex items-center space-x-1">
+            <label className="font-medium" style={labelStyle}>
+              {labels[c] || c}
+            </label>
+            {content}
+          </div>
         </div>
       );
     }
@@ -794,6 +790,9 @@ const RowFormModal = function RowFormModal({
         onFocus={(e) => {
           e.target.select();
           handleFocusField(c);
+          e.target.style.width = 'auto';
+          const w = Math.min(e.target.scrollWidth + 2, boxMaxWidth);
+          e.target.style.width = `${Math.max(boxWidth, w)}px`;
         }}
         inputRef={(el) => (inputRefs.current[c] = el)}
         inputStyle={inputStyle}
@@ -827,6 +826,9 @@ const RowFormModal = function RowFormModal({
         onFocus={(e) => {
           e.target.select();
           handleFocusField(c);
+          e.target.style.width = 'auto';
+          const w = Math.min(e.target.scrollWidth + 2, boxMaxWidth);
+          e.target.style.width = `${Math.max(boxWidth, w)}px`;
         }}
         inputRef={(el) => (inputRefs.current[c] = el)}
         inputStyle={inputStyle}

--- a/tests/db/listRows.test.js
+++ b/tests/db/listRows.test.js
@@ -40,3 +40,16 @@ test('listTableRows returns SQL when debug enabled', async () => {
   restore();
   assert.ok(result.sql.includes('SELECT *'));
 });
+
+test('listTableRows allows search across multiple columns', async () => {
+  const restore = mockPool();
+  await db.listTableRows('users', {
+    search: 'Bob',
+    searchColumns: ['id', 'name'],
+  });
+  const calls = restore();
+  const main = calls.find((c) => c.sql.startsWith('SELECT *'));
+  assert.ok(main.sql.includes('OR'));
+  assert.ok(main.sql.includes('id'));
+  assert.ok(main.sql.includes('name'));
+});


### PR DESCRIPTION
## Summary
- render labels and read-only values on the same row in RowFormModal
- resize inputs in AsyncSearchSelect and RowFormModal on focus and input
- send new `search` parameters from AsyncSearchSelect
- support search across multiple columns in backend
- remove magnifier from disabled table cells
- test new `listTableRows` search option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889b1c23cd88331b9151920d5ac3636