### PR TITLE
Use backend URL for transaction images

### DIFF
--- a/src/erp.mgt.mn/components/RowImageViewModal.jsx
+++ b/src/erp.mgt.mn/components/RowImageViewModal.jsx
@@ -25,12 +25,10 @@ export default function RowImageViewModal({
 
   function getImageUrl(p) {
     if (!p) return '';
-    // If API returns a full URL, use it directly
     if (p.startsWith('http')) return p;
-    // Preserve paths that already start with '/'
-    if (p.startsWith('/')) return p;
-    // Fallback: prepend API base
-    return `${window.API_BASE || window.location.origin}/${p.replace(/^\//, '')}`;
+    const base =
+      (window.API_BASE || API_BASE || window.location.origin).replace(/\/$/, '');
+    return `${base}${p.startsWith('/') ? p : `/${p}`}`;
   }
 
   useEffect(() => {
@@ -70,7 +68,7 @@ export default function RowImageViewModal({
         addToast(`Search: ${params.get('folder') || table}/${primary}`, 'info');
         try {
           const res = await fetch(
-            `/api/transaction_images/${safeTable}/${encodeURIComponent(primary)}?${params.toString()}`,
+            `${API_BASE}/transaction_images/${safeTable}/${encodeURIComponent(primary)}?${params.toString()}`,
             { credentials: 'include' },
           );
           const imgs = res.ok ? await res.json().catch(() => []) : [];
@@ -87,7 +85,7 @@ export default function RowImageViewModal({
           addToast(`Search: ${params.get('folder') || table}/${nm}`, 'info');
           try {
             const res = await fetch(
-              `/api/transaction_images/${safeTable}/${encodeURIComponent(nm)}?${params.toString()}`,
+              `${API_BASE}/transaction_images/${safeTable}/${encodeURIComponent(nm)}?${params.toString()}`,
               { credentials: 'include' },
             );
             const imgs = res.ok ? await res.json().catch(() => []) : [];
@@ -98,11 +96,11 @@ export default function RowImageViewModal({
                   const renameParams = new URLSearchParams();
                   if (folder) renameParams.set('folder', folder);
                   await fetch(
-                    `/api/transaction_images/${safeTable}/${encodeURIComponent(idName)}/rename/${encodeURIComponent(primary)}?${renameParams.toString()}`,
+                    `${API_BASE}/transaction_images/${safeTable}/${encodeURIComponent(idName)}/rename/${encodeURIComponent(primary)}?${renameParams.toString()}`,
                     { method: 'POST', credentials: 'include' },
                   );
                   const res2 = await fetch(
-                    `/api/transaction_images/${safeTable}/${encodeURIComponent(primary)}?${renameParams.toString()}`,
+                    `${API_BASE}/transaction_images/${safeTable}/${encodeURIComponent(primary)}?${renameParams.toString()}`,
                     { credentials: 'include' },
                   );
                   const imgs2 = res2.ok ? await res2.json().catch(() => []) : [];


### PR DESCRIPTION
## Summary
- Prefix transaction image URLs with the API base so requests include `/api` and always go through the backend

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f3f2ddfa083319394a290fa3dc399