### PR TITLE
feat: improve image management

### DIFF
--- a/src/erp.mgt.mn/pages/ImageManagement.jsx
+++ b/src/erp.mgt.mn/pages/ImageManagement.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useRef } from 'react';
 import { useToast } from '../context/ToastContext.jsx';
 
 export default function ImageManagement() {
@@ -46,6 +46,26 @@ export default function ImageManagement() {
     }
   }
 
+  async function selectFolder() {
+    if (window.showDirectoryPicker) {
+      try {
+        const dirHandle = await window.showDirectoryPicker();
+        const arr = [];
+        for await (const entry of dirHandle.values()) {
+          if (entry.kind === 'file') {
+            arr.push(await entry.getFile());
+          }
+        }
+        setFolderName(dirHandle.name || '');
+        await handleSelectFiles(arr);
+      } catch {
+        // ignore
+      }
+    } else {
+      fileRef.current?.click();
+    }
+  }
+
   async function handleCleanup() {
     const path = days ? `/api/transaction_images/cleanup/${days}` : '/api/transaction_images/cleanup';
     try {
@@ -63,14 +83,9 @@ export default function ImageManagement() {
     }
   }
 
-  useEffect(() => {
-    if (tab !== 'fix') return;
-    refreshList();
-  }, [tab, page, pageSize]);
-
-  async function refreshList() {
+  async function detectFromHost(p = page, s = pageSize) {
     try {
-      const res = await fetch(`/api/transaction_images/detect_incomplete?page=${page}&pageSize=${pageSize}`, {
+      const res = await fetch(`/api/transaction_images/detect_incomplete?page=${p}&pageSize=${s}`, {
         credentials: 'include',
       });
       if (res.ok) {
@@ -89,6 +104,8 @@ export default function ImageManagement() {
       setPendingSummary(null);
       setHasMore(false);
     }
+    setPage(p);
+    setPageSize(s);
   }
 
   async function applyFixes() {
@@ -103,7 +120,7 @@ export default function ImageManagement() {
     if (res.ok) {
       const data = await res.json().catch(() => ({}));
       addToast(`Renamed ${data.fixed || 0} file(s)`, 'success');
-      refreshList();
+      detectFromHost(page);
     } else {
       addToast('Rename failed', 'error');
     }
@@ -190,7 +207,7 @@ export default function ImageManagement() {
       ) : (
         <div>
           <div style={{ marginBottom: '0.5rem' }}>
-            <button type="button" onClick={() => fileRef.current?.click()} style={{ marginRight: '0.5rem' }}>
+            <button type="button" onClick={selectFolder} style={{ marginRight: '0.5rem' }}>
               Select Folder
             </button>
             {folderName && <span style={{ marginRight: '0.5rem' }}>{folderName}</span>}
@@ -203,31 +220,6 @@ export default function ImageManagement() {
               style={{ display: 'none' }}
               onChange={(e) => handleSelectFiles(e.target.files)}
             />
-            <button type="button" onClick={refreshList} style={{ marginRight: '0.5rem' }}>
-              Refresh
-            </button>
-            <label style={{ marginRight: '0.5rem' }}>
-              Page Size:{' '}
-              <select
-                value={pageSize}
-                onChange={(e) => {
-                  setPageSize(Number(e.target.value));
-                  setPage(1);
-                }}
-              >
-                {[50, 100, 200].map((n) => (
-                  <option key={n} value={n}>
-                    {n}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <button type="button" disabled={page === 1} onClick={() => setPage(page - 1)} style={{ marginRight: '0.5rem' }}>
-              Prev
-            </button>
-            <button type="button" disabled={!hasMore} onClick={() => setPage(page + 1)}>
-              Next
-            </button>
           </div>
           {uploadSummary && (
             <p style={{ marginBottom: '0.5rem' }}>
@@ -244,6 +236,17 @@ export default function ImageManagement() {
                 disabled={uploadSel.length === 0}
               >
                 Rename &amp; Upload Selected
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setUploads((prev) => prev.filter((u) => !uploadSel.includes(u.tmpPath)));
+                  setUploadSel([]);
+                }}
+                style={{ marginBottom: '0.5rem', marginLeft: '0.5rem' }}
+                disabled={uploadSel.length === 0}
+              >
+                Delete Selected
               </button>
               <table className="min-w-full border border-gray-300 text-sm" style={{ tableLayout: 'fixed' }}>
                 <thead>
@@ -283,6 +286,35 @@ export default function ImageManagement() {
               </table>
             </div>
           )}
+          <div style={{ marginBottom: '0.5rem', marginTop: '1rem' }}>
+            <button type="button" onClick={() => detectFromHost(1)} style={{ marginRight: '0.5rem' }}>
+              Detect from host
+            </button>
+            <label style={{ marginRight: '0.5rem' }}>
+              Page Size:{' '}
+              <select
+                value={pageSize}
+                onChange={(e) => detectFromHost(1, Number(e.target.value))}
+              >
+                {[50, 100, 200].map((n) => (
+                  <option key={n} value={n}>
+                    {n}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              type="button"
+              disabled={page === 1}
+              onClick={() => detectFromHost(page - 1)}
+              style={{ marginRight: '0.5rem' }}
+            >
+              Prev
+            </button>
+            <button type="button" disabled={!hasMore} onClick={() => detectFromHost(page + 1)}>
+              Next
+            </button>
+          </div>
           {pendingSummary && (
             <p style={{ marginBottom: '0.5rem' }}>
               {`Scanned ${pendingSummary.totalFiles || 0} file(s) in ${pendingSummary.folders?.length || 0} folder(s)`}
@@ -301,6 +333,17 @@ export default function ImageManagement() {
                 disabled={selected.length === 0}
               >
                 Rename &amp; Move Selected
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setPending((prev) => prev.filter((p) => !selected.includes(p.currentName)));
+                  setSelected([]);
+                }}
+                style={{ marginBottom: '0.5rem', marginLeft: '0.5rem' }}
+                disabled={selected.length === 0}
+              >
+                Delete Selected
               </button>
               <table className="min-w-full border border-gray-300 text-sm" style={{ tableLayout: 'fixed' }}>
                 <thead>

--- a/tests/api/detectIncompleteImages.test.js
+++ b/tests/api/detectIncompleteImages.test.js
@@ -20,7 +20,13 @@ await test('detectIncompleteImages finds and fixes files', async () => {
   const file = path.join(baseDir, 'abc12345.jpg');
   await fs.writeFile(file, 'x');
 
-  const row = { id: 1, test_num: 'abc12345', label_field: 'num001' };
+  const row = {
+    id: 1,
+    test_num: 'abc12345',
+    label_field: 'num001',
+    trtype: 't1',
+    TransType: 'A',
+  };
 
   const restoreDb = mockPool(async (sql) => {
     if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
@@ -30,11 +36,14 @@ await test('detectIncompleteImages finds and fixes files', async () => {
   });
 
   const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
-  await fs.writeFile(cfgPath, JSON.stringify({
-    transactions_test: {
-      default: { imagenameField: ['label_field'], imageFolder: 'transactions_test' }
-    }
-  }));
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: { imagenameField: ['label_field'], transactionTypeValue: 'A' },
+      },
+    }),
+  );
 
   const { list, hasMore } = await detectIncompleteImages(1);
   assert.equal(hasMore, false);
@@ -44,7 +53,9 @@ await test('detectIncompleteImages finds and fixes files', async () => {
   const count = await fixIncompleteImages(list);
   assert.equal(count, 1);
 
-  const exists = await fs.readdir(baseDir);
+  const exists = await fs.readdir(
+    path.join(process.cwd(), 'uploads', 'txn_images', 't1', 'a'),
+  );
   assert.ok(exists.some((f) => f.includes('num001')));
 
   restoreDb();
@@ -58,7 +69,13 @@ await test('checkUploadedImages renames on upload', async () => {
   const tmp = path.join(process.cwd(), 'uploads', 'tmp', 'abc12345.jpg');
   await fs.writeFile(tmp, 'x');
 
-  const row = { id: 1, test_num: 'abc12345', label_field: 'num002' };
+  const row = {
+    id: 1,
+    test_num: 'abc12345',
+    label_field: 'num002',
+    trtype: 't1',
+    TransType: 'A',
+  };
   const restoreDb = mockPool(async (sql) => {
     if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
     if (/SHOW COLUMNS FROM/.test(sql)) return [[{ Field: 'test_num' }, { Field: 'label_field' }]];
@@ -67,11 +84,14 @@ await test('checkUploadedImages renames on upload', async () => {
   });
 
   const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
-  await fs.writeFile(cfgPath, JSON.stringify({
-    transactions_test: {
-      default: { imagenameField: ['label_field'], imageFolder: 'transactions_test' }
-    }
-  }));
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: { imagenameField: ['label_field'], transactionTypeValue: 'A' },
+      },
+    }),
+  );
 
   const { list, summary } = await checkUploadedImages([{ originalname: 'abc12345.jpg', path: tmp }]);
   assert.equal(summary.processed, 1);
@@ -80,8 +100,53 @@ await test('checkUploadedImages renames on upload', async () => {
 
   const uploaded = await commitUploadedImages(list);
   assert.equal(uploaded, 1);
-  const exists = await fs.readdir(path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test'));
+  const exists = await fs.readdir(
+    path.join(process.cwd(), 'uploads', 'txn_images', 't1', 'a'),
+  );
   assert.ok(exists.some((f) => f.includes('num002')));
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});
+
+await test('detectIncompleteImages fallback naming', async () => {
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  const dir = path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test');
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, 'xyz98765.jpg');
+  await fs.writeFile(file, 'x');
+
+  const row = {
+    id: 1,
+    test_num: 'xyz98765',
+    bmtr_orderid: 'o100',
+    bmtr_orderdid: 'd200',
+    trtype: 't2',
+    TransType: 'B',
+  };
+
+  const restoreDb = mockPool(async (sql) => {
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql))
+      return [[{ Field: 'test_num' }, { Field: 'bmtr_orderid' }, { Field: 'bmtr_orderdid' }]];
+    if (/FROM `transactions_test`/.test(sql)) return [[row]];
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(cfgPath, JSON.stringify({ transactions_test: { default: {} } }));
+
+  const { list } = await detectIncompleteImages(1);
+  assert.equal(list.length, 1);
+  assert.ok(list[0].newName.includes('o100_d200_b_t2'));
+
+  const moved = await fixIncompleteImages(list);
+  assert.equal(moved, 1);
+  const exists = await fs.readdir(
+    path.join(process.cwd(), 'uploads', 'txn_images', 't2', 'b'),
+  );
+  assert.ok(exists.some((f) => f.includes('o100_d200_b_t2')));
 
   restoreDb();
   await fs.writeFile(cfgPath, origCfg);


### PR DESCRIPTION
## Summary
- streamline folder selection and allow manual host detection
- refine rename fallback using order and type fields
- cover rename fallback with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688de7829d1c8331a1f8f1976d58bc8e