### PR TITLE
Add image cleanup utilities

### DIFF
--- a/api-server/routes/transaction_images.js
+++ b/api-server/routes/transaction_images.js
@@ -7,6 +7,7 @@ import {
   renameImages,
   deleteImage,
   deleteAllImages,
+  cleanupOldImages,
 } from '../services/transactionImageService.js';
 
 const router = express.Router();
@@ -77,6 +78,16 @@ router.delete('/:table/:name', requireAuth, async (req, res, next) => {
       req.query.folder,
     );
     res.json({ deleted: count });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/cleanup/:days?', requireAuth, async (req, res, next) => {
+  try {
+    const days = parseInt(req.params.days || req.query.days, 10) || 30;
+    const removed = await cleanupOldImages(days);
+    res.json({ removed });
   } catch (err) {
     next(err);
   }

--- a/tests/api/cleanupOldImages.test.js
+++ b/tests/api/cleanupOldImages.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import path from 'path';
+import { cleanupOldImages } from '../../api-server/services/transactionImageService.js';
+
+const baseDir = path.join(process.cwd(), 'uploads', 'txn_images', 'test');
+
+test('cleanupOldImages removes old files', async () => {
+  await fs.mkdir(baseDir, { recursive: true });
+  const file = path.join(baseDir, 'old.txt');
+  await fs.writeFile(file, 'temp');
+  const oldTime = Date.now() - 40 * 24 * 60 * 60 * 1000;
+  await fs.utimes(file, oldTime / 1000, oldTime / 1000);
+
+  const removed = await cleanupOldImages(30);
+
+  let exists = true;
+  try {
+    await fs.access(file);
+  } catch {
+    exists = false;
+  }
+
+  assert.ok(removed >= 1);
+  assert.equal(exists, false);
+
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- support optional dependency for `mime-types`
- add image cleanup service for purging old files
- expose cleanup route under `/api/transaction_images/cleanup/:days?`
- test image cleanup helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a7dcc2ddc83319a5f89d7508e5d4e