### PR TITLE
Fix image uploads for unsaved rows and benchmark detection

### DIFF
--- a/api-server/routes/transaction_images.js
+++ b/api-server/routes/transaction_images.js
@@ -12,6 +12,7 @@ import {
   fixIncompleteImages,
   checkFolderNames,
   uploadSelectedImages,
+  findBenchmarkCode,
 } from '../services/transactionImageService.js';
 import { getGeneralConfig } from '../services/generalConfig.js';
 
@@ -68,6 +69,16 @@ router.post('/folder_commit', requireAuth, upload.array('images'), async (req, r
     const meta = JSON.parse(req.body.meta || '[]');
     const uploaded = await uploadSelectedImages(req.files || [], meta);
     res.json({ uploaded });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/benchmark_code', requireAuth, async (req, res, next) => {
+  try {
+    const result = await findBenchmarkCode(req.query.name || '');
+    if (result) res.json(result);
+    else res.json({});
   } catch (err) {
     next(err);
   }

--- a/src/erp.mgt.mn/components/RowImageUploadModal.jsx
+++ b/src/erp.mgt.mn/components/RowImageUploadModal.jsx
@@ -35,7 +35,7 @@ export default function RowImageUploadModal({
       setUploaded([]);
       return;
     }
-    if (!row._saved && !row._imageName) {
+    if (!row._saved) {
       setUploaded([]);
       return;
     }
@@ -73,7 +73,8 @@ export default function RowImageUploadModal({
 
   async function handleUpload(selectedFiles) {
     const { name: safeName, missing } = buildName();
-    const finalName = safeName || `tmp_${Date.now()}`;
+    let finalName = `tmp_${Date.now()}`;
+    if (row._saved && safeName) finalName = safeName;
     if (!folder) {
       addToast('Image folder is missing', 'error');
       return;
@@ -103,6 +104,16 @@ export default function RowImageUploadModal({
         setUploaded((u) => [...u, ...imgs]);
         onUploaded(finalName);
         for (const file of filesToUpload) {
+          try {
+            const codeRes = await fetch(
+              `/api/transaction_images/benchmark_code?name=${encodeURIComponent(file.name)}`,
+              { credentials: 'include' },
+            );
+            if (codeRes.ok) {
+              const data = await codeRes.json().catch(() => ({}));
+              if (data.code) detected.push({ code: data.code, qty: data.qty });
+            }
+          } catch {}
           const detForm = new FormData();
           detForm.append('image', file);
           try {

--- a/tests/api/findBenchmarkCode.test.js
+++ b/tests/api/findBenchmarkCode.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { findBenchmarkCode } from '../../api-server/services/transactionImageService.js';
+import * as db from '../../db/index.js';
+
+function mockPool(handler) {
+  const orig = db.pool.query;
+  db.pool.query = handler;
+  return () => { db.pool.query = orig; };
+}
+
+await test('findBenchmarkCode matches codes', async () => {
+  const restore = mockPool(async (sql, params) => {
+    if (/image_benchmark = 1 AND UITransType =/.test(sql)) {
+      if (params[0] === '3001') return [[{ UITransType: '3001' }]];
+      return [[]];
+    }
+    if (/FROM code_transaction WHERE image_benchmark = 1/.test(sql)) {
+      return [[{ UITransType: '4000', UITrtype: 'ABCD' }]];
+    }
+    return [[]];
+  });
+
+  assert.deepEqual(await findBenchmarkCode('1111_3001_5.png'), { code: '3001', qty: 5 });
+  assert.deepEqual(await findBenchmarkCode('foo_abcd_20.jpg'), { code: '4000', qty: 20 });
+  assert.equal(await findBenchmarkCode('none.jpg'), null);
+
+  restore();
+});


### PR DESCRIPTION
## Summary
- skip image fetch when row isn't saved
- generate a temporary name for unsaved uploads
- surface benchmark suggestions in the upload modal
- return qty with benchmark code lookup
- test benchmark filename parsing

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_688b9c05aacc8331ab5f02da9abd7870