### PR TITLE
Implement benchmark code lookup

### DIFF
--- a/api-server/services/transactionImageService.js
+++ b/api-server/services/transactionImageService.js
@@ -478,3 +478,31 @@ export async function uploadSelectedImages(files = [], meta = []) {
   }
   return count;
 }
+
+export async function findBenchmarkCode(fileName) {
+  const base = path.basename(fileName).toLowerCase();
+  const name = base.replace(/\.[^.]+$/, '');
+  const tokens = name.split(/[_-]+/).filter(Boolean);
+
+  for (const t of tokens) {
+    try {
+      const [rows] = await pool.query(
+        'SELECT UITransType FROM code_transaction WHERE UITransType = ? LIMIT 1',
+        [t],
+      );
+      if (rows.length) return String(rows[0].UITransType);
+    } catch {}
+  }
+
+  try {
+    const [rows] = await pool.query(
+      'SELECT UITransType, UITrtype FROM code_transaction WHERE image_benchmark = 1',
+    );
+    for (const r of rows) {
+      const code = String(r.UITrtype || '').toLowerCase();
+      if (code && base.includes(code)) return String(r.UITransType);
+    }
+  } catch {}
+
+  return null;
+}

--- a/docs/benchmark-image-verification.md
+++ b/docs/benchmark-image-verification.md
@@ -1,0 +1,8 @@
+# Benchmark Image Verification
+
+The `findBenchmarkCode` helper inspects an uploaded image filename and maps it to a transaction type code. The lookup works in two steps:
+
+1. Any underscore or dash separated tokens are checked directly against the `code_transaction.UITransType` column.
+2. When that fails, rows where `image_benchmark` is set to `1` are scanned. If the filename contains a row's `UITrtype` value, its `UITransType` is returned.
+
+The utility allows the front end to suggest a transaction code based on existing benchmark images without calling the OpenAI API.

--- a/docs/openai-usage.md
+++ b/docs/openai-usage.md
@@ -24,3 +24,7 @@ This returns the response text from the chat completion API using the key loaded
 The file [`docs/openai-floating-bar.html`](./openai-floating-bar.html) demonstrates a movable floating bar that calls `/api/openai` to fetch a response. The live ERP build includes a React component with the same functionality. The widget can now be collapsed into a small round button so it never blocks important content. Users may drag the bar anywhere on screen, type prompts, and even attach an image or other file. Uploaded files are sent to the API along with the prompt.
 
 The bar adapts to smaller screens and can be reopened via the "AI" button when collapsed.
+
+## Benchmark Image Lookup
+
+Server code also exposes `findBenchmarkCode` for resolving a transaction type code from an uploaded image name. See [Benchmark Image Verification](./benchmark-image-verification.md) for details.


### PR DESCRIPTION
## Summary
- add `findBenchmarkCode` helper in `transactionImageService`
- document benchmark image verification
- note benchmark lookup in OpenAI usage docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bb6d8bf5c83319ba310ba61468ad1