### PR TITLE
Add early transaction image uploads

### DIFF
--- a/api-server/routes/transaction_images.js
+++ b/api-server/routes/transaction_images.js
@@ -5,6 +5,7 @@ import {
   saveImages,
   listImages,
   renameImages,
+  deleteImages,
 } from '../services/transactionImageService.js';
 
 const router = express.Router();
@@ -33,6 +34,19 @@ router.get('/:table/:name', requireAuth, async (req, res, next) => {
   }
 });
 
+router.post('/rename', requireAuth, async (req, res, next) => {
+  try {
+    const { table, oldName, newName, folderPath = '' } = req.body || {};
+    if (!table || !oldName || !newName) {
+      return res.status(400).json({ message: 'missing fields' });
+    }
+    const renamed = await renameImages(table, oldName, newName, folderPath);
+    res.json(renamed);
+  } catch (err) {
+    next(err);
+  }
+});
+
 router.post('/:table/:oldName/rename/:newName', requireAuth, async (req, res, next) => {
   try {
     const folder = req.query.folder || '';
@@ -43,6 +57,31 @@ router.post('/:table/:oldName/rename/:newName', requireAuth, async (req, res, ne
       folder,
     );
     res.json(renamed);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/:table/:name/:file', requireAuth, async (req, res, next) => {
+  try {
+    const folder = req.query.folder || '';
+    const del = await deleteImages(
+      req.params.table,
+      req.params.name,
+      folder,
+      req.params.file,
+    );
+    res.json(del);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/:table/:name', requireAuth, async (req, res, next) => {
+  try {
+    const folder = req.query.folder || '';
+    const del = await deleteImages(req.params.table, req.params.name, folder);
+    res.json(del);
   } catch (err) {
     next(err);
   }

--- a/api-server/services/generalConfig.js
+++ b/api-server/services/generalConfig.js
@@ -18,6 +18,11 @@ const defaults = {
     boxMaxWidth: 150,
     boxMaxHeight: 150,
   },
+  imageStorage: {
+    basePath: 'uploaded_images/',
+    defaultFolder: 'transactions/',
+    posFolder: 'transactions_pos/',
+  },
 };
 
 async function readConfig() {
@@ -49,6 +54,7 @@ export async function updateGeneralConfig(updates = {}) {
   const cfg = await readConfig();
   if (updates.forms) Object.assign(cfg.forms, updates.forms);
   if (updates.pos) Object.assign(cfg.pos, updates.pos);
+  if (updates.imageStorage) Object.assign(cfg.imageStorage, updates.imageStorage);
   await writeConfig(cfg);
   return cfg;
 }

--- a/config/generalConfig.json
+++ b/config/generalConfig.json
@@ -12,5 +12,10 @@
     "boxHeight": 30,
     "boxMaxWidth": 200,
     "boxMaxHeight": 150
+  },
+  "imageStorage": {
+    "basePath": "uploaded_images/",
+    "defaultFolder": "transactions/",
+    "posFolder": "transactions_pos/"
   }
 }

--- a/docs/general-configuration.md
+++ b/docs/general-configuration.md
@@ -30,3 +30,21 @@ Here `boxWidth` defines the initial grid box width of a POS transaction.
 
 The settings can be edited in the **General Configuration** screen
 (module key `general_configuration`) under the Settings menu.
+
+## Image Storage
+
+The optional `imageStorage` section configures where uploaded images are saved.
+
+```json
+{
+  "imageStorage": {
+    "basePath": "uploaded_images/",
+    "defaultFolder": "transactions/",
+    "posFolder": "transactions_pos/"
+  }
+}
+```
+
+`basePath` determines the root folder under the project directory for all
+transaction images. `defaultFolder` and `posFolder` define subfolders used when
+building image paths for regular and POS transactions respectively.

--- a/src/erp.mgt.mn/components/RowImageUploadModal.jsx
+++ b/src/erp.mgt.mn/components/RowImageUploadModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Modal from './Modal.jsx';
 import { useToast } from '../context/ToastContext.jsx';
 import buildImageName from '../utils/buildImageName.js';
@@ -13,10 +13,12 @@ export default function RowImageUploadModal({
   imageFolderFields = [],
   columnCaseMap = {},
   onUploaded = () => {},
+  setField,
 }) {
   const { addToast } = useToast();
   const [files, setFiles] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [uploaded, setUploaded] = useState([]);
   if (!visible) return null;
   function buildName() {
     return buildImageName(row, imagenameFields, columnCaseMap);
@@ -25,13 +27,35 @@ export default function RowImageUploadModal({
     return buildFolderName(row, imageFolderFields, columnCaseMap);
   }
 
+  function getTempName() {
+    const { name, missing } = buildName();
+    if (!name || missing.length) {
+      if (!row._imageName) {
+        const uid = Math.random().toString(36).slice(2, 10);
+        if (setField) setField('_imageName', uid);
+      }
+      return row._imageName || '';
+    }
+    return name;
+  }
+
+  useEffect(() => {
+    if (!visible) return;
+    const { name: folder } = buildFolder();
+    const safe = getTempName();
+    if (!safe) return;
+    const query = folder ? `?folder=${encodeURIComponent(folder)}` : '';
+    fetch(`/api/transaction_images/${table}/${encodeURIComponent(safe)}${query}`, {
+      credentials: 'include',
+    })
+      .then((res) => res.ok ? res.json() : [])
+      .then((imgs) => setUploaded(imgs))
+      .catch(() => setUploaded([]));
+  }, [visible]);
+
   async function handleUpload() {
     const { name: folder } = buildFolder();
-    const { name: safeName, missing } = buildName();
-    if (!safeName || missing.length) {
-      addToast('Please post the transaction before uploading images.', 'error');
-      return;
-    }
+    const safeName = getTempName();
     const query = folder ? `?folder=${encodeURIComponent(folder)}` : '';
     const uploadUrl =
       safeName && table
@@ -47,7 +71,10 @@ export default function RowImageUploadModal({
         const info = folder ? `${folder}/${safeName}` : safeName;
         addToast(`Images uploaded as ${info}`, 'success');
         setFiles([]);
+        if (setField) setField('_imageName', safeName);
         onUploaded(safeName, folder);
+        const list = await fetch(`/api/transaction_images/${table}/${encodeURIComponent(safeName)}${query}`, { credentials: 'include' }).then(r => r.ok ? r.json() : []);
+        setUploaded(list);
       } else {
         const text = await res.text();
         addToast(text || 'Failed to upload images', 'error');
@@ -65,6 +92,46 @@ export default function RowImageUploadModal({
       <button type="button" onClick={handleUpload} disabled={!files.length || loading} style={{ marginLeft: '0.5rem' }}>
         {loading ? 'Uploading...' : 'Upload'}
       </button>
+      {uploaded.length > 0 && (
+        <div style={{ marginTop: '1rem' }}>
+          <h4 className="mt-0 mb-1">Uploaded Images</h4>
+          {uploaded.map((src, idx) => (
+            <div key={idx} style={{ marginBottom: '0.25rem' }}>
+              <img src={src} alt="" style={{ maxWidth: '100px', marginRight: '0.5rem' }} />
+              <button
+                type="button"
+                onClick={async () => {
+                  const parts = src.split('/');
+                  const file = parts[parts.length - 1];
+                  const { name: folder } = buildFolder();
+                  const query = folder ? `?folder=${encodeURIComponent(folder)}` : '';
+                  await fetch(`/api/transaction_images/${table}/${encodeURIComponent(getTempName())}/${encodeURIComponent(file)}${query}`, {
+                    method: 'DELETE',
+                    credentials: 'include',
+                  });
+                  setUploaded((u) => u.filter((_, i) => i !== idx));
+                }}
+              >
+                Delete
+              </button>
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={async () => {
+              const { name: folder } = buildFolder();
+              const query = folder ? `?folder=${encodeURIComponent(folder)}` : '';
+              await fetch(`/api/transaction_images/${table}/${encodeURIComponent(getTempName())}${query}`, {
+                method: 'DELETE',
+                credentials: 'include',
+              });
+              setUploaded([]);
+            }}
+          >
+            Delete All
+          </button>
+        </div>
+      )}
       <div style={{ textAlign: 'right', marginTop: '1rem' }}>
         <button type="button" onClick={onClose}>Close</button>
       </div>

--- a/src/erp.mgt.mn/components/RowImageViewModal.jsx
+++ b/src/erp.mgt.mn/components/RowImageViewModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Modal from './Modal.jsx';
 
-export default function RowImageViewModal({ visible, onClose, images = [] }) {
+export default function RowImageViewModal({ visible, onClose, images = [], onDelete }) {
   if (!visible) return null;
   return (
     <Modal visible={visible} title="View Images" onClose={onClose} width="auto">
@@ -9,6 +9,11 @@ export default function RowImageViewModal({ visible, onClose, images = [] }) {
       {images.map((src, idx) => (
         <div key={idx} style={{ marginBottom: '0.5rem' }}>
           <img src={src} alt="" style={{ maxWidth: '100%' }} />
+          {onDelete && (
+            <button type="button" onClick={() => onDelete(src)} style={{ marginLeft: '0.5rem' }}>
+              Delete
+            </button>
+          )}
         </div>
       ))}
       <div style={{ textAlign: 'right', marginTop: '1rem' }}>


### PR DESCRIPTION
## Summary
- expand `generalConfig.json` with `imageStorage`
- document new image storage options
- create REST endpoints to rename and delete transaction images
- update backend service to support custom image paths
- allow early uploads in `RowImageUploadModal` and preview/delete them
- add image viewer and rename support in `InlineTransactionTable`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889d60e4e188331ae24e21b1231a08c