### PR TITLE
Add feature toggles for AI and inventory

### DIFF
--- a/api-server/middlewares/featureToggle.js
+++ b/api-server/middlewares/featureToggle.js
@@ -1,0 +1,13 @@
+import { getGeneralConfig } from '../services/generalConfig.js';
+
+export default function featureToggle(flag) {
+  return async function (req, res, next) {
+    try {
+      const cfg = await getGeneralConfig();
+      if (cfg.general?.[flag]) return next();
+      res.status(404).json({ message: 'Feature disabled' });
+    } catch (err) {
+      next(err);
+    }
+  };
+}

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -35,6 +35,7 @@ import procedureRoutes from "./routes/procedures.js";
 import procTriggerRoutes from "./routes/proc_triggers.js";
 import generalConfigRoutes from "./routes/general_config.js";
 import { requireAuth } from "./middlewares/auth.js";
+import featureToggle from "./middlewares/featureToggle.js";
 
 // Polyfill for __dirname in ES modules
 const __filename = fileURLToPath(import.meta.url);
@@ -73,8 +74,8 @@ app.use("/api/modules", requireAuth, moduleRoutes);
 app.use("/api/company_modules", requireAuth, companyModuleRoutes);
 app.use("/api/coding_tables", requireAuth, codingTableRoutes);
 app.use("/api/header_mappings", requireAuth, headerMappingRoutes);
-app.use("/api/openai", openaiRoutes);
-app.use("/api/ai_inventory", aiInventoryRoutes);
+app.use("/api/openai", featureToggle('aiApiEnabled'), openaiRoutes);
+app.use("/api/ai_inventory", featureToggle('aiInventoryApiEnabled'), aiInventoryRoutes);
 app.use("/api/display_fields", displayFieldRoutes);
 app.use("/api/coding_table_configs", codingTableConfigRoutes);
 app.use("/api/generated_sql", generatedSqlRoutes);

--- a/api-server/services/generalConfig.js
+++ b/api-server/services/generalConfig.js
@@ -19,6 +19,11 @@ const defaults = {
     boxMaxHeight: 150,
   },
   general: {
+    aiApiEnabled: false,
+    aiInventoryApiEnabled: false,
+    triggerToastEnabled: true,
+    procToastEnabled: true,
+    debugLoggingEnabled: false,
     imageStorage: {
       basePath: 'uploads',
       cleanupDays: 30,

--- a/config/generalConfig.json
+++ b/config/generalConfig.json
@@ -14,6 +14,11 @@
     "boxMaxHeight": 150
   },
   "general": {
+    "aiApiEnabled": false,
+    "aiInventoryApiEnabled": false,
+    "triggerToastEnabled": true,
+    "procToastEnabled": true,
+    "debugLoggingEnabled": false,
     "imageStorage": {
       "basePath": "uploads",
       "cleanupDays": 30

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -11,6 +11,7 @@ import { useModules } from "../hooks/useModules.js";
 import { useTxnModules } from "../hooks/useTxnModules.js";
 import modulePath from "../utils/modulePath.js";
 import AskAIFloat from "./AskAIFloat.jsx";
+import useGeneralConfig from "../hooks/useGeneralConfig.js";
 import { useTabs } from "../context/TabContext.jsx";
 import { useIsLoading } from "../context/LoadingContext.jsx";
 import Spinner from "./Spinner.jsx";
@@ -23,6 +24,7 @@ import Spinner from "./Spinner.jsx";
  */
 export default function ERPLayout() {
   const { user, setUser, company } = useContext(AuthContext);
+  const generalConfig = useGeneralConfig();
   const renderCount = useRef(0);
   useEffect(() => {
   renderCount.current++;
@@ -126,7 +128,7 @@ export default function ERPLayout() {
         />
         <MainWindow title={windowTitle} />
       </div>
-      <AskAIFloat />
+      {generalConfig.general?.aiApiEnabled && <AskAIFloat />}
     </div>
   );
 }

--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -76,6 +76,7 @@ export default forwardRef(function InlineTransactionTable({
   const renderCount = useRef(0);
   const generalConfig = useGeneralConfig();
   const cfg = generalConfig[scope] || {};
+  const general = generalConfig.general || {};
   const userIdSet = new Set(userIdFields);
   const branchIdSet = new Set(branchIdFields);
   const departmentIdSet = new Set(departmentIdFields);
@@ -315,6 +316,7 @@ export default forwardRef(function InlineTransactionTable({
   }
 
   function showTriggerInfo(col) {
+    if (!general.triggerToastEnabled) return;
     const direct = getDirectTriggers(col);
     const paramTrigs = getParamTriggers(col);
 
@@ -350,6 +352,7 @@ export default forwardRef(function InlineTransactionTable({
   }
 
   async function runProcTrigger(rowIdx, col, rowOverride = null) {
+    const showToast = general.procToastEnabled;
     const direct = getDirectTriggers(col);
     const paramTrigs = getParamTriggers(col);
 
@@ -425,21 +428,25 @@ export default forwardRef(function InlineTransactionTable({
           onRowsChange(next);
           return next;
         });
-        window.dispatchEvent(
-          new CustomEvent('toast', {
-            detail: { message: `Returned: ${JSON.stringify(rowData)}`, type: 'info' },
-          }),
-        );
+        if (showToast) {
+          window.dispatchEvent(
+            new CustomEvent('toast', {
+              detail: { message: `Returned: ${JSON.stringify(rowData)}`, type: 'info' },
+            }),
+          );
+        }
         continue;
       }
-      window.dispatchEvent(
-        new CustomEvent('toast', {
-          detail: {
-            message: `${tCol} -> ${procName}(${paramValues.join(', ')})`,
-            type: 'info',
-          },
-        }),
-      );
+      if (showToast) {
+        window.dispatchEvent(
+          new CustomEvent('toast', {
+            detail: {
+              message: `${tCol} -> ${procName}(${paramValues.join(', ')})`,
+              type: 'info',
+            },
+          }),
+        );
+      }
       try {
         const rowData = await callProcedure(
           procName,
@@ -461,19 +468,23 @@ export default forwardRef(function InlineTransactionTable({
             onRowsChange(next);
             return next;
           });
-          window.dispatchEvent(
-            new CustomEvent('toast', {
-              detail: { message: `Returned: ${JSON.stringify(rowData)}`, type: 'info' },
-            }),
-          );
+          if (showToast) {
+            window.dispatchEvent(
+              new CustomEvent('toast', {
+                detail: { message: `Returned: ${JSON.stringify(rowData)}`, type: 'info' },
+              }),
+            );
+          }
         }
       } catch (err) {
         console.error('Procedure call failed', err);
-        window.dispatchEvent(
-          new CustomEvent('toast', {
-            detail: { message: `Procedure failed: ${err.message}`, type: 'error' },
-          }),
-        );
+        if (showToast) {
+          window.dispatchEvent(
+            new CustomEvent('toast', {
+              detail: { message: `Procedure failed: ${err.message}`, type: 'error' },
+            }),
+          );
+        }
       }
     }
   }

--- a/src/erp.mgt.mn/components/InventoryImageUpload.jsx
+++ b/src/erp.mgt.mn/components/InventoryImageUpload.jsx
@@ -1,14 +1,20 @@
 import React, { useState } from 'react';
 import { useToast } from '../context/ToastContext.jsx';
+import useGeneralConfig from '../hooks/useGeneralConfig.js';
 
 export default function InventoryImageUpload({ onResult, multiple = false, uploadUrl = '/api/ai_inventory/identify' }) {
   const [files, setFiles] = useState([]);
   const [loading, setLoading] = useState(false);
   const [items, setItems] = useState([]);
   const { addToast } = useToast();
+  const generalConfig = useGeneralConfig();
 
   async function handleUpload() {
     if (!files.length) return;
+    if (!generalConfig.general?.aiInventoryApiEnabled) {
+      addToast('AI inventory API is disabled', 'error');
+      return;
+    }
     setLoading(true);
     const results = [];
     for (const f of files) {

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -60,6 +60,7 @@ const RowFormModal = function RowFormModal({
   const procCache = useRef({});
   const generalConfig = useGeneralConfig();
   const cfg = generalConfig[scope] || {};
+  const general = generalConfig.general || {};
   labelFontSize = labelFontSize ?? cfg.labelFontSize ?? 14;
   boxWidth = boxWidth ?? cfg.boxWidth ?? 60;
   boxHeight = boxHeight ?? cfg.boxHeight ?? 30;
@@ -425,6 +426,7 @@ const RowFormModal = function RowFormModal({
   }
 
   function showTriggerInfo(col) {
+    if (!general.triggerToastEnabled) return;
     const direct = getDirectTriggers(col);
     const paramTrigs = getParamTriggers(col);
 
@@ -531,21 +533,25 @@ const RowFormModal = function RowFormModal({
           return updated;
         });
         onChange(norm);
-        window.dispatchEvent(
-          new CustomEvent('toast', {
-            detail: { message: `Returned: ${JSON.stringify(row)}`, type: 'info' },
-          }),
-        );
+        if (general.procToastEnabled) {
+          window.dispatchEvent(
+            new CustomEvent('toast', {
+              detail: { message: `Returned: ${JSON.stringify(row)}`, type: 'info' },
+            }),
+          );
+        }
         continue;
       }
-      window.dispatchEvent(
-        new CustomEvent('toast', {
-          detail: {
-            message: `${tCol} -> ${procName}(${paramValues.join(', ')})`,
-            type: 'info',
-        },
-      }),
-    );
+      if (general.procToastEnabled) {
+        window.dispatchEvent(
+          new CustomEvent('toast', {
+            detail: {
+              message: `${tCol} -> ${procName}(${paramValues.join(', ')})`,
+              type: 'info',
+            },
+          }),
+        );
+      }
     try {
       const row = await callProcedure(procName, paramValues, aliases);
       if (row && typeof row === 'object') {
@@ -563,19 +569,23 @@ const RowFormModal = function RowFormModal({
           return updated;
         });
         onChange(norm);
-        window.dispatchEvent(
-          new CustomEvent('toast', {
-            detail: { message: `Returned: ${JSON.stringify(row)}`, type: 'info' },
-          }),
-        );
+        if (general.procToastEnabled) {
+          window.dispatchEvent(
+            new CustomEvent('toast', {
+              detail: { message: `Returned: ${JSON.stringify(row)}`, type: 'info' },
+            }),
+          );
+        }
       }
     } catch (err) {
       console.error('Procedure call failed', err);
-      window.dispatchEvent(
-        new CustomEvent('toast', {
-          detail: { message: `Procedure failed: ${err.message}`, type: 'error' },
-        }),
-      );
+      if (general.procToastEnabled) {
+        window.dispatchEvent(
+          new CustomEvent('toast', {
+            detail: { message: `Procedure failed: ${err.message}`, type: 'error' },
+          }),
+        );
+      }
     }
     }
   }

--- a/src/erp.mgt.mn/hooks/useGeneralConfig.js
+++ b/src/erp.mgt.mn/hooks/useGeneralConfig.js
@@ -4,6 +4,9 @@ const cache = { data: null };
 
 export function updateCache(data) {
   cache.data = data;
+  if (data?.general) {
+    window.erpDebug = !!data.general.debugLoggingEnabled;
+  }
   window.dispatchEvent(new CustomEvent('generalConfigUpdated', { detail: data }));
 }
 
@@ -13,6 +16,9 @@ export default function useGeneralConfig() {
   useEffect(() => {
     if (cache.data !== null) {
       setCfg(cache.data);
+      if (cache.data.general) {
+        window.erpDebug = !!cache.data.general.debugLoggingEnabled;
+      }
       return;
     }
     fetch('/api/general_config', { credentials: 'include' })

--- a/src/erp.mgt.mn/pages/AIInventoryDashboard.jsx
+++ b/src/erp.mgt.mn/pages/AIInventoryDashboard.jsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react';
+import useGeneralConfig from '../hooks/useGeneralConfig.js';
 
 export default function AIInventoryDashboard() {
   const [data, setData] = useState({});
   const [error, setError] = useState('');
+  const generalConfig = useGeneralConfig();
 
   async function fetchData() {
     try {
@@ -27,6 +29,10 @@ export default function AIInventoryDashboard() {
       credentials: 'include',
     });
     fetchData();
+  }
+
+  if (!generalConfig.general?.aiInventoryApiEnabled) {
+    return <p>AI Inventory API disabled.</p>;
   }
 
   const entries = Object.entries(data);

--- a/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
+++ b/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
@@ -18,12 +18,12 @@ export default function GeneralConfiguration() {
   }, [initial]);
 
   function handleChange(e) {
-    const { name, value, type } = e.target;
+    const { name, value, type, checked } = e.target;
     setCfg(c => ({
       ...c,
       [tab]: {
         ...(c?.[tab] || {}),
-        [name]: type === 'number' ? Number(value) : value,
+        [name]: type === 'number' ? Number(value) : type === 'checkbox' ? checked : value,
       },
     }));
   }
@@ -192,6 +192,61 @@ export default function GeneralConfiguration() {
                   }));
                 }}
                 style={{ width: '4rem' }}
+              />
+            </label>
+          </div>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <label>
+              Enable AI API{' '}
+              <input
+                name="aiApiEnabled"
+                type="checkbox"
+                checked={active.aiApiEnabled ?? false}
+                onChange={handleChange}
+              />
+            </label>
+          </div>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <label>
+              Enable AI Inventory API{' '}
+              <input
+                name="aiInventoryApiEnabled"
+                type="checkbox"
+                checked={active.aiInventoryApiEnabled ?? false}
+                onChange={handleChange}
+              />
+            </label>
+          </div>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <label>
+              Show Trigger Toasts{' '}
+              <input
+                name="triggerToastEnabled"
+                type="checkbox"
+                checked={active.triggerToastEnabled ?? false}
+                onChange={handleChange}
+              />
+            </label>
+          </div>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <label>
+              Show Procedure Toasts{' '}
+              <input
+                name="procToastEnabled"
+                type="checkbox"
+                checked={active.procToastEnabled ?? false}
+                onChange={handleChange}
+              />
+            </label>
+          </div>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <label>
+              Enable Debug Logging{' '}
+              <input
+                name="debugLoggingEnabled"
+                type="checkbox"
+                checked={active.debugLoggingEnabled ?? false}
+                onChange={handleChange}
               />
             </label>
           </div>


### PR DESCRIPTION
## Summary
- add feature toggles for AI API usage, inventory AI API, trigger and procedure toasts and debug logging
- expose toggle middleware on the server
- respect toggles in React components and hooks
- show toggle settings in General Configuration screen

## Testing
- `npm test` *(fails: findBenchmarkCode.test.js due to missing export)*

------
https://chatgpt.com/codex/tasks/task_e_688c7738ea1883318a72e626df488e82