### PR TITLE
Add image viewing for transactions

### DIFF
--- a/api-server/routes/transaction_images.js
+++ b/api-server/routes/transaction_images.js
@@ -17,7 +17,12 @@ router.post('/:table/:name', requireAuth, upload.array('images'), async (req, re
     if (!req.files || req.files.length === 0) {
       return res.status(400).json({ message: 'no files' });
     }
-    const files = await saveImages(req.params.table, req.params.name, req.files);
+    const files = await saveImages(
+      req.params.table,
+      req.params.name,
+      req.files,
+      req.query.folder,
+    );
     res.json(files);
   } catch (err) {
     next(err);
@@ -26,7 +31,11 @@ router.post('/:table/:name', requireAuth, upload.array('images'), async (req, re
 
 router.get('/:table/:name', requireAuth, async (req, res, next) => {
   try {
-    const files = await listImages(req.params.table, req.params.name);
+    const files = await listImages(
+      req.params.table,
+      req.params.name,
+      req.query.folder,
+    );
     res.json(files);
   } catch (err) {
     next(err);
@@ -52,6 +61,7 @@ router.delete('/:table/:name/:file', requireAuth, async (req, res, next) => {
     const ok = await deleteImage(
       req.params.table,
       req.params.file,
+      req.query.folder,
     );
     res.json({ ok });
   } catch (err) {
@@ -61,7 +71,11 @@ router.delete('/:table/:name/:file', requireAuth, async (req, res, next) => {
 
 router.delete('/:table/:name', requireAuth, async (req, res, next) => {
   try {
-    const count = await deleteAllImages(req.params.table, req.params.name);
+    const count = await deleteAllImages(
+      req.params.table,
+      req.params.name,
+      req.query.folder,
+    );
     res.json({ deleted: count });
   } catch (err) {
     next(err);

--- a/api-server/services/transactionImageService.js
+++ b/api-server/services/transactionImageService.js
@@ -25,10 +25,10 @@ function sanitizeName(name) {
     .replace(/[^a-z0-9_-]+/gi, '_');
 }
 
-export async function saveImages(table, name, files) {
+export async function saveImages(table, name, files, folder = null) {
   const { baseDir, urlBase } = await getDirs();
   ensureDir(baseDir);
-  const dir = path.join(baseDir, table);
+  const dir = path.join(baseDir, folder || table);
   ensureDir(dir);
   const saved = [];
   const prefix = sanitizeName(name);
@@ -58,22 +58,22 @@ export async function saveImages(table, name, files) {
     } catch {
       await fs.rename(file.path, dest);
     }
-    saved.push(`${urlBase}/${table}/${fileName}`);
+    saved.push(`${urlBase}/${folder || table}/${fileName}`);
   }
   return saved;
 }
 
-export async function listImages(table, name) {
+export async function listImages(table, name, folder = null) {
   const { baseDir, urlBase } = await getDirs();
   ensureDir(baseDir);
-  const dir = path.join(baseDir, table);
+  const dir = path.join(baseDir, folder || table);
   ensureDir(dir);
   const prefix = sanitizeName(name);
   try {
     const files = await fs.readdir(dir);
     return files
       .filter((f) => f.startsWith(prefix + '_'))
-      .map((f) => `${urlBase}/${table}/${f}`);
+      .map((f) => `${urlBase}/${folder || table}/${f}`);
   } catch {
     return [];
   }
@@ -106,9 +106,9 @@ export async function renameImages(table, oldName, newName, folder = null) {
   }
 }
 
-export async function deleteImage(table, file) {
+export async function deleteImage(table, file, folder = null) {
   const { baseDir } = await getDirs();
-  const dir = path.join(baseDir, table);
+  const dir = path.join(baseDir, folder || table);
   try {
     await fs.unlink(path.join(dir, path.basename(file)));
     return true;
@@ -117,10 +117,10 @@ export async function deleteImage(table, file) {
   }
 }
 
-export async function deleteAllImages(table, name) {
+export async function deleteAllImages(table, name, folder = null) {
   const { baseDir } = await getDirs();
   ensureDir(baseDir);
-  const dir = path.join(baseDir, table);
+  const dir = path.join(baseDir, folder || table);
   ensureDir(dir);
   const prefix = sanitizeName(name);
   try {

--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -533,7 +533,12 @@ export default forwardRef(function InlineTransactionTable({
           }
         }
         if (val !== '' && val !== null && val !== undefined) {
-          if ((totalCurrencySet.has(f) || totalAmountSet.has(f)) && isNaN(Number(val))) {
+          const skipNum = /code/i.test(f) || /код/i.test(labels[f] || '');
+          if (
+            (totalCurrencySet.has(f) || totalAmountSet.has(f)) &&
+            !skipNum &&
+            isNaN(Number(val))
+          ) {
             setErrorMsg((labels[f] || f) + ' талбарт буруу тоо байна');
             setInvalidCell({ row: rows.length - 1, field: f });
             const el = inputRefs.current[`${rows.length - 1}-${fields.indexOf(f)}`];
@@ -709,9 +714,11 @@ export default forwardRef(function InlineTransactionTable({
         }
         return;
       }
+      const skipNum = /code/i.test(f) || /код/i.test(labels[f] || '');
       if (
         totalCurrencySet.has(f) &&
         val !== '' &&
+        !skipNum &&
         isNaN(Number(normalizeNumberInput(val)))
       ) {
         setErrorMsg((labels[f] || f) + ' талбарт буруу тоо байна');
@@ -825,9 +832,11 @@ export default forwardRef(function InlineTransactionTable({
       if (e.target.select) e.target.select();
       return;
     }
+    const skipNum = /code/i.test(field) || /код/i.test(labels[field] || '');
     if (
       totalCurrencySet.has(field) &&
       val !== '' &&
+      !skipNum &&
       isNaN(Number(normalizeNumberInput(val)))
     ) {
       setErrorMsg((labels[field] || field) + ' талбарт буруу тоо байна');
@@ -1140,6 +1149,7 @@ export default forwardRef(function InlineTransactionTable({
       <RowImageUploadModal
         visible={uploadRow !== null}
         onClose={() => setUploadRow(null)}
+        table={tableName}
         folder={getImageFolder(rows[uploadRow])}
         row={rows[uploadRow] || {}}
         imagenameFields={imagenameFields}

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -362,9 +362,11 @@ const RowFormModal = function RowFormModal({
       setErrors((er) => ({ ...er, [col]: 'Утга оруулна уу' }));
       return;
     }
+    const skipNum = /code/i.test(col) || /код/i.test(labels[col] || '');
     if (
       (totalAmountSet.has(col) || totalCurrencySet.has(col)) &&
       val !== '' &&
+      !skipNum &&
       isNaN(Number(normalizeNumberInput(val)))
     ) {
       setErrors((er) => ({ ...er, [col]: 'Буруу тоон утга' }));
@@ -642,6 +644,7 @@ const RowFormModal = function RowFormModal({
           if (
             (totalAmountSet.has(f) || totalCurrencySet.has(f)) &&
             normalized[f] !== '' &&
+            !/code/i.test(f) &&
             isNaN(Number(normalizeNumberInput(normalized[f])))
           )
             hasInvalid = true;

--- a/src/erp.mgt.mn/components/RowImageUploadModal.jsx
+++ b/src/erp.mgt.mn/components/RowImageUploadModal.jsx
@@ -6,6 +6,7 @@ import buildImageName from '../utils/buildImageName.js';
 export default function RowImageUploadModal({
   visible,
   onClose,
+  table,
   folder,
   row = {},
   imagenameFields = [],
@@ -27,13 +28,16 @@ export default function RowImageUploadModal({
       setUploaded([]);
       return;
     }
-    fetch(`/api/transaction_images/${folder}/${encodeURIComponent(name)}`, {
+    const safeTable = encodeURIComponent(table);
+    const params = new URLSearchParams();
+    if (folder) params.set('folder', folder);
+    fetch(`/api/transaction_images/${safeTable}/${encodeURIComponent(name)}?${params.toString()}`, {
       credentials: 'include',
     })
       .then((r) => (r.ok ? r.json() : []))
       .then((imgs) => setUploaded(Array.isArray(imgs) ? imgs : []))
       .catch(() => setUploaded([]));
-  }, [visible, folder, row]);
+  }, [visible, folder, row, table]);
 
   async function handleUpload(selectedFiles) {
     const { name: safeName, missing } = buildName();
@@ -48,7 +52,10 @@ export default function RowImageUploadModal({
         'warn',
       );
     }
-    const uploadUrl = `/api/transaction_images/${folder}/${encodeURIComponent(finalName)}`;
+    const safeTable = encodeURIComponent(table);
+    const params = new URLSearchParams();
+    if (folder) params.set('folder', folder);
+    const uploadUrl = `/api/transaction_images/${safeTable}/${encodeURIComponent(finalName)}?${params.toString()}`;
     const filesToUpload = Array.from(selectedFiles || files);
     if (!filesToUpload.length) return;
     setLoading(true);
@@ -77,8 +84,11 @@ export default function RowImageUploadModal({
     const { name } = buildName();
     if (!folder || !name) return;
     try {
+      const safeTable = encodeURIComponent(table);
+      const params = new URLSearchParams();
+      if (folder) params.set('folder', folder);
       await fetch(
-        `/api/transaction_images/${folder}/${encodeURIComponent(name)}/${encodeURIComponent(file)}`,
+        `/api/transaction_images/${safeTable}/${encodeURIComponent(name)}/${encodeURIComponent(file)}?${params.toString()}`,
         { method: 'DELETE', credentials: 'include' },
       );
       setUploaded((u) => u.filter((f) => !f.endsWith(`/${file}`)));
@@ -89,7 +99,10 @@ export default function RowImageUploadModal({
     const { name } = buildName();
     if (!folder || !name) return;
     try {
-      await fetch(`/api/transaction_images/${folder}/${encodeURIComponent(name)}`, {
+      const safeTable = encodeURIComponent(table);
+      const params = new URLSearchParams();
+      if (folder) params.set('folder', folder);
+      await fetch(`/api/transaction_images/${safeTable}/${encodeURIComponent(name)}?${params.toString()}`, {
         method: 'DELETE',
         credentials: 'include',
       });

--- a/src/erp.mgt.mn/components/RowImageViewModal.jsx
+++ b/src/erp.mgt.mn/components/RowImageViewModal.jsx
@@ -1,0 +1,65 @@
+import React, { useState, useEffect } from 'react';
+import Modal from './Modal.jsx';
+import buildImageName from '../utils/buildImageName.js';
+import { useToast } from '../context/ToastContext.jsx';
+
+export default function RowImageViewModal({
+  visible,
+  onClose,
+  table,
+  folder,
+  row = {},
+  imagenameFields = [],
+  columnCaseMap = {},
+}) {
+  const [files, setFiles] = useState([]);
+  const { addToast } = useToast();
+
+  useEffect(() => {
+    if (!visible) return;
+    const { name } = buildImageName(row, imagenameFields, columnCaseMap);
+    if (!folder || !name) {
+      setFiles([]);
+      return;
+    }
+    const safeTable = encodeURIComponent(table);
+    const params = new URLSearchParams();
+    if (folder) params.set('folder', folder);
+    addToast(`Search: ${params.get('folder') || table}/${name}`, 'info');
+    fetch(`/api/transaction_images/${safeTable}/${encodeURIComponent(name)}?${params.toString()}`, {
+      credentials: 'include',
+    })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((imgs) => {
+        const list = Array.isArray(imgs) ? imgs : [];
+        addToast(`Found ${list.length} image(s)`, 'info');
+        setFiles(list);
+      })
+      .catch(() => setFiles([]));
+  }, [visible, folder, row, table]);
+
+  if (!visible) return null;
+
+  return (
+    <Modal visible={visible} title="Images" onClose={onClose} width="auto">
+      {files.length === 0 ? (
+        <p>No images</p>
+      ) : (
+        <div style={{ maxHeight: '40vh', overflowY: 'auto' }}>
+          {files.map((src) => {
+            const name = src.split('/').pop();
+            return (
+              <div key={src} style={{ marginBottom: '0.25rem' }}>
+                <img src={src} alt="" style={{ maxWidth: '100px', marginRight: '0.5rem' }} />
+                <span>{name}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+      <div style={{ textAlign: 'right', marginTop: '1rem' }}>
+        <button type="button" onClick={onClose}>Close</button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -13,6 +13,7 @@ import { useToast } from '../context/ToastContext.jsx';
 import RowFormModal from './RowFormModal.jsx';
 import CascadeDeleteModal from './CascadeDeleteModal.jsx';
 import RowDetailModal from './RowDetailModal.jsx';
+import RowImageViewModal from './RowImageViewModal.jsx';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import formatTimestamp from '../utils/formatTimestamp.js';
 import buildImageName from '../utils/buildImageName.js';
@@ -65,8 +66,8 @@ function normalizeDateInput(value, format) {
 const actionCellStyle = {
   padding: '0.5rem',
   border: '1px solid #d1d5db',
-  width: 150,
-  minWidth: 150,
+  width: 180,
+  minWidth: 180,
   whiteSpace: 'nowrap',
   display: 'flex',
   justifyContent: 'flex-end',
@@ -91,9 +92,10 @@ const TableManager = forwardRef(function TableManager({
   table,
   refreshId = 0,
   formConfig = null,
+  allConfigs = {},
   initialPerPage = 10,
   addLabel = 'Мөр нэмэх',
-  showTable = true
+  showTable = true,
 }, ref) {
   const mounted = useRef(false);
   const renderCount = useRef(0);
@@ -137,6 +139,7 @@ const TableManager = forwardRef(function TableManager({
   const [showDetail, setShowDetail] = useState(false);
   const [detailRow, setDetailRow] = useState(null);
   const [detailRefs, setDetailRefs] = useState([]);
+  const [imagesRow, setImagesRow] = useState(null);
   const [viewDisplayMap, setViewDisplayMap] = useState({});
   const [viewColumns, setViewColumns] = useState({});
   const [editLabels, setEditLabels] = useState(false);
@@ -625,6 +628,21 @@ const TableManager = forwardRef(function TableManager({
     return `${slugify(t1)}/${slugify(String(t2))}`;
   }
 
+  function getConfigForRow(row) {
+    if (!row) return formConfig || {};
+    const configs = Object.values(allConfigs || {});
+    for (const cfg of configs) {
+      if (cfg.table !== table) continue;
+      if (!cfg.transactionTypeField) continue;
+      const key = columnCaseMap[cfg.transactionTypeField.toLowerCase()] || cfg.transactionTypeField;
+      const val = row[key];
+      if (val !== undefined && String(val) === String(cfg.transactionTypeValue)) {
+        return cfg;
+      }
+    }
+    return formConfig || {};
+  }
+
   function getKeyFields() {
     const keys = columnMeta
       .filter((c) => c.key === 'PRI')
@@ -743,6 +761,10 @@ const TableManager = forwardRef(function TableManager({
       setDetailRefs([]);
     }
     setShowDetail(true);
+  }
+
+  function openImages(row) {
+    setImagesRow(row);
   }
 
   function toggleRow(id) {
@@ -876,7 +898,7 @@ const TableManager = forwardRef(function TableManager({
       });
     }
 
-    const baseRowForName = isAdding ? gridRows[0] : editing;
+    const baseRowForName = isAdding ? values : editing;
     const { name: oldImageName } = buildImageName(
       baseRowForName || merged,
       formConfig?.imagenameField || [],
@@ -1606,7 +1628,7 @@ const TableManager = forwardRef(function TableManager({
                 {sort.column === c ? (sort.dir === 'asc' ? ' \u2191' : ' \u2193') : ''}
               </th>
             ))}
-            <th style={{ padding: '0.5rem', border: '1px solid #d1d5db', whiteSpace: 'nowrap', width: 120 }}>Action</th>
+            <th style={{ padding: '0.5rem', border: '1px solid #d1d5db', whiteSpace: 'nowrap', width: 180 }}>Action</th>
           </tr>
           <tr>
             <th style={{ padding: '0.25rem', border: '1px solid #d1d5db', width: 60 }}></th>
@@ -1735,6 +1757,12 @@ const TableManager = forwardRef(function TableManager({
                         style={actionBtnStyle}
                       >
                         👁 View
+                      </button>
+                      <button
+                        onClick={() => openImages(r)}
+                        style={actionBtnStyle}
+                      >
+                        🖼 Images
                       </button>
                       <button
                         onClick={() => openEdit(r)}
@@ -1947,6 +1975,15 @@ const TableManager = forwardRef(function TableManager({
         references={detailRefs}
         labels={labels}
       />
+      <RowImageViewModal
+        visible={imagesRow !== null}
+        onClose={() => setImagesRow(null)}
+        table={table}
+        folder={getImageFolder(imagesRow)}
+        row={imagesRow || {}}
+        imagenameFields={getConfigForRow(imagesRow).imagenameField || []}
+        columnCaseMap={columnCaseMap}
+      />
       {user?.role === 'admin' && (
         <button onClick={() => {
           const map = {};
@@ -2006,6 +2043,7 @@ function propsEqual(prev, next) {
     prev.table === next.table &&
     prev.refreshId === next.refreshId &&
     prev.formConfig === next.formConfig &&
+    prev.allConfigs === next.allConfigs &&
     prev.showTable === next.showTable
   );
 }

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -301,6 +301,7 @@ useEffect(() => {
           table={table}
           refreshId={refreshId}
           formConfig={config}
+          allConfigs={configs}
           initialPerPage={10}
           addLabel="Гүйлгээ нэмэх"
           showTable={showTable}


### PR DESCRIPTION
## Summary
- add `RowImageViewModal` for showing images attached to a row
- allow `TableManager` to display a *View Images* button for every row
- pass all transaction configs so image lookup uses the right config
- handle inventory code fields better when validating numbers
- fix image renaming when saving multiple rows
- encode nested image folders correctly
- show toast when searching for images in `RowImageViewModal`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a5c7550008331b14e3be8bf11a3f4