### PR TITLE
Add row image modals and imageDir config

### DIFF
--- a/api-server/services/generalConfig.js
+++ b/api-server/services/generalConfig.js
@@ -4,6 +4,9 @@ import path from 'path';
 const filePath = path.join(process.cwd(), 'config', 'generalConfig.json');
 
 const defaults = {
+  general: {
+    imageDir: 'txn_images',
+  },
   forms: {
     labelFontSize: 14,
     boxWidth: 60,
@@ -24,11 +27,16 @@ async function readConfig() {
   try {
     const data = await fs.readFile(filePath, 'utf8');
     const parsed = JSON.parse(data);
-    if (parsed.forms || parsed.pos) {
-      return { ...defaults, ...parsed };
+    if (parsed.forms || parsed.pos || parsed.general) {
+      return {
+        general: { ...defaults.general, ...(parsed.general || {}) },
+        forms: { ...defaults.forms, ...(parsed.forms || {}) },
+        pos: { ...defaults.pos, ...(parsed.pos || {}) },
+      };
     }
     // migrate older flat structure to new nested layout
     return {
+      general: { ...defaults.general },
       forms: { ...defaults.forms, ...parsed },
       pos: { ...defaults.pos },
     };
@@ -47,6 +55,7 @@ export async function getGeneralConfig() {
 
 export async function updateGeneralConfig(updates = {}) {
   const cfg = await readConfig();
+  if (updates.general) Object.assign(cfg.general, updates.general);
   if (updates.forms) Object.assign(cfg.forms, updates.forms);
   if (updates.pos) Object.assign(cfg.pos, updates.pos);
   await writeConfig(cfg);

--- a/config/generalConfig.json
+++ b/config/generalConfig.json
@@ -1,4 +1,7 @@
 {
+  "general": {
+    "imageDir": "txn_images"
+  },
   "forms": {
     "labelFontSize": 14,
     "boxWidth": 60,


### PR DESCRIPTION
## Summary
- enable storage location for transaction images in `generalConfig.json`
- expose new `general.imageDir` in general config service
- support viewing and uploading row images from `InlineTransactionTable`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889f8b580048331ab8b9bf6c10dc08c