### PR TITLE
Fix image modal reset and improve AI detection feedback

### DIFF
--- a/api-server/services/aiInventoryService.js
+++ b/api-server/services/aiInventoryService.js
@@ -22,7 +22,9 @@ export async function identifyItems(buffer, mimeType) {
     'Identify inventory items and quantities from this image. Respond with JSON like [{"code":"ITEM1","qty":1}].';
   try {
     const text = await getResponseWithFile(prompt, buffer, mimeType);
-    return JSON.parse(text);
+    const match = text.match(/\[[\s\S]*\]/);
+    const json = match ? match[0] : text;
+    return JSON.parse(json);
   } catch {
     return [];
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "multer": "^1.4.5-lts.1",
     "xlsx": "^0.18.5",
     "openai": "^4.24.0",
-    "express-rate-limit": "^7.5.0"
+    "express-rate-limit": "^7.5.0",
+    "sharp": "^0.33.2",
+    "mime-types": "^2.1.35"
   },
   "devDependencies": {
     "vite": "^6.3.5",

--- a/src/erp.mgt.mn/components/InventoryImageUpload.jsx
+++ b/src/erp.mgt.mn/components/InventoryImageUpload.jsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
+import { useToast } from '../context/ToastContext.jsx';
 
 export default function InventoryImageUpload({ onResult, multiple = false, uploadUrl = '/api/ai_inventory/identify' }) {
   const [files, setFiles] = useState([]);
   const [loading, setLoading] = useState(false);
   const [items, setItems] = useState([]);
+  const { addToast } = useToast();
 
   async function handleUpload() {
     if (!files.length) return;
@@ -18,14 +20,30 @@ export default function InventoryImageUpload({ onResult, multiple = false, uploa
           body: form,
           credentials: 'include',
         });
-        const data = await res.json();
-        results.push(...(data.items || []));
+        if (res.ok) {
+          const data = await res.json();
+          const count = (data.items || []).length;
+          addToast(
+            count ? `${f.name}: ${count} suggestion(s)` : `${f.name}: no suggestions`,
+            count ? 'success' : 'warn',
+          );
+          results.push(...(data.items || []));
+        } else {
+          const text = await res.text();
+          addToast(`${f.name}: ${text || 'AI detection failed'}`, 'error');
+        }
       } catch (err) {
         console.error(err);
+        addToast(`${f.name}: AI detection error: ${err.message}`, 'error');
       }
     }
     setItems(results);
     if (onResult) onResult({ items: results });
+    if (results.length === 0) {
+      addToast('No suggestions found', 'warn');
+    } else {
+      addToast(`Detected ${results.length} item(s)`, 'success');
+    }
     setLoading(false);
   }
 

--- a/src/erp.mgt.mn/components/RowImageUploadModal.jsx
+++ b/src/erp.mgt.mn/components/RowImageUploadModal.jsx
@@ -23,6 +23,8 @@ export default function RowImageUploadModal({
 
   useEffect(() => {
     if (!visible) return;
+    setFiles([]);
+    setUploaded([]);
     const { name } = buildName();
     if (!folder || !name) {
       setUploaded([]);
@@ -38,6 +40,13 @@ export default function RowImageUploadModal({
       .then((imgs) => setUploaded(Array.isArray(imgs) ? imgs : []))
       .catch(() => setUploaded([]));
   }, [visible, folder, row, table]);
+
+  useEffect(() => {
+    if (!visible) {
+      setFiles([]);
+      setUploaded([]);
+    }
+  }, [visible]);
 
   async function handleUpload(selectedFiles) {
     const { name: safeName, missing } = buildName();
@@ -64,11 +73,36 @@ export default function RowImageUploadModal({
     try {
       const res = await fetch(uploadUrl, { method: 'POST', body: form, credentials: 'include' });
       if (res.ok) {
-        addToast(`Images uploaded as ${finalName}`, 'success');
         const imgs = await res.json().catch(() => []);
+        addToast(`Uploaded ${imgs.length} image(s) as ${finalName}`, 'success');
         setFiles([]);
         setUploaded((u) => [...u, ...imgs]);
         onUploaded(finalName);
+        for (const file of filesToUpload) {
+          const detForm = new FormData();
+          detForm.append('image', file);
+          try {
+            const detRes = await fetch('/api/ai_inventory/identify', {
+              method: 'POST',
+              body: detForm,
+              credentials: 'include',
+            });
+            if (detRes.ok) {
+              const data = await detRes.json();
+              const count = (data.items || []).length;
+              addToast(
+                count ? `AI found ${count} suggestion(s)` : 'No AI suggestions',
+                count ? 'success' : 'warn',
+              );
+            } else {
+              const text = await detRes.text();
+              addToast(text || 'AI detection failed', 'error');
+            }
+          } catch (err) {
+            console.error(err);
+            addToast('AI detection error: ' + err.message, 'error');
+          }
+        }
       } else {
         const text = await res.text();
         addToast(text || 'Failed to upload images', 'error');


### PR DESCRIPTION
## Summary
- reset RowImageUploadModal state when closed or row changes
- trigger AI detection for uploaded files with toast feedback
- show per-file AI detection toasts in InventoryImageUpload

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b74552db08331a2f4bc0845d8b2b9