### PR TITLE
refactor fix names folder scan and rename flow

### DIFF
--- a/api-server/routes/transaction_images.js
+++ b/api-server/routes/transaction_images.js
@@ -12,6 +12,7 @@ import {
   fixIncompleteImages,
   checkUploadedImages,
   commitUploadedImages,
+  detectIncompleteFromNames,
 } from '../services/transactionImageService.js';
 import { getGeneralConfig } from '../services/generalConfig.js';
 
@@ -74,6 +75,16 @@ router.post(
     }
   },
 );
+
+router.post('/upload_scan', requireAuth, async (req, res, next) => {
+  try {
+    const names = Array.isArray(req.body?.names) ? req.body.names : [];
+    const { list, summary } = await detectIncompleteFromNames(names);
+    res.json({ list, summary });
+  } catch (err) {
+    next(err);
+  }
+});
 
 router.post('/upload_commit', requireAuth, async (req, res, next) => {
   try {

--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -103,6 +103,23 @@ export async function getConfigsByTable(table) {
   return result;
 }
 
+export async function getConfigsByTransTypeValue(val) {
+  const cfg = await readConfig();
+  const result = [];
+  for (const [tbl, names] of Object.entries(cfg)) {
+    for (const [name, info] of Object.entries(names)) {
+      const parsed = parseEntry(info);
+      if (
+        parsed.transactionTypeValue &&
+        String(parsed.transactionTypeValue) === String(val)
+      ) {
+        result.push({ table: tbl, name, config: parsed });
+      }
+    }
+  }
+  return result;
+}
+
 export async function listTransactionNames({ moduleKey, branchId, departmentId } = {}) {
   const cfg = await readConfig();
   const result = {};

--- a/api-server/services/transactionImageService.js
+++ b/api-server/services/transactionImageService.js
@@ -3,7 +3,7 @@ import fssync from 'fs';
 import path from 'path';
 import { getGeneralConfig } from './generalConfig.js';
 import { pool } from '../../db/index.js';
-import { getConfigsByTable } from './transactionFormConfig.js';
+import { getConfigsByTable, getConfigsByTransTypeValue } from './transactionFormConfig.js';
 import { slugify } from '../utils/slugify.js';
 
 async function getDirs() {
@@ -99,24 +99,47 @@ function buildFolderName(row, fallback = '') {
   return fallback;
 }
 
+async function fetchTxnCodes() {
+  try {
+    const [rows] = await pool.query('SELECT UITrtype, UITransType FROM code_transaction');
+    const trtypes = (rows || [])
+      .map((r) => String(r.UITrtype || '').toLowerCase())
+      .filter(Boolean);
+    const transTypes = (rows || [])
+      .map((r) => String(r.UITransType || ''))
+      .filter(Boolean);
+    return { trtypes, transTypes };
+  } catch {
+    return { trtypes: [], transTypes: [] };
+  }
+}
+
+function hasTxnCode(base, unique, codes) {
+  const leftover = base.toLowerCase().replace(unique.toLowerCase(), '');
+  const tokens = leftover.split(/[_-]/).filter(Boolean);
+  const hasTrtype = tokens.some((t) => codes.trtypes.includes(t));
+  const hasTransType = tokens.some((t) => codes.transTypes.includes(t));
+  return hasTrtype && hasTransType;
+}
+
 export async function findBenchmarkCode(name) {
   if (!name) return null;
   const base = path.basename(name, path.extname(name));
   const parts = base.split(/[_-]/).filter(Boolean);
   for (const p of parts) {
-    const [rows] = await pool.query(
-      'SELECT UITransType FROM code_transaction WHERE UITransType = ?',
-      [p],
-    );
-    if (rows?.length) return rows[0].UITransType;
-  }
-  const [rows] = await pool.query(
-    'SELECT UITransType, UITrtype FROM code_transaction WHERE image_benchmark = 1',
-  );
-  for (const row of rows || []) {
-    const mark = row.UITrtype;
-    if (mark && base.toLowerCase().includes(String(mark).toLowerCase())) {
-      return row.UITransType;
+    if (/^\d{4}$/.test(p)) {
+      const [rows] = await pool.query(
+        'SELECT UITransType FROM code_transaction WHERE UITransType = ?',
+        [p],
+      );
+      if (rows?.length) return rows[0].UITransType;
+    }
+    if (/^[A-Za-z]{4}$/.test(p)) {
+      const [rows] = await pool.query(
+        'SELECT UITransType FROM code_transaction WHERE UITrtype = ?',
+        [p],
+      );
+      if (rows?.length) return rows[0].UITransType;
     }
   }
   return null;
@@ -129,23 +152,46 @@ async function findTxnByParts(inv, sp, transType, timestamp) {
   } catch {
     return null;
   }
+
+  const cfgMatches = await getConfigsByTransTypeValue(transType);
+  const cfgMap = new Map(
+    cfgMatches.map((m) => [m.table.toLowerCase(), m.config]),
+  );
+
   for (const row of tables || []) {
     const tbl = Object.values(row)[0];
+    if (cfgMap.size && !cfgMap.has(tbl.toLowerCase())) continue;
     let cols;
     try {
       [cols] = await pool.query(`SHOW COLUMNS FROM \`${tbl}\``);
     } catch {
       continue;
     }
-    const invCol = cols.find((c) => ['inventory_code', 'z_mat_code'].includes(c.Field.toLowerCase()));
+    const invCol = cols.find((c) =>
+      ['inventory_code', 'z_mat_code', 'bmtr_pmid'].includes(
+        c.Field.toLowerCase(),
+      ),
+    );
     const spCol = cols.find((c) => c.Field.toLowerCase() === 'sp_primary_code');
-    const transCol = cols.find((c) => ['transtype', 'uitranstype', 'ui_transtype'].includes(c.Field.toLowerCase()));
-    const dateCol = cols.find((c) => c.Field.toLowerCase().includes('date'));
+    const transCol = cols.find((c) =>
+      ['transtype', 'uitranstype', 'ui_transtype'].includes(
+        c.Field.toLowerCase(),
+      ),
+    );
     if (!invCol || !spCol || !transCol) continue;
+    const cfg = cfgMap.get(tbl.toLowerCase());
+    let dateCol;
+    if (cfg?.dateField?.length) {
+      const lowers = cfg.dateField.map((d) => String(d).toLowerCase());
+      dateCol = cols.find((c) => lowers.includes(c.Field.toLowerCase()));
+    } else {
+      dateCol = cols.find((c) => c.Field.toLowerCase().includes('date'));
+    }
     let sql = `SELECT * FROM \`${tbl}\` WHERE \`${invCol.Field}\` = ? AND \`${spCol.Field}\` = ? AND \`${transCol.Field}\` = ?`;
     const params = [inv, sp, transType];
     if (dateCol) {
-      sql += ` AND ABS(TIMESTAMPDIFF(SECOND, FROM_UNIXTIME(?/1000), \`${dateCol.Field}\`)) < 86400`;
+      sql +=
+        ` AND ABS(TIMESTAMPDIFF(SECOND, FROM_UNIXTIME(?/1000), \`${dateCol.Field}\`)) < 172800`;
       params.push(timestamp);
     }
     sql += ' LIMIT 1';
@@ -333,6 +379,7 @@ export async function cleanupOldImages(days = 30) {
 
 export async function detectIncompleteImages(page = 1, perPage = 100) {
   const { baseDir } = await getDirs();
+  const codes = await fetchTxnCodes();
   let results = [];
   let dirs;
   const offset = (page - 1) * perPage;
@@ -374,10 +421,13 @@ export async function detectIncompleteImages(page = 1, perPage = 100) {
         const sp = segs.shift();
         const transType = segs.shift();
         unique = segs.join('_');
+        suffix = `__${ts}_${rand}`;
+        if (hasTxnCode(base, unique, codes)) continue;
         found = await findTxnByParts(inv, sp, transType, Number(ts));
       } else {
         ({ unique, suffix } = parseFileUnique(base));
-        if (!unique || unique.length < 4) continue;
+        if (!unique) continue;
+        if (hasTxnCode(base, unique, codes)) continue;
         found = await findTxnByUniqueId(unique);
       }
       if (!found) continue;
@@ -452,6 +502,8 @@ export async function detectIncompleteImages(page = 1, perPage = 100) {
         } else {
           finalBase = `${newBase}_${unique}${suffix}`;
         }
+      } else if (suffix) {
+        finalBase = `${newBase}${suffix}`;
       }
       const newName = `${finalBase}${ext}`;
       count += 1;
@@ -527,6 +579,7 @@ export async function fixIncompleteImages(list = []) {
 export async function checkUploadedImages(files = [], names = []) {
   const results = [];
   let processed = 0;
+  const codes = await fetchTxnCodes();
   const limit = 1000;
   let items = files.length
     ? files
@@ -548,10 +601,13 @@ export async function checkUploadedImages(files = [], names = []) {
       const sp = segs.shift();
       const transType = segs.shift();
       unique = segs.join('_');
+      suffix = `__${ts}_${rand}`;
+      if (hasTxnCode(base, unique, codes)) continue;
       found = await findTxnByParts(inv, sp, transType, Number(ts));
     } else {
       ({ unique, suffix } = parseFileUnique(base));
       if (!unique) continue;
+      if (hasTxnCode(base, unique, codes)) continue;
       found = await findTxnByUniqueId(unique);
     }
     if (!found) continue;
@@ -625,6 +681,8 @@ export async function checkUploadedImages(files = [], names = []) {
       } else {
         finalBase = `${newBase}_${unique}${suffix}`;
       }
+    } else if (suffix) {
+      finalBase = `${newBase}${suffix}`;
     }
     const newName = `${finalBase}${ext}`;
     results.push({
@@ -651,4 +709,20 @@ export async function commitUploadedImages(list = []) {
     } catch {}
   }
   return count;
+}
+
+export async function detectIncompleteFromNames(names = []) {
+  const codes = await fetchTxnCodes();
+  const results = [];
+  let processed = 0;
+  for (const name of names) {
+    const ext = path.extname(name || '');
+    const base = path.basename(name || '', ext);
+    const { unique } = parseFileUnique(base);
+    if (!unique) continue;
+    if (hasTxnCode(base, unique, codes)) continue;
+    results.push({ originalName: name });
+    processed += 1;
+  }
+  return { list: results, summary: { totalFiles: names.length, processed } };
 }

--- a/docs/benchmark-image-verification.md
+++ b/docs/benchmark-image-verification.md
@@ -2,7 +2,7 @@
 
 The `findBenchmarkCode` helper inspects an uploaded image filename and maps it to a transaction type code. The lookup works in two steps:
 
-1. Any underscore or dash separated tokens are checked directly against the `code_transaction.UITransType` column.
-2. When that fails, rows where `image_benchmark` is set to `1` are scanned. If the filename contains a row's `UITrtype` value, its `UITransType` is returned.
+1. Any underscore or dash separated tokens that are four digits long are checked against the `code_transaction.UITransType` column.
+2. Tokens that are four letters long are checked against the `code_transaction.UITrtype` column and return the corresponding `UITransType`.
 
 The utility allows the front end to suggest a transaction code based on existing benchmark images without calling the OpenAI API.

--- a/tests/api/detectIncompleteImages.test.js
+++ b/tests/api/detectIncompleteImages.test.js
@@ -116,6 +116,65 @@ await test('detectIncompleteImages scans entire folder', async () => {
   await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
 });
 
+await test('detectIncompleteImages skips files with transaction codes', async () => {
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  const dir = path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test');
+  await fs.mkdir(dir, { recursive: true });
+  const ts = 1754112726584;
+  await fs.writeFile(path.join(dir, `uuid12345.jpg`), 'x');
+  await fs.writeFile(
+    path.join(dir, `t1_4001_uuid12345_${ts}_abcd12.jpg`),
+    'x',
+  );
+
+  const row = {
+    id: 1,
+    num_field: 'uuid12345',
+    label_field: 'img010',
+    UITrtype: 't1',
+    TransType: '4001',
+  };
+  const restoreDb = mockPool(async (sql, params) => {
+    if (/SELECT UITrtype, UITransType FROM code_transaction/.test(sql))
+      return [[{ UITrtype: 't1', UITransType: '4001' }]];
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql))
+      return [[
+        { Field: 'num_field' },
+        { Field: 'label_field' },
+        { Field: 'UITrtype' },
+        { Field: 'TransType' },
+      ]];
+    if (/FROM `transactions_test`/.test(sql)) {
+      if (params && params[0] && params[0].includes('uuid12345')) return [[row]];
+      return [[]];
+    }
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: {
+          imagenameField: ['label_field'],
+          transactionTypeField: 'TransType',
+          transactionTypeValue: '4001',
+        },
+      },
+    }),
+  );
+
+  const { list } = await detectIncompleteImages(1, 10);
+  assert.equal(list.length, 1);
+  assert.equal(list[0].currentName, 'uuid12345.jpg');
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});
+
 await test('checkUploadedImages handles object names', async () => {
   const restoreDb = mockPool(async () => [[]]);
   const { list, summary } = await checkUploadedImages([], [{ name: 'abc.jpg' }]);
@@ -165,6 +224,72 @@ await test('checkUploadedImages renames on upload', async () => {
     path.join(process.cwd(), 'uploads', 'txn_images', 't1', 'a'),
   );
   assert.ok(exists.some((f) => f.includes('num002')));
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});
+
+await test('checkUploadedImages skips files with transaction codes', async () => {
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  await fs.mkdir(path.join(process.cwd(), 'uploads', 'tmp'), { recursive: true });
+  const ts = 1754112726584;
+  const tmp1 = path.join(process.cwd(), 'uploads', 'tmp', 'uuid12345.jpg');
+  const tmp2 = path.join(
+    process.cwd(),
+    'uploads',
+    'tmp',
+    `t1_4001_uuid12345_${ts}_abcd12.jpg`,
+  );
+  await fs.writeFile(tmp1, 'x');
+  await fs.writeFile(tmp2, 'x');
+
+  const row = {
+    id: 1,
+    num_field: 'uuid12345',
+    label_field: 'img011',
+    UITrtype: 't1',
+    TransType: '4001',
+  };
+  const restoreDb = mockPool(async (sql, params) => {
+    if (/SELECT UITrtype, UITransType FROM code_transaction/.test(sql))
+      return [[{ UITrtype: 't1', UITransType: '4001' }]];
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql))
+      return [[
+        { Field: 'num_field' },
+        { Field: 'label_field' },
+        { Field: 'UITrtype' },
+        { Field: 'TransType' },
+      ]];
+    if (/FROM `transactions_test`/.test(sql)) {
+      if (params && params[0] && params[0].includes('uuid12345')) return [[row]];
+      return [[]];
+    }
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: {
+          imagenameField: ['label_field'],
+          transactionTypeField: 'TransType',
+          transactionTypeValue: '4001',
+        },
+      },
+    }),
+  );
+
+  const { list, summary } = await checkUploadedImages([
+    { originalname: 'uuid12345.jpg', path: tmp1 },
+    { originalname: `t1_4001_uuid12345_${ts}_abcd12.jpg`, path: tmp2 },
+  ]);
+  assert.equal(summary.processed, 1);
+  assert.equal(list.length, 1);
+  assert.equal(list[0].originalName, 'uuid12345.jpg');
 
   restoreDb();
   await fs.writeFile(cfgPath, origCfg);
@@ -263,14 +388,14 @@ await test('detectIncompleteImages handles timestamped names without trtype', as
 
   const { list } = await detectIncompleteImages(1);
   assert.equal(list.length, 1);
-  assert.equal(list[0].newName, 'img003.jpg');
+  assert.equal(list[0].newName, `img003__${ts}_c2kene.jpg`);
 
   const moved = await fixIncompleteImages(list);
   assert.equal(moved, 1);
   const exists = await fs.readdir(
     path.join(process.cwd(), 'uploads', 'txn_images', 't3', '4001'),
   );
-  assert.ok(exists.includes('img003.jpg'));
+  assert.ok(exists.includes(`img003__${ts}_c2kene.jpg`));
 
   restoreDb();
   await fs.writeFile(cfgPath, origCfg);
@@ -326,7 +451,71 @@ await test('detectIncompleteImages ignores timestamp mismatch when searching', a
 
   const { list } = await detectIncompleteImages(1);
   assert.equal(list.length, 1);
-  assert.equal(list[0].newName, 'img009.jpg');
+  assert.equal(list[0].newName, `img009__${ts}_c2kene.jpg`);
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});
+
+await test('detectIncompleteImages finds bmtr_pmid files by trans type and date range', async () => {
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  const dir = path.join(
+    process.cwd(),
+    'uploads',
+    'txn_images',
+    'transactions_test',
+  );
+  await fs.mkdir(dir, { recursive: true });
+  const ts = 1754119571573;
+  const file = path.join(dir, `303204_303204_4001_${ts}_4rpenn.jpg`);
+  await fs.writeFile(file, 'x');
+
+  const row = {
+    id: 1,
+    bmtr_pmid: '303204',
+    sp_primary_code: '303204',
+    TransType: '4001',
+    UITrtype: 't9',
+    label_field: 'img011',
+    created_at: new Date(ts - 36 * 3600 * 1000),
+  };
+
+  const restoreDb = mockPool(async (sql) => {
+    if (/SELECT UITrtype, UITransType FROM code_transaction/.test(sql))
+      return [[{ UITrtype: 't9', UITransType: '4001' }]];
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql))
+      return [[
+        { Field: 'bmtr_pmid' },
+        { Field: 'sp_primary_code' },
+        { Field: 'TransType' },
+        { Field: 'UITrtype' },
+        { Field: 'created_at' },
+        { Field: 'label_field' },
+      ]];
+    if (/FROM `transactions_test`/.test(sql)) return [[row]];
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: {
+          imagenameField: ['label_field'],
+          transactionTypeField: 'TransType',
+          transactionTypeValue: '4001',
+          dateField: ['created_at'],
+        },
+      },
+    }),
+  );
+
+  const { list } = await detectIncompleteImages(1);
+  assert.equal(list.length, 1);
+  assert.equal(list[0].newName, `img011__${ts}_4rpenn.jpg`);
 
   restoreDb();
   await fs.writeFile(cfgPath, origCfg);
@@ -384,14 +573,14 @@ await test('checkUploadedImages handles timestamped names', async () => {
   ]);
   assert.equal(summary.processed, 1);
   assert.equal(list.length, 1);
-  assert.equal(list[0].newName, 'img004.jpg');
+  assert.equal(list[0].newName, `img004__${ts}_c2kene.jpg`);
 
   const uploaded = await commitUploadedImages(list);
   assert.equal(uploaded, 1);
   const exists = await fs.readdir(
     path.join(process.cwd(), 'uploads', 'txn_images', 't3', '4001'),
   );
-  assert.ok(exists.includes('img004.jpg'));
+  assert.ok(exists.includes(`img004__${ts}_c2kene.jpg`));
 
   restoreDb();
   await fs.writeFile(cfgPath, origCfg);
@@ -583,7 +772,7 @@ await test('detectIncompleteImages handles extra unique before timestamp', async
   assert.equal(list.length, 1);
   assert.equal(
     list[0].newName,
-    'img007_ydzfh-sdang-cxfxb-kajww_akihl-zukov-ulioe-fhnde.jpg',
+    `img007_ydzfh-sdang-cxfxb-kajww_akihl-zukov-ulioe-fhnde__${ts}_oge4m7.jpg`,
   );
 
   const moved = await fixIncompleteImages(list);
@@ -592,7 +781,9 @@ await test('detectIncompleteImages handles extra unique before timestamp', async
     path.join(process.cwd(), 'uploads', 'txn_images', 't6', '4001'),
   );
   assert.ok(
-    exists.includes('img007_ydzfh-sdang-cxfxb-kajww_akihl-zukov-ulioe-fhnde.jpg'),
+    exists.includes(
+      `img007_ydzfh-sdang-cxfxb-kajww_akihl-zukov-ulioe-fhnde__${ts}_oge4m7.jpg`,
+    ),
   );
 
   restoreDb();

--- a/tests/api/findBenchmarkCode.test.js
+++ b/tests/api/findBenchmarkCode.test.js
@@ -15,8 +15,9 @@ await test('findBenchmarkCode matches codes', async () => {
       if (params[0] === '1234') return [[{ UITransType: '1234' }]];
       return [[]];
     }
-    if (/FROM code_transaction WHERE image_benchmark = 1/.test(sql)) {
-      return [[{ UITransType: '5678', UITrtype: 'ABCD' }]];
+    if (/FROM code_transaction WHERE UITrtype =/.test(sql)) {
+      if (String(params[0]).toUpperCase() === 'ABCD') return [[{ UITransType: '5678' }]];
+      return [[]];
     }
     return [[]];
   });


### PR DESCRIPTION
## Summary
- scan folders using filenames with server logic to list incomplete images
- add renameSelected and separate rename/upload actions
- chunk upload_check requests to avoid proxy failures when scanning large folders
- add configurable detect size (default 200) limiting both folder and host detection
- verify transaction image names against `code_transaction` codes so only files missing `UITrtype`/`UITransType` values are flagged
- match transaction images by `transactionForm` config `dateField` within ±2 days and include `bmtr_pmid` in lookup
- paginate folder scan results with adjustable page size, navigation and selection controls
- keep original timestamp and random suffix when renaming incomplete images

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e1e78c3048331ba27ba557c00604e