### PR TITLE
Fix sizing in POS forms

### DIFF
--- a/config/generalConfig.json
+++ b/config/generalConfig.json
@@ -10,7 +10,7 @@
     "labelFontSize": 14,
     "boxWidth": 60,
     "boxHeight": 30,
-    "boxMaxWidth": 150,
+    "boxMaxWidth": 200,
     "boxMaxHeight": 150
   }
 }

--- a/docs/general-configuration.md
+++ b/docs/general-configuration.md
@@ -15,7 +15,7 @@
     "labelFontSize": 14,
     "boxWidth": 60,
     "boxHeight": 30,
-    "boxMaxWidth": 150,
+    "boxMaxWidth": 200,
     "boxMaxHeight": 150
   }
 }

--- a/docs/pos-transaction-layout.md
+++ b/docs/pos-transaction-layout.md
@@ -8,7 +8,7 @@ Forms used by POS transactions support a special **fitted** view. In this mode a
     "labelFontSize": 14,
     "boxWidth": 60,
     "boxHeight": 30,
-    "boxMaxWidth": 150,
+    "boxMaxWidth": 200,
     "boxMaxHeight": 150
   }
 }

--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -245,10 +245,10 @@ export default forwardRef(function InlineTransactionTable({
     focusRow.current = null;
   }, [rows, minRows]);
 
-  useEffect(() => {
+  function resizeInputs() {
     Object.values(inputRefs.current).forEach((el) => {
       if (!el) return;
-      if (el.tagName === 'INPUT') {
+      if (el.tagName === 'INPUT' || el.tagName === 'DIV') {
         el.style.width = 'auto';
         const w = Math.min(el.scrollWidth + 2, boxMaxWidth);
         el.style.width = `${Math.max(boxWidth, w)}px`;
@@ -259,7 +259,12 @@ export default forwardRef(function InlineTransactionTable({
         el.style.overflowY = el.scrollHeight > h ? 'auto' : 'hidden';
       }
     });
-  }, [rows, boxWidth, boxMaxWidth, boxMaxHeight]);
+  }
+
+  useEffect(resizeInputs, [rows, boxWidth, boxMaxWidth, boxMaxHeight]);
+  useEffect(() => {
+    resizeInputs();
+  }, []);
 
   useImperativeHandle(ref, () => ({
     getRows: () => rows,
@@ -866,10 +871,21 @@ export default forwardRef(function InlineTransactionTable({
         });
         display = parts.join(' - ');
       }
-      const readonlyStyle = { ...inputStyle, width: 'fit-content', maxWidth: `${boxMaxWidth}px` };
+      const readonlyStyle = {
+        ...inputStyle,
+        width: 'fit-content',
+        minWidth: `${boxWidth}px`,
+        maxWidth: `${boxMaxWidth}px`,
+      };
       return (
         <div className="flex items-center" title={display}>
-          <div className="px-1 border rounded bg-gray-100" style={readonlyStyle}>{display}</div>
+          <div
+            className="px-1 border rounded bg-gray-100"
+            style={readonlyStyle}
+            ref={(el) => (inputRefs.current[`ro-${idx}-${f}`] = el)}
+          >
+            {display}
+          </div>
         </div>
       );
     }

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -138,6 +138,7 @@ const RowFormModal = function RowFormModal({
     return extras;
   });
   const inputRefs = useRef({});
+  const readonlyRefs = useRef({});
   const [errors, setErrors] = useState({});
   const [submitLocked, setSubmitLocked] = useState(false);
   const tableRef = useRef(null);
@@ -267,10 +268,10 @@ const RowFormModal = function RowFormModal({
     setErrors({});
   }, [row, visible, user, company]);
 
-  useEffect(() => {
-    Object.values(inputRefs.current).forEach((el) => {
+  function resizeInputs() {
+    Object.values({ ...inputRefs.current, ...readonlyRefs.current }).forEach((el) => {
       if (!el) return;
-      if (el.tagName === 'INPUT') {
+      if (el.tagName === 'INPUT' || el.tagName === 'DIV') {
         el.style.width = 'auto';
         const w = Math.min(el.scrollWidth + 2, boxMaxWidth);
         el.style.width = `${Math.max(boxWidth, w)}px`;
@@ -281,15 +282,32 @@ const RowFormModal = function RowFormModal({
         el.style.overflowY = el.scrollHeight > h ? 'auto' : 'hidden';
       }
     });
-  }, [formVals, boxWidth, boxMaxWidth, boxMaxHeight]);
+  }
+
+  useEffect(resizeInputs, [formVals, boxWidth, boxMaxWidth, boxMaxHeight]);
+  useEffect(() => {
+    if (visible) resizeInputs();
+  }, [visible]);
 
   if (!visible) return null;
 
   const mainSet = new Set(mainFields);
   const totalAmountSet = new Set(totalAmountFields);
   const totalCurrencySet = new Set(totalCurrencyFields);
-  const headerCols = columns.filter((c) => headerSet.has(c));
-  const footerCols = columns.filter((c) => footerSet.has(c));
+  const headerCols =
+    headerFields.length > 0
+      ? headerFields
+      : columns.filter((c) => headerSet.has(c));
+  const footerCols =
+    footerFields.length > 0
+      ? footerFields
+      : columns.filter((c) => footerSet.has(c));
+  if (window.erpDebug) {
+    console.log('RowFormModal sections', {
+      missingHeader: headerFields.filter((c) => !headerCols.includes(c)),
+      missingFooter: footerFields.filter((c) => !footerCols.includes(c)),
+    });
+  }
   const mainCols =
     mainFields.length > 0
       ? columns.filter((c) => mainSet.has(c))
@@ -314,8 +332,8 @@ const RowFormModal = function RowFormModal({
     height: `${boxHeight}px`,
     maxHeight: `${boxMaxHeight}px`,
     overflow: 'hidden',
-    whiteSpace: 'pre-wrap',
-    wordBreak: 'break-word',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
   };
 
   async function handleKeyDown(e, col) {
@@ -707,10 +725,11 @@ const RowFormModal = function RowFormModal({
   function renderField(c, withLabel = true) {
     const err = errors[c];
     const inputClass = `w-full border rounded ${err ? 'border-red-500' : 'border-gray-300'}`;
-    const disabled = disabledSet.has(c.toLowerCase());
+    const isColumn = columns.includes(c);
+    const disabled = disabledSet.has(c.toLowerCase()) || !isColumn;
 
     if (disabled) {
-      const raw = formVals[c];
+      const raw = isColumn ? formVals[c] : extraVals[c];
       const val = typeof raw === 'object' && raw !== null ? raw.value : raw;
       let display = typeof raw === 'object' && raw !== null ? raw.label || val : val;
       if (
@@ -740,11 +759,16 @@ const RowFormModal = function RowFormModal({
       const readonlyStyle = {
         ...inputStyle,
         width: 'fit-content',
+        minWidth: `${boxWidth}px`,
         maxWidth: `${boxMaxWidth}px`,
       };
       const content = (
         <div className="flex items-center space-x-1" title={display}>
-          <div className="border rounded bg-gray-100 px-2 py-1" style={readonlyStyle}>
+          <div
+            className="border rounded bg-gray-100 px-2 py-1"
+            style={readonlyStyle}
+            ref={(el) => (readonlyRefs.current[c] = el)}
+          >
             {display}
           </div>
         </div>
@@ -1044,12 +1068,26 @@ const RowFormModal = function RowFormModal({
   }
 
   function renderHeaderTable(cols) {
-    if (cols.length === 0) return null;
+    if (cols.length === 0) {
+      return window.erpDebug ? (
+        <div className={fitted ? 'mb-1' : 'mb-2'}>
+          <h3 className="mt-0 mb-1 font-semibold">Header</h3>
+          <div className="text-xs italic text-gray-500">No fields defined</div>
+        </div>
+      ) : null;
+    }
     return renderSection('Header', cols);
   }
 
   function renderSection(title, cols) {
-    if (cols.length === 0) return null;
+    if (cols.length === 0) {
+      return window.erpDebug ? (
+        <div className={fitted ? 'mb-1' : 'mb-2'}>
+          <h3 className="mt-0 mb-1 font-semibold">{title}</h3>
+          <div className="text-xs italic text-gray-500">No fields defined</div>
+        </div>
+      ) : null;
+    }
     return (
       <div className={fitted ? 'mb-1' : 'mb-2'}>
         <h3 className="mt-0 mb-1 font-semibold">{title}</h3>


### PR DESCRIPTION
## Summary
- widen POS form cells via `generalConfig.json`
- keep docs in sync with updated max width value
- improve sizing logic for inputs and read-only fields
- auto-size readonly values in inline tables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889b634c3008331ac2fd932ceaa059c