### PR TITLE
Enhance responsive layout

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -65,6 +65,12 @@ const RowFormModal = function RowFormModal({
   boxHeight = boxHeight ?? cfg.boxHeight ?? 30;
   boxMaxWidth = boxMaxWidth ?? cfg.boxMaxWidth ?? 150;
   boxMaxHeight = boxMaxHeight ?? cfg.boxMaxHeight ?? 150;
+  const [isNarrow, setIsNarrow] = useState(() => window.innerWidth < 768);
+  useEffect(() => {
+    const h = () => setIsNarrow(window.innerWidth < 768);
+    window.addEventListener('resize', h);
+    return () => window.removeEventListener('resize', h);
+  }, []);
 
   renderCount.current++;
   if (renderCount.current > 10 && !warned.current) {
@@ -321,6 +327,8 @@ const RowFormModal = function RowFormModal({
     gap: '2px',
     gridTemplateColumns: fitted
       ? `repeat(auto-fill, minmax(${boxWidth}px, ${boxMaxWidth}px))`
+      : isNarrow
+      ? '1fr'
       : `repeat(2, minmax(${boxWidth}px, ${boxMaxWidth}px))`,
     fontSize: `${inputFontSize}px`,
   };
@@ -331,8 +339,8 @@ const RowFormModal = function RowFormModal({
     width: `${boxWidth}px`,
     minWidth: `${boxWidth}px`,
     maxWidth: `${boxMaxWidth}px`,
-    height: `${boxHeight}px`,
-    maxHeight: `${boxMaxHeight}px`,
+    height: isNarrow ? '44px' : `${boxHeight}px`,
+    maxHeight: isNarrow ? 'none' : `${boxMaxHeight}px`,
     overflow: 'hidden',
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',
@@ -894,7 +902,22 @@ const RowFormModal = function RowFormModal({
       <input
         title={formVals[c]}
         ref={(el) => (inputRefs.current[c] = el)}
-        type="text"
+        type={(() => {
+          if (placeholders[c] === 'YYYY-MM-DD') return 'date';
+          if (placeholders[c] === 'HH:MM:SS') return 'time';
+          const lower = c.toLowerCase();
+          if (lower.includes('email')) return 'email';
+          if (/(amount|qty|count|price|total|number|qty|quantity)/i.test(lower))
+            return 'number';
+          if (lower.includes('phone')) return 'tel';
+          return 'text';
+        })()}
+        inputMode={(() => {
+          const lower = c.toLowerCase();
+          return /(amount|qty|count|price|total|number|qty|quantity)/i.test(lower)
+            ? 'decimal'
+            : undefined;
+        })()}
         placeholder={placeholders[c] || ''}
         value={formVals[c]}
         onChange={(e) => {

--- a/src/erp.mgt.mn/index.css
+++ b/src/erp.mgt.mn/index.css
@@ -279,3 +279,32 @@ th {
   background: #d1d5db;
   font-weight: bold;
 }
+
+@media (max-width: 768px) {
+  .sidebar {
+    transform: translateX(-100%);
+    transition: transform 0.3s;
+    position: fixed;
+    top: 48px;
+    left: 0;
+    z-index: 30;
+    height: calc(100vh - 48px);
+  }
+  .sidebar.open {
+    transform: translateX(0);
+  }
+  .sidebar-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 20;
+  }
+}
+
+@media (max-width: 480px) {
+  table td,
+  table th {
+    padding: 0.25rem;
+    font-size: 0.75rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add mobile sidebar toggle
- adjust sidebar/body styles for small screens
- tweak forms to adapt layout and input sizes
- automatically pick input HTML types from field names
- add responsive CSS rules
- fix mobile numeric input and header layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b69e2ed6083318a7b3643eef0d347