### PR TITLE
Enhance responsive layout

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -36,6 +36,14 @@ export default function ERPLayout() {
   const navigate = useNavigate();
   const location = useLocation();
 
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth < 768);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  useEffect(() => {
+    const handler = () => setIsMobile(window.innerWidth < 768);
+    window.addEventListener('resize', handler);
+    return () => window.removeEventListener('resize', handler);
+  }, []);
+
   const modules = useModules();
   const titleMap = {
     "/": "Blue Link демо",
@@ -97,9 +105,26 @@ export default function ERPLayout() {
 
   return (
     <div style={styles.container}>
-      <Header user={user} onLogout={handleLogout} onHome={handleHome} />
-      <div style={styles.body}>
-        <Sidebar onOpen={handleOpen} />
+      <Header
+        user={user}
+        onLogout={handleLogout}
+        onHome={handleHome}
+        isMobile={isMobile}
+        sidebarOpen={sidebarOpen}
+        onToggleSidebar={() => setSidebarOpen((o) => !o)}
+      />
+      <div style={styles.body(isMobile, sidebarOpen)}>
+        {isMobile && sidebarOpen && (
+          <div
+            className="sidebar-overlay"
+            onClick={() => setSidebarOpen(false)}
+          />
+        )}
+        <Sidebar
+          open={isMobile ? sidebarOpen : true}
+          onOpen={handleOpen}
+          isMobile={isMobile}
+        />
         <MainWindow title={windowTitle} />
       </div>
       <AskAIFloat />
@@ -108,14 +133,23 @@ export default function ERPLayout() {
 }
 
 /** Top header bar **/
-function Header({ user, onLogout, onHome }) {
+function Header({ user, onLogout, onHome, isMobile, onToggleSidebar, sidebarOpen }) {
   const { company } = useContext(AuthContext);
   function handleOpen(id) {
     console.log("open module", id);
   }
 
   return (
-    <header className="sticky-header" style={styles.header}>
+    <header className="sticky-header" style={styles.header(isMobile, sidebarOpen)}>
+      {isMobile && (
+        <button
+          onClick={onToggleSidebar}
+          style={{ ...styles.iconBtn, marginRight: '0.5rem' }}
+          className="sm:hidden"
+        >
+          ☰
+        </button>
+      )}
       <div style={styles.logoSection}>
         <img
           src="/assets/logo‐small.png"
@@ -147,7 +181,7 @@ function Header({ user, onLogout, onHome }) {
 }
 
 /** Left sidebar with “menu groups” and “pinned items” **/
-function Sidebar({ onOpen }) {
+function Sidebar({ onOpen, open, isMobile }) {
   const { company } = useContext(AuthContext);
   const location = useLocation();
   const perms = useRolePermissions();
@@ -213,7 +247,11 @@ function Sidebar({ onOpen }) {
   }
 
   return (
-    <aside id="sidebar" className="sidebar" style={styles.sidebar}>
+    <aside
+      id="sidebar"
+      className={`sidebar ${open ? 'open' : ''}`}
+      style={styles.sidebar(isMobile, open)}
+    >
       <nav className="menu-container">
         {roots.map((m) =>
           m.children.length > 0 ? (
@@ -349,7 +387,7 @@ const styles = {
     fontFamily: "Arial, sans-serif",
     overflowX: "hidden",
   },
-  header: {
+  header: (mobile, open) => ({
     display: "flex",
     alignItems: "center",
     backgroundColor: "#1f2937",
@@ -360,7 +398,9 @@ const styles = {
     position: "sticky",
     top: 0,
     zIndex: 20,
-  },
+    marginLeft: mobile ? 0 : "240px",
+    transition: mobile ? undefined : "margin-left 0.3s",
+  }),
   logoSection: {
     display: "flex",
     alignItems: "center",
@@ -384,6 +424,9 @@ const styles = {
     marginLeft: "2rem",
     display: "flex",
     gap: "0.75rem",
+    overflowX: "auto",
+    whiteSpace: "nowrap",
+    flexGrow: 1,
   },
   iconBtn: {
     background: "transparent",
@@ -413,14 +456,15 @@ const styles = {
     cursor: "pointer",
     fontSize: "0.9rem",
   },
-  body: {
+  body: (mobile, open) => ({
     display: "flex",
     flexGrow: 1,
     backgroundColor: "#f3f4f6",
     overflow: "auto",
-    marginLeft: "240px",
-  },
-  sidebar: {
+    marginLeft: mobile ? 0 : "240px",
+    transition: mobile ? undefined : "margin-left 0.3s",
+  }),
+  sidebar: (mobile, open) => ({
     width: "240px",
     backgroundColor: "#374151",
     color: "#e5e7eb",
@@ -433,8 +477,14 @@ const styles = {
     top: "48px",
     left: 0,
     height: "calc(100vh - 48px)",
-    zIndex: 10,
-  },
+    zIndex: 30,
+    ...(mobile
+      ? {
+          transform: open ? "translateX(0)" : "translateX(-100%)",
+          transition: "transform 0.3s",
+        }
+      : {}),
+  }),
   menuGroup: {
     marginBottom: "1rem",
   },

--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -1007,6 +1007,38 @@ export default forwardRef(function InlineTransactionTable({
           />
       );
     }
+    const lower = f.toLowerCase();
+    const sample = rows[0]?.[f] ?? defaultValues[f];
+    const isNumber =
+      typeof sample === 'number' ||
+      /^-?\d+(\.\d+)?$/.test(String(sample)) ||
+      totalAmountSet.has(f) ||
+      totalCurrencySet.has(f);
+    const commonProps = {
+      className: `w-full border px-1 ${invalid ? 'border-red-500 bg-red-100' : ''}`,
+      style: { ...inputStyle },
+      value: typeof val === 'object' ? val.value : val,
+      title: typeof val === 'object' ? val.value : val,
+      onChange: (e) => handleChange(idx, f, e.target.value),
+      ref: (el) => (inputRefs.current[`${idx}-${colIdx}`] = el),
+      onKeyDown: (e) => handleKeyDown(e, idx, colIdx),
+      onFocus: () => handleFocusField(f),
+    };
+    if (placeholders[f] === 'YYYY-MM-DD') {
+      return <input type="date" {...commonProps} />;
+    }
+    if (placeholders[f] === 'HH:MM:SS') {
+      return <input type="time" {...commonProps} />;
+    }
+    if (lower.includes('email')) {
+      return <input type="email" inputMode="email" {...commonProps} />;
+    }
+    if (lower.includes('phone')) {
+      return <input type="tel" inputMode="tel" {...commonProps} />;
+    }
+    if (isNumber) {
+      return <input type="number" inputMode="decimal" {...commonProps} />;
+    }
     return (
       <textarea
         rows={1}

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -65,6 +65,12 @@ const RowFormModal = function RowFormModal({
   boxHeight = boxHeight ?? cfg.boxHeight ?? 30;
   boxMaxWidth = boxMaxWidth ?? cfg.boxMaxWidth ?? 150;
   boxMaxHeight = boxMaxHeight ?? cfg.boxMaxHeight ?? 150;
+  const [isNarrow, setIsNarrow] = useState(() => window.innerWidth < 768);
+  useEffect(() => {
+    const h = () => setIsNarrow(window.innerWidth < 768);
+    window.addEventListener('resize', h);
+    return () => window.removeEventListener('resize', h);
+  }, []);
 
   renderCount.current++;
   if (renderCount.current > 10 && !warned.current) {
@@ -321,6 +327,8 @@ const RowFormModal = function RowFormModal({
     gap: '2px',
     gridTemplateColumns: fitted
       ? `repeat(auto-fill, minmax(${boxWidth}px, ${boxMaxWidth}px))`
+      : isNarrow
+      ? '1fr'
       : `repeat(2, minmax(${boxWidth}px, ${boxMaxWidth}px))`,
     fontSize: `${inputFontSize}px`,
   };
@@ -331,8 +339,8 @@ const RowFormModal = function RowFormModal({
     width: `${boxWidth}px`,
     minWidth: `${boxWidth}px`,
     maxWidth: `${boxMaxWidth}px`,
-    height: `${boxHeight}px`,
-    maxHeight: `${boxMaxHeight}px`,
+    height: isNarrow ? '44px' : `${boxHeight}px`,
+    maxHeight: isNarrow ? 'none' : `${boxMaxHeight}px`,
     overflow: 'hidden',
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',
@@ -894,7 +902,36 @@ const RowFormModal = function RowFormModal({
       <input
         title={formVals[c]}
         ref={(el) => (inputRefs.current[c] = el)}
-        type="text"
+        type={(() => {
+          if (placeholders[c] === 'YYYY-MM-DD') return 'date';
+          if (placeholders[c] === 'HH:MM:SS') return 'time';
+          const lower = c.toLowerCase();
+          if (lower.includes('email')) return 'email';
+          if (lower.includes('phone')) return 'tel';
+          const sample = row?.[c] ?? defaultValues[c];
+          if (
+            typeof sample === 'number' ||
+            /^-?\d+(\.\d+)?$/.test(String(sample)) ||
+            totalAmountSet.has(c) ||
+            totalCurrencySet.has(c)
+          )
+            return 'number';
+          return 'text';
+        })()}
+        inputMode={(() => {
+          const lower = c.toLowerCase();
+          if (lower.includes('email')) return 'email';
+          if (lower.includes('phone')) return 'tel';
+          const sample = row?.[c] ?? defaultValues[c];
+          if (
+            typeof sample === 'number' ||
+            /^-?\d+(\.\d+)?$/.test(String(sample)) ||
+            totalAmountSet.has(c) ||
+            totalCurrencySet.has(c)
+          )
+            return 'decimal';
+          return undefined;
+        })()}
         placeholder={placeholders[c] || ''}
         value={formVals[c]}
         onChange={(e) => {

--- a/src/erp.mgt.mn/index.css
+++ b/src/erp.mgt.mn/index.css
@@ -279,3 +279,32 @@ th {
   background: #d1d5db;
   font-weight: bold;
 }
+
+@media (max-width: 768px) {
+  .sidebar {
+    transform: translateX(-100%);
+    transition: transform 0.3s;
+    position: fixed;
+    top: 48px;
+    left: 0;
+    z-index: 30;
+    height: calc(100vh - 48px);
+  }
+  .sidebar.open {
+    transform: translateX(0);
+  }
+  .sidebar-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 20;
+  }
+}
+
+@media (max-width: 480px) {
+  table td,
+  table th {
+    padding: 0.25rem;
+    font-size: 0.75rem;
+  }
+}

--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -1951,6 +1951,7 @@ export default function CodingTablesPage() {
             Field Name Row:
             <input
               type="number"
+              inputMode="decimal"
               min="1"
               value={headerRow}
               onChange={handleHeaderRowChange}
@@ -1958,6 +1959,7 @@ export default function CodingTablesPage() {
             Mongolian Field Name Row:
             <input
               type="number"
+              inputMode="decimal"
               min="1"
               value={mnHeaderRow}
               onChange={(e) => setMnHeaderRow(e.target.value)}
@@ -2120,6 +2122,7 @@ export default function CodingTablesPage() {
                       Start Year:{' '}
                       <input
                         type="number"
+                        inputMode="decimal"
                         value={startYear}
                         onChange={(e) => setStartYear(e.target.value)}
                         style={{ marginRight: '0.5rem' }}
@@ -2127,6 +2130,7 @@ export default function CodingTablesPage() {
                       End Year:{' '}
                       <input
                         type="number"
+                        inputMode="decimal"
                         value={endYear}
                         onChange={(e) => setEndYear(e.target.value)}
                       />
@@ -2149,6 +2153,7 @@ export default function CodingTablesPage() {
                     Start Value:{' '}
                     <input
                       type="number"
+                      inputMode="decimal"
                       value={autoIncStart}
                       onChange={(e) => setAutoIncStart(e.target.value)}
                       style={{ width: '6rem' }}
@@ -2308,6 +2313,7 @@ export default function CodingTablesPage() {
                 Group Size:
                 <input
                   type="number"
+                  inputMode="decimal"
                   min="1"
                   value={groupSize}
                   onChange={(e) =>

--- a/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
+++ b/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
@@ -93,6 +93,7 @@ export default function GeneralConfiguration() {
               <input
                 name="labelFontSize"
                 type="number"
+                inputMode="decimal"
                 value={active.labelFontSize ?? ''}
                 onChange={handleChange}
               />
@@ -104,6 +105,7 @@ export default function GeneralConfiguration() {
               <input
                 name="boxWidth"
                 type="number"
+                inputMode="decimal"
                 value={active.boxWidth ?? ''}
                 onChange={handleChange}
               />
@@ -115,6 +117,7 @@ export default function GeneralConfiguration() {
               <input
                 name="boxHeight"
                 type="number"
+                inputMode="decimal"
                 value={active.boxHeight ?? ''}
                 onChange={handleChange}
               />
@@ -126,6 +129,7 @@ export default function GeneralConfiguration() {
               <input
                 name="boxMaxWidth"
                 type="number"
+                inputMode="decimal"
                 value={active.boxMaxWidth ?? ''}
                 onChange={handleChange}
               />
@@ -137,6 +141,7 @@ export default function GeneralConfiguration() {
               <input
                 name="boxMaxHeight"
                 type="number"
+                inputMode="decimal"
                 value={active.boxMaxHeight ?? ''}
                 onChange={handleChange}
               />
@@ -171,6 +176,7 @@ export default function GeneralConfiguration() {
               <input
                 name="imageStorage.cleanupDays"
                 type="number"
+                inputMode="decimal"
                 value={active.imageStorage?.cleanupDays ?? ''}
                 onChange={(e) => {
                   const val = Number(e.target.value);

--- a/src/erp.mgt.mn/pages/ImageManagement.jsx
+++ b/src/erp.mgt.mn/pages/ImageManagement.jsx
@@ -161,6 +161,7 @@ export default function ImageManagement() {
               Cleanup files older than (days):{' '}
               <input
                 type="number"
+                inputMode="decimal"
                 value={days}
                 onChange={(e) => setDays(e.target.value)}
                 style={{ width: '4rem' }}


### PR DESCRIPTION
## Summary
- add sliding header/body when sidebar opens
- set number inputs to trigger numeric keypad
- guess number fields in RowFormModal based on sample data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b69e2ed6083318a7b3643eef0d347