### PR TITLE
Handle transaction image identifiers

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -41,6 +41,7 @@ const RowFormModal = function RowFormModal({
   fitted = false,
   table = '',
   imagenameField = [],
+  imageIdField = '',
   scope = 'forms',
   labelFontSize,
   boxWidth,
@@ -988,32 +989,33 @@ const RowFormModal = function RowFormModal({
       return (
         <div className="mb-4">
           <h3 className="mt-0 mb-1 font-semibold">Main</h3>
-          <InlineTransactionTable
-            ref={useGrid ? tableRef : undefined}
-            fields={cols}
-            relations={relations}
-            relationConfigs={relationConfigs}
-            relationData={relationData}
-            labels={labels}
-            totalAmountFields={totalAmountFields}
-            totalCurrencyFields={totalCurrencyFields}
-            viewSource={viewSource}
-            viewDisplays={viewDisplays}
-            viewColumns={viewColumns}
-            procTriggers={procTriggers}
-            user={user}
-            company={company}
-            columnCaseMap={columnCaseMap}
-            tableName={table}
-            imagenameFields={imagenameField}
-            userIdFields={userIdFields}
-            branchIdFields={branchIdFields}
-            departmentIdFields={departmentIdFields}
-            companyIdFields={companyIdFields}
-            collectRows={useGrid}
-            minRows={1}
-            onRowSubmit={onSubmit}
-            onRowsChange={(rows) => {
+            <InlineTransactionTable
+              ref={useGrid ? tableRef : undefined}
+              fields={cols}
+              relations={relations}
+              relationConfigs={relationConfigs}
+              relationData={relationData}
+              labels={labels}
+              totalAmountFields={totalAmountFields}
+              totalCurrencyFields={totalCurrencyFields}
+              viewSource={viewSource}
+              viewDisplays={viewDisplays}
+              viewColumns={viewColumns}
+              procTriggers={procTriggers}
+              user={user}
+              company={company}
+              columnCaseMap={columnCaseMap}
+              tableName={table}
+              imagenameFields={imagenameField}
+              imageIdField={imageIdField}
+              userIdFields={userIdFields}
+              branchIdFields={branchIdFields}
+              departmentIdFields={departmentIdFields}
+              companyIdFields={companyIdFields}
+              collectRows={useGrid}
+              minRows={1}
+              onRowSubmit={onSubmit}
+              onRowsChange={(rows) => {
               setGridRows(rows);
               onRowsChange(rows);
             }}

--- a/src/erp.mgt.mn/components/RowImageUploadModal.jsx
+++ b/src/erp.mgt.mn/components/RowImageUploadModal.jsx
@@ -14,6 +14,7 @@ export default function RowImageUploadModal({
   rowKey = 0,
   imagenameFields = [],
   columnCaseMap = {},
+  imageIdField = '',
   onUploaded = () => {},
   onSuggestion = () => {},
 }) {
@@ -24,8 +25,16 @@ export default function RowImageUploadModal({
   const [suggestions, setSuggestions] = useState([]);
   const generalConfig = useGeneralConfig();
   const [showSuggestModal, setShowSuggestModal] = useState(false);
-  function buildName() {
-    return buildImageName(row, imagenameFields, columnCaseMap);
+  function buildName(fields = imagenameFields) {
+    let list = [];
+    if (fields === imagenameFields) {
+      list = [...imagenameFields, imageIdField].filter(Boolean);
+    } else if (fields.length) {
+      list = fields;
+    } else if (imageIdField) {
+      list = [imageIdField];
+    }
+    return buildImageName(row, list, columnCaseMap);
   }
 
   useEffect(() => {
@@ -41,21 +50,76 @@ export default function RowImageUploadModal({
       setUploaded([]);
       return;
     }
-    const { name } = buildName();
-    if (!name) {
-      setUploaded([]);
-      return;
+    const primary = buildName().name;
+    const { name: idName } = imageIdField ? buildName([imageIdField]) : { name: '' };
+    const altNames = [];
+    if (idName && idName !== primary) altNames.push(idName);
+    if (row._imageName && ![primary, ...altNames].includes(row._imageName)) {
+      altNames.push(row._imageName);
     }
     const safeTable = encodeURIComponent(table);
     const params = new URLSearchParams();
     if (folder) params.set('folder', folder);
-    fetch(`/api/transaction_images/${safeTable}/${encodeURIComponent(name)}?${params.toString()}`, {
-      credentials: 'include',
-    })
-      .then((r) => (r.ok ? r.json() : []))
-      .then((imgs) => setUploaded(Array.isArray(imgs) ? imgs : []))
-      .catch(() => setUploaded([]));
-  }, [visible, folder, rowKey, table, row._imageName, row._saved]);
+    (async () => {
+      if (primary) {
+        try {
+          const res = await fetch(
+            `/api/transaction_images/${safeTable}/${encodeURIComponent(primary)}?${params.toString()}`,
+            { credentials: 'include' },
+          );
+          const imgs = res.ok ? await res.json().catch(() => []) : [];
+          const list = Array.isArray(imgs) ? imgs : [];
+          if (list.length > 0) {
+            setUploaded(list);
+            list.forEach((p) => addToast(`Found image: ${p}`, 'info'));
+            return;
+          }
+        } catch {
+          /* ignore */
+        }
+      }
+      for (const nm of altNames) {
+        try {
+          const res = await fetch(
+            `/api/transaction_images/${safeTable}/${encodeURIComponent(nm)}?${params.toString()}`,
+            { credentials: 'include' },
+          );
+          const imgs = res.ok ? await res.json().catch(() => []) : [];
+          const list = Array.isArray(imgs) ? imgs : [];
+          if (list.length > 0) {
+            if (nm === idName && primary) {
+              try {
+                await fetch(
+                  `/api/transaction_images/${safeTable}/${encodeURIComponent(idName)}/rename/${encodeURIComponent(primary)}?${params.toString()}`,
+                  { method: 'POST', credentials: 'include' },
+                );
+                const res2 = await fetch(
+                  `/api/transaction_images/${safeTable}/${encodeURIComponent(primary)}?${params.toString()}`,
+                  { credentials: 'include' },
+                );
+                const imgs2 = res2.ok ? await res2.json().catch(() => []) : [];
+                const list2 = Array.isArray(imgs2) ? imgs2 : [];
+                if (list2.length > 0) {
+                  setUploaded(list2);
+                  list2.forEach((p) => addToast(`Found image: ${p}`, 'info'));
+                  return;
+                }
+              } catch {
+                /* ignore */
+              }
+            } else {
+              setUploaded(list);
+              list.forEach((p) => addToast(`Found image: ${p}`, 'info'));
+              return;
+            }
+          }
+        } catch {
+          /* ignore */
+        }
+      }
+      setUploaded([]);
+    })();
+  }, [visible, folder, rowKey, table, row._imageName, row._saved, imageIdField]);
 
 
   useEffect(() => {
@@ -75,7 +139,11 @@ export default function RowImageUploadModal({
 
   async function handleUpload(selectedFiles) {
     const { name: safeName, missing } = buildName();
-    const finalName = safeName || `tmp_${Date.now()}`;
+    let finalName = safeName || `tmp_${Date.now()}`;
+    if (!safeName && imageIdField) {
+      const { name: idName } = buildName([imageIdField]);
+      if (idName) finalName = `${finalName}_${idName}`;
+    }
     if (!folder) {
       addToast('Image folder is missing', 'error');
       return;

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -973,9 +973,12 @@ const TableManager = forwardRef(function TableManager({
             ...merged,
             [formConfig.imageIdField]: savedRow[formConfig.imageIdField],
           };
+          const nameFields = (formConfig?.imagenameField || []).concat(
+            formConfig?.imageIdField || '',
+          ).filter(Boolean);
           const { name: newImageName } = buildImageName(
             rowForName,
-            formConfig?.imagenameField || [],
+            nameFields,
             columnCaseMap,
           );
           const folder = getImageFolder(rowForName);
@@ -1952,6 +1955,7 @@ const TableManager = forwardRef(function TableManager({
         columnCaseMap={columnCaseMap}
         table={table}
         imagenameField={formConfig?.imagenameField || []}
+        imageIdField={formConfig?.imageIdField || ''}
         viewSource={viewSourceMap}
         viewDisplays={viewDisplayMap}
         viewColumns={viewColumns}
@@ -1984,6 +1988,7 @@ const TableManager = forwardRef(function TableManager({
         row={imagesRow || {}}
         imagenameFields={getConfigForRow(imagesRow).imagenameField || []}
         columnCaseMap={columnCaseMap}
+        imageIdField={getConfigForRow(imagesRow).imageIdField || ''}
       />
       {user?.role === 'admin' && (
         <button onClick={() => {

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -988,6 +988,9 @@ export default function PosTransactionsPage() {
                       imagenameField={
                         formConfigs[config.masterTable]?.imagenameField || []
                       }
+                      imageIdField={
+                        formConfigs[config.masterTable]?.imageIdField || ''
+                      }
                       relations={relationsMap[t.table] || {}}
                       relationConfigs={relationConfigs[t.table] || {}}
                       relationData={relationData[t.table] || {}}


### PR DESCRIPTION
## Summary
- Append transaction identifiers to temporary uploads and rename by identifier when found
- Include identifiers in final image names for saved rows
- Auto-rename image files found via identifier when viewing

## Testing
- `npm test` *(fails: ENOENT utime old.txt)*


------
https://chatgpt.com/codex/tasks/task_e_688f041edc3483318646e9f091d57277