### PR TITLE
Add image storage base path setting

### DIFF
--- a/api-server/services/generalConfig.js
+++ b/api-server/services/generalConfig.js
@@ -18,19 +18,29 @@ const defaults = {
     boxMaxWidth: 150,
     boxMaxHeight: 150,
   },
+  general: {
+    imageStorage: {
+      basePath: 'uploads',
+    },
+  },
 };
 
 async function readConfig() {
   try {
     const data = await fs.readFile(filePath, 'utf8');
     const parsed = JSON.parse(data);
-    if (parsed.forms || parsed.pos) {
-      return { ...defaults, ...parsed };
+    if (parsed.forms || parsed.pos || parsed.general) {
+      return {
+        ...defaults,
+        ...parsed,
+        general: { ...defaults.general, ...(parsed.general || {}) },
+      };
     }
     // migrate older flat structure to new nested layout
     return {
       forms: { ...defaults.forms, ...parsed },
       pos: { ...defaults.pos },
+      general: { ...defaults.general },
     };
   } catch {
     return { ...defaults };
@@ -49,6 +59,7 @@ export async function updateGeneralConfig(updates = {}) {
   const cfg = await readConfig();
   if (updates.forms) Object.assign(cfg.forms, updates.forms);
   if (updates.pos) Object.assign(cfg.pos, updates.pos);
+  if (updates.general) Object.assign(cfg.general, updates.general);
   await writeConfig(cfg);
   return cfg;
 }

--- a/api-server/services/transactionImageService.js
+++ b/api-server/services/transactionImageService.js
@@ -7,8 +7,9 @@ import { getGeneralConfig } from './generalConfig.js';
 async function getDirs() {
   const cfg = await getGeneralConfig();
   const subdir = cfg.general?.imageDir || 'txn_images';
-  const baseDir = path.join(process.cwd(), 'uploads', subdir);
-  const urlBase = `/uploads/${subdir}`;
+  const basePath = cfg.general?.imageStorage?.basePath || 'uploads';
+  const baseDir = path.join(process.cwd(), basePath, subdir);
+  const urlBase = `/${basePath}/${subdir}`;
   return { baseDir, urlBase };
 }
 

--- a/config/generalConfig.json
+++ b/config/generalConfig.json
@@ -12,5 +12,10 @@
     "boxHeight": 30,
     "boxMaxWidth": 200,
     "boxMaxHeight": 150
+  },
+  "general": {
+    "imageStorage": {
+      "basePath": "uploads"
+    }
   }
 }

--- a/docs/general-configuration.md
+++ b/docs/general-configuration.md
@@ -1,6 +1,7 @@
 # General Configuration
 
-`config/generalConfig.json` now groups settings under `forms` and `pos`.
+`config/generalConfig.json` now groups settings under `forms`, `pos` and a new
+`general` section.
 
 ```json
 {
@@ -17,6 +18,11 @@
     "boxHeight": 30,
     "boxMaxWidth": 200,
     "boxMaxHeight": 150
+  },
+  "general": {
+    "imageStorage": {
+      "basePath": "uploads"
+    }
   }
 }
 ```
@@ -27,6 +33,10 @@ up to `boxMaxWidth`/`boxMaxHeight` as text is entered and wrap when necessary.
 
 The **POS** section provides the same options specifically for POS transactions.
 Here `boxWidth` defines the initial grid box width of a POS transaction.
+
+The **General** tab now contains `imageStorage.basePath` which sets the root
+directory for any uploaded transaction images. The default value `"uploads"`
+creates files under `<repo>/uploads/<table>/`.
 
 The settings can be edited in the **General Configuration** screen
 (module key `general_configuration`) under the Settings menu.

--- a/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
+++ b/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
@@ -18,10 +18,13 @@ export default function GeneralConfiguration() {
   }, [initial]);
 
   function handleChange(e) {
-    const { name, value } = e.target;
+    const { name, value, type } = e.target;
     setCfg(c => ({
       ...c,
-      [tab]: { ...(c?.[tab] || {}), [name]: Number(value) },
+      [tab]: {
+        ...(c?.[tab] || {}),
+        [name]: type === 'number' ? Number(value) : value,
+      },
     }));
   }
 
@@ -64,6 +67,12 @@ export default function GeneralConfiguration() {
         >
           POS
         </button>
+        <button
+          className={`tab-button ${tab === 'general' ? 'active' : ''}`}
+          onClick={() => setTab('general')}
+        >
+          General
+        </button>
       </div>
       <div style={{ marginBottom: '0.5rem' }}>
         <button onClick={() => setTab('forms')} disabled={tab === 'forms'}>
@@ -72,62 +81,90 @@ export default function GeneralConfiguration() {
         <button onClick={() => setTab('pos')} disabled={tab === 'pos'} style={{ marginLeft: '0.5rem' }}>
           POS
         </button>
+        <button onClick={() => setTab('general')} disabled={tab === 'general'} style={{ marginLeft: '0.5rem' }}>
+          General
+        </button>
       </div>
-      <div style={{ marginBottom: '0.5rem' }}>
-        <label>
-          Label Font Size{' '}
-          <input
-            name="labelFontSize"
-            type="number"
-            value={active.labelFontSize ?? ''}
-            onChange={handleChange}
-          />
-        </label>
-      </div>
-      <div style={{ marginBottom: '0.5rem' }}>
-        <label>
-          Box Width{' '}
-          <input
-            name="boxWidth"
-            type="number"
-            value={active.boxWidth ?? ''}
-            onChange={handleChange}
-          />
-        </label>
-      </div>
-      <div style={{ marginBottom: '0.5rem' }}>
-        <label>
-          Box Height{' '}
-          <input
-            name="boxHeight"
-            type="number"
-            value={active.boxHeight ?? ''}
-            onChange={handleChange}
-          />
-        </label>
-      </div>
-      <div style={{ marginBottom: '0.5rem' }}>
-        <label>
-          Box Max Width{' '}
-          <input
-            name="boxMaxWidth"
-            type="number"
-            value={active.boxMaxWidth ?? ''}
-            onChange={handleChange}
-          />
-        </label>
-      </div>
-      <div style={{ marginBottom: '0.5rem' }}>
-        <label>
-          Box Max Height{' '}
-          <input
-            name="boxMaxHeight"
-            type="number"
-            value={active.boxMaxHeight ?? ''}
-            onChange={handleChange}
-          />
-        </label>
-      </div>
+      {tab !== 'general' ? (
+        <>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <label>
+              Label Font Size{' '}
+              <input
+                name="labelFontSize"
+                type="number"
+                value={active.labelFontSize ?? ''}
+                onChange={handleChange}
+              />
+            </label>
+          </div>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <label>
+              Box Width{' '}
+              <input
+                name="boxWidth"
+                type="number"
+                value={active.boxWidth ?? ''}
+                onChange={handleChange}
+              />
+            </label>
+          </div>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <label>
+              Box Height{' '}
+              <input
+                name="boxHeight"
+                type="number"
+                value={active.boxHeight ?? ''}
+                onChange={handleChange}
+              />
+            </label>
+          </div>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <label>
+              Box Max Width{' '}
+              <input
+                name="boxMaxWidth"
+                type="number"
+                value={active.boxMaxWidth ?? ''}
+                onChange={handleChange}
+              />
+            </label>
+          </div>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <label>
+              Box Max Height{' '}
+              <input
+                name="boxMaxHeight"
+                type="number"
+                value={active.boxMaxHeight ?? ''}
+                onChange={handleChange}
+              />
+            </label>
+          </div>
+        </>
+      ) : (
+        <div style={{ marginBottom: '0.5rem' }}>
+          <label>
+            Base Path{' '}
+            <input
+              name="imageStorage.basePath"
+              type="text"
+              value={active.imageStorage?.basePath ?? ''}
+              onChange={(e) => {
+                const val = e.target.value;
+                setCfg((c) => ({
+                  ...c,
+                  general: {
+                    ...(c.general || {}),
+                    imageStorage: { ...(c.general?.imageStorage || {}), basePath: val },
+                  },
+                }));
+              }}
+            />
+          </label>
+        </div>
+      )}
       <button onClick={handleSave} disabled={saving}>
         Save
       </button>


### PR DESCRIPTION
## Summary
- extend general config with new `general.imageStorage.basePath`
- expose image base path in General Configuration UI
- update transaction image service to honor the new path
- document new field in general configuration docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a0d704d2c83319e99ae24d6c7ac76