### PR TITLE
Fix workbook upload crash

### DIFF
--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -73,6 +73,8 @@ export default function CodingTablesPage() {
   const [configMap, setConfigMap] = useState({});
   const interruptRef = useRef(false);
   const abortCtrlRef = useRef(null);
+  const [loadingWorkbook, setLoadingWorkbook] = useState(false);
+  const workerRef = useRef(null);
 
   useEffect(() => {
     fetch('/api/coding_table_configs', { credentials: 'include' })
@@ -89,16 +91,24 @@ export default function CodingTablesPage() {
 
   useEffect(() => {
     function onKey(e) {
-      if (e.key === 'Escape' && uploading) {
-        if (window.confirm('Interrupt insert process?')) {
-          interruptRef.current = true;
-          if (abortCtrlRef.current) abortCtrlRef.current.abort();
+      if (e.key === 'Escape') {
+        if (uploading) {
+          if (window.confirm('Interrupt insert process?')) {
+            interruptRef.current = true;
+            if (abortCtrlRef.current) abortCtrlRef.current.abort();
+          }
+        } else if (loadingWorkbook) {
+          if (window.confirm('Cancel workbook load?')) {
+            if (workerRef.current) workerRef.current.terminate();
+            workerRef.current = null;
+            setLoadingWorkbook(false);
+          }
         }
       }
     }
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
-  }, [uploading]);
+  }, [uploading, loadingWorkbook]);
 
   const allFields = useMemo(() => {
     // keep duplicates so user can easily spot them and clean extras the same way
@@ -185,13 +195,38 @@ export default function CodingTablesPage() {
     setExtraFields((f) => f.filter((_, i) => i !== idx));
   }
 
-  function loadWorkbook(file) {
-    file.arrayBuffer().then((ab) => {
-      const wb = XLSX.read(ab);
-      setWorkbook(wb);
-      setSheets(wb.SheetNames);
-      const firstSheet = wb.SheetNames[0];
-      setSheet(firstSheet);
+  async function loadWorkbook(file) {
+    setLoadingWorkbook(true);
+    try {
+      const ab = await file.arrayBuffer();
+      const worker = new Worker(
+        new URL('../utils/workbookWorker.js', import.meta.url),
+      );
+      workerRef.current = worker;
+      await new Promise((resolve) => {
+        worker.onmessage = (ev) => {
+          const { workbook: wb, error } = ev.data;
+          workerRef.current = null;
+          setLoadingWorkbook(false);
+          if (error || !wb) {
+            console.error('Failed to load workbook', error);
+            addToast(
+              'Unable to read file. Please select a valid Excel file.',
+              'error',
+            );
+            setWorkbook(null);
+            setSheets([]);
+            setSelectedFile(null);
+          } else {
+            setWorkbook(wb);
+            setSheets(wb.SheetNames);
+            const firstSheet = wb.SheetNames[0];
+            setSheet(firstSheet);
+          }
+          resolve();
+        };
+        worker.postMessage({ arrayBuffer: ab });
+      });
       setHeaderRow(1);
       setMnHeaderRow('');
       setHeaders([]);
@@ -214,7 +249,18 @@ export default function CodingTablesPage() {
       setStartYear('');
       setEndYear('');
       setAutoIncStart('1');
-    });
+    } catch (err) {
+      console.error('Failed to load workbook', err);
+      addToast('Unable to read file. Please select a valid Excel file.', 'error');
+      setWorkbook(null);
+      setSheets([]);
+      setSelectedFile(null);
+      setLoadingWorkbook(false);
+      if (workerRef.current) {
+        workerRef.current.terminate();
+        workerRef.current = null;
+      }
+    }
   }
 
   function handleFile(e) {
@@ -1934,6 +1980,11 @@ export default function CodingTablesPage() {
       <input type="file" accept=".xlsx,.xls" onChange={handleFile} ref={fileInputRef} />
       {selectedFile && (
         <button onClick={refreshFile} style={{ marginLeft: '0.5rem' }}>Refresh File</button>
+      )}
+      {loadingWorkbook && (
+        <div style={{ marginTop: '0.5rem' }}>
+          <progress /> Loading workbook...
+        </div>
       )}
       {sheets.length > 0 && (
         <div>

--- a/src/erp.mgt.mn/utils/workbookWorker.js
+++ b/src/erp.mgt.mn/utils/workbookWorker.js
@@ -1,0 +1,13 @@
+import * as XLSX from 'xlsx';
+
+self.onmessage = (e) => {
+  const { id, arrayBuffer } = e.data;
+  let workbook = null;
+  let error = null;
+  try {
+    workbook = XLSX.read(arrayBuffer);
+  } catch (err) {
+    error = err.message || String(err);
+  }
+  self.postMessage({ id, workbook, error });
+};


### PR DESCRIPTION
## Summary
- show an error toast if loading a coding table workbook fails
- load workbook in a Web Worker
- add cancelation support with ESC key

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688c9f310de483318d65aac0cb31a026