### PR TITLE
Serve transaction images via static route

### DIFF
--- a/api-server/app.js
+++ b/api-server/app.js
@@ -30,11 +30,15 @@ app.use(express.json({ limit: '100mb' }));
 app.use(express.urlencoded({ extended: true, limit: '100mb' }));
 app.use(cookieParser());
 
+app.use(logger);
+
+// Serve uploaded images statically before CSRF so image requests don't require tokens
+const uploadsDir = path.resolve(__dirname, "../uploads");
+app.use("/uploads", express.static(uploadsDir));
+
 // Setup CSRF protection using cookies
 const csrfProtection = csurf({ cookie: true });
 app.use(csrfProtection);
-
-app.use(logger);
 
 // Health-check: also verify DB connection
 app.get("/api/auth/health", async (req, res, next) => {

--- a/api-server/routes/transaction_images.js
+++ b/api-server/routes/transaction_images.js
@@ -19,6 +19,11 @@ import { getGeneralConfig } from '../services/generalConfig.js';
 const router = express.Router();
 const upload = multer({ dest: 'uploads/tmp' });
 
+function toAbsolute(req, list) {
+  const base = `${req.protocol}://${req.get('host')}`;
+  return list.map((p) => (p.startsWith('http') ? p : `${base}${p}`));
+}
+
 // Cleanup old images before the dynamic routes so /cleanup isn't captured
 router.delete('/cleanup/:days?', requireAuth, async (req, res, next) => {
   try {
@@ -107,7 +112,7 @@ router.post('/:table/:name', requireAuth, upload.array('images'), async (req, re
       req.files,
       req.query.folder,
     );
-    res.json(files);
+    res.json(toAbsolute(req, files));
   } catch (err) {
     next(err);
   }
@@ -120,7 +125,7 @@ router.get('/:table/:name', requireAuth, async (req, res, next) => {
       req.params.name,
       req.query.folder,
     );
-    res.json(files);
+    res.json(toAbsolute(req, files));
   } catch (err) {
     next(err);
   }
@@ -134,7 +139,7 @@ router.post('/:table/:oldName/rename/:newName', requireAuth, async (req, res, ne
       req.params.newName,
       req.query.folder,
     );
-    res.json(files);
+    res.json(toAbsolute(req, files));
   } catch (err) {
     next(err);
   }

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -49,8 +49,9 @@ app.use(logger);
 
 // Serve uploaded images statically
 const imgCfg = await getGeneralConfig();
-const imgBase = imgCfg.general?.imageStorage?.basePath || 'uploads';
-app.use(`/${imgBase}`, express.static(path.join(process.cwd(), imgBase)));
+const imgBase = imgCfg.general?.imageStorage?.basePath || "uploads";
+const uploadsDir = path.resolve(__dirname, "../", imgBase);
+app.use(`/${imgBase}`, express.static(uploadsDir));
 
 // Health-check: also verify DB connection
 app.get("/api/auth/health", async (req, res, next) => {

--- a/api-server/services/transactionImageService.js
+++ b/api-server/services/transactionImageService.js
@@ -1,18 +1,23 @@
 import fs from 'fs/promises';
 import fssync from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { getGeneralConfig } from './generalConfig.js';
 import { pool } from '../../db/index.js';
 import { getConfigsByTable, getConfigsByTransTypeValue } from './transactionFormConfig.js';
 import { slugify } from '../utils/slugify.js';
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '../../');
+
 async function getDirs() {
   const cfg = await getGeneralConfig();
   const subdir = cfg.general?.imageDir || 'txn_images';
   const basePath = cfg.general?.imageStorage?.basePath || 'uploads';
-  const baseDir = path.join(process.cwd(), basePath, subdir);
+  const baseDir = path.join(projectRoot, basePath, subdir);
   const urlBase = `/${basePath}/${subdir}`;
-  return { baseDir, urlBase };
+  return { baseDir, urlBase, basePath };
 }
 
 function ensureDir(dir) {
@@ -375,7 +380,7 @@ export async function deleteAllImages(table, name, folder = null) {
 }
 
 export async function cleanupOldImages(days = 30) {
-  const { baseDir } = await getDirs();
+  const { baseDir, basePath } = await getDirs();
   const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
   let removed = 0;
 
@@ -403,7 +408,7 @@ export async function cleanupOldImages(days = 30) {
   }
 
   await walk(baseDir);
-  await walk(path.join(process.cwd(), 'uploads', 'tmp'));
+  await walk(path.join(projectRoot, basePath, 'tmp'));
 
   return removed;
 }

--- a/src/erp.mgt.mn/utils/apiBase.js
+++ b/src/erp.mgt.mn/utils/apiBase.js
@@ -1,1 +1,8 @@
-export const API_BASE = `${(import.meta.env.BASE_URL || '/').replace(/\/$/, '')}/api`;
+// Prefer an explicit VITE_API_BASE (e.g. https://backend.example.com/api)
+// and fall back to a relative "/api" path so the frontend can run behind
+// the same origin as the backend without extra configuration.
+const rawBase = import.meta.env.VITE_API_BASE || '/api';
+export const API_BASE = rawBase.replace(/\/$/, '');
+
+// Helper to strip the trailing "/api" segment for building non-API URLs
+export const API_ROOT = API_BASE.replace(/\/api\/?$/, '');


### PR DESCRIPTION
## Summary
- Prefix transaction image responses with the request origin so the frontend receives fully qualified URLs
- Use backend-provided image URLs directly in the viewer instead of fetching blobs
- Allow the frontend to configure its API base URL and derive the static uploads root from it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f3f2ddfa083319394a290fa3dc399