### PR TITLE
feat: improve image management

### DIFF
--- a/tests/api/detectIncompleteImages.test.js
+++ b/tests/api/detectIncompleteImages.test.js
@@ -20,7 +20,13 @@ await test('detectIncompleteImages finds and fixes files', async () => {
   const file = path.join(baseDir, 'abc12345.jpg');
   await fs.writeFile(file, 'x');
 
-  const row = { id: 1, test_num: 'abc12345', label_field: 'num001' };
+  const row = {
+    id: 1,
+    test_num: 'abc12345',
+    label_field: 'num001',
+    trtype: 't1',
+    TransType: 'A',
+  };
 
   const restoreDb = mockPool(async (sql) => {
     if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
@@ -30,11 +36,14 @@ await test('detectIncompleteImages finds and fixes files', async () => {
   });
 
   const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
-  await fs.writeFile(cfgPath, JSON.stringify({
-    transactions_test: {
-      default: { imagenameField: ['label_field'], imageFolder: 'transactions_test' }
-    }
-  }));
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: { imagenameField: ['label_field'], transactionTypeValue: 'A' },
+      },
+    }),
+  );
 
   const { list, hasMore } = await detectIncompleteImages(1);
   assert.equal(hasMore, false);
@@ -44,7 +53,9 @@ await test('detectIncompleteImages finds and fixes files', async () => {
   const count = await fixIncompleteImages(list);
   assert.equal(count, 1);
 
-  const exists = await fs.readdir(baseDir);
+  const exists = await fs.readdir(
+    path.join(process.cwd(), 'uploads', 'txn_images', 't1', 'a'),
+  );
   assert.ok(exists.some((f) => f.includes('num001')));
 
   restoreDb();
@@ -58,7 +69,13 @@ await test('checkUploadedImages renames on upload', async () => {
   const tmp = path.join(process.cwd(), 'uploads', 'tmp', 'abc12345.jpg');
   await fs.writeFile(tmp, 'x');
 
-  const row = { id: 1, test_num: 'abc12345', label_field: 'num002' };
+  const row = {
+    id: 1,
+    test_num: 'abc12345',
+    label_field: 'num002',
+    trtype: 't1',
+    TransType: 'A',
+  };
   const restoreDb = mockPool(async (sql) => {
     if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
     if (/SHOW COLUMNS FROM/.test(sql)) return [[{ Field: 'test_num' }, { Field: 'label_field' }]];
@@ -67,11 +84,14 @@ await test('checkUploadedImages renames on upload', async () => {
   });
 
   const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
-  await fs.writeFile(cfgPath, JSON.stringify({
-    transactions_test: {
-      default: { imagenameField: ['label_field'], imageFolder: 'transactions_test' }
-    }
-  }));
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: { imagenameField: ['label_field'], transactionTypeValue: 'A' },
+      },
+    }),
+  );
 
   const { list, summary } = await checkUploadedImages([{ originalname: 'abc12345.jpg', path: tmp }]);
   assert.equal(summary.processed, 1);
@@ -80,8 +100,53 @@ await test('checkUploadedImages renames on upload', async () => {
 
   const uploaded = await commitUploadedImages(list);
   assert.equal(uploaded, 1);
-  const exists = await fs.readdir(path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test'));
+  const exists = await fs.readdir(
+    path.join(process.cwd(), 'uploads', 'txn_images', 't1', 'a'),
+  );
   assert.ok(exists.some((f) => f.includes('num002')));
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});
+
+await test('detectIncompleteImages fallback naming', async () => {
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  const dir = path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test');
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, 'xyz98765.jpg');
+  await fs.writeFile(file, 'x');
+
+  const row = {
+    id: 1,
+    test_num: 'xyz98765',
+    bmtr_orderid: 'o100',
+    bmtr_orderdid: 'd200',
+    trtype: 't2',
+    TransType: 'B',
+  };
+
+  const restoreDb = mockPool(async (sql) => {
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql))
+      return [[{ Field: 'test_num' }, { Field: 'bmtr_orderid' }, { Field: 'bmtr_orderdid' }]];
+    if (/FROM `transactions_test`/.test(sql)) return [[row]];
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(cfgPath, JSON.stringify({ transactions_test: { default: {} } }));
+
+  const { list } = await detectIncompleteImages(1);
+  assert.equal(list.length, 1);
+  assert.ok(list[0].newName.includes('o100_d200_b_t2'));
+
+  const moved = await fixIncompleteImages(list);
+  assert.equal(moved, 1);
+  const exists = await fs.readdir(
+    path.join(process.cwd(), 'uploads', 'txn_images', 't2', 'b'),
+  );
+  assert.ok(exists.some((f) => f.includes('o100_d200_b_t2')));
 
   restoreDb();
   await fs.writeFile(cfgPath, origCfg);


### PR DESCRIPTION
## Summary
- allow Escape to cancel host detection or folder scans after confirming
- rely on directory picker for folder selection and remove upload fallback
- ensure upload checks can be aborted

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688de7829d1c8331a1f8f1976d58bc8e