### PR TITLE
Fix image name detection and update UI

### DIFF
--- a/api-server/services/transactionImageService.js
+++ b/api-server/services/transactionImageService.js
@@ -332,7 +332,6 @@ export async function detectIncompleteImages(page = 1, perPage = 100) {
         const check = await checkFolderNames([{ name: it.name }]);
         if (check.length === 0) continue;
         const item = check[0];
-        if (sanitizeName(it.name) === sanitizeName(item.newName)) continue;
         count += 1;
         if (count > offset && results.length < perPage) {
           results.push({
@@ -477,4 +476,30 @@ export async function uploadSelectedImages(files = [], meta = []) {
     }
   }
   return count;
+}
+
+export async function findBenchmarkCode(name) {
+  const digit = name.match(/\d{4}/);
+  if (digit) {
+    try {
+      const [rows] = await pool.query(
+        'SELECT UITransType FROM code_transaction WHERE UITransType = ?',
+        [digit[0]],
+      );
+      if (rows.length) return rows[0].UITransType;
+    } catch {}
+  }
+  const alpha = name.match(/[A-Za-z]{4}/);
+  if (alpha) {
+    try {
+      const [rows] = await pool.query(
+        'SELECT UITransType, UITrtype FROM code_transaction WHERE image_benchmark = 1',
+      );
+      const row = (rows || []).find(
+        (r) => String(r.UITrtype).toLowerCase() === alpha[0].toLowerCase(),
+      );
+      if (row) return row.UITransType;
+    } catch {}
+  }
+  return null;
 }

--- a/src/erp.mgt.mn/pages/ImageManagement.jsx
+++ b/src/erp.mgt.mn/pages/ImageManagement.jsx
@@ -375,7 +375,7 @@ export default function ImageManagement() {
                   style={{ marginRight: '0.5rem' }}
                   disabled={checkLoading || pageFiles.length === 0}
                 >
-                  {checkLoading ? 'Checking...' : 'Check Names'}
+                  {checkLoading ? 'Renaming...' : 'Rename'}
                 </button>
                 <button type="button" onClick={deleteSelected} style={{ marginRight: '0.5rem' }} disabled={folderSel.length === 0}>
                   Delete Selected


### PR DESCRIPTION
## Summary
- remove overly strict check in `detectIncompleteImages`
- add missing `findBenchmarkCode` service
- rename "Check Names" button to "Rename" on image management page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bb8ce531c83318834c19023470712