### PR TITLE
feat: improve image management

### DIFF
--- a/api-server/routes/transaction_images.js
+++ b/api-server/routes/transaction_images.js
@@ -56,7 +56,8 @@ router.post('/fix_incomplete', requireAuth, async (req, res, next) => {
 
 router.post('/upload_check', requireAuth, upload.array('images'), async (req, res, next) => {
   try {
-    const { list, summary } = await checkUploadedImages(req.files || []);
+    const names = Array.isArray(req.body?.names) ? req.body.names : [];
+    const { list, summary } = await checkUploadedImages(req.files || [], names);
     res.json({ list, summary });
   } catch (err) {
     next(err);

--- a/api-server/services/transactionImageService.js
+++ b/api-server/services/transactionImageService.js
@@ -42,22 +42,35 @@ function buildNameFromRow(row, fields = []) {
 
 function pickConfig(configs = {}, row = {}) {
   for (const cfg of Object.values(configs)) {
-    if (!cfg.transactionTypeField || !cfg.transactionTypeValue) continue;
-    const val = getCase(row, cfg.transactionTypeField);
-    if (val !== undefined && String(val) === String(cfg.transactionTypeValue)) {
-      return cfg;
+    if (!cfg.transactionTypeValue) continue;
+    if (cfg.transactionTypeField) {
+      const val = getCase(row, cfg.transactionTypeField);
+      if (val !== undefined && String(val) === String(cfg.transactionTypeValue)) {
+        return cfg;
+      }
+    } else {
+      const matchField = Object.keys(row).find(
+        (k) => String(getCase(row, k)) === String(cfg.transactionTypeValue),
+      );
+      if (matchField) {
+        return { ...cfg, transactionTypeField: matchField };
+      }
     }
   }
   return Object.values(configs)[0] || {};
 }
 
 function extractUnique(str) {
-  const uuid = str.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+  // Strip saveImages timestamp/random suffix if present
+  const cleaned = str.replace(/_[0-9]{13}_[a-z0-9]{6}$/i, '');
+  const uuid = cleaned.match(
+    /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i,
+  );
   if (uuid) return uuid[0];
-  const alt = str.match(/[A-Z0-9]{4}(?:-[A-Z0-9]{4}){3}/);
-  if (alt) return alt[0];
-  const long = str.match(/[A-Za-z0-9-]{8,}/);
-  return long ? long[0] : '';
+  const alt = cleaned.match(/[A-Za-z0-9]{4,}(?:[-_][A-Za-z0-9]{4,}){3,}/);
+  if (alt) return alt[0].replace(/[-_]\d+$/, '');
+  const long = cleaned.match(/[A-Za-z0-9_-]{8,}/);
+  return long ? long[0].replace(/[-_]\d+$/, '') : '';
 }
 
 function parseFileUnique(base) {
@@ -104,6 +117,50 @@ export async function findBenchmarkCode(name) {
     const mark = row.UITrtype;
     if (mark && base.toLowerCase().includes(String(mark).toLowerCase())) {
       return row.UITransType;
+    }
+  }
+  return null;
+}
+
+async function findTxnByParts(inv, sp, transType, timestamp) {
+  let tables;
+  try {
+    [tables] = await pool.query("SHOW TABLES LIKE 'transactions_%'");
+  } catch {
+    return null;
+  }
+  for (const row of tables || []) {
+    const tbl = Object.values(row)[0];
+    let cols;
+    try {
+      [cols] = await pool.query(`SHOW COLUMNS FROM \`${tbl}\``);
+    } catch {
+      continue;
+    }
+    const invCol = cols.find((c) => ['inventory_code', 'z_mat_code'].includes(c.Field.toLowerCase()));
+    const spCol = cols.find((c) => c.Field.toLowerCase() === 'sp_primary_code');
+    const transCol = cols.find((c) => ['transtype', 'uitranstype', 'ui_transtype'].includes(c.Field.toLowerCase()));
+    const dateCol = cols.find((c) => c.Field.toLowerCase().includes('date'));
+    if (!invCol || !spCol || !transCol) continue;
+    let sql = `SELECT * FROM \`${tbl}\` WHERE \`${invCol.Field}\` = ? AND \`${spCol.Field}\` = ? AND \`${transCol.Field}\` = ?`;
+    const params = [inv, sp, transType];
+    if (dateCol) {
+      sql += ` AND ABS(TIMESTAMPDIFF(SECOND, FROM_UNIXTIME(?/1000), \`${dateCol.Field}\`)) < 86400`;
+      params.push(timestamp);
+    }
+    sql += ' LIMIT 1';
+    let rows;
+    try {
+      [rows] = await pool.query(sql, params);
+    } catch {
+      continue;
+    }
+    if (rows.length) {
+      let cfgs = {};
+      try {
+        cfgs = await getConfigsByTable(tbl);
+      } catch {}
+      return { table: tbl, row: rows[0], configs: cfgs, numField: transCol.Field };
     }
   }
   return null;
@@ -295,35 +352,53 @@ export async function detectIncompleteImages(page = 1, perPage = 100) {
     }
     folders.add(entry.name);
     totalFiles += files.length;
-    files = files.slice(0, 1000);
+    const limit = perPage * page;
+    files = files.slice(0, limit);
     for (const f of files) {
       const ext = path.extname(f);
       const base = path.basename(f, ext);
       const parts = base.split('_');
-      if (parts.length >= 5) continue;
-      const { unique, suffix } = parseFileUnique(base);
-      if (!unique || unique.length < 8) continue;
-      const found = await findTxnByUniqueId(unique);
+      const isSave = /_\d{13}_[a-z0-9]{6}$/i.test(base);
+      if (parts.length >= 5 && !isSave) continue;
+      let unique = '';
+      let suffix = '';
+      let found;
+      if (isSave) {
+        const [inv, sp, transType, ts] = parts;
+        found = await findTxnByParts(inv, sp, transType, Number(ts));
+      } else {
+        ({ unique, suffix } = parseFileUnique(base));
+        if (!unique || unique.length < 8) continue;
+        found = await findTxnByUniqueId(unique);
+      }
       if (!found) continue;
       const { row, configs, numField } = found;
 
       const cfg = pickConfig(configs, row);
       let newBase = '';
       let folderRaw = '';
-      const tType = getCase(row, 'trtype');
+      const tType =
+        getCase(row, 'trtype') ||
+        getCase(row, 'UITrtype') ||
+        getCase(row, 'TRTYPENAME') ||
+        getCase(row, 'trtypename') ||
+        getCase(row, 'uitranstypename') ||
+        getCase(row, 'transtype');
       const transTypeVal =
         getCase(row, 'TransType') ||
         getCase(row, 'UITransType') ||
         getCase(row, 'UITransTypeName') ||
         getCase(row, 'transtype');
-      if (cfg?.imagenameField?.length) {
+      if (
+        cfg?.imagenameField?.length &&
+        tType &&
+        cfg.transactionTypeValue &&
+        cfg.transactionTypeField &&
+        String(getCase(row, cfg.transactionTypeField)) === String(cfg.transactionTypeValue)
+      ) {
         newBase = buildNameFromRow(row, cfg.imagenameField);
         if (newBase) {
-          if (tType && cfg.transactionTypeValue) {
-            folderRaw = `${slugify(String(tType))}/${slugify(String(cfg.transactionTypeValue))}`;
-          } else {
-            folderRaw = buildFolderName(row, cfg.imageFolder || entry.name);
-          }
+          folderRaw = `${slugify(String(tType))}/${slugify(String(cfg.transactionTypeValue))}`;
         }
       }
       if (!newBase) {
@@ -335,7 +410,7 @@ export async function detectIncompleteImages(page = 1, perPage = 100) {
           'sp_primary_code',
           'pid',
         ];
-        let baseName = buildNameFromRow(row, fields);
+        const basePart = buildNameFromRow(row, fields);
         const o1 = [getCase(row, 'bmtr_orderid'), getCase(row, 'bmtr_orderdid')]
           .filter(Boolean)
           .join('~');
@@ -343,9 +418,11 @@ export async function detectIncompleteImages(page = 1, perPage = 100) {
           .filter(Boolean)
           .join('~');
         const ord = o1 || o2;
-        if (baseName && ord && tType && transTypeVal) {
-          baseName = sanitizeName([baseName, ord, transTypeVal, tType].join('_'));
-          newBase = baseName;
+        if (ord && tType && transTypeVal) {
+          const parts = [];
+          if (basePart) parts.push(basePart);
+          parts.push(ord, transTypeVal, tType);
+          newBase = sanitizeName(parts.join('_'));
           folderRaw = `${slugify(String(tType))}/${slugify(String(transTypeVal))}`;
         }
       }
@@ -358,10 +435,12 @@ export async function detectIncompleteImages(page = 1, perPage = 100) {
       const folderDisplay = '/' + String(folderRaw).replace(/^\/+/, '');
       const sanitizedUnique = sanitizeName(unique);
       let finalBase = newBase;
-      if (sanitizeName(newBase).includes(sanitizedUnique)) {
-        finalBase = `${newBase}${suffix}`;
-      } else {
-        finalBase = `${newBase}_${unique}${suffix}`;
+      if (unique) {
+        if (sanitizeName(newBase).includes(sanitizedUnique)) {
+          finalBase = `${newBase}${suffix}`;
+        } else {
+          finalBase = `${newBase}_${unique}${suffix}`;
+        }
       }
       const newName = `${finalBase}${ext}`;
       count += 1;
@@ -434,36 +513,55 @@ export async function fixIncompleteImages(list = []) {
   return count;
 }
 
-export async function checkUploadedImages(files = []) {
+export async function checkUploadedImages(files = [], names = []) {
   const results = [];
   let processed = 0;
   const limit = 1000;
-  files = files.slice(0, limit);
-  for (const file of files) {
-    const ext = path.extname(file.originalname);
-    const base = path.basename(file.originalname, ext);
-    const { unique, suffix } = parseFileUnique(base);
-    if (!unique) continue;
-    const found = await findTxnByUniqueId(unique);
+  let items = files.length ? files : names.map((n) => ({ originalname: n }));
+  items = items.slice(0, limit);
+  for (const file of items) {
+    const ext = path.extname(file.originalname || '');
+    const base = path.basename(file.originalname || '', ext);
+    const parts = base.split('_');
+    const isSave = /_\d{13}_[a-z0-9]{6}$/i.test(base);
+    let unique = '';
+    let suffix = '';
+    let found;
+    if (isSave) {
+      const [inv, sp, transType, ts] = parts;
+      found = await findTxnByParts(inv, sp, transType, Number(ts));
+    } else {
+      ({ unique, suffix } = parseFileUnique(base));
+      if (!unique) continue;
+      found = await findTxnByUniqueId(unique);
+    }
     if (!found) continue;
     const { row, configs, numField } = found;
     const cfg = pickConfig(configs, row);
     let newBase = '';
     let folderRaw = '';
-    const tType = getCase(row, 'trtype');
+    const tType =
+      getCase(row, 'trtype') ||
+      getCase(row, 'UITrtype') ||
+      getCase(row, 'TRTYPENAME') ||
+      getCase(row, 'trtypename') ||
+      getCase(row, 'uitranstypename') ||
+      getCase(row, 'transtype');
     const transTypeVal =
       getCase(row, 'TransType') ||
       getCase(row, 'UITransType') ||
       getCase(row, 'UITransTypeName') ||
       getCase(row, 'transtype');
-    if (cfg?.imagenameField?.length) {
+    if (
+      cfg?.imagenameField?.length &&
+      tType &&
+      cfg.transactionTypeValue &&
+      cfg.transactionTypeField &&
+      String(getCase(row, cfg.transactionTypeField)) === String(cfg.transactionTypeValue)
+    ) {
       newBase = buildNameFromRow(row, cfg.imagenameField);
       if (newBase) {
-        if (tType && cfg.transactionTypeValue) {
-          folderRaw = `${slugify(String(tType))}/${slugify(String(cfg.transactionTypeValue))}`;
-        } else {
-          folderRaw = buildFolderName(row, cfg.imageFolder || found.table);
-        }
+        folderRaw = `${slugify(String(tType))}/${slugify(String(cfg.transactionTypeValue))}`;
       }
     }
     if (!newBase) {
@@ -475,7 +573,7 @@ export async function checkUploadedImages(files = []) {
         'sp_primary_code',
         'pid',
       ];
-      let baseName = buildNameFromRow(row, fields);
+      const basePart = buildNameFromRow(row, fields);
       const o1 = [getCase(row, 'bmtr_orderid'), getCase(row, 'bmtr_orderdid')]
         .filter(Boolean)
         .join('~');
@@ -483,9 +581,11 @@ export async function checkUploadedImages(files = []) {
         .filter(Boolean)
         .join('~');
       const ord = o1 || o2;
-      if (baseName && ord && tType && transTypeVal) {
-        baseName = sanitizeName([baseName, ord, transTypeVal, tType].join('_'));
-        newBase = baseName;
+      if (ord && tType && transTypeVal) {
+        const partsArr = [];
+        if (basePart) partsArr.push(basePart);
+        partsArr.push(ord, transTypeVal, tType);
+        newBase = sanitizeName(partsArr.join('_'));
         folderRaw = `${slugify(String(tType))}/${slugify(String(transTypeVal))}`;
       }
     }
@@ -498,10 +598,12 @@ export async function checkUploadedImages(files = []) {
     const folderDisplay = '/' + String(folderRaw).replace(/^\/+/, '');
     const sanitizedUnique = sanitizeName(unique);
     let finalBase = newBase;
-    if (sanitizeName(newBase).includes(sanitizedUnique)) {
-      finalBase = `${newBase}${suffix}`;
-    } else {
-      finalBase = `${newBase}_${unique}${suffix}`;
+    if (unique) {
+      if (sanitizeName(newBase).includes(sanitizedUnique)) {
+        finalBase = `${newBase}${suffix}`;
+      } else {
+        finalBase = `${newBase}_${unique}${suffix}`;
+      }
     }
     const newName = `${finalBase}${ext}`;
     results.push({
@@ -510,9 +612,10 @@ export async function checkUploadedImages(files = []) {
       newName,
       folder: folderRaw,
       folderDisplay,
+      id: file.path || file.originalname,
     });
   }
-  return { list: results, summary: { totalFiles: files.length, processed } };
+  return { list: results, summary: { totalFiles: items.length, processed } };
 }
 
 export async function commitUploadedImages(list = []) {

--- a/tests/api/detectIncompleteImages.test.js
+++ b/tests/api/detectIncompleteImages.test.js
@@ -20,7 +20,13 @@ await test('detectIncompleteImages finds and fixes files', async () => {
   const file = path.join(baseDir, 'abc12345.jpg');
   await fs.writeFile(file, 'x');
 
-  const row = { id: 1, test_num: 'abc12345', label_field: 'num001' };
+  const row = {
+    id: 1,
+    test_num: 'abc12345',
+    label_field: 'num001',
+    trtype: 't1',
+    TransType: 'A',
+  };
 
   const restoreDb = mockPool(async (sql) => {
     if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
@@ -30,11 +36,14 @@ await test('detectIncompleteImages finds and fixes files', async () => {
   });
 
   const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
-  await fs.writeFile(cfgPath, JSON.stringify({
-    transactions_test: {
-      default: { imagenameField: ['label_field'], imageFolder: 'transactions_test' }
-    }
-  }));
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: { imagenameField: ['label_field'], transactionTypeValue: 'A' },
+      },
+    }),
+  );
 
   const { list, hasMore } = await detectIncompleteImages(1);
   assert.equal(hasMore, false);
@@ -44,7 +53,9 @@ await test('detectIncompleteImages finds and fixes files', async () => {
   const count = await fixIncompleteImages(list);
   assert.equal(count, 1);
 
-  const exists = await fs.readdir(baseDir);
+  const exists = await fs.readdir(
+    path.join(process.cwd(), 'uploads', 'txn_images', 't1', 'a'),
+  );
   assert.ok(exists.some((f) => f.includes('num001')));
 
   restoreDb();
@@ -58,7 +69,13 @@ await test('checkUploadedImages renames on upload', async () => {
   const tmp = path.join(process.cwd(), 'uploads', 'tmp', 'abc12345.jpg');
   await fs.writeFile(tmp, 'x');
 
-  const row = { id: 1, test_num: 'abc12345', label_field: 'num002' };
+  const row = {
+    id: 1,
+    test_num: 'abc12345',
+    label_field: 'num002',
+    trtype: 't1',
+    TransType: 'A',
+  };
   const restoreDb = mockPool(async (sql) => {
     if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
     if (/SHOW COLUMNS FROM/.test(sql)) return [[{ Field: 'test_num' }, { Field: 'label_field' }]];
@@ -67,11 +84,14 @@ await test('checkUploadedImages renames on upload', async () => {
   });
 
   const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
-  await fs.writeFile(cfgPath, JSON.stringify({
-    transactions_test: {
-      default: { imagenameField: ['label_field'], imageFolder: 'transactions_test' }
-    }
-  }));
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: { imagenameField: ['label_field'], transactionTypeValue: 'A' },
+      },
+    }),
+  );
 
   const { list, summary } = await checkUploadedImages([{ originalname: 'abc12345.jpg', path: tmp }]);
   assert.equal(summary.processed, 1);
@@ -80,8 +100,226 @@ await test('checkUploadedImages renames on upload', async () => {
 
   const uploaded = await commitUploadedImages(list);
   assert.equal(uploaded, 1);
-  const exists = await fs.readdir(path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test'));
+  const exists = await fs.readdir(
+    path.join(process.cwd(), 'uploads', 'txn_images', 't1', 'a'),
+  );
   assert.ok(exists.some((f) => f.includes('num002')));
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});
+
+await test('detectIncompleteImages fallback naming', async () => {
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  const dir = path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test');
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, 'xyz98765.jpg');
+  await fs.writeFile(file, 'x');
+
+  const row = {
+    id: 1,
+    test_num: 'xyz98765',
+    bmtr_orderid: 'o100',
+    bmtr_orderdid: 'd200',
+    trtype: 't2',
+    TransType: 'B',
+  };
+
+  const restoreDb = mockPool(async (sql) => {
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql))
+      return [[{ Field: 'test_num' }, { Field: 'bmtr_orderid' }, { Field: 'bmtr_orderdid' }]];
+    if (/FROM `transactions_test`/.test(sql)) return [[row]];
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(cfgPath, JSON.stringify({ transactions_test: { default: {} } }));
+
+  const { list } = await detectIncompleteImages(1);
+  assert.equal(list.length, 1);
+  assert.ok(list[0].newName.includes('o100_d200_b_t2'));
+
+  const moved = await fixIncompleteImages(list);
+  assert.equal(moved, 1);
+  const exists = await fs.readdir(
+    path.join(process.cwd(), 'uploads', 'txn_images', 't2', 'b'),
+  );
+  assert.ok(exists.some((f) => f.includes('o100_d200_b_t2')));
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});
+
+await test('detectIncompleteImages handles timestamped names without trtype', async () => {
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  const dir = path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test');
+  await fs.mkdir(dir, { recursive: true });
+  const ts = 1754112726584;
+  const file = path.join(dir, `300021_300021_4001_${ts}_c2kene.jpg`);
+  await fs.writeFile(file, 'x');
+
+  const row = {
+    id: 1,
+    z_mat_code: '300021',
+    sp_primary_code: '300021',
+    TransType: '4001',
+    UITrtype: 't3',
+    label_field: 'img003',
+    created_at: new Date(ts),
+  };
+
+  const restoreDb = mockPool(async (sql) => {
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql))
+      return [[
+        { Field: 'z_mat_code' },
+        { Field: 'sp_primary_code' },
+        { Field: 'TransType' },
+        { Field: 'UITrtype' },
+        { Field: 'created_at' },
+        { Field: 'label_field' },
+      ]];
+    if (/FROM `transactions_test`/.test(sql)) return [[row]];
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: {
+          imagenameField: ['label_field'],
+          transactionTypeField: 'TransType',
+          transactionTypeValue: '4001',
+        },
+      },
+    }),
+  );
+
+  const { list } = await detectIncompleteImages(1);
+  assert.equal(list.length, 1);
+  assert.equal(list[0].newName, 'img003.jpg');
+
+  const moved = await fixIncompleteImages(list);
+  assert.equal(moved, 1);
+  const exists = await fs.readdir(
+    path.join(process.cwd(), 'uploads', 'txn_images', 't3', '4001'),
+  );
+  assert.ok(exists.includes('img003.jpg'));
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});
+
+await test('checkUploadedImages handles timestamped names', async () => {
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  await fs.mkdir(path.join(process.cwd(), 'uploads', 'tmp'), { recursive: true });
+  const ts = 1754112726584;
+  const tmp = path.join(process.cwd(), 'uploads', 'tmp', `300021_300021_4001_${ts}_c2kene.jpg`);
+  await fs.writeFile(tmp, 'x');
+
+  const row = {
+    id: 1,
+    z_mat_code: '300021',
+    sp_primary_code: '300021',
+    TransType: '4001',
+    UITrtype: 't3',
+    label_field: 'img004',
+    created_at: new Date(ts),
+  };
+
+  const restoreDb = mockPool(async (sql) => {
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql))
+      return [[
+        { Field: 'z_mat_code' },
+        { Field: 'sp_primary_code' },
+        { Field: 'TransType' },
+        { Field: 'UITrtype' },
+        { Field: 'created_at' },
+        { Field: 'label_field' },
+      ]];
+    if (/FROM `transactions_test`/.test(sql)) return [[row]];
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: {
+          imagenameField: ['label_field'],
+          transactionTypeField: 'TransType',
+          transactionTypeValue: '4001',
+        },
+      },
+    }),
+  );
+
+  const { list, summary } = await checkUploadedImages([
+    { originalname: path.basename(tmp), path: tmp },
+  ]);
+  assert.equal(summary.processed, 1);
+  assert.equal(list.length, 1);
+  assert.equal(list[0].newName, 'img004.jpg');
+
+  const uploaded = await commitUploadedImages(list);
+  assert.equal(uploaded, 1);
+  const exists = await fs.readdir(
+    path.join(process.cwd(), 'uploads', 'txn_images', 't3', '4001'),
+  );
+  assert.ok(exists.includes('img004.jpg'));
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});
+
+await test('detectIncompleteImages handles UUID with numeric suffix', async () => {
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  const dir = path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test');
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, 'A5E68912-2218-41BD-BB11-E4810BB30C96-4.jpg');
+  await fs.writeFile(file, 'x');
+
+  const row = {
+    id: 1,
+    test_num: 'A5E68912-2218-41BD-BB11-E4810BB30C96',
+    label_field: 'img005',
+    trtype: 't4',
+    TransType: 'C',
+  };
+
+  const restoreDb = mockPool(async (sql) => {
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql))
+      return [[{ Field: 'test_num' }, { Field: 'label_field' }]];
+    if (/FROM `transactions_test`/.test(sql)) return [[row]];
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: { imagenameField: ['label_field'], transactionTypeValue: 'C' },
+      },
+    }),
+  );
+
+  const { list } = await detectIncompleteImages(1);
+  assert.equal(list.length, 1);
+  assert.equal(
+    list[0].newName,
+    'img005_A5E68912-2218-41BD-BB11-E4810BB30C96-4.jpg',
+  );
 
   restoreDb();
   await fs.writeFile(cfgPath, origCfg);


### PR DESCRIPTION
## Summary
- trim saveImages suffixes and trailing counters when extracting unique IDs, allowing detection of images like `A5E68912-2218-41BD-BB11-E4810BB30C96-4.jpg`
- limit host detection scans to the current page size and allow folder scans to send just file names for faster previews
- let upload checks accept name lists as well as uploaded files and return stable IDs for later commits

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688de7829d1c8331a1f8f1976d58bc8e