### PR TITLE
Enhance image utilities

### DIFF
--- a/api-server/routes/transaction_images.js
+++ b/api-server/routes/transaction_images.js
@@ -7,6 +7,9 @@ import {
   renameImages,
   deleteImage,
   deleteAllImages,
+  cleanupOldImages,
+} from '../services/transactionImageService.js';
+import { getGeneralConfig } from '../services/generalConfig.js';
 } from '../services/transactionImageService.js';
 
 const router = express.Router();
@@ -77,6 +80,20 @@ router.delete('/:table/:name', requireAuth, async (req, res, next) => {
       req.query.folder,
     );
     res.json({ deleted: count });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/cleanup/:days?', requireAuth, async (req, res, next) => {
+  try {
+    let days = parseInt(req.params.days || req.query.days, 10);
+    if (!days || Number.isNaN(days)) {
+      const cfg = await getGeneralConfig();
+      days = cfg.general?.imageStorage?.cleanupDays || 30;
+    }
+    const removed = await cleanupOldImages(days);
+    res.json({ removed });
   } catch (err) {
     next(err);
   }

--- a/api-server/services/transactionImageService.js
+++ b/api-server/services/transactionImageService.js
@@ -1,7 +1,6 @@
 import fs from 'fs/promises';
 import fssync from 'fs';
 import path from 'path';
-import mime from 'mime-types';
 import { getGeneralConfig } from './generalConfig.js';
 
 async function getDirs() {
@@ -32,31 +31,36 @@ export async function saveImages(table, name, files, folder = null) {
   ensureDir(dir);
   const saved = [];
   const prefix = sanitizeName(name);
+  let mimeLib;
+  try {
+    mimeLib = (await import('mime-types')).default;
+  } catch {}
   for (const file of files) {
     const ext =
-      path.extname(file.originalname) || `.${mime.extension(file.mimetype) || 'bin'}`;
+      path.extname(file.originalname) || `.${mimeLib?.extension(file.mimetype) || 'bin'}`;
     const unique = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
     const fileName = `${prefix}_${unique}${ext}`;
     const dest = path.join(dir, fileName);
+    let optimized = false;
     try {
-      if (file.size > 1500000) {
-        let sharpLib;
-        try {
-          sharpLib = (await import('sharp')).default;
-        } catch {}
-        if (sharpLib) {
-          await sharpLib(file.path)
-            .resize({ width: 1200, height: 1200, fit: 'inside' })
-            .toFile(dest);
-          await fs.unlink(file.path);
-        } else {
-          await fs.rename(file.path, dest);
-        }
-      } else {
-        await fs.rename(file.path, dest);
+      let sharpLib;
+      try {
+        sharpLib = (await import('sharp')).default;
+      } catch {}
+      if (sharpLib) {
+        await sharpLib(file.path)
+          .resize({ width: 1200, height: 1200, fit: 'inside' })
+          .toFile(dest);
+        await fs.unlink(file.path);
+        optimized = true;
       }
-    } catch {
-      await fs.rename(file.path, dest);
+    } catch {}
+    if (!optimized) {
+      try {
+        await fs.rename(file.path, dest);
+      } catch {
+        // ignore
+      }
     }
     saved.push(`${urlBase}/${folder || table}/${fileName}`);
   }
@@ -136,4 +140,38 @@ export async function deleteAllImages(table, name, folder = null) {
   } catch {
     return 0;
   }
+}
+
+export async function cleanupOldImages(days = 30) {
+  const { baseDir } = await getDirs();
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+  let removed = 0;
+
+  async function walk(dir) {
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else if (entry.isFile()) {
+        try {
+          const stat = await fs.stat(full);
+          if (stat.mtimeMs < cutoff) {
+            await fs.unlink(full);
+            removed += 1;
+          }
+        } catch {}
+      }
+    }
+  }
+
+  await walk(baseDir);
+  await walk(path.join(process.cwd(), 'uploads', 'tmp'));
+
+  return removed;
 }

--- a/config/generalConfig.json
+++ b/config/generalConfig.json
@@ -15,7 +15,8 @@
   },
   "general": {
     "imageStorage": {
-      "basePath": "uploads"
+      "basePath": "uploads",
+      "cleanupDays": 30
     }
   }
 }

--- a/db/defaultModules.js
+++ b/db/defaultModules.js
@@ -13,6 +13,7 @@ export default [
   { moduleKey: 'coding_tables', label: 'Кодын хүснэгтүүд', parentKey: 'developer', showInSidebar: true, showInHeader: false },
   { moduleKey: 'forms_management', label: 'Маягтын удирдлага', parentKey: 'developer', showInSidebar: true, showInHeader: false },
   { moduleKey: 'report_management', label: 'Тайлангийн удирдлага', parentKey: 'developer', showInSidebar: true, showInHeader: false },
+  { moduleKey: 'image_management', label: 'Image Management', parentKey: 'developer', showInSidebar: true, showInHeader: false },
   { moduleKey: 'general_configuration', label: 'Ерөнхий тохиргоо', parentKey: 'settings', showInSidebar: true, showInHeader: false },
   { moduleKey: 'change_password', label: 'Нууц үг солих', parentKey: 'settings', showInSidebar: true, showInHeader: false },
   { moduleKey: 'pos_transaction_management', label: 'POS Transactions', parentKey: 'developer', showInSidebar: true, showInHeader: false },

--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -29,6 +29,7 @@ import SettingsPage, { GeneralSettings } from './pages/Settings.jsx';
 import ChangePasswordPage from './pages/ChangePassword.jsx';
 import BlueLinkPage from './pages/BlueLinkPage.jsx';
 import InventoryPage from './pages/InventoryPage.jsx';
+import ImageManagementPage from './pages/ImageManagement.jsx';
 import FinanceTransactionsPage from './pages/FinanceTransactions.jsx';
 import { useModules } from './hooks/useModules.js';
 import { useTxnModules } from './hooks/useTxnModules.js';
@@ -69,6 +70,7 @@ export default function App() {
     pos_transaction_management: <PosTxnConfigPage />,
     pos_transactions: <PosTransactionsPage />,
     general_configuration: <GeneralConfigurationPage />,
+    image_management: <ImageManagementPage />,
     change_password: <ChangePasswordPage />,
   };
 
@@ -97,6 +99,7 @@ export default function App() {
     'report_management',
     'relations_config',
     'pos_transaction_management',
+    'image_management',
     'general_configuration',
   ]);
 

--- a/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
+++ b/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
@@ -164,6 +164,27 @@ export default function GeneralConfiguration() {
             />
           </label>
         </div>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <label>
+            Cleanup Days{' '}
+            <input
+              name="imageStorage.cleanupDays"
+              type="number"
+              value={active.imageStorage?.cleanupDays ?? ''}
+              onChange={(e) => {
+                const val = Number(e.target.value);
+                setCfg((c) => ({
+                  ...c,
+                  general: {
+                    ...(c.general || {}),
+                    imageStorage: { ...(c.general?.imageStorage || {}), cleanupDays: val },
+                  },
+                }));
+              }}
+              style={{ width: '4rem' }}
+            />
+          </label>
+        </div>
       )}
       <button onClick={handleSave} disabled={saving}>
         Save

--- a/src/erp.mgt.mn/pages/ImageManagement.jsx
+++ b/src/erp.mgt.mn/pages/ImageManagement.jsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { useToast } from '../context/ToastContext.jsx';
+
+export default function ImageManagement() {
+  const { addToast } = useToast();
+  const [days, setDays] = useState('');
+  const [result, setResult] = useState(null);
+
+  async function handleCleanup() {
+    const path = days ? `/api/transaction_images/cleanup/${days}` : '/api/transaction_images/cleanup';
+    try {
+      const res = await fetch(path, { method: 'DELETE', credentials: 'include' });
+      if (res.ok) {
+        const data = await res.json().catch(() => ({}));
+        const removed = data.removed || 0;
+        setResult(removed);
+        addToast(`Removed ${removed} file(s)`, 'success');
+      } else {
+        addToast('Cleanup failed', 'error');
+      }
+    } catch {
+      addToast('Cleanup failed', 'error');
+    }
+  }
+
+  return (
+    <div>
+      <h2>Image Management</h2>
+      <div style={{ marginBottom: '0.5rem' }}>
+        <label>
+          Cleanup files older than (days):{' '}
+          <input
+            type="number"
+            value={days}
+            onChange={(e) => setDays(e.target.value)}
+            style={{ width: '4rem' }}
+          />
+        </label>
+        <button type="button" onClick={handleCleanup} style={{ marginLeft: '0.5rem' }}>
+          Cleanup
+        </button>
+      </div>
+      {result !== null && <p>{result} file(s) removed.</p>}
+    </div>
+  );
+}

--- a/tests/api/cleanupOldImages.test.js
+++ b/tests/api/cleanupOldImages.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import path from 'path';
+import { cleanupOldImages } from '../../api-server/services/transactionImageService.js';
+
+const baseDir = path.join(process.cwd(), 'uploads', 'txn_images', 'test');
+
+test('cleanupOldImages removes old files', async () => {
+  await fs.mkdir(baseDir, { recursive: true });
+  const file = path.join(baseDir, 'old.txt');
+  await fs.writeFile(file, 'temp');
+  const oldTime = Date.now() - 40 * 24 * 60 * 60 * 1000;
+  await fs.utimes(file, oldTime / 1000, oldTime / 1000);
+
+  const removed = await cleanupOldImages(30);
+
+  let exists = true;
+  try {
+    await fs.access(file);
+  } catch {
+    exists = false;
+  }
+
+  assert.ok(removed >= 1);
+  assert.equal(exists, false);
+
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- optimize uploads via optional sharp
- add cleanupDays setting to general config
- use cleanupDays when calling old-image cleanup API
- expose cleanup UI under Image Management
- register image_management module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a7dcc2ddc83319a5f89d7508e5d4e