### PR TITLE
Add fix images tab

### DIFF
--- a/api-server/routes/transaction_images.js
+++ b/api-server/routes/transaction_images.js
@@ -36,7 +36,8 @@ router.delete('/cleanup/:days?', requireAuth, async (req, res, next) => {
 router.get('/detect_incomplete', requireAuth, async (req, res, next) => {
   try {
     const page = parseInt(req.query.page, 10) || 1;
-    const data = await detectIncompleteImages(page);
+    const perPage = parseInt(req.query.perPage, 10) || 100;
+    const data = await detectIncompleteImages(page, perPage);
     res.json(data);
   } catch (err) {
     next(err);

--- a/api-server/services/transactionImageService.js
+++ b/api-server/services/transactionImageService.js
@@ -144,6 +144,18 @@ function appendOptionalParts(row, base) {
   return sanitizeName(combined);
 }
 
+async function getTxnCodeSets() {
+  try {
+    const [rows] = await pool.query('SELECT UITransType, UITrtype FROM code_transaction');
+    return {
+      digits: new Set(rows.map((r) => String(r.UITransType)) || []),
+      letters: new Set(rows.map((r) => String(r.UITrtype).toUpperCase()) || []),
+    };
+  } catch {
+    return { digits: new Set(), letters: new Set() };
+  }
+}
+
 export async function findBenchmarkCode(name) {
   if (!name) return null;
   const base = path.basename(name, path.extname(name));
@@ -330,10 +342,14 @@ export async function detectIncompleteImages(page = 1, perPage = 100) {
   const { baseDir } = await getDirs();
   const results = [];
   const offset = (page - 1) * perPage;
-  let count = 0;
+  let totalFound = 0;
+  let totalScanned = 0;
   let hasMore = false;
+  const scannedDirs = new Set();
+  const codes = await getTxnCodeSets();
 
   async function walk(dir, rel) {
+    scannedDirs.add(rel || '/');
     let entries;
     try {
       entries = await fs.readdir(dir, { withFileTypes: true });
@@ -347,12 +363,21 @@ export async function detectIncompleteImages(page = 1, perPage = 100) {
         await walk(full, path.join(rel, entry.name));
         if (hasMore) return;
       } else if (entry.isFile()) {
+        totalScanned += 1;
         const ext = path.extname(entry.name);
         const base = path.basename(entry.name, ext);
         const { unique, suffix } = parseFileUnique(base);
         if (!unique) continue;
-        const parts = sanitizeName(base).split(/[_-]+/);
-        if (parts.some((p) => /^\d{4}$/.test(p) || /^[a-z]{4}$/i.test(p))) continue;
+        const cleaned = base.replace(new RegExp(`[_-]*${unique}[_-]*`, 'i'), '');
+        const parts = sanitizeName(cleaned)
+          .split(/[_-]+/)
+          .filter(Boolean);
+        if (
+          parts.some(
+            (p) => codes.digits.has(p) || codes.letters.has(p.toUpperCase()),
+          )
+        )
+          continue;
         const found = await findTxnByUniqueId(unique);
         if (!found) continue;
         const { row, configs, numField } = found;
@@ -385,8 +410,8 @@ export async function detectIncompleteImages(page = 1, perPage = 100) {
           finalBase = `${newBase}_${unique}${suffix}`;
         }
         const newName = `${finalBase}${ext}`;
-        count += 1;
-        if (count > offset && results.length < perPage) {
+        totalFound += 1;
+        if (totalFound > offset && results.length < perPage) {
           results.push({
             folder: folderRaw,
             folderDisplay,
@@ -403,7 +428,13 @@ export async function detectIncompleteImages(page = 1, perPage = 100) {
   }
 
   await walk(baseDir, '');
-  return { list: results, hasMore };
+  return {
+    list: results,
+    hasMore,
+    scanned: Array.from(scannedDirs),
+    total: totalFound,
+    files: totalScanned,
+  };
 }
 
 async function findTxnByUniqueId(idPart) {

--- a/src/erp.mgt.mn/pages/ImageManagement.jsx
+++ b/src/erp.mgt.mn/pages/ImageManagement.jsx
@@ -3,8 +3,15 @@ import { useToast } from '../context/ToastContext.jsx';
 
 export default function ImageManagement() {
   const { addToast } = useToast();
+  const [tab, setTab] = useState('cleanup');
   const [days, setDays] = useState('');
   const [result, setResult] = useState(null);
+
+  const [list, setList] = useState([]);
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(100);
+  const [hasMore, setHasMore] = useState(false);
+  const [selected, setSelected] = useState(new Set());
   async function handleCleanup() {
     const path = days ? `/api/transaction_images/cleanup/${days}` : '/api/transaction_images/cleanup';
     try {
@@ -22,24 +29,210 @@ export default function ImageManagement() {
     }
   }
 
+  async function fetchList(pg = page, pp = perPage) {
+    const params = new URLSearchParams({ page: pg, perPage: pp });
+    addToast('Detecting images...', 'info');
+    try {
+      const res = await fetch(`/api/transaction_images/detect_incomplete?${params}`, { credentials: 'include' });
+      if (!res.ok) throw new Error('failed');
+      const data = await res.json();
+      setList(data.list || []);
+      setHasMore(Boolean(data.hasMore));
+      setSelected(new Set());
+      const folders = (data.scanned || []).join(', ') || 'none';
+      const files = data.files || 0;
+      addToast(
+        `Scanned ${files} file(s) in ${folders}. Found ${data.total || 0} file(s)`,
+        'success',
+      );
+    } catch {
+      addToast('Detect failed', 'error');
+    }
+  }
+
+  function handleDetect() {
+    setPage(1);
+    fetchList(1, perPage);
+  }
+
+  function handlePrev() {
+    if (page > 1) {
+      const p = page - 1;
+      setPage(p);
+      fetchList(p, perPage);
+    }
+  }
+
+  function handleNext() {
+    if (hasMore) {
+      const p = page + 1;
+      setPage(p);
+      fetchList(p, perPage);
+    }
+  }
+
+  function handlePageSize(e) {
+    const val = parseInt(e.target.value, 10) || 100;
+    setPerPage(val);
+    setPage(1);
+    fetchList(1, val);
+  }
+
+  function toggleSelect(idx) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx);
+      else next.add(idx);
+      return next;
+    });
+  }
+
+  function handleDelete() {
+    setList(list.filter((_, i) => !selected.has(i)));
+    setSelected(new Set());
+  }
+
+  async function handleRename() {
+    const items = list.filter((_, i) => selected.has(i));
+    if (items.length === 0) return;
+    const preview = items.map((it) => `${it.currentName} -> ${it.folder}/${it.newName}`).join('\n');
+    if (!window.confirm(`Rename and move the following files?\n${preview}`)) return;
+    try {
+      const res = await fetch('/api/transaction_images/fix_incomplete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ list: items }),
+      });
+      if (!res.ok) throw new Error('failed');
+      const data = await res.json().catch(() => ({}));
+      addToast(`Renamed ${data.fixed || 0} file(s)`, 'success');
+      fetchList(page, perPage);
+    } catch {
+      addToast('Rename failed', 'error');
+    }
+  }
+
   return (
     <div>
       <h2>Image Management</h2>
       <div style={{ marginBottom: '0.5rem' }}>
-        <label>
-          Cleanup files older than (days):{' '}
-          <input
-            type="number"
-            value={days}
-            onChange={(e) => setDays(e.target.value)}
-            style={{ width: '4rem' }}
-          />
-        </label>
-        <button type="button" onClick={handleCleanup} style={{ marginLeft: '0.5rem' }}>
+        <button
+          onClick={() => setTab('cleanup')}
+          style={tab === 'cleanup' ? styles.activeTab : styles.tab}
+        >
           Cleanup
         </button>
+        <button
+          onClick={() => setTab('fix')}
+          style={tab === 'fix' ? styles.activeTab : styles.tab}
+        >
+          Fix Images
+        </button>
       </div>
-      {result !== null && <p>{result} file(s) removed.</p>}
+      {tab === 'cleanup' && (
+        <div style={{ marginBottom: '1rem' }}>
+          <label>
+            Cleanup files older than (days):{' '}
+            <input
+              type="number"
+              value={days}
+              onChange={(e) => setDays(e.target.value)}
+              style={{ width: '4rem' }}
+            />
+          </label>
+          <button type="button" onClick={handleCleanup} style={{ marginLeft: '0.5rem' }}>
+            Cleanup
+          </button>
+          {result !== null && <p>{result} file(s) removed.</p>}
+        </div>
+      )}
+      {tab === 'fix' && (
+        <div>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <button onClick={handleDetect}>Detect from host</button>
+            <label style={{ marginLeft: '1rem' }}>
+              Page Size:{' '}
+              <input
+                type="number"
+                value={perPage}
+                onChange={handlePageSize}
+                style={{ width: '4rem' }}
+              />
+            </label>
+            <button onClick={handlePrev} disabled={page <= 1} style={{ marginLeft: '0.5rem' }}>
+              Previous
+            </button>
+            <button onClick={handleNext} disabled={!hasMore} style={{ marginLeft: '0.5rem' }}>
+              Next
+            </button>
+            <button
+              onClick={handleDelete}
+              disabled={selected.size === 0}
+              style={{ marginLeft: '0.5rem' }}
+            >
+              Delete
+            </button>
+            <button
+              onClick={handleRename}
+              disabled={selected.size === 0}
+              style={{ marginLeft: '0.5rem' }}
+            >
+              Rename
+            </button>
+          </div>
+          {list.length === 0 ? (
+            <p>No files.</p>
+          ) : (
+            <div className="table-container overflow-x-auto" style={{ maxHeight: '70vh' }}>
+              <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                <thead>
+                  <tr style={{ backgroundColor: '#e5e7eb' }}>
+                    <th style={{ padding: '0.25rem', border: '1px solid #d1d5db' }}></th>
+                    <th style={{ padding: '0.25rem', border: '1px solid #d1d5db' }}>Current</th>
+                    <th style={{ padding: '0.25rem', border: '1px solid #d1d5db' }}>New Name</th>
+                    <th style={{ padding: '0.25rem', border: '1px solid #d1d5db' }}>Folder</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {list.map((item, idx) => (
+                    <tr key={idx}>
+                      <td style={{ padding: '0.25rem', border: '1px solid #d1d5db', textAlign: 'center' }}>
+                        <input
+                          type="checkbox"
+                          checked={selected.has(idx)}
+                          onChange={() => toggleSelect(idx)}
+                        />
+                      </td>
+                      <td style={{ padding: '0.25rem', border: '1px solid #d1d5db' }}>{item.currentName}</td>
+                      <td style={{ padding: '0.25rem', border: '1px solid #d1d5db' }}>{item.newName}</td>
+                      <td style={{ padding: '0.25rem', border: '1px solid #d1d5db' }}>{item.folderDisplay}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
+
+const styles = {
+  tab: {
+    padding: '0.25rem 0.5rem',
+    cursor: 'pointer',
+    backgroundColor: '#d1d5db',
+    border: '1px solid #9ca3af',
+    marginRight: '0.25rem',
+  },
+  activeTab: {
+    padding: '0.25rem 0.5rem',
+    cursor: 'pointer',
+    backgroundColor: '#ffffff',
+    border: '1px solid #9ca3af',
+    marginRight: '0.25rem',
+    borderBottom: 'none',
+  },
+};

--- a/tests/api/detectIncompleteImages.test.js
+++ b/tests/api/detectIncompleteImages.test.js
@@ -70,8 +70,11 @@ await test('detectIncompleteImages finds and fixes files', async () => {
     }
   }));
 
-  const { list, hasMore } = await detectIncompleteImages(1);
+  const { list, hasMore, scanned, total, files } = await detectIncompleteImages(1);
   assert.equal(hasMore, false);
+  assert.ok(Array.isArray(scanned));
+  assert.ok(typeof files === 'number');
+  assert.equal(total, 1);
   assert.equal(list.length, 1);
   assert.ok(list[0].newName.includes('num001'));
   assert.ok(list[0].newName.includes('z1_b1_bp1'));
@@ -89,6 +92,49 @@ await test('detectIncompleteImages finds and fixes files', async () => {
   await fs.writeFile(cfgPath, origCfg);
   await fs.rm(path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test'), { recursive: true, force: true });
   await fs.rm(path.join(process.cwd(), 'uploads', 'tmp'), { recursive: true, force: true });
+});
+
+await test('detectIncompleteImages skips files with txn codes', async () => {
+  await fs.rm(baseDir, { recursive: true, force: true });
+  await fs.mkdir(baseDir, { recursive: true });
+  const file = path.join(baseDir, '4001_tool_abc12345.jpg');
+  await fs.writeFile(file, 'x');
+
+  const row = {
+    id: 1,
+    test_num: 'abc12345',
+    label_field: 'num003',
+    trtype: '4001',
+    TransType: 'tool',
+  };
+
+  const restoreDb = mockPool(async (sql) => {
+    if (/code_transaction/.test(sql)) {
+      return [[{ UITransType: '4001', UITrtype: 'TOOL' }]];
+    }
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql)) {
+      return [[{ Field: 'test_num' }, { Field: 'label_field' }]];
+    }
+    if (/FROM `transactions_test`/.test(sql)) return [[row]];
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(cfgPath, JSON.stringify({
+    transactions_test: {
+      default: { imagenameField: ['label_field'], imageFolder: 'transactions_test' }
+    }
+  }));
+
+  const { list, total, files } = await detectIncompleteImages(1);
+  assert.ok(typeof files === 'number');
+  assert.equal(total, 0);
+  assert.equal(list.length, 0);
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(baseDir, { recursive: true, force: true });
 });
 
 await test('uploadSelectedImages renames on upload', async () => {


### PR DESCRIPTION
## Summary
- extend `detect_incomplete` endpoint with folder scan stats
- skip 4-letter/4-digit checks inside the unique ID when detecting
- show toast progress and summary in Image Management
- use transaction codes from `code_transaction` when detecting incomplete images
- add a test for files containing valid transaction codes
- show scanned folders and file count

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d1912b1408331a8d9bc92ad444917