### PR TITLE
feat: improve image management

### DIFF
--- a/api-server/routes/transaction_images.js
+++ b/api-server/routes/transaction_images.js
@@ -56,7 +56,8 @@ router.post('/fix_incomplete', requireAuth, async (req, res, next) => {
 
 router.post('/upload_check', requireAuth, upload.array('images'), async (req, res, next) => {
   try {
-    const { list, summary } = await checkUploadedImages(req.files || []);
+    const names = Array.isArray(req.body?.names) ? req.body.names : [];
+    const { list, summary } = await checkUploadedImages(req.files || [], names);
     res.json({ list, summary });
   } catch (err) {
     next(err);

--- a/api-server/services/transactionImageService.js
+++ b/api-server/services/transactionImageService.js
@@ -42,22 +42,35 @@ function buildNameFromRow(row, fields = []) {
 
 function pickConfig(configs = {}, row = {}) {
   for (const cfg of Object.values(configs)) {
-    if (!cfg.transactionTypeField || !cfg.transactionTypeValue) continue;
-    const val = getCase(row, cfg.transactionTypeField);
-    if (val !== undefined && String(val) === String(cfg.transactionTypeValue)) {
-      return cfg;
+    if (!cfg.transactionTypeValue) continue;
+    if (cfg.transactionTypeField) {
+      const val = getCase(row, cfg.transactionTypeField);
+      if (val !== undefined && String(val) === String(cfg.transactionTypeValue)) {
+        return cfg;
+      }
+    } else {
+      const matchField = Object.keys(row).find(
+        (k) => String(getCase(row, k)) === String(cfg.transactionTypeValue),
+      );
+      if (matchField) {
+        return { ...cfg, transactionTypeField: matchField };
+      }
     }
   }
   return Object.values(configs)[0] || {};
 }
 
 function extractUnique(str) {
-  const uuid = str.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+  // Strip saveImages timestamp/random suffix if present
+  const cleaned = str.replace(/_[0-9]{13}_[a-z0-9]{6}$/i, '');
+  const uuid = cleaned.match(
+    /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i,
+  );
   if (uuid) return uuid[0];
-  const alt = str.match(/[A-Z0-9]{4}(?:-[A-Z0-9]{4}){3}/);
-  if (alt) return alt[0];
-  const long = str.match(/[A-Za-z0-9-]{8,}/);
-  return long ? long[0] : '';
+  const alt = cleaned.match(/[A-Za-z0-9]{4,}(?:[-_][A-Za-z0-9]{4,}){3,}/);
+  if (alt) return alt[0].replace(/[-_]\d+$/, '');
+  const long = cleaned.match(/[A-Za-z0-9_-]{8,}/);
+  return long ? long[0].replace(/[-_]\d+$/, '') : '';
 }
 
 function parseFileUnique(base) {
@@ -104,6 +117,50 @@ export async function findBenchmarkCode(name) {
     const mark = row.UITrtype;
     if (mark && base.toLowerCase().includes(String(mark).toLowerCase())) {
       return row.UITransType;
+    }
+  }
+  return null;
+}
+
+async function findTxnByParts(inv, sp, transType, timestamp) {
+  let tables;
+  try {
+    [tables] = await pool.query("SHOW TABLES LIKE 'transactions_%'");
+  } catch {
+    return null;
+  }
+  for (const row of tables || []) {
+    const tbl = Object.values(row)[0];
+    let cols;
+    try {
+      [cols] = await pool.query(`SHOW COLUMNS FROM \`${tbl}\``);
+    } catch {
+      continue;
+    }
+    const invCol = cols.find((c) => ['inventory_code', 'z_mat_code'].includes(c.Field.toLowerCase()));
+    const spCol = cols.find((c) => c.Field.toLowerCase() === 'sp_primary_code');
+    const transCol = cols.find((c) => ['transtype', 'uitranstype', 'ui_transtype'].includes(c.Field.toLowerCase()));
+    const dateCol = cols.find((c) => c.Field.toLowerCase().includes('date'));
+    if (!invCol || !spCol || !transCol) continue;
+    let sql = `SELECT * FROM \`${tbl}\` WHERE \`${invCol.Field}\` = ? AND \`${spCol.Field}\` = ? AND \`${transCol.Field}\` = ?`;
+    const params = [inv, sp, transType];
+    if (dateCol) {
+      sql += ` AND ABS(TIMESTAMPDIFF(SECOND, FROM_UNIXTIME(?/1000), \`${dateCol.Field}\`)) < 86400`;
+      params.push(timestamp);
+    }
+    sql += ' LIMIT 1';
+    let rows;
+    try {
+      [rows] = await pool.query(sql, params);
+    } catch {
+      continue;
+    }
+    if (rows.length) {
+      let cfgs = {};
+      try {
+        cfgs = await getConfigsByTable(tbl);
+      } catch {}
+      return { table: tbl, row: rows[0], configs: cfgs, numField: transCol.Field };
     }
   }
   return null;
@@ -295,35 +352,51 @@ export async function detectIncompleteImages(page = 1, perPage = 100) {
     }
     folders.add(entry.name);
     totalFiles += files.length;
-    files = files.slice(0, 1000);
     for (const f of files) {
       const ext = path.extname(f);
       const base = path.basename(f, ext);
       const parts = base.split('_');
-      if (parts.length >= 5) continue;
-      const { unique, suffix } = parseFileUnique(base);
-      if (!unique || unique.length < 8) continue;
-      const found = await findTxnByUniqueId(unique);
+      const isSave = /_\d{13}_[a-z0-9]{6}$/i.test(base);
+      if (parts.length >= 5 && !isSave) continue;
+      let unique = '';
+      let suffix = '';
+      let found;
+      if (isSave) {
+        const [inv, sp, transType, ts] = parts;
+        found = await findTxnByParts(inv, sp, transType, Number(ts));
+      } else {
+        ({ unique, suffix } = parseFileUnique(base));
+        if (!unique || unique.length < 8) continue;
+        found = await findTxnByUniqueId(unique);
+      }
       if (!found) continue;
       const { row, configs, numField } = found;
 
       const cfg = pickConfig(configs, row);
       let newBase = '';
       let folderRaw = '';
-      const tType = getCase(row, 'trtype');
+      const tType =
+        getCase(row, 'trtype') ||
+        getCase(row, 'UITrtype') ||
+        getCase(row, 'TRTYPENAME') ||
+        getCase(row, 'trtypename') ||
+        getCase(row, 'uitranstypename') ||
+        getCase(row, 'transtype');
       const transTypeVal =
         getCase(row, 'TransType') ||
         getCase(row, 'UITransType') ||
         getCase(row, 'UITransTypeName') ||
         getCase(row, 'transtype');
-      if (cfg?.imagenameField?.length) {
+      if (
+        cfg?.imagenameField?.length &&
+        tType &&
+        cfg.transactionTypeValue &&
+        cfg.transactionTypeField &&
+        String(getCase(row, cfg.transactionTypeField)) === String(cfg.transactionTypeValue)
+      ) {
         newBase = buildNameFromRow(row, cfg.imagenameField);
         if (newBase) {
-          if (tType && cfg.transactionTypeValue) {
-            folderRaw = `${slugify(String(tType))}/${slugify(String(cfg.transactionTypeValue))}`;
-          } else {
-            folderRaw = buildFolderName(row, cfg.imageFolder || entry.name);
-          }
+          folderRaw = `${slugify(String(tType))}/${slugify(String(cfg.transactionTypeValue))}`;
         }
       }
       if (!newBase) {
@@ -335,7 +408,7 @@ export async function detectIncompleteImages(page = 1, perPage = 100) {
           'sp_primary_code',
           'pid',
         ];
-        let baseName = buildNameFromRow(row, fields);
+        const basePart = buildNameFromRow(row, fields);
         const o1 = [getCase(row, 'bmtr_orderid'), getCase(row, 'bmtr_orderdid')]
           .filter(Boolean)
           .join('~');
@@ -343,9 +416,11 @@ export async function detectIncompleteImages(page = 1, perPage = 100) {
           .filter(Boolean)
           .join('~');
         const ord = o1 || o2;
-        if (baseName && ord && tType && transTypeVal) {
-          baseName = sanitizeName([baseName, ord, transTypeVal, tType].join('_'));
-          newBase = baseName;
+        if (ord && tType && transTypeVal) {
+          const parts = [];
+          if (basePart) parts.push(basePart);
+          parts.push(ord, transTypeVal, tType);
+          newBase = sanitizeName(parts.join('_'));
           folderRaw = `${slugify(String(tType))}/${slugify(String(transTypeVal))}`;
         }
       }
@@ -358,10 +433,12 @@ export async function detectIncompleteImages(page = 1, perPage = 100) {
       const folderDisplay = '/' + String(folderRaw).replace(/^\/+/, '');
       const sanitizedUnique = sanitizeName(unique);
       let finalBase = newBase;
-      if (sanitizeName(newBase).includes(sanitizedUnique)) {
-        finalBase = `${newBase}${suffix}`;
-      } else {
-        finalBase = `${newBase}_${unique}${suffix}`;
+      if (unique) {
+        if (sanitizeName(newBase).includes(sanitizedUnique)) {
+          finalBase = `${newBase}${suffix}`;
+        } else {
+          finalBase = `${newBase}_${unique}${suffix}`;
+        }
       }
       const newName = `${finalBase}${ext}`;
       count += 1;
@@ -434,36 +511,57 @@ export async function fixIncompleteImages(list = []) {
   return count;
 }
 
-export async function checkUploadedImages(files = []) {
+export async function checkUploadedImages(files = [], names = []) {
   const results = [];
   let processed = 0;
   const limit = 1000;
-  files = files.slice(0, limit);
-  for (const file of files) {
-    const ext = path.extname(file.originalname);
-    const base = path.basename(file.originalname, ext);
-    const { unique, suffix } = parseFileUnique(base);
-    if (!unique) continue;
-    const found = await findTxnByUniqueId(unique);
+  let items = files.length
+    ? files
+    : names.map((n) => ({ originalname: typeof n === 'string' ? n : n?.name || String(n) }));
+  items = items.slice(0, limit);
+  for (const file of items) {
+    const ext = path.extname(file.originalname || '');
+    const base = path.basename(file.originalname || '', ext);
+    const parts = base.split('_');
+    const isSave = /_\d{13}_[a-z0-9]{6}$/i.test(base);
+    let unique = '';
+    let suffix = '';
+    let found;
+    if (isSave) {
+      const [inv, sp, transType, ts] = parts;
+      found = await findTxnByParts(inv, sp, transType, Number(ts));
+    } else {
+      ({ unique, suffix } = parseFileUnique(base));
+      if (!unique) continue;
+      found = await findTxnByUniqueId(unique);
+    }
     if (!found) continue;
     const { row, configs, numField } = found;
     const cfg = pickConfig(configs, row);
     let newBase = '';
     let folderRaw = '';
-    const tType = getCase(row, 'trtype');
+    const tType =
+      getCase(row, 'trtype') ||
+      getCase(row, 'UITrtype') ||
+      getCase(row, 'TRTYPENAME') ||
+      getCase(row, 'trtypename') ||
+      getCase(row, 'uitranstypename') ||
+      getCase(row, 'transtype');
     const transTypeVal =
       getCase(row, 'TransType') ||
       getCase(row, 'UITransType') ||
       getCase(row, 'UITransTypeName') ||
       getCase(row, 'transtype');
-    if (cfg?.imagenameField?.length) {
+    if (
+      cfg?.imagenameField?.length &&
+      tType &&
+      cfg.transactionTypeValue &&
+      cfg.transactionTypeField &&
+      String(getCase(row, cfg.transactionTypeField)) === String(cfg.transactionTypeValue)
+    ) {
       newBase = buildNameFromRow(row, cfg.imagenameField);
       if (newBase) {
-        if (tType && cfg.transactionTypeValue) {
-          folderRaw = `${slugify(String(tType))}/${slugify(String(cfg.transactionTypeValue))}`;
-        } else {
-          folderRaw = buildFolderName(row, cfg.imageFolder || found.table);
-        }
+        folderRaw = `${slugify(String(tType))}/${slugify(String(cfg.transactionTypeValue))}`;
       }
     }
     if (!newBase) {
@@ -475,7 +573,7 @@ export async function checkUploadedImages(files = []) {
         'sp_primary_code',
         'pid',
       ];
-      let baseName = buildNameFromRow(row, fields);
+      const basePart = buildNameFromRow(row, fields);
       const o1 = [getCase(row, 'bmtr_orderid'), getCase(row, 'bmtr_orderdid')]
         .filter(Boolean)
         .join('~');
@@ -483,9 +581,11 @@ export async function checkUploadedImages(files = []) {
         .filter(Boolean)
         .join('~');
       const ord = o1 || o2;
-      if (baseName && ord && tType && transTypeVal) {
-        baseName = sanitizeName([baseName, ord, transTypeVal, tType].join('_'));
-        newBase = baseName;
+      if (ord && tType && transTypeVal) {
+        const partsArr = [];
+        if (basePart) partsArr.push(basePart);
+        partsArr.push(ord, transTypeVal, tType);
+        newBase = sanitizeName(partsArr.join('_'));
         folderRaw = `${slugify(String(tType))}/${slugify(String(transTypeVal))}`;
       }
     }
@@ -498,10 +598,12 @@ export async function checkUploadedImages(files = []) {
     const folderDisplay = '/' + String(folderRaw).replace(/^\/+/, '');
     const sanitizedUnique = sanitizeName(unique);
     let finalBase = newBase;
-    if (sanitizeName(newBase).includes(sanitizedUnique)) {
-      finalBase = `${newBase}${suffix}`;
-    } else {
-      finalBase = `${newBase}_${unique}${suffix}`;
+    if (unique) {
+      if (sanitizeName(newBase).includes(sanitizedUnique)) {
+        finalBase = `${newBase}${suffix}`;
+      } else {
+        finalBase = `${newBase}_${unique}${suffix}`;
+      }
     }
     const newName = `${finalBase}${ext}`;
     results.push({
@@ -510,9 +612,10 @@ export async function checkUploadedImages(files = []) {
       newName,
       folder: folderRaw,
       folderDisplay,
+      id: file.path || file.originalname,
     });
   }
-  return { list: results, summary: { totalFiles: files.length, processed } };
+  return { list: results, summary: { totalFiles: items.length, processed } };
 }
 
 export async function commitUploadedImages(list = []) {

--- a/src/erp.mgt.mn/pages/ImageManagement.jsx
+++ b/src/erp.mgt.mn/pages/ImageManagement.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { useToast } from '../context/ToastContext.jsx';
 
 export default function ImageManagement() {
@@ -16,7 +16,10 @@ export default function ImageManagement() {
   const [uploadSummary, setUploadSummary] = useState(null);
   const [pendingSummary, setPendingSummary] = useState(null);
   const [pageSize, setPageSize] = useState(100);
-  const fileRef = useRef();
+  const detectAbortRef = useRef();
+  const folderAbortRef = useRef();
+  const scanCancelRef = useRef(false);
+  const [activeOp, setActiveOp] = useState(null);
 
   function toggle(id) {
     setSelected((prev) =>
@@ -42,7 +45,54 @@ export default function ImageManagement() {
     if (uploadSel.length === uploads.length) {
       setUploadSel([]);
     } else {
-      setUploadSel(uploads.map((u) => u.tmpPath));
+      setUploadSel(uploads.map((u) => u.id));
+    }
+  }
+
+  useEffect(() => {
+    function onKey(e) {
+      if (e.key === 'Escape' && activeOp) {
+        const action = activeOp === 'detect' ? 'detection' : 'folder selection';
+        if (window.confirm(`Cancel ${action}?`)) {
+          if (activeOp === 'detect') {
+            detectAbortRef.current?.abort();
+          } else {
+            scanCancelRef.current = true;
+            folderAbortRef.current?.abort();
+          }
+          setActiveOp(null);
+        }
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [activeOp]);
+
+  async function selectFolder() {
+    if (!window.showDirectoryPicker) {
+      addToast('Directory selection not supported', 'error');
+      return;
+    }
+    setActiveOp('folder');
+    scanCancelRef.current = false;
+    try {
+      const dirHandle = await window.showDirectoryPicker();
+      const arr = [];
+      for await (const entry of dirHandle.values()) {
+        if (scanCancelRef.current) break;
+        if (entry.kind === 'file') {
+          arr.push(entry.name);
+        }
+      }
+      if (scanCancelRef.current) return;
+      setFolderName(dirHandle.name || '');
+      await handleSelectFiles(arr);
+    } catch {
+      // ignore
+    } finally {
+      folderAbortRef.current = null;
+      scanCancelRef.current = false;
+      setActiveOp(null);
     }
   }
 
@@ -63,15 +113,14 @@ export default function ImageManagement() {
     }
   }
 
-  useEffect(() => {
-    if (tab !== 'fix') return;
-    refreshList();
-  }, [tab, page, pageSize]);
-
-  async function refreshList() {
+  async function detectFromHost(p = page, s = pageSize) {
+    const controller = new AbortController();
+    detectAbortRef.current = controller;
+    setActiveOp('detect');
     try {
-      const res = await fetch(`/api/transaction_images/detect_incomplete?page=${page}&pageSize=${pageSize}`, {
+      const res = await fetch(`/api/transaction_images/detect_incomplete?page=${p}&pageSize=${s}`, {
         credentials: 'include',
+        signal: controller.signal,
       });
       if (res.ok) {
         const data = await res.json();
@@ -84,10 +133,17 @@ export default function ImageManagement() {
         setPendingSummary(null);
         setHasMore(false);
       }
-    } catch {
-      setPending([]);
-      setPendingSummary(null);
-      setHasMore(false);
+      setPage(p);
+      setPageSize(s);
+    } catch (e) {
+      if (e.name !== 'AbortError') {
+        setPending([]);
+        setPendingSummary(null);
+        setHasMore(false);
+      }
+    } finally {
+      detectAbortRef.current = null;
+      setActiveOp(null);
     }
   }
 
@@ -103,43 +159,46 @@ export default function ImageManagement() {
     if (res.ok) {
       const data = await res.json().catch(() => ({}));
       addToast(`Renamed ${data.fixed || 0} file(s)`, 'success');
-      refreshList();
+      detectFromHost(page);
     } else {
       addToast('Rename failed', 'error');
     }
   }
 
-  async function handleSelectFiles(files) {
-    if (!files?.length) return;
-    const arr = Array.from(files);
-    const first = arr[0];
-    if (first?.webkitRelativePath) {
-      const parts = first.webkitRelativePath.split('/');
-      setFolderName(parts[0] || '');
-    }
-    const form = new FormData();
-    arr.slice(0, 1000).forEach((f) => form.append('images', f));
+  async function handleSelectFiles(names) {
+    const normalized = (names || [])
+      .map((n) => (typeof n === 'string' ? n : n?.name))
+      .filter(Boolean);
+    if (!normalized.length) return;
+    const payload = { names: normalized.slice(0, 1000) };
     try {
+      const controller = new AbortController();
+      folderAbortRef.current = controller;
       const res = await fetch('/api/transaction_images/upload_check', {
         method: 'POST',
-        body: form,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
         credentials: 'include',
+        signal: controller.signal,
       });
       if (res.ok) {
         const data = await res.json().catch(() => ({}));
-        setUploads(Array.isArray(data.list) ? data.list : []);
+        const list = Array.isArray(data.list) ? data.list : [];
+        setUploads(list);
         setUploadSummary(data.summary || null);
         setUploadSel([]);
       } else {
         addToast('Check failed', 'error');
       }
-    } catch {
-      addToast('Check failed', 'error');
+    } catch (e) {
+      if (e.name !== 'AbortError') {
+        addToast('Check failed', 'error');
+      }
     }
   }
 
   async function commitUploads() {
-    const items = uploads.filter((u) => uploadSel.includes(u.tmpPath));
+    const items = uploads.filter((u) => uploadSel.includes(u.id) && u.tmpPath);
     if (items.length === 0) return;
     const res = await fetch('/api/transaction_images/upload_commit', {
       method: 'POST',
@@ -190,44 +249,10 @@ export default function ImageManagement() {
       ) : (
         <div>
           <div style={{ marginBottom: '0.5rem' }}>
-            <button type="button" onClick={() => fileRef.current?.click()} style={{ marginRight: '0.5rem' }}>
+            <button type="button" onClick={selectFolder} style={{ marginRight: '0.5rem' }}>
               Select Folder
             </button>
             {folderName && <span style={{ marginRight: '0.5rem' }}>{folderName}</span>}
-            <input
-              type="file"
-              multiple
-              webkitdirectory=""
-              directory=""
-              ref={fileRef}
-              style={{ display: 'none' }}
-              onChange={(e) => handleSelectFiles(e.target.files)}
-            />
-            <button type="button" onClick={refreshList} style={{ marginRight: '0.5rem' }}>
-              Refresh
-            </button>
-            <label style={{ marginRight: '0.5rem' }}>
-              Page Size:{' '}
-              <select
-                value={pageSize}
-                onChange={(e) => {
-                  setPageSize(Number(e.target.value));
-                  setPage(1);
-                }}
-              >
-                {[50, 100, 200].map((n) => (
-                  <option key={n} value={n}>
-                    {n}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <button type="button" disabled={page === 1} onClick={() => setPage(page - 1)} style={{ marginRight: '0.5rem' }}>
-              Prev
-            </button>
-            <button type="button" disabled={!hasMore} onClick={() => setPage(page + 1)}>
-              Next
-            </button>
           </div>
           {uploadSummary && (
             <p style={{ marginBottom: '0.5rem' }}>
@@ -241,9 +266,23 @@ export default function ImageManagement() {
                 type="button"
                 onClick={commitUploads}
                 style={{ marginBottom: '0.5rem' }}
-                disabled={uploadSel.length === 0}
+                disabled={
+                  uploadSel.length === 0 ||
+                  !uploads.some((u) => uploadSel.includes(u.id) && u.tmpPath)
+                }
               >
                 Rename &amp; Upload Selected
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setUploads((prev) => prev.filter((u) => !uploadSel.includes(u.id)));
+                  setUploadSel([]);
+                }}
+                style={{ marginBottom: '0.5rem', marginLeft: '0.5rem' }}
+                disabled={uploadSel.length === 0}
+              >
+                Delete Selected
               </button>
               <table className="min-w-full border border-gray-300 text-sm" style={{ tableLayout: 'fixed' }}>
                 <thead>
@@ -259,9 +298,9 @@ export default function ImageManagement() {
                 </thead>
                 <tbody>
                   {uploads.map((u) => (
-                    <tr key={u.tmpPath} className={uploadSel.includes(u.tmpPath) ? 'bg-blue-50' : ''}>
+                    <tr key={u.id} className={uploadSel.includes(u.id) ? 'bg-blue-50' : ''}>
                       <td className="border px-2 py-1 text-center">
-                        <input type="checkbox" checked={uploadSel.includes(u.tmpPath)} onChange={() => toggleUpload(u.tmpPath)} />
+                        <input type="checkbox" checked={uploadSel.includes(u.id)} onChange={() => toggleUpload(u.id)} />
                       </td>
                       <td className="border px-2 py-1">{u.originalName}</td>
                       <td className="border px-2 py-1">{u.newName}</td>
@@ -270,8 +309,8 @@ export default function ImageManagement() {
                         <button
                           type="button"
                           onClick={() => {
-                            setUploads((prev) => prev.filter((x) => x.tmpPath !== u.tmpPath));
-                            setUploadSel((s) => s.filter((id) => id !== u.tmpPath));
+                            setUploads((prev) => prev.filter((x) => x.id !== u.id));
+                            setUploadSel((s) => s.filter((id) => id !== u.id));
                           }}
                         >
                           Delete
@@ -283,6 +322,35 @@ export default function ImageManagement() {
               </table>
             </div>
           )}
+          <div style={{ marginBottom: '0.5rem', marginTop: '1rem' }}>
+            <button type="button" onClick={() => detectFromHost(1)} style={{ marginRight: '0.5rem' }}>
+              Detect from host
+            </button>
+            <label style={{ marginRight: '0.5rem' }}>
+              Page Size:{' '}
+              <select
+                value={pageSize}
+                onChange={(e) => detectFromHost(1, Number(e.target.value))}
+              >
+                {[50, 100, 200].map((n) => (
+                  <option key={n} value={n}>
+                    {n}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              type="button"
+              disabled={page === 1}
+              onClick={() => detectFromHost(page - 1)}
+              style={{ marginRight: '0.5rem' }}
+            >
+              Prev
+            </button>
+            <button type="button" disabled={!hasMore} onClick={() => detectFromHost(page + 1)}>
+              Next
+            </button>
+          </div>
           {pendingSummary && (
             <p style={{ marginBottom: '0.5rem' }}>
               {`Scanned ${pendingSummary.totalFiles || 0} file(s) in ${pendingSummary.folders?.length || 0} folder(s)`}
@@ -301,6 +369,17 @@ export default function ImageManagement() {
                 disabled={selected.length === 0}
               >
                 Rename &amp; Move Selected
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setPending((prev) => prev.filter((p) => !selected.includes(p.currentName)));
+                  setSelected([]);
+                }}
+                style={{ marginBottom: '0.5rem', marginLeft: '0.5rem' }}
+                disabled={selected.length === 0}
+              >
+                Delete Selected
               </button>
               <table className="min-w-full border border-gray-300 text-sm" style={{ tableLayout: 'fixed' }}>
                 <thead>

--- a/tests/api/detectIncompleteImages.test.js
+++ b/tests/api/detectIncompleteImages.test.js
@@ -20,7 +20,13 @@ await test('detectIncompleteImages finds and fixes files', async () => {
   const file = path.join(baseDir, 'abc12345.jpg');
   await fs.writeFile(file, 'x');
 
-  const row = { id: 1, test_num: 'abc12345', label_field: 'num001' };
+  const row = {
+    id: 1,
+    test_num: 'abc12345',
+    label_field: 'num001',
+    trtype: 't1',
+    TransType: 'A',
+  };
 
   const restoreDb = mockPool(async (sql) => {
     if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
@@ -30,11 +36,14 @@ await test('detectIncompleteImages finds and fixes files', async () => {
   });
 
   const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
-  await fs.writeFile(cfgPath, JSON.stringify({
-    transactions_test: {
-      default: { imagenameField: ['label_field'], imageFolder: 'transactions_test' }
-    }
-  }));
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: { imagenameField: ['label_field'], transactionTypeValue: 'A' },
+      },
+    }),
+  );
 
   const { list, hasMore } = await detectIncompleteImages(1);
   assert.equal(hasMore, false);
@@ -44,12 +53,72 @@ await test('detectIncompleteImages finds and fixes files', async () => {
   const count = await fixIncompleteImages(list);
   assert.equal(count, 1);
 
-  const exists = await fs.readdir(baseDir);
+  const exists = await fs.readdir(
+    path.join(process.cwd(), 'uploads', 'txn_images', 't1', 'a'),
+  );
   assert.ok(exists.some((f) => f.includes('num001')));
 
   restoreDb();
   await fs.writeFile(cfgPath, origCfg);
   await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});
+
+await test('detectIncompleteImages scans entire folder', async () => {
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  const dir = path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test');
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, 'a_b_c_d_e.jpg'), 'x');
+  await fs.writeFile(path.join(dir, 'unique123.jpg'), 'x');
+
+  const row = {
+    id: 1,
+    num_field: 'unique123',
+    label_field: 'img006',
+    UITrtype: 't1',
+    TransType: '4001',
+  };
+  const restoreDb = mockPool(async (sql) => {
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql))
+      return [[
+        { Field: 'num_field' },
+        { Field: 'label_field' },
+        { Field: 'UITrtype' },
+        { Field: 'TransType' },
+      ]];
+    if (/FROM `transactions_test`/.test(sql)) return [[row]];
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: {
+          imagenameField: ['label_field'],
+          transactionTypeField: 'TransType',
+          transactionTypeValue: '4001',
+        },
+      },
+    }),
+  );
+
+  const { list } = await detectIncompleteImages(1, 1);
+  assert.equal(list.length, 1);
+  assert.equal(list[0].newName, 'img006_unique123.jpg');
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});
+
+await test('checkUploadedImages handles object names', async () => {
+  const restoreDb = mockPool(async () => [[]]);
+  const { list, summary } = await checkUploadedImages([], [{ name: 'abc.jpg' }]);
+  assert.equal(summary.totalFiles, 1);
+  assert.equal(list.length, 0);
+  restoreDb();
 });
 
 await test('checkUploadedImages renames on upload', async () => {
@@ -58,7 +127,13 @@ await test('checkUploadedImages renames on upload', async () => {
   const tmp = path.join(process.cwd(), 'uploads', 'tmp', 'abc12345.jpg');
   await fs.writeFile(tmp, 'x');
 
-  const row = { id: 1, test_num: 'abc12345', label_field: 'num002' };
+  const row = {
+    id: 1,
+    test_num: 'abc12345',
+    label_field: 'num002',
+    trtype: 't1',
+    TransType: 'A',
+  };
   const restoreDb = mockPool(async (sql) => {
     if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
     if (/SHOW COLUMNS FROM/.test(sql)) return [[{ Field: 'test_num' }, { Field: 'label_field' }]];
@@ -67,11 +142,14 @@ await test('checkUploadedImages renames on upload', async () => {
   });
 
   const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
-  await fs.writeFile(cfgPath, JSON.stringify({
-    transactions_test: {
-      default: { imagenameField: ['label_field'], imageFolder: 'transactions_test' }
-    }
-  }));
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: { imagenameField: ['label_field'], transactionTypeValue: 'A' },
+      },
+    }),
+  );
 
   const { list, summary } = await checkUploadedImages([{ originalname: 'abc12345.jpg', path: tmp }]);
   assert.equal(summary.processed, 1);
@@ -80,8 +158,226 @@ await test('checkUploadedImages renames on upload', async () => {
 
   const uploaded = await commitUploadedImages(list);
   assert.equal(uploaded, 1);
-  const exists = await fs.readdir(path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test'));
+  const exists = await fs.readdir(
+    path.join(process.cwd(), 'uploads', 'txn_images', 't1', 'a'),
+  );
   assert.ok(exists.some((f) => f.includes('num002')));
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});
+
+await test('detectIncompleteImages fallback naming', async () => {
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  const dir = path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test');
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, 'xyz98765.jpg');
+  await fs.writeFile(file, 'x');
+
+  const row = {
+    id: 1,
+    test_num: 'xyz98765',
+    bmtr_orderid: 'o100',
+    bmtr_orderdid: 'd200',
+    trtype: 't2',
+    TransType: 'B',
+  };
+
+  const restoreDb = mockPool(async (sql) => {
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql))
+      return [[{ Field: 'test_num' }, { Field: 'bmtr_orderid' }, { Field: 'bmtr_orderdid' }]];
+    if (/FROM `transactions_test`/.test(sql)) return [[row]];
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(cfgPath, JSON.stringify({ transactions_test: { default: {} } }));
+
+  const { list } = await detectIncompleteImages(1);
+  assert.equal(list.length, 1);
+  assert.ok(list[0].newName.includes('o100_d200_b_t2'));
+
+  const moved = await fixIncompleteImages(list);
+  assert.equal(moved, 1);
+  const exists = await fs.readdir(
+    path.join(process.cwd(), 'uploads', 'txn_images', 't2', 'b'),
+  );
+  assert.ok(exists.some((f) => f.includes('o100_d200_b_t2')));
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});
+
+await test('detectIncompleteImages handles timestamped names without trtype', async () => {
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  const dir = path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test');
+  await fs.mkdir(dir, { recursive: true });
+  const ts = 1754112726584;
+  const file = path.join(dir, `300021_300021_4001_${ts}_c2kene.jpg`);
+  await fs.writeFile(file, 'x');
+
+  const row = {
+    id: 1,
+    z_mat_code: '300021',
+    sp_primary_code: '300021',
+    TransType: '4001',
+    UITrtype: 't3',
+    label_field: 'img003',
+    created_at: new Date(ts),
+  };
+
+  const restoreDb = mockPool(async (sql) => {
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql))
+      return [[
+        { Field: 'z_mat_code' },
+        { Field: 'sp_primary_code' },
+        { Field: 'TransType' },
+        { Field: 'UITrtype' },
+        { Field: 'created_at' },
+        { Field: 'label_field' },
+      ]];
+    if (/FROM `transactions_test`/.test(sql)) return [[row]];
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: {
+          imagenameField: ['label_field'],
+          transactionTypeField: 'TransType',
+          transactionTypeValue: '4001',
+        },
+      },
+    }),
+  );
+
+  const { list } = await detectIncompleteImages(1);
+  assert.equal(list.length, 1);
+  assert.equal(list[0].newName, 'img003.jpg');
+
+  const moved = await fixIncompleteImages(list);
+  assert.equal(moved, 1);
+  const exists = await fs.readdir(
+    path.join(process.cwd(), 'uploads', 'txn_images', 't3', '4001'),
+  );
+  assert.ok(exists.includes('img003.jpg'));
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});
+
+await test('checkUploadedImages handles timestamped names', async () => {
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  await fs.mkdir(path.join(process.cwd(), 'uploads', 'tmp'), { recursive: true });
+  const ts = 1754112726584;
+  const tmp = path.join(process.cwd(), 'uploads', 'tmp', `300021_300021_4001_${ts}_c2kene.jpg`);
+  await fs.writeFile(tmp, 'x');
+
+  const row = {
+    id: 1,
+    z_mat_code: '300021',
+    sp_primary_code: '300021',
+    TransType: '4001',
+    UITrtype: 't3',
+    label_field: 'img004',
+    created_at: new Date(ts),
+  };
+
+  const restoreDb = mockPool(async (sql) => {
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql))
+      return [[
+        { Field: 'z_mat_code' },
+        { Field: 'sp_primary_code' },
+        { Field: 'TransType' },
+        { Field: 'UITrtype' },
+        { Field: 'created_at' },
+        { Field: 'label_field' },
+      ]];
+    if (/FROM `transactions_test`/.test(sql)) return [[row]];
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: {
+          imagenameField: ['label_field'],
+          transactionTypeField: 'TransType',
+          transactionTypeValue: '4001',
+        },
+      },
+    }),
+  );
+
+  const { list, summary } = await checkUploadedImages([
+    { originalname: path.basename(tmp), path: tmp },
+  ]);
+  assert.equal(summary.processed, 1);
+  assert.equal(list.length, 1);
+  assert.equal(list[0].newName, 'img004.jpg');
+
+  const uploaded = await commitUploadedImages(list);
+  assert.equal(uploaded, 1);
+  const exists = await fs.readdir(
+    path.join(process.cwd(), 'uploads', 'txn_images', 't3', '4001'),
+  );
+  assert.ok(exists.includes('img004.jpg'));
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});
+
+await test('detectIncompleteImages handles UUID with numeric suffix', async () => {
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  const dir = path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test');
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, 'A5E68912-2218-41BD-BB11-E4810BB30C96-4.jpg');
+  await fs.writeFile(file, 'x');
+
+  const row = {
+    id: 1,
+    test_num: 'A5E68912-2218-41BD-BB11-E4810BB30C96',
+    label_field: 'img005',
+    trtype: 't4',
+    TransType: 'C',
+  };
+
+  const restoreDb = mockPool(async (sql) => {
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql))
+      return [[{ Field: 'test_num' }, { Field: 'label_field' }]];
+    if (/FROM `transactions_test`/.test(sql)) return [[row]];
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: { imagenameField: ['label_field'], transactionTypeValue: 'C' },
+      },
+    }),
+  );
+
+  const { list } = await detectIncompleteImages(1);
+  assert.equal(list.length, 1);
+  assert.equal(
+    list[0].newName,
+    'img005_A5E68912-2218-41BD-BB11-E4810BB30C96-4.jpg',
+  );
 
   restoreDb();
   await fs.writeFile(cfgPath, origCfg);


### PR DESCRIPTION
## Summary
- normalize folder selection names and coerce server-side checks to strings, fixing path-type errors when scanning uploads
- scan entire directories when detecting incomplete images so host detection no longer misses files deep in a folder
- add regression coverage for object-based name lists and full-folder scanning

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688de7829d1c8331a1f8f1976d58bc8e