### PR TITLE
Fix image upload temp ID generation

### DIFF
--- a/src/erp.mgt.mn/components/RowImageUploadModal.jsx
+++ b/src/erp.mgt.mn/components/RowImageUploadModal.jsx
@@ -21,10 +21,9 @@ export default function RowImageUploadModal({
   const tempNameRef = useRef(row._tmpImageName || null);
 
   function genTempName() {
-    if (typeof crypto !== 'undefined' && crypto.randomUUID) {
-      return crypto.randomUUID();
-    }
-    return Math.random().toString(36).slice(2);
+    return (
+      Date.now().toString(36) + Math.random().toString(36).slice(2)
+    );
   }
 
   if (!tempNameRef.current) {


### PR DESCRIPTION
## Summary
- avoid referencing missing `crypto` global when generating temporary names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889e4b0d9e08331a0290a50d30aa780