### PR TITLE
Fix detection summary for incomplete images

### DIFF
--- a/api-server/routes/transaction_images.js
+++ b/api-server/routes/transaction_images.js
@@ -10,6 +10,7 @@ import {
   cleanupOldImages,
   detectIncompleteImages,
   fixIncompleteImages,
+  deleteIncompleteImages,
   checkFolderNames,
   uploadSelectedImages,
 } from '../services/transactionImageService.js';
@@ -45,9 +46,19 @@ router.get('/detect_incomplete', requireAuth, async (req, res, next) => {
 
 router.post('/fix_incomplete', requireAuth, async (req, res, next) => {
   try {
+  const arr = Array.isArray(req.body?.list) ? req.body.list : [];
+  const fixed = await fixIncompleteImages(arr);
+  res.json({ fixed });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/delete_incomplete', requireAuth, async (req, res, next) => {
+  try {
     const arr = Array.isArray(req.body?.list) ? req.body.list : [];
-    const fixed = await fixIncompleteImages(arr);
-    res.json({ fixed });
+    const deleted = await deleteIncompleteImages(arr);
+    res.json({ deleted });
   } catch (err) {
     next(err);
   }

--- a/src/erp.mgt.mn/pages/ImageManagement.jsx
+++ b/src/erp.mgt.mn/pages/ImageManagement.jsx
@@ -3,12 +3,24 @@ import { useToast } from '../context/ToastContext.jsx';
 
 export default function ImageManagement() {
   const { addToast } = useToast();
+  const [activeTab, setActiveTab] = useState('cleanup');
   const [days, setDays] = useState('');
   const [result, setResult] = useState(null);
+
+  const [list, setList] = useState([]);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  const [selected, setSelected] = useState([]);
+  const [detectResult, setDetectResult] = useState(null);
   async function handleCleanup() {
-    const path = days ? `/api/transaction_images/cleanup/${days}` : '/api/transaction_images/cleanup';
+    const path = days
+      ? `/api/transaction_images/cleanup/${days}`
+      : '/api/transaction_images/cleanup';
     try {
-      const res = await fetch(path, { method: 'DELETE', credentials: 'include' });
+      const res = await fetch(path, {
+        method: 'DELETE',
+        credentials: 'include',
+      });
       if (res.ok) {
         const data = await res.json().catch(() => ({}));
         const removed = data.removed || 0;
@@ -22,24 +34,233 @@ export default function ImageManagement() {
     }
   }
 
+  async function handleDetect(pg = 1) {
+    try {
+      const res = await fetch(
+        `/api/transaction_images/detect_incomplete?page=${pg}`,
+        { credentials: 'include' },
+      );
+      if (res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setList(data.list || []);
+        setHasMore(!!data.hasMore);
+        setPage(pg);
+        setSelected([]);
+        const found = data.found || (data.list || []).length;
+        const scanned = data.scanned || 0;
+        const folder = data.folder || '';
+        setDetectResult({ found, scanned, folder });
+        addToast(
+          `Scanned ${scanned} file(s) in ${folder}. Found ${found} incomplete file(s)`,
+          'success',
+        );
+      } else {
+        setDetectResult(null);
+        addToast('Detect failed', 'error');
+      }
+    } catch {
+      setDetectResult(null);
+      addToast('Detect failed', 'error');
+    }
+  }
+
+  function toggle(idx, checked) {
+    setSelected((cur) => {
+      if (checked) return [...cur, idx];
+      return cur.filter((i) => i !== idx);
+    });
+  }
+
+  async function handleFixSelected() {
+    const items = selected.map((i) => list[i]);
+    if (items.length === 0) return;
+    try {
+      const res = await fetch('/api/transaction_images/fix_incomplete', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ list: items }),
+      });
+      if (res.ok) {
+        const data = await res.json().catch(() => ({}));
+        const fixed = data.fixed || 0;
+        addToast(`Renamed ${fixed} file(s)`, 'success');
+        handleDetect(page);
+      } else {
+        addToast('Rename failed', 'error');
+      }
+    } catch {
+      addToast('Rename failed', 'error');
+    }
+  }
+
+  async function handleDeleteSelected() {
+    const items = selected.map((i) => list[i]);
+    if (items.length === 0) return;
+    try {
+      const res = await fetch('/api/transaction_images/delete_incomplete', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ list: items }),
+      });
+      if (res.ok) {
+        const data = await res.json().catch(() => ({}));
+        const deleted = data.deleted || 0;
+        addToast(`Deleted ${deleted} file(s)`, 'success');
+        handleDetect(page);
+      } else {
+        addToast('Delete failed', 'error');
+      }
+    } catch {
+      addToast('Delete failed', 'error');
+    }
+  }
+
   return (
     <div>
       <h2>Image Management</h2>
       <div style={{ marginBottom: '0.5rem' }}>
-        <label>
-          Cleanup files older than (days):{' '}
-          <input
-            type="number"
-            value={days}
-            onChange={(e) => setDays(e.target.value)}
-            style={{ width: '4rem' }}
-          />
-        </label>
-        <button type="button" onClick={handleCleanup} style={{ marginLeft: '0.5rem' }}>
+        <button
+          type="button"
+          onClick={() => setActiveTab('cleanup')}
+          style={activeTab === 'cleanup' ? styles.activeTab : styles.tab}
+        >
           Cleanup
         </button>
+        <button
+          type="button"
+          onClick={() => setActiveTab('fix')}
+          style={activeTab === 'fix' ? styles.activeTab : styles.tab}
+        >
+          Fix Images
+        </button>
       </div>
-      {result !== null && <p>{result} file(s) removed.</p>}
+
+      {activeTab === 'cleanup' && (
+        <div>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <label>
+              Cleanup files older than (days):{' '}
+              <input
+                type="number"
+                value={days}
+                onChange={(e) => setDays(e.target.value)}
+                style={{ width: '4rem' }}
+              />
+            </label>
+            <button
+              type="button"
+              onClick={handleCleanup}
+              style={{ marginLeft: '0.5rem' }}
+            >
+              Cleanup
+            </button>
+          </div>
+          {result !== null && <p>{result} file(s) removed.</p>}
+        </div>
+      )}
+
+      {activeTab === 'fix' && (
+        <div>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <button type="button" onClick={() => handleDetect(1)}>
+              Detect from host
+            </button>
+            {list.length > 0 && (
+              <>
+                <button
+                  type="button"
+                  onClick={handleFixSelected}
+                  style={{ marginLeft: '0.5rem' }}
+                >
+                  Rename &amp; Move Selected
+                </button>
+                <button
+                  type="button"
+                  onClick={handleDeleteSelected}
+                  style={{ marginLeft: '0.5rem' }}
+                >
+                  Delete Selected
+                </button>
+              </>
+            )}
+          </div>
+          {detectResult && (
+            <p style={{ marginTop: '0.5rem' }}>
+              Scanned {detectResult.scanned} file(s) in {detectResult.folder}. Found{' '}
+              {detectResult.found} incomplete file(s).
+            </p>
+          )}
+
+          {list.length > 0 && (
+            <table style={{ width: '100%', marginBottom: '0.5rem' }}>
+              <thead>
+                <tr>
+                  <th />
+                  <th>Current Name</th>
+                  <th>New Name</th>
+                  <th>Folder</th>
+                </tr>
+              </thead>
+              <tbody>
+                {list.map((item, idx) => (
+                  <tr key={idx}>
+                    <td>
+                      <input
+                        type="checkbox"
+                        checked={selected.includes(idx)}
+                        onChange={(e) => toggle(idx, e.target.checked)}
+                      />
+                    </td>
+                    <td>{item.currentName}</td>
+                    <td>{item.newName}</td>
+                    <td>{item.folderDisplay}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+
+          {list.length > 0 && (
+            <div style={{ marginBottom: '0.5rem' }}>
+              <button
+                type="button"
+                onClick={() => handleDetect(page - 1)}
+                disabled={page <= 1}
+              >
+                Previous
+              </button>
+              <span style={{ margin: '0 0.5rem' }}>Page {page} (100 per page)</span>
+              <button
+                type="button"
+                onClick={() => handleDetect(page + 1)}
+                disabled={!hasMore}
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
+
+const styles = {
+  tab: {
+    background: 'transparent',
+    border: '1px solid #ccc',
+    padding: '0.25rem 0.5rem',
+    marginRight: '0.25rem',
+    cursor: 'pointer',
+  },
+  activeTab: {
+    background: '#e5e7eb',
+    border: '1px solid #ccc',
+    borderBottom: 'none',
+    padding: '0.25rem 0.5rem',
+    marginRight: '0.25rem',
+    cursor: 'pointer',
+  },
+};

--- a/tests/api/detectIncompleteImages.test.js
+++ b/tests/api/detectIncompleteImages.test.js
@@ -2,7 +2,13 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'fs/promises';
 import path from 'path';
-import { detectIncompleteImages, fixIncompleteImages, checkFolderNames, uploadSelectedImages } from '../../api-server/services/transactionImageService.js';
+import {
+  detectIncompleteImages,
+  fixIncompleteImages,
+  deleteIncompleteImages,
+  checkFolderNames,
+  uploadSelectedImages,
+} from '../../api-server/services/transactionImageService.js';
 import * as db from '../../db/index.js';
 
 function mockPool(handler) {
@@ -70,9 +76,12 @@ await test('detectIncompleteImages finds and fixes files', async () => {
     }
   }));
 
-  const { list, hasMore } = await detectIncompleteImages(1);
+  const { list, hasMore, scanned, found, folder } = await detectIncompleteImages(1);
   assert.equal(hasMore, false);
   assert.equal(list.length, 1);
+  assert.equal(found, 1);
+  assert.equal(scanned, 1);
+  assert.ok(folder.includes('txn_images'));
   assert.ok(list[0].newName.includes('num001'));
   assert.ok(list[0].newName.includes('z1_b1_bp1'));
   assert.ok(list[0].newName.includes('oid~odid'));
@@ -165,4 +174,18 @@ await test('uploadSelectedImages renames on upload', async () => {
   await fs.writeFile(cfgPath, origCfg);
   await fs.rm(path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test'), { recursive: true, force: true });
   await fs.rm(path.join(process.cwd(), 'uploads', 'tmp'), { recursive: true, force: true });
+});
+
+await test('deleteIncompleteImages removes files', async () => {
+  const dir = path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test');
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, 'abc12345.jpg');
+  await fs.writeFile(file, 'x');
+
+  const count = await deleteIncompleteImages([{ currentPath: file }]);
+  assert.equal(count, 1);
+  const remaining = await fs.readdir(dir);
+  assert.equal(remaining.length, 0);
+  await fs.rm(dir, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Summary
- improve detection logic by requiring both four-digit and four-letter parts before skipping
- return scanned file count and folder path from the detection API
- display scan summary in the Image Management page
- update tests for new detection behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d0a64398c8331b10f8652e4b49b56