### PR TITLE
Enhance responsive layout

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -36,6 +36,14 @@ export default function ERPLayout() {
   const navigate = useNavigate();
   const location = useLocation();
 
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth < 768);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  useEffect(() => {
+    const handler = () => setIsMobile(window.innerWidth < 768);
+    window.addEventListener('resize', handler);
+    return () => window.removeEventListener('resize', handler);
+  }, []);
+
   const modules = useModules();
   const titleMap = {
     "/": "Blue Link демо",
@@ -97,9 +105,25 @@ export default function ERPLayout() {
 
   return (
     <div style={styles.container}>
-      <Header user={user} onLogout={handleLogout} onHome={handleHome} />
-      <div style={styles.body}>
-        <Sidebar onOpen={handleOpen} />
+      <Header
+        user={user}
+        onLogout={handleLogout}
+        onHome={handleHome}
+        isMobile={isMobile}
+        onToggleSidebar={() => setSidebarOpen((o) => !o)}
+      />
+      <div style={styles.body(isMobile)}>
+        {isMobile && sidebarOpen && (
+          <div
+            className="sidebar-overlay"
+            onClick={() => setSidebarOpen(false)}
+          />
+        )}
+        <Sidebar
+          open={isMobile ? sidebarOpen : true}
+          onOpen={handleOpen}
+          isMobile={isMobile}
+        />
         <MainWindow title={windowTitle} />
       </div>
       <AskAIFloat />
@@ -108,7 +132,7 @@ export default function ERPLayout() {
 }
 
 /** Top header bar **/
-function Header({ user, onLogout, onHome }) {
+function Header({ user, onLogout, onHome, isMobile, onToggleSidebar }) {
   const { company } = useContext(AuthContext);
   function handleOpen(id) {
     console.log("open module", id);
@@ -116,6 +140,15 @@ function Header({ user, onLogout, onHome }) {
 
   return (
     <header className="sticky-header" style={styles.header}>
+      {isMobile && (
+        <button
+          onClick={onToggleSidebar}
+          style={{ ...styles.iconBtn, marginRight: '0.5rem' }}
+          className="sm:hidden"
+        >
+          ☰
+        </button>
+      )}
       <div style={styles.logoSection}>
         <img
           src="/assets/logo‐small.png"
@@ -147,7 +180,7 @@ function Header({ user, onLogout, onHome }) {
 }
 
 /** Left sidebar with “menu groups” and “pinned items” **/
-function Sidebar({ onOpen }) {
+function Sidebar({ onOpen, open, isMobile }) {
   const { company } = useContext(AuthContext);
   const location = useLocation();
   const perms = useRolePermissions();
@@ -213,7 +246,11 @@ function Sidebar({ onOpen }) {
   }
 
   return (
-    <aside id="sidebar" className="sidebar" style={styles.sidebar}>
+    <aside
+      id="sidebar"
+      className={`sidebar ${open ? 'open' : ''}`}
+      style={styles.sidebar(isMobile, open)}
+    >
       <nav className="menu-container">
         {roots.map((m) =>
           m.children.length > 0 ? (
@@ -413,14 +450,14 @@ const styles = {
     cursor: "pointer",
     fontSize: "0.9rem",
   },
-  body: {
+  body: (mobile) => ({
     display: "flex",
     flexGrow: 1,
     backgroundColor: "#f3f4f6",
     overflow: "auto",
-    marginLeft: "240px",
-  },
-  sidebar: {
+    marginLeft: mobile ? 0 : "240px",
+  }),
+  sidebar: (mobile, open) => ({
     width: "240px",
     backgroundColor: "#374151",
     color: "#e5e7eb",
@@ -433,8 +470,14 @@ const styles = {
     top: "48px",
     left: 0,
     height: "calc(100vh - 48px)",
-    zIndex: 10,
-  },
+    zIndex: 30,
+    ...(mobile
+      ? {
+          transform: open ? "translateX(0)" : "translateX(-100%)",
+          transition: "transform 0.3s",
+        }
+      : {}),
+  }),
   menuGroup: {
     marginBottom: "1rem",
   },

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -65,6 +65,12 @@ const RowFormModal = function RowFormModal({
   boxHeight = boxHeight ?? cfg.boxHeight ?? 30;
   boxMaxWidth = boxMaxWidth ?? cfg.boxMaxWidth ?? 150;
   boxMaxHeight = boxMaxHeight ?? cfg.boxMaxHeight ?? 150;
+  const [isNarrow, setIsNarrow] = useState(() => window.innerWidth < 768);
+  useEffect(() => {
+    const h = () => setIsNarrow(window.innerWidth < 768);
+    window.addEventListener('resize', h);
+    return () => window.removeEventListener('resize', h);
+  }, []);
 
   renderCount.current++;
   if (renderCount.current > 10 && !warned.current) {
@@ -321,6 +327,8 @@ const RowFormModal = function RowFormModal({
     gap: '2px',
     gridTemplateColumns: fitted
       ? `repeat(auto-fill, minmax(${boxWidth}px, ${boxMaxWidth}px))`
+      : isNarrow
+      ? '1fr'
       : `repeat(2, minmax(${boxWidth}px, ${boxMaxWidth}px))`,
     fontSize: `${inputFontSize}px`,
   };
@@ -331,8 +339,8 @@ const RowFormModal = function RowFormModal({
     width: `${boxWidth}px`,
     minWidth: `${boxWidth}px`,
     maxWidth: `${boxMaxWidth}px`,
-    height: `${boxHeight}px`,
-    maxHeight: `${boxMaxHeight}px`,
+    height: isNarrow ? '44px' : `${boxHeight}px`,
+    maxHeight: isNarrow ? 'none' : `${boxMaxHeight}px`,
     overflow: 'hidden',
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',
@@ -894,7 +902,15 @@ const RowFormModal = function RowFormModal({
       <input
         title={formVals[c]}
         ref={(el) => (inputRefs.current[c] = el)}
-        type="text"
+        type={(() => {
+          if (placeholders[c] === 'YYYY-MM-DD') return 'date';
+          if (placeholders[c] === 'HH:MM:SS') return 'time';
+          const lower = c.toLowerCase();
+          if (lower.includes('email')) return 'email';
+          if (/(amount|qty|count|price|total|number)/i.test(lower)) return 'number';
+          if (lower.includes('phone')) return 'tel';
+          return 'text';
+        })()}
         placeholder={placeholders[c] || ''}
         value={formVals[c]}
         onChange={(e) => {

--- a/src/erp.mgt.mn/index.css
+++ b/src/erp.mgt.mn/index.css
@@ -279,3 +279,32 @@ th {
   background: #d1d5db;
   font-weight: bold;
 }
+
+@media (max-width: 768px) {
+  .sidebar {
+    transform: translateX(-100%);
+    transition: transform 0.3s;
+    position: fixed;
+    top: 48px;
+    left: 0;
+    z-index: 30;
+    height: calc(100vh - 48px);
+  }
+  .sidebar.open {
+    transform: translateX(0);
+  }
+  .sidebar-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 20;
+  }
+}
+
+@media (max-width: 480px) {
+  table td,
+  table th {
+    padding: 0.25rem;
+    font-size: 0.75rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add mobile sidebar toggle
- adjust sidebar/body styles for small screens
- tweak forms to adapt layout and input sizes
- automatically pick input HTML types from field names
- add responsive CSS rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b69e2ed6083318a7b3643eef0d347