### PR TITLE
Implement incomplete image fix utility

### DIFF
--- a/api-server/routes/transaction_images.js
+++ b/api-server/routes/transaction_images.js
@@ -8,6 +8,10 @@ import {
   deleteImage,
   deleteAllImages,
   cleanupOldImages,
+  detectIncompleteImages,
+  fixIncompleteImages,
+  checkUploadedImages,
+  commitUploadedImages,
 } from '../services/transactionImageService.js';
 import { getGeneralConfig } from '../services/generalConfig.js';
 
@@ -24,6 +28,45 @@ router.delete('/cleanup/:days?', requireAuth, async (req, res, next) => {
     }
     const removed = await cleanupOldImages(days);
     res.json({ removed });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/detect_incomplete', requireAuth, async (req, res, next) => {
+  try {
+    const page = parseInt(req.query.page, 10) || 1;
+    const data = await detectIncompleteImages(page);
+    res.json(data);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/fix_incomplete', requireAuth, async (req, res, next) => {
+  try {
+    const arr = Array.isArray(req.body?.list) ? req.body.list : [];
+    const fixed = await fixIncompleteImages(arr);
+    res.json({ fixed });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/upload_check', requireAuth, upload.array('images'), async (req, res, next) => {
+  try {
+    const list = await checkUploadedImages(req.files || []);
+    res.json({ list });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/upload_commit', requireAuth, async (req, res, next) => {
+  try {
+    const arr = Array.isArray(req.body?.list) ? req.body.list : [];
+    const uploaded = await commitUploadedImages(arr);
+    res.json({ uploaded });
   } catch (err) {
     next(err);
   }

--- a/api-server/services/transactionImageService.js
+++ b/api-server/services/transactionImageService.js
@@ -2,6 +2,9 @@ import fs from 'fs/promises';
 import fssync from 'fs';
 import path from 'path';
 import { getGeneralConfig } from './generalConfig.js';
+import { pool } from '../../db/index.js';
+import { getConfigsByTable } from './transactionFormConfig.js';
+import { slugify } from '../utils/slugify.js';
 
 async function getDirs() {
   const cfg = await getGeneralConfig();
@@ -22,6 +25,66 @@ function sanitizeName(name) {
   return String(name)
     .toLowerCase()
     .replace(/[^a-z0-9_-]+/gi, '_');
+}
+
+function getCase(row, field) {
+  if (!row) return undefined;
+  if (row[field] !== undefined) return row[field];
+  const lower = field.toLowerCase();
+  const key = Object.keys(row).find((k) => k.toLowerCase() === lower);
+  return key ? row[key] : undefined;
+}
+
+function buildNameFromRow(row, fields = []) {
+  const vals = fields.map((f) => getCase(row, f)).filter((v) => v);
+  return sanitizeName(vals.join('_'));
+}
+
+function pickConfig(configs = {}, row = {}) {
+  for (const cfg of Object.values(configs)) {
+    if (!cfg.transactionTypeField || !cfg.transactionTypeValue) continue;
+    const val = getCase(row, cfg.transactionTypeField);
+    if (val !== undefined && String(val) === String(cfg.transactionTypeValue)) {
+      return cfg;
+    }
+  }
+  return Object.values(configs)[0] || {};
+}
+
+function extractUnique(str) {
+  const uuid = str.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+  if (uuid) return uuid[0];
+  const alt = str.match(/[A-Z0-9]{4}(?:-[A-Z0-9]{4}){3}/);
+  if (alt) return alt[0];
+  const long = str.match(/[A-Za-z0-9-]{8,}/);
+  return long ? long[0] : '';
+}
+
+function parseFileUnique(base) {
+  const unique = extractUnique(base);
+  if (!unique) return { unique: '', suffix: '' };
+  const idx = base.toLowerCase().indexOf(unique.toLowerCase());
+  const suffix = idx >= 0 ? base.slice(idx + unique.length) : '';
+  return { unique, suffix };
+}
+
+function buildFolderName(row, fallback = '') {
+  const part1 =
+    getCase(row, 'trtype') ||
+    getCase(row, 'TRTYPE') ||
+    getCase(row, 'trtypenum');
+  const part2 =
+    getCase(row, 'TransType') ||
+    getCase(row, 'UITransType') ||
+    getCase(row, 'UITransTypeName') ||
+    getCase(row, 'TRTYPENAME') ||
+    getCase(row, 'trtypename') ||
+    getCase(row, 'uitranstypename') ||
+    getCase(row, 'transtype');
+  if (part1 && part2) {
+    return `${slugify(String(part1))}/${slugify(String(part2))}`;
+  }
+  return fallback;
 }
 
 export async function saveImages(table, name, files, folder = null) {
@@ -181,4 +244,255 @@ export async function cleanupOldImages(days = 30) {
   await walk(path.join(process.cwd(), 'uploads', 'tmp'));
 
   return removed;
+}
+
+export async function detectIncompleteImages(page = 1, perPage = 100) {
+  const { baseDir } = await getDirs();
+  let results = [];
+  let dirs;
+  const offset = (page - 1) * perPage;
+  let count = 0;
+  let hasMore = false;
+  try {
+    dirs = await fs.readdir(baseDir, { withFileTypes: true });
+  } catch {
+    return { list: results, hasMore };
+  }
+
+  for (const entry of dirs) {
+    if (!entry.isDirectory() || !entry.name.startsWith('transactions_')) continue;
+    const dirPath = path.join(baseDir, entry.name);
+    let files;
+    try {
+      files = await fs.readdir(dirPath);
+    } catch {
+      continue;
+    }
+    for (const f of files) {
+      const ext = path.extname(f);
+      const base = path.basename(f, ext);
+      const { unique, suffix } = parseFileUnique(base);
+      if (!unique || unique.length < 8) continue;
+      const found = await findTxnByUniqueId(unique);
+      if (!found) continue;
+      const { row, configs, numField } = found;
+
+      const curSan = sanitizeName(base);
+      const trans4d = sanitizeName(String(getCase(row, 'trtype') || ''));
+      const trans4l = sanitizeName(String(getCase(row, 'TransType') || ''));
+      const hasCodes =
+        (trans4d ? curSan.includes(trans4d) : true) &&
+        (trans4l ? curSan.includes(trans4l) : true);
+      if (hasCodes) continue;
+
+      const cfg = pickConfig(configs, row);
+      const fields = cfg?.imagenameField || [];
+      let newBase = buildNameFromRow(row, fields);
+
+      const transDigit = getCase(row, 'trtype');
+      const transType = getCase(row, 'TransType');
+      if (!newBase && !fields.length && !transType) {
+        const fallback = [
+          'z_mat_code',
+          'or_bcode',
+          'bmtr_pmid',
+          'pmid',
+          'sp_primary_code',
+          'TransType',
+          'trtype',
+          'bmtr_num',
+          'or_num',
+          'z_num',
+          'ordrnum',
+          'num',
+          'pid',
+        ];
+        const extra = [];
+        const o1 = [getCase(row, 'bmtr_orderid'), getCase(row, 'bmtr_orderdid')]
+          .filter(Boolean)
+          .join('~');
+        if (o1) extra.push(o1);
+        const o2 = [getCase(row, 'ordrid'), getCase(row, 'ordrdid')]
+          .filter(Boolean)
+          .join('~');
+        if (o2) extra.push(o2);
+        newBase = buildNameFromRow(row, fallback);
+        if (extra.length) newBase = sanitizeName([newBase, ...extra].join('_'));
+      }
+      if (!newBase && numField) {
+        newBase = sanitizeName(String(row[numField]));
+      }
+      if (!newBase) continue;
+      if (transDigit && !sanitizeName(newBase).includes(sanitizeName(transDigit))) {
+        newBase = sanitizeName(`${transDigit}_${newBase}`);
+      }
+      if (transType && !sanitizeName(newBase).includes(sanitizeName(transType))) {
+        newBase = sanitizeName(`${newBase}_${transType}`);
+      }
+      const folderRaw = buildFolderName(row, cfg?.imageFolder || entry.name);
+      const folderDisplay = '/' + String(folderRaw).replace(/^\/+/, '');
+      const sanitizedUnique = sanitizeName(unique);
+      let finalBase = newBase;
+      if (sanitizeName(newBase).includes(sanitizedUnique)) {
+        finalBase = `${newBase}${suffix}`;
+      } else {
+        finalBase = `${newBase}_${unique}${suffix}`;
+      }
+      const newName = `${finalBase}${ext}`;
+      count += 1;
+      if (count > offset && results.length < perPage) {
+        results.push({
+          folder: folderRaw,
+          folderDisplay,
+          currentName: f,
+          newName,
+          currentPath: path.join(dirPath, f),
+        });
+      } else if (results.length >= perPage) {
+        hasMore = true;
+        break;
+      }
+    }
+    if (hasMore) break;
+  }
+  return { list: results, hasMore };
+}
+
+async function findTxnByUniqueId(idPart) {
+  let tables;
+  try {
+    [tables] = await pool.query("SHOW TABLES LIKE 'transactions_%'");
+  } catch {
+    return null;
+  }
+  for (const row of tables || []) {
+    const tbl = Object.values(row)[0];
+    let cols;
+    try {
+      [cols] = await pool.query(`SHOW COLUMNS FROM \`${tbl}\``);
+    } catch {
+      continue;
+    }
+    const numCol = cols.find((c) => c.Field.toLowerCase().includes('num'));
+    if (!numCol) continue;
+    let rows;
+    try {
+      [rows] = await pool.query(
+        `SELECT * FROM \`${tbl}\` WHERE \`${numCol.Field}\` LIKE ? LIMIT 1`,
+        [`%${idPart}%`],
+      );
+    } catch {
+      continue;
+    }
+    if (rows.length) {
+      let cfgs = {};
+      try {
+        cfgs = await getConfigsByTable(tbl);
+      } catch {}
+      return { table: tbl, row: rows[0], configs: cfgs, numField: numCol.Field };
+    }
+  }
+  return null;
+}
+
+export async function fixIncompleteImages(list = []) {
+  const { baseDir } = await getDirs();
+  let count = 0;
+  for (const item of list) {
+    const dir = path.join(baseDir, item.folder || '');
+    ensureDir(dir);
+    try {
+      await fs.rename(item.currentPath, path.join(dir, item.newName));
+      count += 1;
+    } catch {}
+  }
+  return count;
+}
+
+export async function checkUploadedImages(files = []) {
+  const results = [];
+  for (const file of files) {
+    const ext = path.extname(file.originalname);
+    const base = path.basename(file.originalname, ext);
+    const { unique, suffix } = parseFileUnique(base);
+    if (!unique) continue;
+    const found = await findTxnByUniqueId(unique);
+    if (!found) continue;
+    const { row, configs, numField } = found;
+    const cfg = pickConfig(configs, row);
+    let newBase = buildNameFromRow(row, cfg?.imagenameField || []);
+    const transDigit = getCase(row, 'trtype');
+    const transType = getCase(row, 'TransType');
+    if (!newBase && !(cfg?.imagenameField || []).length && !transType) {
+      const fallback = [
+        'z_mat_code',
+        'or_bcode',
+        'bmtr_pmid',
+        'pmid',
+        'sp_primary_code',
+        'TransType',
+        'trtype',
+        'bmtr_num',
+        'or_num',
+        'z_num',
+        'ordrnum',
+        'num',
+        'pid',
+      ];
+      const extra = [];
+      const o1 = [getCase(row, 'bmtr_orderid'), getCase(row, 'bmtr_orderdid')]
+        .filter(Boolean)
+        .join('~');
+      if (o1) extra.push(o1);
+      const o2 = [getCase(row, 'ordrid'), getCase(row, 'ordrdid')]
+        .filter(Boolean)
+        .join('~');
+      if (o2) extra.push(o2);
+      newBase = buildNameFromRow(row, fallback);
+      if (extra.length) newBase = sanitizeName([newBase, ...extra].join('_'));
+    }
+
+    if (!newBase && numField) {
+      newBase = sanitizeName(String(row[numField]));
+    }
+    if (!newBase) continue;
+    if (transDigit && !sanitizeName(newBase).includes(sanitizeName(transDigit))) {
+      newBase = sanitizeName(`${transDigit}_${newBase}`);
+    }
+    if (transType && !sanitizeName(newBase).includes(sanitizeName(transType))) {
+      newBase = sanitizeName(`${newBase}_${transType}`);
+    }
+    const folderRaw = buildFolderName(row, cfg?.imageFolder || found.table);
+    const folderDisplay = '/' + String(folderRaw).replace(/^\/+/, '');
+    const sanitizedUnique = sanitizeName(unique);
+    let finalBase = newBase;
+    if (sanitizeName(newBase).includes(sanitizedUnique)) {
+      finalBase = `${newBase}${suffix}`;
+    } else {
+      finalBase = `${newBase}_${unique}${suffix}`;
+    }
+    const newName = `${finalBase}${ext}`;
+    results.push({
+      tmpPath: file.path,
+      originalName: file.originalname,
+      newName,
+      folder: folderRaw,
+      folderDisplay,
+    });
+  }
+  return results;
+}
+
+export async function commitUploadedImages(list = []) {
+  const { baseDir } = await getDirs();
+  let count = 0;
+  for (const item of list) {
+    const dir = path.join(baseDir, item.folder || '');
+    ensureDir(dir);
+    try {
+      await fs.rename(item.tmpPath, path.join(dir, item.newName));
+      count += 1;
+    } catch {}
+  }
+  return count;
 }

--- a/src/erp.mgt.mn/pages/ImageManagement.jsx
+++ b/src/erp.mgt.mn/pages/ImageManagement.jsx
@@ -1,10 +1,47 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useToast } from '../context/ToastContext.jsx';
 
 export default function ImageManagement() {
   const { addToast } = useToast();
   const [days, setDays] = useState('');
   const [result, setResult] = useState(null);
+  const [tab, setTab] = useState('cleanup');
+  const [pending, setPending] = useState([]);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  const [selected, setSelected] = useState([]);
+  const [uploads, setUploads] = useState([]);
+  const [uploadSel, setUploadSel] = useState([]);
+  const [folderFiles, setFolderFiles] = useState([]);
+  const fileRef = useRef();
+
+  function toggle(id) {
+    setSelected((prev) =>
+      prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id],
+    );
+  }
+
+  function toggleAll() {
+    if (selected.length === pending.length) {
+      setSelected([]);
+    } else {
+      setSelected(pending.map((p) => p.currentName));
+    }
+  }
+
+  function toggleUpload(id) {
+    setUploadSel((prev) =>
+      prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id],
+    );
+  }
+
+  function toggleUploadAll() {
+    if (uploadSel.length === uploads.length) {
+      setUploadSel([]);
+    } else {
+      setUploadSel(uploads.map((u) => u.tmpPath));
+    }
+  }
 
   async function handleCleanup() {
     const path = days ? `/api/transaction_images/cleanup/${days}` : '/api/transaction_images/cleanup';
@@ -23,24 +60,223 @@ export default function ImageManagement() {
     }
   }
 
+  useEffect(() => {
+    if (tab !== 'fix') {
+      setPending([]);
+      setUploads([]);
+      setUploadSel([]);
+      setSelected([]);
+      setPage(1);
+    }
+  }, [tab]);
+
+  async function refreshList(p = page) {
+    try {
+      const res = await fetch(`/api/transaction_images/detect_incomplete?page=${p}`, {
+        credentials: 'include',
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setPending(Array.isArray(data.list) ? data.list : []);
+        setHasMore(!!data.hasMore);
+        setSelected([]);
+      } else {
+        setPending([]);
+        setHasMore(false);
+      }
+    } catch {
+      setPending([]);
+      setHasMore(false);
+    }
+  }
+
+  async function applyFixes() {
+    const items = pending.filter((p) => selected.includes(p.currentName));
+    if (items.length === 0) return;
+    const res = await fetch('/api/transaction_images/fix_incomplete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ list: items }),
+    });
+    if (res.ok) {
+      const data = await res.json().catch(() => ({}));
+      addToast(`Renamed ${data.fixed || 0} file(s)`, 'success');
+      refreshList();
+    } else {
+      addToast('Rename failed', 'error');
+    }
+  }
+
+  function handleFolderChange(files) {
+    setFolderFiles(Array.from(files || []));
+  }
+
+  async function checkFolder() {
+    if (folderFiles.length === 0) return;
+    const form = new FormData();
+    folderFiles.forEach((f) => form.append('images', f));
+    try {
+      const res = await fetch('/api/transaction_images/upload_check', {
+        method: 'POST',
+        body: form,
+        credentials: 'include',
+      });
+      if (res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setUploads(Array.isArray(data.list) ? data.list : []);
+        setUploadSel([]);
+      } else {
+        addToast('Check failed', 'error');
+      }
+    } catch {
+      addToast('Check failed', 'error');
+    }
+  }
+
+  async function commitUploads() {
+    const items = uploads.filter((u) => uploadSel.includes(u.tmpPath));
+    if (items.length === 0) return;
+    const res = await fetch('/api/transaction_images/upload_commit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ list: items }),
+    });
+    if (res.ok) {
+      const data = await res.json().catch(() => ({}));
+      addToast(`Uploaded ${data.uploaded || 0} file(s)`, 'success');
+      setUploads([]);
+      setUploadSel([]);
+    } else {
+      addToast('Upload failed', 'error');
+    }
+  }
+
   return (
     <div>
       <h2>Image Management</h2>
-      <div style={{ marginBottom: '0.5rem' }}>
-        <label>
-          Cleanup files older than (days):{' '}
-          <input
-            type="number"
-            value={days}
-            onChange={(e) => setDays(e.target.value)}
-            style={{ width: '4rem' }}
-          />
-        </label>
-        <button type="button" onClick={handleCleanup} style={{ marginLeft: '0.5rem' }}>
+      <div className="tab-button-group" style={{ marginBottom: '0.5rem' }}>
+        <button className={`tab-button ${tab === 'cleanup' ? 'active' : ''}`} onClick={() => setTab('cleanup')}>
           Cleanup
         </button>
+        <button className={`tab-button ${tab === 'fix' ? 'active' : ''}`} onClick={() => setTab('fix')}>
+          Fix Names
+        </button>
       </div>
-      {result !== null && <p>{result} file(s) removed.</p>}
+      {tab === 'cleanup' ? (
+        <div>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <label>
+              Cleanup files older than (days):{' '}
+              <input
+                type="number"
+                value={days}
+                onChange={(e) => setDays(e.target.value)}
+                style={{ width: '4rem' }}
+              />
+            </label>
+            <button type="button" onClick={handleCleanup} style={{ marginLeft: '0.5rem' }}>
+              Cleanup
+            </button>
+          </div>
+          {result !== null && <p>{result} file(s) removed.</p>}
+        </div>
+      ) : (
+        <div>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <button type="button" onClick={() => fileRef.current?.click()} style={{ marginRight: '0.5rem' }}>
+              Select Folder
+            </button>
+            <input
+              type="file"
+              multiple
+              webkitdirectory="true"
+              directory="true"
+              ref={fileRef}
+              style={{ display: 'none' }}
+              onChange={(e) => handleFolderChange(e.target.files)}
+            />
+            <button type="button" onClick={checkFolder} style={{ marginRight: '0.5rem' }}>
+              Check Folder
+            </button>
+            <button type="button" onClick={refreshList} style={{ marginRight: '0.5rem' }}>
+              Refresh
+            </button>
+            <button type="button" disabled={page === 1} onClick={() => { const p = page - 1; setPage(p); refreshList(p); }} style={{ marginRight: '0.5rem' }}>
+              Prev
+            </button>
+            <button type="button" disabled={!hasMore} onClick={() => { const p = page + 1; setPage(p); refreshList(p); }}>
+              Next
+            </button>
+          </div>
+          {uploads.length > 0 && (
+            <div style={{ marginBottom: '1rem' }}>
+              <h4>Uploads</h4>
+              <table className="min-w-full border border-gray-300 text-sm" style={{ tableLayout: 'fixed' }}>
+                <thead>
+                  <tr>
+                    <th className="border px-2 py-1">
+                      <input type="checkbox" checked={uploadSel.length === uploads.length && uploads.length > 0} onChange={toggleUploadAll} />
+                    </th>
+                    <th className="border px-2 py-1">Original</th>
+                    <th className="border px-2 py-1">New Name</th>
+                    <th className="border px-2 py-1">Folder</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {uploads.map((u) => (
+                    <tr key={u.tmpPath} className={uploadSel.includes(u.tmpPath) ? 'bg-blue-50' : ''}>
+                      <td className="border px-2 py-1 text-center">
+                        <input type="checkbox" checked={uploadSel.includes(u.tmpPath)} onChange={() => toggleUpload(u.tmpPath)} />
+                      </td>
+                      <td className="border px-2 py-1">{u.originalName}</td>
+                      <td className="border px-2 py-1">{u.newName}</td>
+                      <td className="border px-2 py-1">{u.folderDisplay}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <button type="button" onClick={commitUploads} style={{ marginTop: '0.5rem' }} disabled={uploadSel.length === 0}>
+                Rename &amp; Upload Selected
+              </button>
+            </div>
+          )}
+          {pending.length === 0 ? (
+            <p>No incomplete names found.</p>
+          ) : (
+            <div>
+              <table className="min-w-full border border-gray-300 text-sm" style={{ tableLayout: 'fixed' }}>
+                <thead>
+                  <tr>
+                    <th className="border px-2 py-1">
+                      <input type="checkbox" checked={selected.length === pending.length && pending.length > 0} onChange={toggleAll} />
+                    </th>
+                    <th className="border px-2 py-1">Current</th>
+                    <th className="border px-2 py-1">New Name</th>
+                    <th className="border px-2 py-1">Folder</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pending.map((p) => (
+                    <tr key={p.currentName} className={selected.includes(p.currentName) ? 'bg-blue-50' : ''}>
+                      <td className="border px-2 py-1 text-center">
+                        <input type="checkbox" checked={selected.includes(p.currentName)} onChange={() => toggle(p.currentName)} />
+                      </td>
+                      <td className="border px-2 py-1">{p.currentName}</td>
+                      <td className="border px-2 py-1">{p.newName}</td>
+                      <td className="border px-2 py-1">{p.folderDisplay}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <button type="button" onClick={applyFixes} style={{ marginTop: '0.5rem' }} disabled={selected.length === 0}>
+                Rename &amp; Move Selected
+              </button>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/tests/api/cleanupOldImages.test.js
+++ b/tests/api/cleanupOldImages.test.js
@@ -4,7 +4,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { cleanupOldImages } from '../../api-server/services/transactionImageService.js';
 
-const baseDir = path.join(process.cwd(), 'uploads', 'txn_images', 'test');
+const baseDir = path.join(process.cwd(), 'uploads', 'txn_images', 'test_cleanup');
 
 test('cleanupOldImages removes old files', async () => {
   await fs.mkdir(baseDir, { recursive: true });
@@ -25,5 +25,5 @@ test('cleanupOldImages removes old files', async () => {
   assert.ok(removed >= 1);
   assert.equal(exists, false);
 
-  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  await fs.rm(baseDir, { recursive: true, force: true });
 });

--- a/tests/api/detectIncompleteImages.test.js
+++ b/tests/api/detectIncompleteImages.test.js
@@ -1,0 +1,92 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import path from 'path';
+import { detectIncompleteImages, fixIncompleteImages, checkUploadedImages, commitUploadedImages } from '../../api-server/services/transactionImageService.js';
+import * as db from '../../db/index.js';
+
+function mockPool(handler) {
+  const orig = db.pool.query;
+  db.pool.query = handler;
+  return () => { db.pool.query = orig; };
+}
+
+const cfgPath = path.join(process.cwd(), 'config', 'transactionForms.json');
+const baseDir = path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test');
+
+await test('detectIncompleteImages finds and fixes files', async () => {
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  await fs.mkdir(baseDir, { recursive: true });
+  const file = path.join(baseDir, 'abc12345.jpg');
+  await fs.writeFile(file, 'x');
+
+  const row = { id: 1, test_num: 'abc12345', label_field: 'num001', trtype: '4001', TransType: 'tool' };
+
+  const restoreDb = mockPool(async (sql) => {
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql)) return [[{ Field: 'test_num' }, { Field: 'label_field' }, { Field: 'trtype' }, { Field: 'TransType' }]];
+    if (/FROM `transactions_test`/.test(sql)) return [[row]];
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(cfgPath, JSON.stringify({
+    transactions_test: {
+      default: { imagenameField: ['label_field'], imageFolder: 'transactions_test' }
+    }
+  }));
+
+  const { list, hasMore } = await detectIncompleteImages(1);
+  assert.equal(hasMore, false);
+  assert.equal(list.length, 1);
+  assert.ok(list[0].newName.includes('num001'));
+  assert.equal(list[0].folder, '4001/tool');
+
+  const count = await fixIncompleteImages(list);
+  assert.equal(count, 1);
+
+  const target = path.join(process.cwd(), 'uploads', 'txn_images', '4001', 'tool');
+  const exists = await fs.readdir(target);
+  assert.ok(exists.some((f) => f.includes('num001')));
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});
+
+await test('checkUploadedImages renames on upload', async () => {
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  await fs.mkdir(path.join(process.cwd(), 'uploads', 'tmp'), { recursive: true });
+  const tmp = path.join(process.cwd(), 'uploads', 'tmp', 'abc12345.jpg');
+  await fs.writeFile(tmp, 'x');
+
+  const row = { id: 1, test_num: 'abc12345', label_field: 'num002', trtype: '4001', TransType: 'tool' };
+  const restoreDb = mockPool(async (sql) => {
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql)) return [[{ Field: 'test_num' }, { Field: 'label_field' }, { Field: 'trtype' }, { Field: 'TransType' }]];
+    if (/FROM `transactions_test`/.test(sql)) return [[row]];
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(cfgPath, JSON.stringify({
+    transactions_test: {
+      default: { imagenameField: ['label_field'], imageFolder: 'transactions_test' }
+    }
+  }));
+
+  const list = await checkUploadedImages([{ originalname: 'abc12345.jpg', path: tmp }]);
+  assert.equal(list.length, 1);
+  assert.ok(list[0].newName.includes('num002'));
+  assert.equal(list[0].folder, '4001/tool');
+
+  const uploaded = await commitUploadedImages(list);
+  assert.equal(uploaded, 1);
+  const updir = path.join(process.cwd(), 'uploads', 'txn_images', '4001', 'tool');
+  const exists = await fs.readdir(updir);
+  assert.ok(exists.some((f) => f.includes('num002')));
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- add helper to compute folder name from transaction fields
- allow detection API to display the target folder
- add upload flow with name check and commit routes
- extend Image Management page with local upload fixing
- cover upload workflow in tests
- adjust folder order and folder checking logic
- support manual refresh and folder selection UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b36f2485c8331abafec39b8215b1f