### PR TITLE
Fix workbook upload crash

### DIFF
--- a/src/erp.mgt.mn/utils/workbookWorker.js
+++ b/src/erp.mgt.mn/utils/workbookWorker.js
@@ -1,0 +1,13 @@
+import * as XLSX from 'xlsx';
+
+self.onmessage = (e) => {
+  const { id, arrayBuffer } = e.data;
+  let workbook = null;
+  let error = null;
+  try {
+    workbook = XLSX.read(arrayBuffer, { type: 'array' });
+  } catch (err) {
+    error = err.message || String(err);
+  }
+  self.postMessage({ id, workbook, error });
+};


### PR DESCRIPTION
## Summary
- show an error toast if loading a coding table workbook fails
- load workbook in a Web Worker
- add cancelation support with ESC key
- add progress indicator when reading a workbook
- allow uploading `.xlsb` files

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688c9f310de483318d65aac0cb31a026