### PR TITLE
feat: allow saving and loading multiple image management sessions

### DIFF
--- a/src/erp.mgt.mn/pages/ImageManagement.jsx
+++ b/src/erp.mgt.mn/pages/ImageManagement.jsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { useToast } from '../context/ToastContext.jsx';
 
 const FOLDER_STATE_KEY = 'imgMgmtFolderState';
+const SESSIONS_KEY = 'imgMgmtSessions';
 
 function extractDateFromName(name) {
   const match = typeof name === 'string' ? name.match(/(?:__|_)(\d{13})_/) : null;
@@ -47,24 +48,107 @@ export default function ImageManagement() {
       if (raw) {
         const parsed = JSON.parse(raw);
         if (parsed.folderName) setFolderName(parsed.folderName);
-        if (Array.isArray(parsed.uploads)) setUploads(parsed.uploads);
-        if (Array.isArray(parsed.ignored)) setIgnored(parsed.ignored);
+        if (Array.isArray(parsed.uploads)) setUploads(parsed.uploads.map((u) => ({ ...u, processed: !!u.processed })));
+        if (Array.isArray(parsed.ignored)) setIgnored(parsed.ignored.map((u) => ({ ...u, processed: !!u.processed })));
+        if (Array.isArray(parsed.pending)) setPending(parsed.pending.map((u) => ({ ...u, processed: !!u.processed })));
+        if (Array.isArray(parsed.hostIgnored))
+          setHostIgnored(parsed.hostIgnored.map((u) => ({ ...u, processed: !!u.processed })));
       }
     } catch {
       // ignore
     }
   }, []);
 
-  function persistState(up = uploads, ig = ignored, folder = folderName) {
+  function buildState(
+    up = uploads,
+    ig = ignored,
+    folder = folderName,
+    pend = pending,
+    hostIg = hostIgnored,
+  ) {
+    return {
+      folderName: folder,
+      uploads: up.map(({ handle, ...rest }) => rest),
+      ignored: ig.map(({ handle, ...rest }) => rest),
+      pending: pend,
+      hostIgnored: hostIg,
+    };
+  }
+
+  function persistState(
+    up = uploads,
+    ig = ignored,
+    folder = folderName,
+    pend = pending,
+    hostIg = hostIgnored,
+  ) {
     try {
-      const data = {
-        folderName: folder,
-        uploads: up.map(({ handle, ...rest }) => rest),
-        ignored: ig.map(({ handle, ...rest }) => rest),
-      };
-      localStorage.setItem(FOLDER_STATE_KEY, JSON.stringify(data));
+      localStorage.setItem(FOLDER_STATE_KEY, JSON.stringify(buildState(up, ig, folder, pend, hostIg)));
     } catch {
       // ignore
+    }
+  }
+
+  function getSessions() {
+    try {
+      const parsed = JSON.parse(localStorage.getItem(SESSIONS_KEY) || '{}');
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+
+  function saveSession() {
+    const name = prompt('Session name?', new Date().toISOString());
+    if (!name) return;
+    try {
+      const sessions = getSessions();
+      sessions[name] = buildState();
+      localStorage.setItem(SESSIONS_KEY, JSON.stringify(sessions));
+      persistState();
+      addToast('State saved', 'success');
+    } catch {
+      addToast('Failed to save state', 'error');
+    }
+  }
+
+  function loadSession() {
+    try {
+      const sessions = getSessions();
+      const names = Object.keys(sessions);
+      if (names.length === 0) {
+        addToast('No saved sessions', 'error');
+        return;
+      }
+      const name = prompt(`Load which session?\n${names.join('\n')}`);
+      if (!name || !sessions[name]) return;
+      const data = sessions[name];
+      setFolderName(data.folderName || '');
+      setUploads(Array.isArray(data.uploads) ? data.uploads.map((u) => ({ ...u, processed: !!u.processed })) : []);
+      setIgnored(Array.isArray(data.ignored) ? data.ignored.map((u) => ({ ...u, processed: !!u.processed })) : []);
+      setPending(Array.isArray(data.pending) ? data.pending.map((u) => ({ ...u, processed: !!u.processed })) : []);
+      setHostIgnored(
+        Array.isArray(data.hostIgnored)
+          ? data.hostIgnored.map((u) => ({ ...u, processed: !!u.processed }))
+          : [],
+      );
+      setSelected([]);
+      setHostIgnoredSel([]);
+      setUploadSel([]);
+      setUploadPage(1);
+      setIgnoredPage(1);
+      setHostIgnoredPage(1);
+      setPage(1);
+      persistState(
+        data.uploads || [],
+        data.ignored || [],
+        data.folderName || '',
+        data.pending || [],
+        data.hostIgnored || [],
+      );
+      addToast('State loaded', 'success');
+    } catch {
+      addToast('Failed to load session', 'error');
     }
   }
 
@@ -91,10 +175,14 @@ export default function ImageManagement() {
   }
 
   function toggleAll() {
-    if (selected.length === pending.length) {
+    const unprocessed = pending.filter((p) => !p.processed).map((p) => p.currentName);
+    const all = pending.map((p) => p.currentName);
+    if (selected.length === all.length) {
       setSelected([]);
+    } else if (selected.length === unprocessed.length && unprocessed.length !== all.length) {
+      setSelected(all);
     } else {
-      setSelected(pending.map((p) => p.currentName));
+      setSelected(unprocessed);
     }
   }
 
@@ -105,12 +193,19 @@ export default function ImageManagement() {
   }
 
   function toggleHostIgnoredAll(list) {
-    const ids = list.map((p) => p.currentName);
-    const allSelected = ids.every((id) => hostIgnoredSel.includes(id));
+    const allIds = list.map((p) => p.currentName);
+    const unprocessedIds = list.filter((p) => !p.processed).map((p) => p.currentName);
+    const allSelected = allIds.every((id) => hostIgnoredSel.includes(id));
+    const unprocessedSelected =
+      unprocessedIds.length > 0 &&
+      unprocessedIds.every((id) => hostIgnoredSel.includes(id)) &&
+      !allSelected;
     if (allSelected) {
-      setHostIgnoredSel((prev) => prev.filter((id) => !ids.includes(id)));
+      setHostIgnoredSel((prev) => prev.filter((id) => !allIds.includes(id)));
+    } else if (unprocessedSelected || unprocessedIds.length === allIds.length) {
+      setHostIgnoredSel((prev) => [...prev, ...allIds.filter((id) => !prev.includes(id))]);
     } else {
-      setHostIgnoredSel((prev) => [...prev, ...ids.filter((id) => !prev.includes(id))]);
+      setHostIgnoredSel((prev) => [...prev, ...unprocessedIds.filter((id) => !prev.includes(id))]);
     }
   }
 
@@ -121,12 +216,19 @@ export default function ImageManagement() {
   }
 
   function toggleUploadAll(list) {
-    const ids = list.filter((u) => !u.processed).map((u) => u.id);
-    const allSelected = ids.every((id) => uploadSel.includes(id));
+    const allIds = list.map((u) => u.id);
+    const unprocessedIds = list.filter((u) => !u.processed).map((u) => u.id);
+    const allSelected = allIds.every((id) => uploadSel.includes(id));
+    const unprocessedSelected =
+      unprocessedIds.length > 0 &&
+      unprocessedIds.every((id) => uploadSel.includes(id)) &&
+      !allSelected;
     if (allSelected) {
-      setUploadSel((prev) => prev.filter((id) => !ids.includes(id)));
+      setUploadSel((prev) => prev.filter((id) => !allIds.includes(id)));
+    } else if (unprocessedSelected || unprocessedIds.length === allIds.length) {
+      setUploadSel((prev) => [...prev, ...allIds.filter((id) => !prev.includes(id))]);
     } else {
-      setUploadSel((prev) => [...prev, ...ids.filter((id) => !prev.includes(id))]);
+      setUploadSel((prev) => [...prev, ...unprocessedIds.filter((id) => !prev.includes(id))]);
     }
   }
 
@@ -222,10 +324,14 @@ export default function ImageManagement() {
       setUploadSel([]);
       setUploadPage(1);
       setIgnoredPage(1);
+      setPending([]);
+      setHostIgnored([]);
+      setSelected([]);
+      setHostIgnoredSel([]);
       setReport(
         `Scanned ${names.length} file(s), found ${processed} incomplete name(s), ${skipped.length} unflagged.`,
       );
-      persistState(uploadsList, ignoredList, dirHandle.name || '');
+      persistState(uploadsList, ignoredList, dirHandle.name || '', [], []);
     } catch {
       // ignore
     } finally {
@@ -266,7 +372,11 @@ export default function ImageManagement() {
           ? data.list
               .slice()
               .sort((a, b) => a.currentName.localeCompare(b.currentName))
-              .map((p) => ({ ...p, description: extractDateFromName(p.currentName) }))
+              .map((p) => ({
+                ...p,
+                description: extractDateFromName(p.currentName),
+                processed: false,
+              }))
           : [];
         const miss = Array.isArray(data.skipped)
           ? data.skipped
@@ -275,6 +385,7 @@ export default function ImageManagement() {
               .map((p) => ({
                 ...p,
                 description: extractDateFromName(p.currentName),
+                processed: false,
               }))
           : [];
         setPending(list);
@@ -288,12 +399,14 @@ export default function ImageManagement() {
         setReport(
           `Scanned ${sum.totalFiles || 0} file(s), found ${sum.incompleteFound || 0} incomplete name(s), ${sum.skipped || 0} not incomplete.`,
         );
+        persistState(uploads, ignored, folderName, list, miss);
       } else {
         setPending([]);
         setHostIgnored([]);
         setHostIgnoredPage(1);
         setPendingSummary(null);
         setHasMore(false);
+        persistState(uploads, ignored, folderName, [], []);
       }
       setPage(p);
     } catch (e) {
@@ -303,6 +416,7 @@ export default function ImageManagement() {
         setHostIgnoredPage(1);
         setPendingSummary(null);
         setHasMore(false);
+        persistState(uploads, ignored, folderName, [], []);
       }
     } finally {
       detectAbortRef.current = null;
@@ -312,8 +426,8 @@ export default function ImageManagement() {
   }
 
   async function applyFixesSelection(list, sel) {
-    const items = list.filter((p) => sel.includes(p.currentName));
-    if (items.length === 0) return;
+    const items = list.filter((p) => sel.includes(p.currentName) && !p.processed);
+    if (items.length === 0) return null;
     const res = await fetch('/api/transaction_images/fix_incomplete', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -324,18 +438,32 @@ export default function ImageManagement() {
       const data = await res.json().catch(() => ({}));
       addToast(`Renamed ${data.fixed || 0} file(s)`, 'success');
       setReport(`Renamed ${data.fixed || 0} file(s)`);
-      detectFromHost(page);
+      const newList = list.map((p) =>
+        sel.includes(p.currentName) ? { ...p, processed: true } : p,
+      );
+      return newList;
     } else {
       addToast('Rename failed', 'error');
+      return null;
     }
   }
 
   async function applyFixes() {
-    await applyFixesSelection(pending, selected);
+    const newPending = await applyFixesSelection(pending, selected);
+    if (newPending) {
+      setPending(newPending);
+      setSelected([]);
+      persistState(uploads, ignored, folderName, newPending, hostIgnored);
+    }
   }
 
   async function applyFixesHostIgnored() {
-    await applyFixesSelection(hostIgnored, hostIgnoredSel);
+    const newHostIgnored = await applyFixesSelection(hostIgnored, hostIgnoredSel);
+    if (newHostIgnored) {
+      setHostIgnored(newHostIgnored);
+      setHostIgnoredSel([]);
+      persistState(uploads, ignored, folderName, pending, newHostIgnored);
+    }
   }
 
   async function renameSelected() {
@@ -457,6 +585,16 @@ export default function ImageManagement() {
               Select Folder
             </button>
             {folderName && <span style={{ marginRight: '0.5rem' }}>{folderName}</span>}
+            <button
+              type="button"
+              onClick={saveSession}
+              style={{ marginRight: '0.5rem' }}
+            >
+              Save
+            </button>
+            <button type="button" onClick={loadSession}>
+              Load
+            </button>
           </div>
           {uploadSummary && (
             <p style={{ marginBottom: '0.5rem' }}>
@@ -748,8 +886,10 @@ export default function ImageManagement() {
               <button
                 type="button"
                 onClick={() => {
-                  setPending((prev) => prev.filter((p) => !selected.includes(p.currentName)));
+                  const remaining = pending.filter((p) => !selected.includes(p.currentName));
+                  setPending(remaining);
                   setSelected([]);
+                  persistState(uploads, ignored, folderName, remaining, hostIgnored);
                 }}
                 style={{ marginBottom: '0.5rem', marginLeft: '0.5rem' }}
                 disabled={selected.length === 0}
@@ -810,8 +950,12 @@ export default function ImageManagement() {
               <button
                 type="button"
                 onClick={() => {
-                  setHostIgnored((prev) => prev.filter((p) => !hostIgnoredSel.includes(p.currentName)));
+                  const remaining = hostIgnored.filter(
+                    (p) => !hostIgnoredSel.includes(p.currentName),
+                  );
+                  setHostIgnored(remaining);
                   setHostIgnoredSel([]);
+                  persistState(uploads, ignored, folderName, pending, remaining);
                 }}
                 style={{ marginBottom: '0.5rem', marginLeft: '0.5rem' }}
                 disabled={hostIgnoredSel.length === 0}


### PR DESCRIPTION
## Summary
- store image management table state in named sessions
- add Save button to snapshot current tables and Load button to restore a saved session
- sanitize session store to avoid "No saved sessions" when legacy array format exists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f57e307d08331a63cd197f95ea8b7