### PR TITLE
Improve image detection feedback

### DIFF
--- a/api-server/routes/transaction_images.js
+++ b/api-server/routes/transaction_images.js
@@ -56,8 +56,8 @@ router.post('/fix_incomplete', requireAuth, async (req, res, next) => {
 router.post('/folder_check', requireAuth, async (req, res, next) => {
   try {
     const arr = Array.isArray(req.body?.list) ? req.body.list : [];
-    const list = await checkFolderNames(arr);
-    res.json({ list });
+    const data = await checkFolderNames(arr);
+    res.json(data);
   } catch (err) {
     next(err);
   }

--- a/src/erp.mgt.mn/components/FixImagesTab.jsx
+++ b/src/erp.mgt.mn/components/FixImagesTab.jsx
@@ -1,0 +1,295 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { useToast } from '../context/ToastContext.jsx';
+
+export default function FixImagesTab() {
+  const { addToast } = useToast();
+  const [mode, setMode] = useState(null); // 'host' or 'local'
+  const [page, setPage] = useState(1);
+  const [list, setList] = useState([]);
+  const [hasMore, setHasMore] = useState(false);
+  const [files, setFiles] = useState([]);
+  const [selected, setSelected] = useState(new Set());
+  const [localFolder, setLocalFolder] = useState('');
+  const [status, setStatus] = useState('');
+  const inputRef = useRef(null);
+  const pageSize = 100;
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.setAttribute('webkitdirectory', '');
+      inputRef.current.setAttribute('directory', '');
+    }
+  }, []);
+
+  function clearAll() {
+    setList([]);
+    setHasMore(false);
+    setSelected(new Set());
+    setStatus('');
+  }
+
+  async function detectHost(p = 1) {
+    setMode('host');
+    setPage(p);
+    clearAll();
+    addToast('Scanning host folders...', 'info');
+    setStatus('');
+    try {
+      const res = await fetch(`/api/transaction_images/detect_incomplete?page=${p}`, {
+        credentials: 'include',
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setList(Array.isArray(data.list) ? data.list : []);
+        setHasMore(!!data.hasMore);
+        setStatus(data.message || '');
+        addToast(data.message || `found ${data.list.length} file(s)`, 'success');
+      } else {
+        addToast('Host detection failed', 'error');
+      }
+    } catch {
+      addToast('Host detection failed', 'error');
+    }
+  }
+
+  async function detectLocal(fileList, folderName = '') {
+    const arr = Array.from(fileList || []);
+    if (!arr.length) {
+      addToast('No files selected', 'info');
+      return;
+    }
+    setMode('local');
+    setPage(1);
+    setFiles(arr);
+    clearAll();
+    const root = folderName || (arr[0].webkitRelativePath
+      ? arr[0].webkitRelativePath.split('/')[0]
+      : '');
+    setLocalFolder(root);
+    addToast(`Scanning folder ${root || ''}...`, 'info');
+    setStatus('');
+    const meta = arr.map((f, idx) => ({ name: f.name, index: idx }));
+    try {
+      const res = await fetch('/api/transaction_images/folder_check', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ list: meta }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        const foundList = data.list || [];
+        const msg = data.message || `found ${foundList.length} file(s)`;
+        setList(foundList);
+        setHasMore(arr.length > pageSize);
+        setStatus(msg);
+        addToast(msg, 'success');
+      } else {
+        addToast('Local detection failed', 'error');
+      }
+    } catch {
+      addToast('Local detection failed', 'error');
+    }
+  }
+
+  function toggle(index) {
+    setSelected((s) => {
+      const n = new Set(s);
+      if (n.has(index)) n.delete(index);
+      else n.add(index);
+      return n;
+    });
+  }
+
+  function toggleAll(checked, display) {
+    setSelected((s) => {
+      const n = new Set(s);
+      if (checked) display.forEach((_, idx) => n.add(idx + (page - 1) * pageSize));
+      else display.forEach((_, idx) => n.delete(idx + (page - 1) * pageSize));
+      return n;
+    });
+  }
+
+  async function fixSelected() {
+    const items = Array.from(selected).map((i) => list[i]);
+    if (!items.length) return;
+    if (mode === 'host') {
+      try {
+        const res = await fetch('/api/transaction_images/fix_incomplete', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ list: items }),
+        });
+        if (res.ok) {
+          const data = await res.json();
+          addToast(`Renamed ${data.fixed} file(s)`, 'success');
+          setStatus(`Renamed ${data.fixed} file(s)`);
+          detectHost(page);
+        } else {
+          addToast('Rename failed', 'error');
+        }
+      } catch {
+        addToast('Rename failed', 'error');
+      }
+    } else if (mode === 'local') {
+      const form = new FormData();
+      const meta = [];
+      Array.from(selected).forEach((i) => {
+        const item = list[i];
+        const file = files[item.index];
+        if (file) form.append('images', file);
+        meta.push({ name: item.originalName, newName: item.newName, folder: item.folder });
+      });
+      form.append('meta', JSON.stringify(meta));
+      try {
+        const res = await fetch('/api/transaction_images/folder_commit', {
+          method: 'POST',
+          credentials: 'include',
+          body: form,
+        });
+        if (res.ok) {
+          const data = await res.json();
+          addToast(`Uploaded ${data.uploaded} file(s)`, 'success');
+          setStatus(`Uploaded ${data.uploaded} file(s)`);
+        } else {
+          addToast('Upload failed', 'error');
+        }
+      } catch {
+        addToast('Upload failed', 'error');
+      }
+    }
+  }
+
+  const display = mode === 'local'
+    ? list.slice((page - 1) * pageSize, page * pageSize)
+    : list;
+  const allSelected = display.length > 0 && display.every((_, idx) => selected.has(idx + (page - 1) * pageSize));
+
+  return (
+    <div>
+      <div style={{ marginBottom: '0.5rem' }}>
+        <button onClick={() => detectHost(1)}>Detect from Host</button>
+        <input
+          ref={inputRef}
+          type="file"
+          style={{ display: 'none' }}
+          webkitdirectory="true"
+          directory="true"
+          multiple
+          onChange={(e) => {
+            detectLocal(e.target.files);
+            e.target.value = '';
+          }}
+        />
+        <button
+          type="button"
+          onClick={async () => {
+            if (window.showDirectoryPicker) {
+              try {
+                const dirHandle = await window.showDirectoryPicker();
+                const files = [];
+                async function collect(handle, pathParts = []) {
+                  for await (const [name, h] of handle.entries()) {
+                    if (h.kind === 'file') {
+                      const f = await h.getFile();
+                      f.webkitRelativePath = [...pathParts, name].join('/');
+                      files.push(f);
+                    } else if (h.kind === 'directory') {
+                      await collect(h, [...pathParts, name]);
+                    }
+                  }
+                }
+                await collect(dirHandle, [dirHandle.name]);
+                detectLocal(files, dirHandle.name);
+              } catch {
+                /* ignore */
+              }
+            } else {
+              inputRef.current?.click();
+            }
+          }}
+          style={{ marginLeft: '0.5rem' }}
+        >
+          Detect from Local
+        </button>
+        {mode === 'local' && localFolder && (
+          <span style={{ marginLeft: '0.5rem' }}>[{localFolder}]</span>
+        )}
+        {mode === 'host' && (
+          <button onClick={fixSelected} style={{ marginLeft: '0.5rem' }}>
+            Rename &amp; Move Selected
+          </button>
+        )}
+        {mode === 'local' && (
+          <button onClick={fixSelected} style={{ marginLeft: '0.5rem' }}>
+            Rename &amp; Upload Selected
+          </button>
+        )}
+      </div>
+      {status && (
+        <p style={{ marginTop: '0.5rem' }}>{status}</p>
+      )}
+      {display.length > 0 && (
+        <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+          <thead>
+            <tr>
+              <th style={{ border: '1px solid #d1d5db', padding: '0.25rem' }}>
+                <input
+                  type="checkbox"
+                  checked={allSelected}
+                  onChange={(e) => toggleAll(e.target.checked, display)}
+                />
+              </th>
+              <th style={{ border: '1px solid #d1d5db', padding: '0.25rem' }}>Current</th>
+              <th style={{ border: '1px solid #d1d5db', padding: '0.25rem' }}>Name Suggestion</th>
+              <th style={{ border: '1px solid #d1d5db', padding: '0.25rem' }}>Move</th>
+              <th style={{ border: '1px solid #d1d5db', padding: '0.25rem' }}>Delete</th>
+            </tr>
+          </thead>
+          <tbody>
+            {display.map((item, idx) => (
+              <tr key={idx}>
+                <td style={{ border: '1px solid #d1d5db', padding: '0.25rem' }}>
+                  <input
+                    type="checkbox"
+                    checked={selected.has(idx + (page - 1) * pageSize)}
+                    onChange={() => toggle(idx + (page - 1) * pageSize)}
+                  />
+                </td>
+                <td style={{ border: '1px solid #d1d5db', padding: '0.25rem' }}>
+                  {item.currentName || item.originalName}
+                </td>
+                <td style={{ border: '1px solid #d1d5db', padding: '0.25rem' }}>{item.newName}</td>
+                <td style={{ border: '1px solid #d1d5db', padding: '0.25rem' }}>{item.folderDisplay}</td>
+                <td style={{ border: '1px solid #d1d5db', padding: '0.25rem' }}>
+                  <button onClick={() => {
+                    const index = idx + (page - 1) * pageSize;
+                    setList((l) => l.filter((_, i) => i !== index));
+                    setSelected((s) => { const n = new Set(s); n.delete(index); return n; });
+                  }}>×</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {display.length > 0 && (
+        <div style={{ marginTop: '0.5rem' }}>
+          <button onClick={() => { if (page > 1) setPage(page - 1); }} disabled={page === 1}>
+            Previous
+          </button>
+          <button
+            onClick={() => {
+              if (mode === 'host') detectHost(page + 1); else setPage(page + 1);
+            }}
+            disabled={mode === 'host' ? !hasMore : page * pageSize >= list.length}
+            style={{ marginLeft: '0.5rem' }}
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/erp.mgt.mn/pages/ImageManagement.jsx
+++ b/src/erp.mgt.mn/pages/ImageManagement.jsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
 import { useToast } from '../context/ToastContext.jsx';
+import FixImagesTab from '../components/FixImagesTab.jsx';
 
 export default function ImageManagement() {
   const { addToast } = useToast();
   const [days, setDays] = useState('');
   const [result, setResult] = useState(null);
+  const [tab, setTab] = useState('cleanup');
   async function handleCleanup() {
     const path = days ? `/api/transaction_images/cleanup/${days}` : '/api/transaction_images/cleanup';
     try {
@@ -26,20 +28,35 @@ export default function ImageManagement() {
     <div>
       <h2>Image Management</h2>
       <div style={{ marginBottom: '0.5rem' }}>
-        <label>
-          Cleanup files older than (days):{' '}
-          <input
-            type="number"
-            value={days}
-            onChange={(e) => setDays(e.target.value)}
-            style={{ width: '4rem' }}
-          />
-        </label>
-        <button type="button" onClick={handleCleanup} style={{ marginLeft: '0.5rem' }}>
-          Cleanup
+        <button onClick={() => setTab('cleanup')}>Cleanup</button>
+        <button onClick={() => setTab('fix')} style={{ marginLeft: '0.5rem' }}>
+          Fix Images
         </button>
       </div>
-      {result !== null && <p>{result} file(s) removed.</p>}
+      {tab === 'cleanup' && (
+        <div style={{ marginBottom: '1rem' }}>
+          <label>
+            Cleanup files older than (days):{' '}
+            <input
+              type="number"
+              value={days}
+              onChange={(e) => setDays(e.target.value)}
+              style={{ width: '4rem' }}
+            />
+          </label>
+          <button
+            type="button"
+            onClick={handleCleanup}
+            style={{ marginLeft: '0.5rem' }}
+          >
+            Cleanup
+          </button>
+          {result !== null && (
+            <p style={{ marginTop: '0.5rem' }}>{result} file(s) removed.</p>
+          )}
+        </div>
+      )}
+      {tab === 'fix' && <FixImagesTab />}
     </div>
   );
 }

--- a/tests/api/detectIncompleteImages.test.js
+++ b/tests/api/detectIncompleteImages.test.js
@@ -147,11 +147,11 @@ await test('uploadSelectedImages renames on upload', async () => {
   }));
 
   const check = await checkFolderNames([{ name: 'abc12345.jpg', index: 0 }]);
-  assert.ok(check[0].newName.includes('z1_b1_bp1'));
+  assert.ok(check.list[0].newName.includes('z1_b1_bp1'));
   const list = [{
     name: 'abc12345.jpg',
-    newName: check[0].newName,
-    folder: check[0].folder,
+    newName: check.list[0].newName,
+    folder: check.list[0].folder,
   }];
   const uploaded = await uploadSelectedImages([
     { originalname: 'abc12345.jpg', path: tmp }
@@ -165,4 +165,25 @@ await test('uploadSelectedImages renames on upload', async () => {
   await fs.writeFile(cfgPath, origCfg);
   await fs.rm(path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test'), { recursive: true, force: true });
   await fs.rm(path.join(process.cwd(), 'uploads', 'tmp'), { recursive: true, force: true });
+});
+
+await test('checkFolderNames handles varied unique ids', async () => {
+  const samples = [
+    '1-ab593e82-abbd-4421-91f6-5b7e2687da33-18.jpg',
+    '120180002323_120180002323_4001_ydzfh-sdang-cxfxb-kajww_akihl-zukov-ulioe-fhnde_1753974108927_oge4m7.jpg',
+    '300048_300048_4001_1753984944999_cxkvuz.jpg',
+    '800688-2c589c0f-369a-4827-8b4c-fc5aeaf88a1c-26.jpg'
+  ];
+
+  const restoreDb = mockPool(async (sql) => {
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql)) return [[{ Field: 'test_num' }]];
+    if (/FROM `transactions_test`/.test(sql)) return [[{ test_num: 'dummy' }]];
+    return [[]];
+  });
+
+  const res = await checkFolderNames(samples.map((n, i) => ({ name: n, index: i })));
+  assert.equal(res.list.length, samples.length);
+
+  restoreDb();
 });


### PR DESCRIPTION
## Summary
- ensure host detection uses base path correctly
- display detection status messages in Fix Images UI
- keep local folder name and show counts in status line
- broaden unique ID regex patterns to detect complex cases
- add tests covering varied unique IDs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ceda6554c8331abec9ebd7e81508b