### PR TITLE
Handle non-extensible React objects in debug hooks

### DIFF
--- a/src/erp.mgt.mn/utils/debugHooks.js
+++ b/src/erp.mgt.mn/utils/debugHooks.js
@@ -3,6 +3,13 @@ import { debugLog } from './debug.js';
 
 export function setupDebugHooks() {
   if (typeof window === 'undefined' || !window.erpDebug) return;
+  // Some React builds are frozen/non-extensible (e.g. production builds).
+  // Attempting to patch such objects throws a runtime error which breaks the
+  // application during startup. Skip installing debug hooks in that case.
+  if (!Object.isExtensible(React)) {
+    console.warn('Unable to patch React hooks for debug; React object is not extensible');
+    return;
+  }
   if (React.__erpDebugPatched) return;
   Object.defineProperty(React, '__erpDebugPatched', { value: true });
 


### PR DESCRIPTION
## Summary
- Skip installing debug hooks when React object is not extensible to avoid runtime error
- Log a warning instead of throwing when debug hooks cannot be patched

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f14c458e48331bda1051ac3bebcf4