### PR TITLE
refactor fix names folder scan and rename flow

### DIFF
--- a/api-server/routes/transaction_images.js
+++ b/api-server/routes/transaction_images.js
@@ -12,6 +12,7 @@ import {
   fixIncompleteImages,
   checkUploadedImages,
   commitUploadedImages,
+  detectIncompleteFromNames,
 } from '../services/transactionImageService.js';
 import { getGeneralConfig } from '../services/generalConfig.js';
 
@@ -74,6 +75,16 @@ router.post(
     }
   },
 );
+
+router.post('/upload_scan', requireAuth, async (req, res, next) => {
+  try {
+    const names = Array.isArray(req.body?.names) ? req.body.names : [];
+    const { list, skipped, summary } = await detectIncompleteFromNames(names);
+    res.json({ list, skipped, summary });
+  } catch (err) {
+    next(err);
+  }
+});
 
 router.post('/upload_commit', requireAuth, async (req, res, next) => {
   try {

--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -103,6 +103,23 @@ export async function getConfigsByTable(table) {
   return result;
 }
 
+export async function getConfigsByTransTypeValue(val) {
+  const cfg = await readConfig();
+  const result = [];
+  for (const [tbl, names] of Object.entries(cfg)) {
+    for (const [name, info] of Object.entries(names)) {
+      const parsed = parseEntry(info);
+      if (
+        parsed.transactionTypeValue &&
+        String(parsed.transactionTypeValue) === String(val)
+      ) {
+        result.push({ table: tbl, name, config: parsed });
+      }
+    }
+  }
+  return result;
+}
+
 export async function listTransactionNames({ moduleKey, branchId, departmentId } = {}) {
   const cfg = await readConfig();
   const result = {};

--- a/api-server/services/transactionImageService.js
+++ b/api-server/services/transactionImageService.js
@@ -3,7 +3,7 @@ import fssync from 'fs';
 import path from 'path';
 import { getGeneralConfig } from './generalConfig.js';
 import { pool } from '../../db/index.js';
-import { getConfigsByTable } from './transactionFormConfig.js';
+import { getConfigsByTable, getConfigsByTransTypeValue } from './transactionFormConfig.js';
 import { slugify } from '../utils/slugify.js';
 
 async function getDirs() {
@@ -81,6 +81,28 @@ function parseFileUnique(base) {
   return { unique, suffix };
 }
 
+function parseSaveName(base) {
+  const m = base.match(
+    /^(.*?)(?:_(\d{13})_([a-z0-9]{6})|__([a-z0-9]{6}))$/i,
+  );
+  if (!m) return null;
+  const pre = m[1];
+  const ts = m[2] || '';
+  const rand = m[3] || m[4] || '';
+  const segs = pre.split('_');
+  const inv = segs.shift() || '';
+  let sp = '';
+  let transType = '';
+  if (segs.length >= 2) {
+    sp = segs.shift();
+    transType = segs.shift();
+  } else if (segs.length === 1) {
+    transType = segs.shift();
+  }
+  const unique = segs.join('_');
+  return { inv, sp, transType, unique, ts, rand, pre };
+}
+
 function buildFolderName(row, fallback = '') {
   const part1 =
     getCase(row, 'trtype') ||
@@ -99,24 +121,47 @@ function buildFolderName(row, fallback = '') {
   return fallback;
 }
 
+async function fetchTxnCodes() {
+  try {
+    const [rows] = await pool.query('SELECT UITrtype, UITransType FROM code_transaction');
+    const trtypes = (rows || [])
+      .map((r) => String(r.UITrtype || '').toLowerCase())
+      .filter(Boolean);
+    const transTypes = (rows || [])
+      .map((r) => String(r.UITransType || ''))
+      .filter(Boolean);
+    return { trtypes, transTypes };
+  } catch {
+    return { trtypes: [], transTypes: [] };
+  }
+}
+
+function hasTxnCode(base, unique, codes) {
+  const leftover = base.toLowerCase().replace(unique.toLowerCase(), '');
+  const tokens = leftover.split(/[_-]/).filter(Boolean);
+  const hasTrtype = tokens.some((t) => codes.trtypes.includes(t));
+  const hasTransType = tokens.some((t) => codes.transTypes.includes(t));
+  return hasTrtype && hasTransType;
+}
+
 export async function findBenchmarkCode(name) {
   if (!name) return null;
   const base = path.basename(name, path.extname(name));
   const parts = base.split(/[_-]/).filter(Boolean);
   for (const p of parts) {
-    const [rows] = await pool.query(
-      'SELECT UITransType FROM code_transaction WHERE UITransType = ?',
-      [p],
-    );
-    if (rows?.length) return rows[0].UITransType;
-  }
-  const [rows] = await pool.query(
-    'SELECT UITransType, UITrtype FROM code_transaction WHERE image_benchmark = 1',
-  );
-  for (const row of rows || []) {
-    const mark = row.UITrtype;
-    if (mark && base.toLowerCase().includes(String(mark).toLowerCase())) {
-      return row.UITransType;
+    if (/^\d{4}$/.test(p)) {
+      const [rows] = await pool.query(
+        'SELECT UITransType FROM code_transaction WHERE UITransType = ?',
+        [p],
+      );
+      if (rows?.length) return rows[0].UITransType;
+    }
+    if (/^[A-Za-z]{4}$/.test(p)) {
+      const [rows] = await pool.query(
+        'SELECT UITransType FROM code_transaction WHERE UITrtype = ?',
+        [p],
+      );
+      if (rows?.length) return rows[0].UITransType;
     }
   }
   return null;
@@ -129,23 +174,50 @@ async function findTxnByParts(inv, sp, transType, timestamp) {
   } catch {
     return null;
   }
+
+  const cfgMatches = await getConfigsByTransTypeValue(transType);
+  const cfgMap = new Map(
+    cfgMatches.map((m) => [m.table.toLowerCase(), m.config]),
+  );
+
   for (const row of tables || []) {
     const tbl = Object.values(row)[0];
+    if (cfgMap.size && !cfgMap.has(tbl.toLowerCase())) continue;
     let cols;
     try {
       [cols] = await pool.query(`SHOW COLUMNS FROM \`${tbl}\``);
     } catch {
       continue;
     }
-    const invCol = cols.find((c) => ['inventory_code', 'z_mat_code'].includes(c.Field.toLowerCase()));
+    const invCol = cols.find((c) =>
+      ['inventory_code', 'z_mat_code', 'bmtr_pmid'].includes(
+        c.Field.toLowerCase(),
+      ),
+    );
     const spCol = cols.find((c) => c.Field.toLowerCase() === 'sp_primary_code');
-    const transCol = cols.find((c) => ['transtype', 'uitranstype', 'ui_transtype'].includes(c.Field.toLowerCase()));
-    const dateCol = cols.find((c) => c.Field.toLowerCase().includes('date'));
-    if (!invCol || !spCol || !transCol) continue;
-    let sql = `SELECT * FROM \`${tbl}\` WHERE \`${invCol.Field}\` = ? AND \`${spCol.Field}\` = ? AND \`${transCol.Field}\` = ?`;
-    const params = [inv, sp, transType];
-    if (dateCol) {
-      sql += ` AND ABS(TIMESTAMPDIFF(SECOND, FROM_UNIXTIME(?/1000), \`${dateCol.Field}\`)) < 86400`;
+    const transCol = cols.find((c) =>
+      ['transtype', 'uitranstype', 'ui_transtype'].includes(
+        c.Field.toLowerCase(),
+      ),
+    );
+    if (!invCol || !transCol) continue;
+    const cfg = cfgMap.get(tbl.toLowerCase());
+    let dateCol;
+    if (cfg?.dateField?.length) {
+      const lowers = cfg.dateField.map((d) => String(d).toLowerCase());
+      dateCol = cols.find((c) => lowers.includes(c.Field.toLowerCase()));
+    } else {
+      dateCol = cols.find((c) => c.Field.toLowerCase().includes('date'));
+    }
+    let sql = `SELECT * FROM \`${tbl}\` WHERE \`${invCol.Field}\` = ? AND \`${transCol.Field}\` = ?`;
+    const params = [inv, transType];
+    if (sp && spCol) {
+      sql += ` AND \`${spCol.Field}\` = ?`;
+      params.push(sp);
+    }
+    if (dateCol && timestamp) {
+      sql +=
+        ` AND ABS(TIMESTAMPDIFF(SECOND, FROM_UNIXTIME(?/1000), \`${dateCol.Field}\`)) < 172800`;
       params.push(timestamp);
     }
     sql += ' LIMIT 1';
@@ -153,20 +225,25 @@ async function findTxnByParts(inv, sp, transType, timestamp) {
     try {
       [rows] = await pool.query(sql, params);
       if (!rows.length && dateCol) {
-        [rows] = await pool.query(
-          `SELECT * FROM \`${tbl}\` WHERE \`${invCol.Field}\` = ? AND \`${spCol.Field}\` = ? AND \`${transCol.Field}\` = ? LIMIT 1`,
-          [inv, sp, transType],
-        );
+        let sql2 = `SELECT * FROM \`${tbl}\` WHERE \`${invCol.Field}\` = ? AND \`${transCol.Field}\` = ?`;
+        const p2 = [inv, transType];
+        if (sp && spCol) {
+          sql2 += ` AND \`${spCol.Field}\` = ?`;
+          p2.push(sp);
+        }
+        sql2 += ' LIMIT 1';
+        [rows] = await pool.query(sql2, p2);
       }
     } catch {
       continue;
     }
     if (rows.length) {
+      const rowObj = rows[0];
       let cfgs = {};
       try {
         cfgs = await getConfigsByTable(tbl);
       } catch {}
-      return { table: tbl, row: rows[0], configs: cfgs, numField: transCol.Field };
+      return { table: tbl, row: rowObj, configs: cfgs, numField: transCol.Field };
     }
   }
   return null;
@@ -333,7 +410,9 @@ export async function cleanupOldImages(days = 30) {
 
 export async function detectIncompleteImages(page = 1, perPage = 100) {
   const { baseDir } = await getDirs();
+  const codes = await fetchTxnCodes();
   let results = [];
+  const skipped = [];
   let dirs;
   const offset = (page - 1) * perPage;
   let count = 0;
@@ -361,26 +440,68 @@ export async function detectIncompleteImages(page = 1, perPage = 100) {
     for (const f of files) {
       const ext = path.extname(f);
       const base = path.basename(f, ext);
-      const parts = base.split('_');
-      const isSave = /_\d{13}_[a-z0-9]{6}$/i.test(base);
+      const filePath = path.join(dirPath, f);
       let unique = '';
       let suffix = '';
       let found;
-      if (isSave) {
-        const segs = parts.slice();
-        const rand = segs.pop();
-        const ts = segs.pop();
-        const inv = segs.shift();
-        const sp = segs.shift();
-        const transType = segs.shift();
-        unique = segs.join('_');
-        found = await findTxnByParts(inv, sp, transType, Number(ts));
+      const save = parseSaveName(base);
+      if (save) {
+        ({ unique } = save);
+        suffix = `__${save.ts}_${save.rand}`;
+        if (hasTxnCode(base, unique, codes)) {
+          skipped.push({
+            currentName: f,
+            newName: f,
+            folder: entry.name,
+            folderDisplay: '/' + entry.name,
+            currentPath: filePath,
+            reason: 'Contains transaction codes',
+          });
+          continue;
+        }
+        found = await findTxnByParts(
+          save.inv,
+          save.sp,
+          save.transType,
+          Number(save.ts),
+        );
       } else {
         ({ unique, suffix } = parseFileUnique(base));
-        if (!unique || unique.length < 4) continue;
+        if (!unique) {
+          skipped.push({
+            currentName: f,
+            newName: f,
+            folder: entry.name,
+            folderDisplay: '/' + entry.name,
+            currentPath: filePath,
+            reason: 'No unique identifier',
+          });
+          continue;
+        }
+        if (hasTxnCode(base, unique, codes)) {
+          skipped.push({
+            currentName: f,
+            newName: f,
+            folder: entry.name,
+            folderDisplay: '/' + entry.name,
+            currentPath: filePath,
+            reason: 'Contains transaction codes',
+          });
+          continue;
+        }
         found = await findTxnByUniqueId(unique);
       }
-      if (!found) continue;
+      if (!found) {
+        skipped.push({
+          currentName: f,
+          newName: f,
+          folder: entry.name,
+          folderDisplay: '/' + entry.name,
+          currentPath: filePath,
+          reason: 'No matching transaction',
+        });
+        continue;
+      }
       const { row, configs, numField } = found;
 
       const cfg = pickConfig(configs, row);
@@ -441,7 +562,17 @@ export async function detectIncompleteImages(page = 1, perPage = 100) {
         newBase = sanitizeName(String(row[numField]));
         folderRaw = buildFolderName(row, cfg?.imageFolder || entry.name);
       }
-      if (!newBase) continue;
+      if (!newBase) {
+        skipped.push({
+          currentName: f,
+          newName: f,
+          folder: entry.name,
+          folderDisplay: '/' + entry.name,
+          currentPath: filePath,
+          reason: 'No rename mapping',
+        });
+        continue;
+      }
       incompleteFound += 1;
       const folderDisplay = '/' + String(folderRaw).replace(/^\/+/, '');
       const sanitizedUnique = sanitizeName(unique);
@@ -452,6 +583,8 @@ export async function detectIncompleteImages(page = 1, perPage = 100) {
         } else {
           finalBase = `${newBase}_${unique}${suffix}`;
         }
+      } else if (suffix) {
+        finalBase = `${newBase}${suffix}`;
       }
       const newName = `${finalBase}${ext}`;
       count += 1;
@@ -470,7 +603,18 @@ export async function detectIncompleteImages(page = 1, perPage = 100) {
     }
     if (hasMore) break;
   }
-  return { list: results, hasMore, summary: { totalFiles, folders: Array.from(folders), incompleteFound, processed: results.length } };
+  return {
+    list: results,
+    skipped,
+    hasMore,
+    summary: {
+      totalFiles,
+      folders: Array.from(folders),
+      incompleteFound,
+      processed: results.length,
+      skipped: skipped.length,
+    },
+  };
 }
 
 async function findTxnByUniqueId(idPart) {
@@ -527,34 +671,36 @@ export async function fixIncompleteImages(list = []) {
 export async function checkUploadedImages(files = [], names = []) {
   const results = [];
   let processed = 0;
+  const codes = await fetchTxnCodes();
   const limit = 1000;
   let items = files.length
     ? files
     : names.map((n) => ({ originalname: typeof n === 'string' ? n : n?.name || String(n) }));
   items = items.slice(0, limit);
-  for (const file of items) {
-    const ext = path.extname(file.originalname || '');
-    const base = path.basename(file.originalname || '', ext);
-    const parts = base.split('_');
-    const isSave = /_\d{13}_[a-z0-9]{6}$/i.test(base);
-    let unique = '';
-    let suffix = '';
-    let found;
-    if (isSave) {
-      const segs = parts.slice();
-      const rand = segs.pop();
-      const ts = segs.pop();
-      const inv = segs.shift();
-      const sp = segs.shift();
-      const transType = segs.shift();
-      unique = segs.join('_');
-      found = await findTxnByParts(inv, sp, transType, Number(ts));
-    } else {
-      ({ unique, suffix } = parseFileUnique(base));
-      if (!unique) continue;
-      found = await findTxnByUniqueId(unique);
-    }
-    if (!found) continue;
+    for (const file of items) {
+      const ext = path.extname(file.originalname || '');
+      const base = path.basename(file.originalname || '', ext);
+      let unique = '';
+      let suffix = '';
+      let found;
+      const save = parseSaveName(base);
+      if (save) {
+        ({ unique } = save);
+        suffix = `__${save.ts}_${save.rand}`;
+        if (hasTxnCode(base, unique, codes)) continue;
+        found = await findTxnByParts(
+          save.inv,
+          save.sp,
+          save.transType,
+          Number(save.ts),
+        );
+      } else {
+        ({ unique, suffix } = parseFileUnique(base));
+        if (!unique) continue;
+        if (hasTxnCode(base, unique, codes)) continue;
+        found = await findTxnByUniqueId(unique);
+      }
+      if (!found) continue;
     const { row, configs, numField } = found;
     const cfg = pickConfig(configs, row);
     let newBase = '';
@@ -625,6 +771,8 @@ export async function checkUploadedImages(files = [], names = []) {
       } else {
         finalBase = `${newBase}_${unique}${suffix}`;
       }
+    } else if (suffix) {
+      finalBase = `${newBase}${suffix}`;
     }
     const newName = `${finalBase}${ext}`;
     results.push({
@@ -651,4 +799,31 @@ export async function commitUploadedImages(list = []) {
     } catch {}
   }
   return count;
+}
+
+export async function detectIncompleteFromNames(names = []) {
+  const codes = await fetchTxnCodes();
+  const results = [];
+  const skipped = [];
+  let processed = 0;
+  for (const name of names) {
+    const ext = path.extname(name || '');
+    const base = path.basename(name || '', ext);
+    const { unique } = parseFileUnique(base);
+    if (!unique) {
+      skipped.push({ originalName: name, reason: 'No unique identifier' });
+      continue;
+    }
+    if (hasTxnCode(base, unique, codes)) {
+      skipped.push({ originalName: name, reason: 'Contains transaction codes' });
+      continue;
+    }
+    results.push({ originalName: name });
+    processed += 1;
+  }
+  return {
+    list: results,
+    skipped,
+    summary: { totalFiles: names.length, processed, skipped: skipped.length },
+  };
 }

--- a/docs/benchmark-image-verification.md
+++ b/docs/benchmark-image-verification.md
@@ -2,7 +2,7 @@
 
 The `findBenchmarkCode` helper inspects an uploaded image filename and maps it to a transaction type code. The lookup works in two steps:
 
-1. Any underscore or dash separated tokens are checked directly against the `code_transaction.UITransType` column.
-2. When that fails, rows where `image_benchmark` is set to `1` are scanned. If the filename contains a row's `UITrtype` value, its `UITransType` is returned.
+1. Any underscore or dash separated tokens that are four digits long are checked against the `code_transaction.UITransType` column.
+2. Tokens that are four letters long are checked against the `code_transaction.UITrtype` column and return the corresponding `UITransType`.
 
 The utility allows the front end to suggest a transaction code based on existing benchmark images without calling the OpenAI API.

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -1,4 +1,3 @@
-import isEqual from 'lodash.isequal';
 import React, {
   useState,
   useEffect,
@@ -13,6 +12,14 @@ import { useRolePermissions } from '../hooks/useRolePermissions.js';
 import { useCompanyModules } from '../hooks/useCompanyModules.js';
 import { useTxnSession } from '../context/TxnSessionContext.jsx';
 import { useToast } from '../context/ToastContext.jsx';
+
+function isEqual(a, b) {
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}
 
 export default function FinanceTransactions({ moduleKey = 'finance_transactions', moduleLabel = '' }) {
   const renderCount = useRef(0);

--- a/src/erp.mgt.mn/pages/ImageManagement.jsx
+++ b/src/erp.mgt.mn/pages/ImageManagement.jsx
@@ -1,6 +1,17 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useToast } from '../context/ToastContext.jsx';
 
+function extractDateFromName(name) {
+  const match = typeof name === 'string' ? name.match(/(?:__|_)(\d{13})_/) : null;
+  if (match) {
+    const d = new Date(Number(match[1]));
+    if (!isNaN(d.getTime())) {
+      return d.toISOString().split('T')[0];
+    }
+  }
+  return '';
+}
+
 export default function ImageManagement() {
   const { addToast } = useToast();
   const [days, setDays] = useState('');
@@ -10,16 +21,39 @@ export default function ImageManagement() {
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(false);
   const [selected, setSelected] = useState([]);
+  const [hostIgnored, setHostIgnored] = useState([]);
+  const [hostIgnoredSel, setHostIgnoredSel] = useState([]);
+  const [hostIgnoredPage, setHostIgnoredPage] = useState(1);
   const [uploads, setUploads] = useState([]);
   const [uploadSel, setUploadSel] = useState([]);
+  const [uploadPage, setUploadPage] = useState(1);
+  const [uploadPageSize, setUploadPageSize] = useState(200);
+  const [ignored, setIgnored] = useState([]);
+  const [ignoredPage, setIgnoredPage] = useState(1);
   const [folderName, setFolderName] = useState('');
   const [uploadSummary, setUploadSummary] = useState(null);
   const [pendingSummary, setPendingSummary] = useState(null);
-  const [pageSize, setPageSize] = useState(100);
+  const [pageSize, setPageSize] = useState(200);
   const detectAbortRef = useRef();
-  const folderAbortRef = useRef();
   const scanCancelRef = useRef(false);
   const [activeOp, setActiveOp] = useState(null);
+  const [report, setReport] = useState('');
+
+  const uploadStart = (uploadPage - 1) * uploadPageSize;
+  const pageUploads = uploads.slice(uploadStart, uploadStart + uploadPageSize);
+  const uploadHasMore = uploadStart + uploadPageSize < uploads.length;
+  const uploadLastPage = Math.max(1, Math.ceil(uploads.length / uploadPageSize));
+  const ignoredStart = (ignoredPage - 1) * uploadPageSize;
+  const pageIgnored = ignored.slice(ignoredStart, ignoredStart + uploadPageSize);
+  const ignoredHasMore = ignoredStart + uploadPageSize < ignored.length;
+  const ignoredLastPage = Math.max(1, Math.ceil(ignored.length / uploadPageSize));
+  const hostIgnoredStart = (hostIgnoredPage - 1) * pageSize;
+  const pageHostIgnored = hostIgnored.slice(hostIgnoredStart, hostIgnoredStart + pageSize);
+  const hostIgnoredHasMore = hostIgnoredStart + pageSize < hostIgnored.length;
+  const hostIgnoredLastPage = Math.max(1, Math.ceil(hostIgnored.length / pageSize));
+  const lastPage = pendingSummary
+    ? Math.max(1, Math.ceil((pendingSummary.incompleteFound || 0) / pageSize))
+    : 1;
 
   function toggle(id) {
     setSelected((prev) =>
@@ -35,17 +69,35 @@ export default function ImageManagement() {
     }
   }
 
+  function toggleHostIgnored(id) {
+    setHostIgnoredSel((prev) =>
+      prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id],
+    );
+  }
+
+  function toggleHostIgnoredAll(list) {
+    const ids = list.map((p) => p.currentName);
+    const allSelected = ids.every((id) => hostIgnoredSel.includes(id));
+    if (allSelected) {
+      setHostIgnoredSel((prev) => prev.filter((id) => !ids.includes(id)));
+    } else {
+      setHostIgnoredSel((prev) => [...prev, ...ids.filter((id) => !prev.includes(id))]);
+    }
+  }
+
   function toggleUpload(id) {
     setUploadSel((prev) =>
       prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id],
     );
   }
 
-  function toggleUploadAll() {
-    if (uploadSel.length === uploads.length) {
-      setUploadSel([]);
+  function toggleUploadAll(list) {
+    const ids = list.map((u) => u.id);
+    const allSelected = ids.every((id) => uploadSel.includes(id));
+    if (allSelected) {
+      setUploadSel((prev) => prev.filter((id) => !ids.includes(id)));
     } else {
-      setUploadSel(uploads.map((u) => u.id));
+      setUploadSel((prev) => [...prev, ...ids.filter((id) => !prev.includes(id))]);
     }
   }
 
@@ -58,7 +110,6 @@ export default function ImageManagement() {
             detectAbortRef.current?.abort();
           } else {
             scanCancelRef.current = true;
-            folderAbortRef.current?.abort();
           }
           setActiveOp(null);
         }
@@ -77,20 +128,77 @@ export default function ImageManagement() {
     scanCancelRef.current = false;
     try {
       const dirHandle = await window.showDirectoryPicker();
-      const arr = [];
+      const handles = {};
+      const names = [];
       for await (const entry of dirHandle.values()) {
         if (scanCancelRef.current) break;
         if (entry.kind === 'file') {
-          arr.push(entry.name);
+          names.push(entry.name);
+          handles[entry.name] = entry;
         }
       }
       if (scanCancelRef.current) return;
+      const chunkSize = 200;
+      let all = [];
+      let skipped = [];
+      let processed = 0;
+      for (let i = 0; i < names.length; i += chunkSize) {
+        if (scanCancelRef.current) return;
+        let res;
+        try {
+          res = await fetch('/api/transaction_images/upload_scan', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ names: names.slice(i, i + chunkSize) }),
+          });
+        } catch {
+          addToast('Folder scan failed', 'error');
+          return;
+        }
+        if (!res.ok) {
+          addToast('Folder scan failed', 'error');
+          return;
+        }
+        const data = await res.json().catch(() => ({}));
+        const list = Array.isArray(data.list) ? data.list : [];
+        const miss = Array.isArray(data.skipped) ? data.skipped : [];
+        processed += data?.summary?.processed || 0;
+        all = all.concat(list);
+        skipped = skipped.concat(miss);
+      }
+      if (scanCancelRef.current) return;
       setFolderName(dirHandle.name || '');
-      await handleSelectFiles(arr);
+      const sorted = all.slice().sort((a, b) => a.originalName.localeCompare(b.originalName));
+      setUploads(
+        sorted.map((u) => ({
+          originalName: u.originalName,
+          id: u.originalName,
+          handle: handles[u.originalName],
+          description: extractDateFromName(u.originalName),
+        }))
+      );
+      const skippedSorted = skipped
+        .slice()
+        .sort((a, b) => a.originalName.localeCompare(b.originalName));
+      setIgnored(
+        skippedSorted.map((u) => ({
+          originalName: u.originalName,
+          id: u.originalName,
+          handle: handles[u.originalName],
+          reason: u.reason,
+        })),
+      );
+      setUploadSummary({ totalFiles: names.length, processed, unflagged: skipped.length });
+      setUploadSel([]);
+      setUploadPage(1);
+      setIgnoredPage(1);
+      setReport(
+        `Scanned ${names.length} file(s), found ${processed} incomplete name(s), ${skipped.length} unflagged.`,
+      );
     } catch {
       // ignore
     } finally {
-      folderAbortRef.current = null;
       scanCancelRef.current = false;
       setActiveOp(null);
     }
@@ -113,31 +221,56 @@ export default function ImageManagement() {
     }
   }
 
-  async function detectFromHost(p = page, s = pageSize) {
+  async function detectFromHost(p = page) {
     const controller = new AbortController();
     detectAbortRef.current = controller;
     setActiveOp('detect');
     try {
-      const res = await fetch(`/api/transaction_images/detect_incomplete?page=${p}&pageSize=${s}`, {
+      const res = await fetch(`/api/transaction_images/detect_incomplete?page=${p}&pageSize=${pageSize}`, {
         credentials: 'include',
         signal: controller.signal,
       });
       if (res.ok) {
         const data = await res.json();
-        setPending(Array.isArray(data.list) ? data.list : []);
+        const list = Array.isArray(data.list)
+          ? data.list
+              .slice()
+              .sort((a, b) => a.currentName.localeCompare(b.currentName))
+              .map((p) => ({ ...p, description: extractDateFromName(p.currentName) }))
+          : [];
+        const miss = Array.isArray(data.skipped)
+          ? data.skipped
+              .slice()
+              .sort((a, b) => a.currentName.localeCompare(b.currentName))
+              .map((p) => ({
+                ...p,
+                description: extractDateFromName(p.currentName),
+              }))
+          : [];
+        setPending(list);
+        setHostIgnored(miss);
+        setHostIgnoredPage(1);
         setPendingSummary(data.summary || null);
         setHasMore(!!data.hasMore);
         setSelected([]);
+        setHostIgnoredSel([]);
+        const sum = data.summary || {};
+        setReport(
+          `Scanned ${sum.totalFiles || 0} file(s), found ${sum.incompleteFound || 0} incomplete name(s), ${sum.skipped || 0} not incomplete.`,
+        );
       } else {
         setPending([]);
+        setHostIgnored([]);
+        setHostIgnoredPage(1);
         setPendingSummary(null);
         setHasMore(false);
       }
       setPage(p);
-      setPageSize(s);
     } catch (e) {
       if (e.name !== 'AbortError') {
         setPending([]);
+        setHostIgnored([]);
+        setHostIgnoredPage(1);
         setPendingSummary(null);
         setHasMore(false);
       }
@@ -146,11 +279,10 @@ export default function ImageManagement() {
       setActiveOp(null);
     }
     setPage(p);
-    setPageSize(s);
   }
 
-  async function applyFixes() {
-    const items = pending.filter((p) => selected.includes(p.currentName));
+  async function applyFixesSelection(list, sel) {
+    const items = list.filter((p) => sel.includes(p.currentName));
     if (items.length === 0) return;
     const res = await fetch('/api/transaction_images/fix_incomplete', {
       method: 'POST',
@@ -161,60 +293,74 @@ export default function ImageManagement() {
     if (res.ok) {
       const data = await res.json().catch(() => ({}));
       addToast(`Renamed ${data.fixed || 0} file(s)`, 'success');
+      setReport(`Renamed ${data.fixed || 0} file(s)`);
       detectFromHost(page);
     } else {
       addToast('Rename failed', 'error');
     }
   }
 
-  async function handleSelectFiles(names) {
-    const normalized = (names || [])
-      .map((n) => (typeof n === 'string' ? n : n?.name))
-      .filter(Boolean);
-    if (!normalized.length) return;
-    const controller = new AbortController();
-    folderAbortRef.current = controller;
-    const chunkSize = 200;
-    const all = [];
-    let total = 0;
-    let processed = 0;
+  async function applyFixes() {
+    await applyFixesSelection(pending, selected);
+  }
+
+  async function applyFixesHostIgnored() {
+    await applyFixesSelection(hostIgnored, hostIgnoredSel);
+  }
+
+  async function renameSelected() {
+    const items = [...uploads, ...ignored].filter(
+      (u) => uploadSel.includes(u.id) && u.handle && !u.tmpPath,
+    );
+    if (items.length === 0) return;
+    const formData = new FormData();
     try {
-      for (let i = 0; i < normalized.length; i += chunkSize) {
-        if (scanCancelRef.current) break;
-        const chunk = normalized.slice(i, i + chunkSize);
-        const res = await fetch('/api/transaction_images/upload_check', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ names: chunk }),
-          credentials: 'include',
-          signal: controller.signal,
+      for (const u of items) {
+        const file = await u.handle.getFile();
+        formData.append('images', file, u.originalName);
+      }
+    } catch {
+      addToast('Rename failed', 'error');
+      return;
+    }
+    try {
+      const res = await fetch('/api/transaction_images/upload_check', {
+        method: 'POST',
+        body: formData,
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        addToast('Rename failed', 'error');
+        return;
+      }
+      const data = await res.json().catch(() => ({}));
+      const list = Array.isArray(data.list) ? data.list : [];
+      setUploads((prev) => {
+        const mapped = prev.map((u) => {
+          const found = list.find((x) => x.originalName === u.originalName);
+          const merged = found ? { ...u, ...found, id: u.id } : u;
+          return { ...merged, description: extractDateFromName(merged.originalName) };
         });
-        if (!res.ok) {
-          addToast('Check failed', 'error');
-          return;
-        }
-        const data = await res.json().catch(() => ({}));
-        const list = Array.isArray(data.list) ? data.list : [];
-        all.push(...list);
-        total += data.summary?.totalFiles || chunk.length;
-        processed += data.summary?.processed || 0;
-      }
-      if (!scanCancelRef.current) {
-        setUploads(all);
-        setUploadSummary({ totalFiles: total, processed });
-        setUploadSel([]);
-      }
-    } catch (e) {
-      if (e.name !== 'AbortError') {
-        addToast('Check failed', 'error');
-      }
-    } finally {
-      folderAbortRef.current = null;
+        return mapped.sort((a, b) => a.originalName.localeCompare(b.originalName));
+      });
+      setIgnored((prev) => {
+        const mapped = prev.map((u) => {
+          const found = list.find((x) => x.originalName === u.originalName);
+          const merged = found ? { ...u, ...found, id: u.id } : u;
+          return { ...merged, description: extractDateFromName(merged.originalName) };
+        });
+        return mapped.sort((a, b) => a.originalName.localeCompare(b.originalName));
+      });
+      setReport(`Renamed ${list.length} file(s)`);
+    } catch {
+      addToast('Rename failed', 'error');
     }
   }
 
   async function commitUploads() {
-    const items = uploads.filter((u) => uploadSel.includes(u.id) && u.tmpPath);
+    const items = [...uploads, ...ignored].filter(
+      (u) => uploadSel.includes(u.id) && u.tmpPath,
+    );
     if (items.length === 0) return;
     const res = await fetch('/api/transaction_images/upload_commit', {
       method: 'POST',
@@ -225,9 +371,10 @@ export default function ImageManagement() {
     if (res.ok) {
       const data = await res.json().catch(() => ({}));
       addToast(`Uploaded ${data.uploaded || 0} file(s)`, 'success');
-      setUploads([]);
+      setUploads((prev) => prev.filter((u) => !uploadSel.includes(u.id)));
+      setIgnored((prev) => prev.filter((u) => !uploadSel.includes(u.id)));
       setUploadSel([]);
-      setUploadSummary(null);
+      setReport(`Uploaded ${data.uploaded || 0} file(s)`);
     } else {
       addToast('Upload failed', 'error');
     }
@@ -264,6 +411,9 @@ export default function ImageManagement() {
         </div>
       ) : (
         <div>
+          {report && (
+            <p style={{ color: 'red', marginBottom: '0.5rem' }}>{report}</p>
+          )}
           <div style={{ marginBottom: '0.5rem' }}>
             <button type="button" onClick={selectFolder} style={{ marginRight: '0.5rem' }}>
               Select Folder
@@ -272,70 +422,218 @@ export default function ImageManagement() {
           </div>
           {uploadSummary && (
             <p style={{ marginBottom: '0.5rem' }}>
-              {`Scanned ${uploadSummary.totalFiles || 0} file(s), processed ${uploadSummary.processed || 0}.`}
+              {`Scanned ${uploadSummary.totalFiles || 0} file(s), found ${uploadSummary.processed || 0} incomplete name(s), ${uploadSummary.unflagged || 0} unflagged.`}
             </p>
           )}
-          {uploads.length > 0 && (
+          {(uploads.length > 0 || ignored.length > 0) && (
             <div style={{ marginBottom: '1rem' }}>
               <h4>Uploads</h4>
+              <button
+                type="button"
+                onClick={renameSelected}
+                style={{ marginBottom: '0.5rem', marginRight: '0.5rem' }}
+                disabled={uploadSel.length === 0}
+              >
+                Rename Selected
+              </button>
               <button
                 type="button"
                 onClick={commitUploads}
                 style={{ marginBottom: '0.5rem' }}
                 disabled={
                   uploadSel.length === 0 ||
-                  !uploads.some((u) => uploadSel.includes(u.id) && u.tmpPath)
+                  ![...uploads, ...ignored].some((u) => uploadSel.includes(u.id) && u.tmpPath)
                 }
               >
-                Rename &amp; Upload Selected
+                Upload Selected
               </button>
               <button
                 type="button"
                 onClick={() => {
                   setUploads((prev) => prev.filter((u) => !uploadSel.includes(u.id)));
+                  setIgnored((prev) => prev.filter((u) => !uploadSel.includes(u.id)));
                   setUploadSel([]);
+                  setReport(`Deleted ${uploadSel.length} file(s)`);
                 }}
                 style={{ marginBottom: '0.5rem', marginLeft: '0.5rem' }}
                 disabled={uploadSel.length === 0}
               >
                 Delete Selected
               </button>
-              <table className="min-w-full border border-gray-300 text-sm" style={{ tableLayout: 'fixed' }}>
-                <thead>
-                  <tr>
-                    <th className="border px-2 py-1">
-                      <input type="checkbox" checked={uploadSel.length === uploads.length && uploads.length > 0} onChange={toggleUploadAll} />
-                    </th>
-                    <th className="border px-2 py-1">Original</th>
-                    <th className="border px-2 py-1">New Name</th>
-                    <th className="border px-2 py-1">Folder</th>
-                    <th className="border px-2 py-1">Delete</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {uploads.map((u) => (
-                    <tr key={u.id} className={uploadSel.includes(u.id) ? 'bg-blue-50' : ''}>
-                      <td className="border px-2 py-1 text-center">
-                        <input type="checkbox" checked={uploadSel.includes(u.id)} onChange={() => toggleUpload(u.id)} />
-                      </td>
-                      <td className="border px-2 py-1">{u.originalName}</td>
-                      <td className="border px-2 py-1">{u.newName}</td>
-                      <td className="border px-2 py-1">{u.folderDisplay}</td>
-                      <td className="border px-2 py-1 text-center">
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setUploads((prev) => prev.filter((x) => x.id !== u.id));
-                            setUploadSel((s) => s.filter((id) => id !== u.id));
-                          }}
-                        >
-                          Delete
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+              <div style={{ marginBottom: '0.5rem' }}>
+                <label style={{ marginRight: '0.5rem' }}>
+                  Page Size:{' '}
+                  <input
+                    type="number"
+                    value={uploadPageSize}
+                    onChange={(e) => {
+                      setUploadPageSize(Number(e.target.value));
+                      setUploadPage(1);
+                      setIgnoredPage(1);
+                    }}
+                    style={{ width: '4rem' }}
+                  />
+                </label>
+              </div>
+              {uploads.length > 0 && (
+                <div style={{ marginBottom: '1rem' }}>
+                  <div style={{ marginBottom: '0.5rem' }}>
+                    <button
+                      type="button"
+                      disabled={uploadPage === 1}
+                      onClick={() => setUploadPage(1)}
+                      style={{ marginRight: '0.5rem' }}
+                    >
+                      First
+                    </button>
+                    <button
+                      type="button"
+                      disabled={uploadPage === 1}
+                      onClick={() => setUploadPage(uploadPage - 1)}
+                      style={{ marginRight: '0.5rem' }}
+                    >
+                      Prev
+                    </button>
+                    <button
+                      type="button"
+                      disabled={!uploadHasMore}
+                      onClick={() => setUploadPage(uploadPage + 1)}
+                      style={{ marginRight: '0.5rem' }}
+                    >
+                      Next
+                    </button>
+                    <button
+                      type="button"
+                      disabled={uploadPage === uploadLastPage}
+                      onClick={() => setUploadPage(uploadLastPage)}
+                    >
+                      Last
+                    </button>
+                  </div>
+                  <table className="min-w-full border border-gray-300 text-sm" style={{ tableLayout: 'fixed' }}>
+                    <thead>
+                      <tr>
+                        <th className="border px-2 py-1">
+                          <input
+                            type="checkbox"
+                            checked={pageUploads.length > 0 && pageUploads.every((u) => uploadSel.includes(u.id))}
+                            onChange={() => toggleUploadAll(pageUploads)}
+                          />
+                        </th>
+                        <th className="border px-2 py-1">Original</th>
+                        <th className="border px-2 py-1">New Name</th>
+                        <th className="border px-2 py-1">Folder</th>
+                        <th className="border px-2 py-1">Description</th>
+                        <th className="border px-2 py-1">Delete</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {pageUploads.map((u) => (
+                        <tr key={u.id} className={uploadSel.includes(u.id) ? 'bg-blue-50' : ''}>
+                          <td className="border px-2 py-1 text-center">
+                            <input type="checkbox" checked={uploadSel.includes(u.id)} onChange={() => toggleUpload(u.id)} />
+                          </td>
+                          <td className="border px-2 py-1">{u.originalName}</td>
+                          <td className="border px-2 py-1">{u.newName}</td>
+                          <td className="border px-2 py-1">{u.folderDisplay}</td>
+                          <td className="border px-2 py-1">{u.description}</td>
+                          <td className="border px-2 py-1 text-center">
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setUploads((prev) => prev.filter((x) => x.id !== u.id));
+                                setUploadSel((s) => s.filter((id) => id !== u.id));
+                              }}
+                            >
+                              Delete
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+              {ignored.length > 0 && (
+                <div>
+                  <h4>Not Incomplete</h4>
+                  <div style={{ marginBottom: '0.5rem' }}>
+                    <button
+                      type="button"
+                      disabled={ignoredPage === 1}
+                      onClick={() => setIgnoredPage(1)}
+                      style={{ marginRight: '0.5rem' }}
+                    >
+                      First
+                    </button>
+                    <button
+                      type="button"
+                      disabled={ignoredPage === 1}
+                      onClick={() => setIgnoredPage(ignoredPage - 1)}
+                      style={{ marginRight: '0.5rem' }}
+                    >
+                      Prev
+                    </button>
+                    <button
+                      type="button"
+                      disabled={!ignoredHasMore}
+                      onClick={() => setIgnoredPage(ignoredPage + 1)}
+                      style={{ marginRight: '0.5rem' }}
+                    >
+                      Next
+                    </button>
+                    <button
+                      type="button"
+                      disabled={ignoredPage === ignoredLastPage}
+                      onClick={() => setIgnoredPage(ignoredLastPage)}
+                    >
+                      Last
+                    </button>
+                  </div>
+                  <table className="min-w-full border border-gray-300 text-sm" style={{ tableLayout: 'fixed' }}>
+                    <thead>
+                      <tr>
+                        <th className="border px-2 py-1">
+                          <input
+                            type="checkbox"
+                            checked={pageIgnored.length > 0 && pageIgnored.every((u) => uploadSel.includes(u.id))}
+                            onChange={() => toggleUploadAll(pageIgnored)}
+                          />
+                        </th>
+                        <th className="border px-2 py-1">Original</th>
+                        <th className="border px-2 py-1">New Name</th>
+                        <th className="border px-2 py-1">Folder</th>
+                        <th className="border px-2 py-1">Description</th>
+                        <th className="border px-2 py-1">Delete</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {pageIgnored.map((u) => (
+                        <tr key={u.id} className={uploadSel.includes(u.id) ? 'bg-blue-50' : ''}>
+                          <td className="border px-2 py-1 text-center">
+                            <input type="checkbox" checked={uploadSel.includes(u.id)} onChange={() => toggleUpload(u.id)} />
+                          </td>
+                          <td className="border px-2 py-1">{u.originalName}</td>
+                          <td className="border px-2 py-1">{u.newName}</td>
+                          <td className="border px-2 py-1">{u.folderDisplay}</td>
+                          <td className="border px-2 py-1">{u.reason}</td>
+                          <td className="border px-2 py-1 text-center">
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setIgnored((prev) => prev.filter((x) => x.id !== u.id));
+                                setUploadSel((s) => s.filter((id) => id !== u.id));
+                              }}
+                            >
+                              Delete
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
             </div>
           )}
           <div style={{ marginBottom: '0.5rem', marginTop: '1rem' }}>
@@ -344,17 +642,21 @@ export default function ImageManagement() {
             </button>
             <label style={{ marginRight: '0.5rem' }}>
               Page Size:{' '}
-              <select
+              <input
+                type="number"
                 value={pageSize}
-                onChange={(e) => detectFromHost(1, Number(e.target.value))}
-              >
-                {[50, 100, 200].map((n) => (
-                  <option key={n} value={n}>
-                    {n}
-                  </option>
-                ))}
-              </select>
+                onChange={(e) => setPageSize(Number(e.target.value))}
+                style={{ width: '4rem' }}
+              />
             </label>
+            <button
+              type="button"
+              disabled={page === 1}
+              onClick={() => detectFromHost(1)}
+              style={{ marginRight: '0.5rem' }}
+            >
+              First
+            </button>
             <button
               type="button"
               disabled={page === 1}
@@ -363,8 +665,20 @@ export default function ImageManagement() {
             >
               Prev
             </button>
-            <button type="button" disabled={!hasMore} onClick={() => detectFromHost(page + 1)}>
+            <button
+              type="button"
+              disabled={!hasMore}
+              onClick={() => detectFromHost(page + 1)}
+              style={{ marginRight: '0.5rem' }}
+            >
               Next
+            </button>
+            <button
+              type="button"
+              disabled={page === lastPage}
+              onClick={() => detectFromHost(lastPage)}
+            >
+              Last
             </button>
           </div>
           {pendingSummary && (
@@ -406,6 +720,7 @@ export default function ImageManagement() {
                     <th className="border px-2 py-1">Current</th>
                     <th className="border px-2 py-1">New Name</th>
                     <th className="border px-2 py-1">Folder</th>
+                    <th className="border px-2 py-1">Description</th>
                     <th className="border px-2 py-1">Delete</th>
                   </tr>
                 </thead>
@@ -418,12 +733,123 @@ export default function ImageManagement() {
                       <td className="border px-2 py-1">{p.currentName}</td>
                       <td className="border px-2 py-1">{p.newName}</td>
                       <td className="border px-2 py-1">{p.folderDisplay}</td>
+                      <td className="border px-2 py-1">{p.description}</td>
                       <td className="border px-2 py-1 text-center">
                         <button
                           type="button"
                           onClick={() => {
                             setPending((prev) => prev.filter((x) => x.currentName !== p.currentName));
                             setSelected((s) => s.filter((id) => id !== p.currentName));
+                          }}
+                        >
+                          Delete
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {hostIgnored.length > 0 && (
+            <div style={{ marginTop: '1rem' }}>
+              <h4>Not Incomplete</h4>
+              <button
+                type="button"
+                onClick={applyFixesHostIgnored}
+                style={{ marginBottom: '0.5rem' }}
+                disabled={hostIgnoredSel.length === 0}
+              >
+                Rename &amp; Move Selected
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setHostIgnored((prev) => prev.filter((p) => !hostIgnoredSel.includes(p.currentName)));
+                  setHostIgnoredSel([]);
+                }}
+                style={{ marginBottom: '0.5rem', marginLeft: '0.5rem' }}
+                disabled={hostIgnoredSel.length === 0}
+              >
+                Delete Selected
+              </button>
+              <div style={{ marginBottom: '0.5rem' }}>
+                <button
+                  type="button"
+                  disabled={hostIgnoredPage === 1}
+                  onClick={() => setHostIgnoredPage(1)}
+                  style={{ marginRight: '0.5rem' }}
+                >
+                  First
+                </button>
+                <button
+                  type="button"
+                  disabled={hostIgnoredPage === 1}
+                  onClick={() => setHostIgnoredPage(hostIgnoredPage - 1)}
+                  style={{ marginRight: '0.5rem' }}
+                >
+                  Prev
+                </button>
+                <button
+                  type="button"
+                  disabled={!hostIgnoredHasMore}
+                  onClick={() => setHostIgnoredPage(hostIgnoredPage + 1)}
+                  style={{ marginRight: '0.5rem' }}
+                >
+                  Next
+                </button>
+                <button
+                  type="button"
+                  disabled={hostIgnoredPage === hostIgnoredLastPage}
+                  onClick={() => setHostIgnoredPage(hostIgnoredLastPage)}
+                >
+                  Last
+                </button>
+              </div>
+              <table className="min-w-full border border-gray-300 text-sm" style={{ tableLayout: 'fixed' }}>
+                <thead>
+                  <tr>
+                    <th className="border px-2 py-1">
+                      <input
+                        type="checkbox"
+                        checked={
+                          pageHostIgnored.length > 0 &&
+                          pageHostIgnored.every((p) => hostIgnoredSel.includes(p.currentName))
+                        }
+                        onChange={() => toggleHostIgnoredAll(pageHostIgnored)}
+                      />
+                    </th>
+                    <th className="border px-2 py-1">Original</th>
+                    <th className="border px-2 py-1">New Name</th>
+                    <th className="border px-2 py-1">Folder</th>
+                    <th className="border px-2 py-1">Description</th>
+                    <th className="border px-2 py-1">Delete</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pageHostIgnored.map((p) => (
+                    <tr key={p.currentName} className={hostIgnoredSel.includes(p.currentName) ? 'bg-blue-50' : ''}>
+                      <td className="border px-2 py-1 text-center">
+                        <input
+                          type="checkbox"
+                          checked={hostIgnoredSel.includes(p.currentName)}
+                          onChange={() => toggleHostIgnored(p.currentName)}
+                        />
+                      </td>
+                      <td className="border px-2 py-1">{p.currentName}</td>
+                      <td className="border px-2 py-1">{p.newName}</td>
+                      <td className="border px-2 py-1">{p.folderDisplay}</td>
+                      <td className="border px-2 py-1">
+                        {p.description}
+                        {p.description && p.reason ? ' - ' : ''}
+                        {p.reason}
+                      </td>
+                      <td className="border px-2 py-1 text-center">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setHostIgnored((prev) => prev.filter((x) => x.currentName !== p.currentName));
+                            setHostIgnoredSel((s) => s.filter((id) => id !== p.currentName));
                           }}
                         >
                           Delete

--- a/src/erp.mgt.mn/utils/debugHooks.js
+++ b/src/erp.mgt.mn/utils/debugHooks.js
@@ -4,7 +4,7 @@ import { debugLog } from './debug.js';
 export function setupDebugHooks() {
   if (typeof window === 'undefined' || !window.erpDebug) return;
   if (React.__erpDebugPatched) return;
-  React.__erpDebugPatched = true;
+  Object.defineProperty(React, '__erpDebugPatched', { value: true });
 
   function replaceHook(name, wrapper) {
     const desc = Object.getOwnPropertyDescriptor(React, name);

--- a/tests/api/cleanupOldImages.test.js
+++ b/tests/api/cleanupOldImages.test.js
@@ -6,7 +6,7 @@ import { cleanupOldImages } from '../../api-server/services/transactionImageServ
 
 const baseDir = path.join(process.cwd(), 'uploads', 'txn_images', 'test_cleanup');
 
-test('cleanupOldImages removes old files', async () => {
+test('cleanupOldImages removes old files', { concurrency: false }, async () => {
   await fs.mkdir(baseDir, { recursive: true });
   const file = path.join(baseDir, 'old.txt');
   await fs.writeFile(file, 'temp');

--- a/tests/api/detectIncompleteImages.test.js
+++ b/tests/api/detectIncompleteImages.test.js
@@ -2,7 +2,13 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'fs/promises';
 import path from 'path';
-import { detectIncompleteImages, fixIncompleteImages, checkUploadedImages, commitUploadedImages } from '../../api-server/services/transactionImageService.js';
+import {
+  detectIncompleteImages,
+  fixIncompleteImages,
+  checkUploadedImages,
+  commitUploadedImages,
+  detectIncompleteFromNames,
+} from '../../api-server/services/transactionImageService.js';
 import * as db from '../../db/index.js';
 
 function mockPool(handler) {
@@ -116,6 +122,68 @@ await test('detectIncompleteImages scans entire folder', async () => {
   await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
 });
 
+await test('detectIncompleteImages skips files with transaction codes', { concurrency: false }, async () => {
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  const dir = path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test');
+  await fs.mkdir(dir, { recursive: true });
+  const ts = 1754112726584;
+  await fs.writeFile(path.join(dir, `uuid12345.jpg`), 'x');
+  await fs.writeFile(
+    path.join(dir, `t1_4001_uuid12345_${ts}_abcd12.jpg`),
+    'x',
+  );
+
+  const row = {
+    id: 1,
+    num_field: 'uuid12345',
+    label_field: 'img010',
+    UITrtype: 't1',
+    TransType: '4001',
+  };
+  const restoreDb = mockPool(async (sql, params) => {
+    if (/SELECT UITrtype, UITransType FROM code_transaction/.test(sql))
+      return [[{ UITrtype: 't1', UITransType: '4001' }]];
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql))
+      return [[
+        { Field: 'num_field' },
+        { Field: 'label_field' },
+        { Field: 'UITrtype' },
+        { Field: 'TransType' },
+      ]];
+    if (/FROM `transactions_test`/.test(sql)) {
+      if (params && params[0] && params[0].includes('uuid12345')) return [[row]];
+      return [[]];
+    }
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: {
+          imagenameField: ['label_field'],
+          transactionTypeField: 'TransType',
+          transactionTypeValue: '4001',
+        },
+      },
+    }),
+  );
+
+  const { list, skipped } = await detectIncompleteImages(1, 10);
+  assert.equal(list.length, 1);
+  assert.equal(list[0].currentName, 'uuid12345.jpg');
+  assert.equal(skipped.length, 1);
+  assert.equal(skipped[0].currentName, `t1_4001_uuid12345_${ts}_abcd12.jpg`);
+  assert.equal(skipped[0].reason, 'Contains transaction codes');
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});
+
 await test('checkUploadedImages handles object names', async () => {
   const restoreDb = mockPool(async () => [[]]);
   const { list, summary } = await checkUploadedImages([], [{ name: 'abc.jpg' }]);
@@ -165,6 +233,72 @@ await test('checkUploadedImages renames on upload', async () => {
     path.join(process.cwd(), 'uploads', 'txn_images', 't1', 'a'),
   );
   assert.ok(exists.some((f) => f.includes('num002')));
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});
+
+await test('checkUploadedImages skips files with transaction codes', async () => {
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  await fs.mkdir(path.join(process.cwd(), 'uploads', 'tmp'), { recursive: true });
+  const ts = 1754112726584;
+  const tmp1 = path.join(process.cwd(), 'uploads', 'tmp', 'uuid12345.jpg');
+  const tmp2 = path.join(
+    process.cwd(),
+    'uploads',
+    'tmp',
+    `t1_4001_uuid12345_${ts}_abcd12.jpg`,
+  );
+  await fs.writeFile(tmp1, 'x');
+  await fs.writeFile(tmp2, 'x');
+
+  const row = {
+    id: 1,
+    num_field: 'uuid12345',
+    label_field: 'img011',
+    UITrtype: 't1',
+    TransType: '4001',
+  };
+  const restoreDb = mockPool(async (sql, params) => {
+    if (/SELECT UITrtype, UITransType FROM code_transaction/.test(sql))
+      return [[{ UITrtype: 't1', UITransType: '4001' }]];
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql))
+      return [[
+        { Field: 'num_field' },
+        { Field: 'label_field' },
+        { Field: 'UITrtype' },
+        { Field: 'TransType' },
+      ]];
+    if (/FROM `transactions_test`/.test(sql)) {
+      if (params && params[0] && params[0].includes('uuid12345')) return [[row]];
+      return [[]];
+    }
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: {
+          imagenameField: ['label_field'],
+          transactionTypeField: 'TransType',
+          transactionTypeValue: '4001',
+        },
+      },
+    }),
+  );
+
+  const { list, summary } = await checkUploadedImages([
+    { originalname: 'uuid12345.jpg', path: tmp1 },
+    { originalname: `t1_4001_uuid12345_${ts}_abcd12.jpg`, path: tmp2 },
+  ]);
+  assert.equal(summary.processed, 1);
+  assert.equal(list.length, 1);
+  assert.equal(list[0].originalName, 'uuid12345.jpg');
 
   restoreDb();
   await fs.writeFile(cfgPath, origCfg);
@@ -263,14 +397,14 @@ await test('detectIncompleteImages handles timestamped names without trtype', as
 
   const { list } = await detectIncompleteImages(1);
   assert.equal(list.length, 1);
-  assert.equal(list[0].newName, 'img003.jpg');
+  assert.equal(list[0].newName, `img003__${ts}_c2kene.jpg`);
 
   const moved = await fixIncompleteImages(list);
   assert.equal(moved, 1);
   const exists = await fs.readdir(
     path.join(process.cwd(), 'uploads', 'txn_images', 't3', '4001'),
   );
-  assert.ok(exists.includes('img003.jpg'));
+  assert.ok(exists.includes(`img003__${ts}_c2kene.jpg`));
 
   restoreDb();
   await fs.writeFile(cfgPath, origCfg);
@@ -326,7 +460,135 @@ await test('detectIncompleteImages ignores timestamp mismatch when searching', a
 
   const { list } = await detectIncompleteImages(1);
   assert.equal(list.length, 1);
-  assert.equal(list[0].newName, 'img009.jpg');
+  assert.equal(list[0].newName, `img009__${ts}_c2kene.jpg`);
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});
+
+await test('detectIncompleteImages finds bmtr_pmid files within 2-day range', async () => {
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  const dir = path.join(
+    process.cwd(),
+    'uploads',
+    'txn_images',
+    'transactions_test',
+  );
+  await fs.mkdir(dir, { recursive: true });
+  const ts = 1754119571573;
+  const file = path.join(dir, `303204_303204_4001_${ts}_4rpenn.jpg`);
+  await fs.writeFile(file, 'x');
+
+  const row = {
+    id: 1,
+    bmtr_pmid: '303204',
+    sp_primary_code: '303204',
+    TransType: '4001',
+    UITrtype: 't9',
+    label_field: 'img011',
+    created_at: new Date(ts - 1 * 24 * 3600 * 1000),
+  };
+
+  const restoreDb = mockPool(async (sql) => {
+    if (/SELECT UITrtype, UITransType FROM code_transaction/.test(sql))
+      return [[{ UITrtype: 't9', UITransType: '4001' }]];
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql))
+      return [[
+        { Field: 'bmtr_pmid' },
+        { Field: 'sp_primary_code' },
+        { Field: 'TransType' },
+        { Field: 'UITrtype' },
+        { Field: 'created_at' },
+        { Field: 'label_field' },
+      ]];
+    if (/FROM `transactions_test`/.test(sql)) return [[row]];
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: {
+          imagenameField: ['label_field'],
+          transactionTypeField: 'TransType',
+          transactionTypeValue: '4001',
+          dateField: ['created_at'],
+        },
+      },
+    }),
+  );
+
+  const { list } = await detectIncompleteImages(1);
+  assert.equal(list.length, 1);
+  assert.equal(list[0].newName, `img011__${ts}_4rpenn.jpg`);
+
+  restoreDb();
+  await fs.writeFile(cfgPath, origCfg);
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+});
+
+await test('detectIncompleteImages handles files without sp_primary_code', async () => {
+  await fs.rm(path.join(process.cwd(), 'uploads'), { recursive: true, force: true });
+  const dir = path.join(
+    process.cwd(),
+    'uploads',
+    'txn_images',
+    'transactions_test',
+  );
+  await fs.mkdir(dir, { recursive: true });
+  const ts = 1754117891085;
+  const file = path.join(dir, `300531_4001_${ts}_wfrv5b.jpg`);
+  await fs.writeFile(file, 'x');
+
+  const row = {
+    id: 1,
+    bmtr_pmid: '300531',
+    TransType: '4001',
+    UITrtype: 't1',
+    label_field: 'img012',
+    created_at: new Date(ts - 1 * 24 * 3600 * 1000),
+  };
+
+  const restoreDb = mockPool(async (sql) => {
+    if (/SELECT UITrtype, UITransType FROM code_transaction/.test(sql))
+      return [[{ UITrtype: 't1', UITransType: '4001' }]];
+    if (/SHOW TABLES LIKE/.test(sql)) return [[{ t: 'transactions_test' }]];
+    if (/SHOW COLUMNS FROM/.test(sql))
+      return [[
+        { Field: 'bmtr_pmid' },
+        { Field: 'sp_primary_code' },
+        { Field: 'TransType' },
+        { Field: 'UITrtype' },
+        { Field: 'created_at' },
+        { Field: 'label_field' },
+      ]];
+    if (/FROM `transactions_test`/.test(sql)) return [[row]];
+    return [[]];
+  });
+
+  const origCfg = await fs.readFile(cfgPath, 'utf8').catch(() => '{}');
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify({
+      transactions_test: {
+        default: {
+          imagenameField: ['label_field'],
+          transactionTypeField: 'TransType',
+          transactionTypeValue: '4001',
+          dateField: ['created_at'],
+        },
+      },
+    }),
+  );
+
+  const { list, skipped } = await detectIncompleteImages(1);
+  assert.equal(list.length, 1);
+  assert.equal(skipped.length, 0);
+  assert.equal(list[0].newName, `img012__${ts}_wfrv5b.jpg`);
 
   restoreDb();
   await fs.writeFile(cfgPath, origCfg);
@@ -384,14 +646,14 @@ await test('checkUploadedImages handles timestamped names', async () => {
   ]);
   assert.equal(summary.processed, 1);
   assert.equal(list.length, 1);
-  assert.equal(list[0].newName, 'img004.jpg');
+  assert.equal(list[0].newName, `img004__${ts}_c2kene.jpg`);
 
   const uploaded = await commitUploadedImages(list);
   assert.equal(uploaded, 1);
   const exists = await fs.readdir(
     path.join(process.cwd(), 'uploads', 'txn_images', 't3', '4001'),
   );
-  assert.ok(exists.includes('img004.jpg'));
+  assert.ok(exists.includes(`img004__${ts}_c2kene.jpg`));
 
   restoreDb();
   await fs.writeFile(cfgPath, origCfg);
@@ -583,7 +845,7 @@ await test('detectIncompleteImages handles extra unique before timestamp', async
   assert.equal(list.length, 1);
   assert.equal(
     list[0].newName,
-    'img007_ydzfh-sdang-cxfxb-kajww_akihl-zukov-ulioe-fhnde.jpg',
+    `img007_ydzfh-sdang-cxfxb-kajww_akihl-zukov-ulioe-fhnde__${ts}_oge4m7.jpg`,
   );
 
   const moved = await fixIncompleteImages(list);
@@ -592,7 +854,9 @@ await test('detectIncompleteImages handles extra unique before timestamp', async
     path.join(process.cwd(), 'uploads', 'txn_images', 't6', '4001'),
   );
   assert.ok(
-    exists.includes('img007_ydzfh-sdang-cxfxb-kajww_akihl-zukov-ulioe-fhnde.jpg'),
+    exists.includes(
+      `img007_ydzfh-sdang-cxfxb-kajww_akihl-zukov-ulioe-fhnde__${ts}_oge4m7.jpg`,
+    ),
   );
 
   restoreDb();
@@ -638,4 +902,21 @@ await test('checkUploadedImages handles names array', async () => {
 
   restoreDb();
   await fs.writeFile(cfgPath, origCfg);
+});
+
+await test('detectIncompleteFromNames reports unflagged reasons', async () => {
+  const restoreDb = mockPool(async (sql) => {
+    if (/SELECT UITrtype, UITransType FROM code_transaction/.test(sql)) {
+      return [[{ UITrtype: 't1', UITransType: '4001' }]];
+    }
+    return [[]];
+  });
+  const { list, skipped, summary } = await detectIncompleteFromNames([
+    'a.jpg',
+    '12345678-1234-1234-1234-123456789abc_t1_4001.jpg',
+  ]);
+  assert.equal(list.length, 0);
+  assert.equal(skipped.length, 2);
+  assert.equal(summary.skipped, 2);
+  restoreDb();
 });

--- a/tests/api/findBenchmarkCode.test.js
+++ b/tests/api/findBenchmarkCode.test.js
@@ -15,8 +15,9 @@ await test('findBenchmarkCode matches codes', async () => {
       if (params[0] === '1234') return [[{ UITransType: '1234' }]];
       return [[]];
     }
-    if (/FROM code_transaction WHERE image_benchmark = 1/.test(sql)) {
-      return [[{ UITransType: '5678', UITrtype: 'ABCD' }]];
+    if (/FROM code_transaction WHERE UITrtype =/.test(sql)) {
+      if (String(params[0]).toUpperCase() === 'ABCD') return [[{ UITransType: '5678' }]];
+      return [[]];
     }
     return [[]];
   });


### PR DESCRIPTION
## Summary
- support save-pattern filenames missing `sp_primary_code` and optional timestamps so transaction type values like `4001` are parsed reliably
- narrow transaction lookup to ±2 days and skip `sp_primary_code` filter when absent, preventing false “No matching transaction” errors
- add regression tests for bmtr_pmid files within a 2‑day range and for filenames lacking `sp_primary_code`

## Testing
- `npm test`
- `npm run build:erp`


------
https://chatgpt.com/codex/tasks/task_e_688e1e78c3048331ba27ba557c00604e