### PR TITLE
Fix image upload button

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -1094,18 +1094,16 @@ export default forwardRef(function InlineTransactionTable({
               ))}
               <td className="border px-1 py-1 text-center">
                 {(() => {
-                  const { name: safe, missing } = buildImageName(
+                  const { name: safe } = buildImageName(
                     r,
                     imagenameFields,
                     columnCaseMap,
                   );
-                  const canUpload = !!safe && missing.length === 0;
                   return (
                     <>
                       <button
                         type="button"
-                        disabled={!canUpload}
-                        title={!canUpload ? 'Please post first' : 'Upload image'}
+                        title={!safe ? 'Please post first' : 'Upload image'}
                         onClick={() => openUpload(idx)}
                         style={{ marginRight: '0.25rem' }}
                       >


### PR DESCRIPTION
## Summary
- enable image upload button in inline transaction table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889e21a94a4833186b9596b64893e79