### PR TITLE
Serve transaction images via static route

### DIFF
--- a/api-server/app.js
+++ b/api-server/app.js
@@ -30,11 +30,15 @@ app.use(express.json({ limit: '100mb' }));
 app.use(express.urlencoded({ extended: true, limit: '100mb' }));
 app.use(cookieParser());
 
+app.use(logger);
+
+// Serve uploaded images statically before CSRF so image requests don't require tokens
+const uploadsDir = path.resolve(__dirname, "../uploads");
+app.use("/uploads", express.static(uploadsDir));
+
 // Setup CSRF protection using cookies
 const csrfProtection = csurf({ cookie: true });
 app.use(csrfProtection);
-
-app.use(logger);
 
 // Health-check: also verify DB connection
 app.get("/api/auth/health", async (req, res, next) => {

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -49,8 +49,9 @@ app.use(logger);
 
 // Serve uploaded images statically
 const imgCfg = await getGeneralConfig();
-const imgBase = imgCfg.general?.imageStorage?.basePath || 'uploads';
-app.use(`/${imgBase}`, express.static(path.join(process.cwd(), imgBase)));
+const imgBase = imgCfg.general?.imageStorage?.basePath || "uploads";
+const uploadsDir = path.resolve(__dirname, "../", imgBase);
+app.use(`/${imgBase}`, express.static(uploadsDir));
 
 // Health-check: also verify DB connection
 app.get("/api/auth/health", async (req, res, next) => {

--- a/src/erp.mgt.mn/components/RowImageViewModal.jsx
+++ b/src/erp.mgt.mn/components/RowImageViewModal.jsx
@@ -22,16 +22,7 @@ export default function RowImageViewModal({
 
   const placeholder =
     'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMBAZLr5z0AAAAASUVORK5CYII=';
-
-  function getImageUrl(p) {
-    if (!p) return '';
-    // If API returns a full URL, use it directly
-    if (p.startsWith('http')) return p;
-    // Preserve paths that already start with '/'
-    if (p.startsWith('/')) return p;
-    // Fallback: prepend API base
-    return `${window.API_BASE || window.location.origin}/${p.replace(/^\//, '')}`;
-  }
+  const apiRoot = API_BASE.replace(/\/api\/?$/, '');
 
   useEffect(() => {
     if (!visible) return;
@@ -63,6 +54,27 @@ export default function RowImageViewModal({
     if (folder !== table && table.startsWith('transactions_')) {
       folders.push(table);
     }
+    async function buildFileList(list) {
+      const urls = [];
+      const entries = [];
+      for (const p of list) {
+        const name = p.split('/').pop();
+        const url = p.startsWith('http') ? p : `${apiRoot}${p}`;
+        try {
+          const res = await fetch(url, { credentials: 'include' });
+          if (!res.ok) throw new Error('bad status');
+          const blob = await res.blob();
+          const objectUrl = URL.createObjectURL(blob);
+          urls.push(objectUrl);
+          entries.push({ path: p, name, src: objectUrl });
+        } catch {
+          entries.push({ path: p, name, src: placeholder });
+        }
+      }
+      return { entries, urls };
+    }
+
+    const objectUrls = [];
     (async () => {
       for (const fld of folders) {
         const params = new URLSearchParams();
@@ -70,14 +82,16 @@ export default function RowImageViewModal({
         addToast(`Search: ${params.get('folder') || table}/${primary}`, 'info');
         try {
           const res = await fetch(
-            `/api/transaction_images/${safeTable}/${encodeURIComponent(primary)}?${params.toString()}`,
+            `${API_BASE}/transaction_images/${safeTable}/${encodeURIComponent(primary)}?${params.toString()}`,
             { credentials: 'include' },
           );
           const imgs = res.ok ? await res.json().catch(() => []) : [];
           const list = Array.isArray(imgs) ? imgs : [];
           if (list.length > 0) {
             list.forEach((p) => addToast(`Found image: ${p}`, 'info'));
-            setFiles(list);
+            const { entries, urls } = await buildFileList(list);
+            objectUrls.push(...urls);
+            setFiles(entries);
             return;
           }
         } catch {
@@ -87,7 +101,7 @@ export default function RowImageViewModal({
           addToast(`Search: ${params.get('folder') || table}/${nm}`, 'info');
           try {
             const res = await fetch(
-              `/api/transaction_images/${safeTable}/${encodeURIComponent(nm)}?${params.toString()}`,
+              `${API_BASE}/transaction_images/${safeTable}/${encodeURIComponent(nm)}?${params.toString()}`,
               { credentials: 'include' },
             );
             const imgs = res.ok ? await res.json().catch(() => []) : [];
@@ -98,18 +112,20 @@ export default function RowImageViewModal({
                   const renameParams = new URLSearchParams();
                   if (folder) renameParams.set('folder', folder);
                   await fetch(
-                    `/api/transaction_images/${safeTable}/${encodeURIComponent(idName)}/rename/${encodeURIComponent(primary)}?${renameParams.toString()}`,
+                    `${API_BASE}/transaction_images/${safeTable}/${encodeURIComponent(idName)}/rename/${encodeURIComponent(primary)}?${renameParams.toString()}`,
                     { method: 'POST', credentials: 'include' },
                   );
                   const res2 = await fetch(
-                    `/api/transaction_images/${safeTable}/${encodeURIComponent(primary)}?${renameParams.toString()}`,
+                    `${API_BASE}/transaction_images/${safeTable}/${encodeURIComponent(primary)}?${renameParams.toString()}`,
                     { credentials: 'include' },
                   );
                   const imgs2 = res2.ok ? await res2.json().catch(() => []) : [];
                   const list2 = Array.isArray(imgs2) ? imgs2 : [];
                   if (list2.length > 0) {
                     list2.forEach((p) => addToast(`Found image: ${p}`, 'info'));
-                    setFiles(list2);
+                    const { entries, urls } = await buildFileList(list2);
+                    objectUrls.push(...urls);
+                    setFiles(entries);
                     return;
                   }
                 } catch {
@@ -117,7 +133,9 @@ export default function RowImageViewModal({
                 }
               } else {
                 list.forEach((p) => addToast(`Found image: ${p}`, 'info'));
-                setFiles(list);
+                const { entries, urls } = await buildFileList(list);
+                objectUrls.push(...urls);
+                setFiles(entries);
                 return;
               }
             }
@@ -128,6 +146,9 @@ export default function RowImageViewModal({
       }
       setFiles([]);
     })();
+    return () => {
+      objectUrls.forEach((u) => URL.revokeObjectURL(u));
+    };
   }, [visible, folder, row, table, imageIdField, imagenameFields]);
 
   useEffect(() => {
@@ -146,28 +167,25 @@ export default function RowImageViewModal({
 
   const listView = (
     <div style={{ maxHeight: '40vh', overflowY: 'auto' }}>
-      {files.map((src) => {
-        const name = src.split('/').pop();
-        return (
-          <div key={src} style={{ marginBottom: '0.25rem' }}>
-            <img
-              src={getImageUrl(src)}
-              alt=""
-              onError={(e) => {
-                e.currentTarget.onerror = null;
-                e.currentTarget.src = placeholder;
-              }}
-              style={{ maxWidth: '100px', marginRight: '0.5rem' }}
-            />
-            <span
-              style={{ cursor: 'pointer', color: '#2563eb' }}
-              onClick={() => handleView(src)}
-            >
-              {name}
-            </span>
-          </div>
-        );
-      })}
+      {files.map((f) => (
+        <div key={f.path} style={{ marginBottom: '0.25rem' }}>
+          <img
+            src={f.src}
+            alt=""
+            onError={(e) => {
+              e.currentTarget.onerror = null;
+              e.currentTarget.src = placeholder;
+            }}
+            style={{ maxWidth: '100px', marginRight: '0.5rem' }}
+          />
+          <span
+            style={{ cursor: 'pointer', color: '#2563eb' }}
+            onClick={() => handleView(f.src)}
+          >
+            {f.name}
+          </span>
+        </div>
+      ))}
     </div>
   );
 
@@ -181,17 +199,17 @@ export default function RowImageViewModal({
         gap: '0.5rem',
       }}
     >
-      {files.map((src) => (
+      {files.map((f) => (
         <img
-          key={src}
-          src={getImageUrl(src)}
+          key={f.path}
+          src={f.src}
           alt=""
           onError={(e) => {
             e.currentTarget.onerror = null;
             e.currentTarget.src = placeholder;
           }}
           style={{ cursor: 'pointer', width: '150px', height: '150px', objectFit: 'cover' }}
-          onClick={() => handleView(src)}
+          onClick={() => handleView(f.src)}
         />
       ))}
     </div>
@@ -228,7 +246,7 @@ export default function RowImageViewModal({
             onClick={() => setFullscreen(null)}
           >
             <img
-              src={getImageUrl(fullscreen)}
+              src={fullscreen}
               alt=""
               onError={(e) => {
                 e.currentTarget.onerror = null;


### PR DESCRIPTION
## Summary
- Fetch transaction images from the backend with credentials and render them via blob URLs
- Serve uploaded images statically by mounting the backend `/uploads` directory
- Clean up blob URLs on unmount to avoid memory leaks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f3f2ddfa083319394a290fa3dc399