### PR TITLE
Fix image viewer modal

### DIFF
--- a/src/erp.mgt.mn/components/RowImageViewModal.jsx
+++ b/src/erp.mgt.mn/components/RowImageViewModal.jsx
@@ -18,6 +18,16 @@ export default function RowImageViewModal({
   const [fullscreen, setFullscreen] = useState(null);
   const { addToast } = useToast();
 
+  const placeholder =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMBAZLr5z0AAAAASUVORK5CYII=';
+
+  function getImageUrl(p) {
+    if (!p) return '';
+    if (/^https?:\/\//i.test(p)) return p;
+    if (p.startsWith('/')) return `${window.location.origin}${p}`;
+    return p;
+  }
+
   useEffect(() => {
     if (!visible) return;
     const { name } = buildImageName(row, imagenameFields, columnCaseMap);
@@ -76,7 +86,15 @@ export default function RowImageViewModal({
         const name = src.split('/').pop();
         return (
           <div key={src} style={{ marginBottom: '0.25rem' }}>
-            <img src={src} alt="" style={{ maxWidth: '100px', marginRight: '0.5rem' }} />
+            <img
+              src={getImageUrl(src)}
+              alt=""
+              onError={(e) => {
+                e.currentTarget.onerror = null;
+                e.currentTarget.src = placeholder;
+              }}
+              style={{ maxWidth: '100px', marginRight: '0.5rem' }}
+            />
             <span
               style={{ cursor: 'pointer', color: '#2563eb' }}
               onClick={() => handleView(src)}
@@ -102,8 +120,12 @@ export default function RowImageViewModal({
       {files.map((src) => (
         <img
           key={src}
-          src={src}
+          src={getImageUrl(src)}
           alt=""
+          onError={(e) => {
+            e.currentTarget.onerror = null;
+            e.currentTarget.src = placeholder;
+          }}
           style={{ cursor: 'pointer', width: '150px', height: '150px', objectFit: 'cover' }}
           onClick={() => handleView(src)}
         />
@@ -142,8 +164,12 @@ export default function RowImageViewModal({
             onClick={() => setFullscreen(null)}
           >
             <img
-              src={fullscreen}
+              src={getImageUrl(fullscreen)}
               alt=""
+              onError={(e) => {
+                e.currentTarget.onerror = null;
+                e.currentTarget.src = placeholder;
+              }}
               style={{ maxWidth: '90%', maxHeight: '90%' }}
             />
           </div>,


### PR DESCRIPTION
## Summary
- handle images with full URLs in RowImageViewModal
- add error handling and fallback placeholder image

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b8a8782b08331a94056d56d582539