### PR TITLE
feat: enhance image management

### DIFF
--- a/api-server/routes/transaction_images.js
+++ b/api-server/routes/transaction_images.js
@@ -36,7 +36,8 @@ router.delete('/cleanup/:days?', requireAuth, async (req, res, next) => {
 router.get('/detect_incomplete', requireAuth, async (req, res, next) => {
   try {
     const page = parseInt(req.query.page, 10) || 1;
-    const data = await detectIncompleteImages(page);
+    const perPage = parseInt(req.query.pageSize, 10) || 100;
+    const data = await detectIncompleteImages(page, perPage);
     res.json(data);
   } catch (err) {
     next(err);
@@ -55,8 +56,8 @@ router.post('/fix_incomplete', requireAuth, async (req, res, next) => {
 
 router.post('/upload_check', requireAuth, upload.array('images'), async (req, res, next) => {
   try {
-    const list = await checkUploadedImages(req.files || []);
-    res.json({ list });
+    const { list, summary } = await checkUploadedImages(req.files || []);
+    res.json({ list, summary });
   } catch (err) {
     next(err);
   }

--- a/tests/api/detectIncompleteImages.test.js
+++ b/tests/api/detectIncompleteImages.test.js
@@ -73,7 +73,8 @@ await test('checkUploadedImages renames on upload', async () => {
     }
   }));
 
-  const list = await checkUploadedImages([{ originalname: 'abc12345.jpg', path: tmp }]);
+  const { list, summary } = await checkUploadedImages([{ originalname: 'abc12345.jpg', path: tmp }]);
+  assert.equal(summary.processed, 1);
   assert.equal(list.length, 1);
   assert.ok(list[0].newName.includes('num002'));
 


### PR DESCRIPTION
## Summary
- scan host and folder images with pagination, folder summaries, and rename logic
- allow folder selection with summaries and row deletion
- expose rename helpers via updated API routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688de35f4a008331be32ffe8b95e00d7