### PR TITLE
Fix image list for new transaction

### DIFF
--- a/src/erp.mgt.mn/components/RowImageUploadModal.jsx
+++ b/src/erp.mgt.mn/components/RowImageUploadModal.jsx
@@ -35,10 +35,6 @@ export default function RowImageUploadModal({
       setUploaded([]);
       return;
     }
-    if (!row._saved && !row._imageName) {
-      setUploaded([]);
-      return;
-    }
     const { name } = buildName();
     if (!name) {
       setUploaded([]);


### PR DESCRIPTION
## Summary
- show existing images when opening the upload modal even if the row hasn't been saved yet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b9c05aacc8331ab5f02da9abd7870