### PR TITLE
feat: allow saving and loading multiple image management sessions

### DIFF
--- a/src/erp.mgt.mn/pages/ImageManagement.jsx
+++ b/src/erp.mgt.mn/pages/ImageManagement.jsx
@@ -2,6 +2,8 @@ import React, { useState, useRef, useEffect } from 'react';
 import { useToast } from '../context/ToastContext.jsx';
 
 const FOLDER_STATE_KEY = 'imgMgmtFolderState';
+const SESSIONS_KEY = 'imgMgmtSessions';
+const SESSION_PREFIX = 'imgMgmtSession:';
 
 function extractDateFromName(name) {
   const match = typeof name === 'string' ? name.match(/(?:__|_)(\d{13})_/) : null;
@@ -20,7 +22,7 @@ export default function ImageManagement() {
   const [result, setResult] = useState(null);
   const [tab, setTab] = useState('cleanup');
   const [pending, setPending] = useState([]);
-  const [page, setPage] = useState(1);
+  const [pendingPage, setPendingPage] = useState(1);
   const [hasMore, setHasMore] = useState(false);
   const [selected, setSelected] = useState([]);
   const [hostIgnored, setHostIgnored] = useState([]);
@@ -40,6 +42,8 @@ export default function ImageManagement() {
   const scanCancelRef = useRef(false);
   const [activeOp, setActiveOp] = useState(null);
   const [report, setReport] = useState('');
+  const [sessionNames, setSessionNames] = useState([]);
+  const [selectedSession, setSelectedSession] = useState('');
 
   useEffect(() => {
     try {
@@ -47,24 +51,201 @@ export default function ImageManagement() {
       if (raw) {
         const parsed = JSON.parse(raw);
         if (parsed.folderName) setFolderName(parsed.folderName);
-        if (Array.isArray(parsed.uploads)) setUploads(parsed.uploads);
-        if (Array.isArray(parsed.ignored)) setIgnored(parsed.ignored);
+        if (Array.isArray(parsed.uploads))
+          setUploads(
+            parsed.uploads.map((u) => ({
+              ...u,
+              id: u.originalName,
+              description: extractDateFromName(u.originalName),
+              processed: !!u.processed,
+            })),
+          );
+        if (Array.isArray(parsed.ignored))
+          setIgnored(
+            parsed.ignored.map((u) => ({
+              ...u,
+              id: u.originalName,
+              description: extractDateFromName(u.originalName),
+              processed: !!u.processed,
+            })),
+          );
+        if (Array.isArray(parsed.pending))
+          setPending(parsed.pending.map((u) => ({ ...u, processed: !!u.processed })));
+        if (Array.isArray(parsed.hostIgnored))
+          setHostIgnored(parsed.hostIgnored.map((u) => ({ ...u, processed: !!u.processed })));
       }
     } catch {
       // ignore
     }
+    setSessionNames(getSessionNames());
   }, []);
 
-  function persistState(up = uploads, ig = ignored, folder = folderName) {
+  function stateLabel(item = {}) {
+    if (item.processed) return 'Processed';
+    if (item.newName) return 'New';
+    return '';
+    }
+
+  function safeString(val) {
+    return val !== undefined && val !== null ? String(val) : undefined;
+  }
+
+  function buildSessionData(partial = {}) {
+    const dataUploads = partial.uploads ?? uploads;
+    const dataIgnored = partial.ignored ?? ignored;
+    const dataPending = partial.pending ?? pending;
+    const dataHostIgnored = partial.hostIgnored ?? hostIgnored;
+
+    return {
+      folderName: safeString(partial.folderName ?? folderName) || '',
+      uploads: Array.isArray(dataUploads)
+        ? dataUploads
+            .filter(Boolean)
+            .map(({ originalName, newName, tmpPath, processed }) => ({
+              originalName,
+              newName,
+              tmpPath,
+              processed,
+            }))
+        : [],
+      ignored: Array.isArray(dataIgnored)
+        ? dataIgnored
+            .filter(Boolean)
+            .map(({ originalName, newName, tmpPath, reason, processed }) => ({
+              originalName,
+              newName,
+              tmpPath,
+              reason,
+              processed,
+            }))
+        : [],
+      pending: Array.isArray(dataPending)
+        ? dataPending
+            .filter(Boolean)
+            .map(({ currentName, newName, processed }) => ({
+              currentName,
+              newName,
+              processed,
+            }))
+        : [],
+      hostIgnored: Array.isArray(dataHostIgnored)
+        ? dataHostIgnored
+            .filter(Boolean)
+            .map(({ currentName, reason, processed }) => ({
+              currentName,
+              reason,
+              processed,
+            }))
+        : [],
+    };
+  }
+
+  function persistState(partial) {
     try {
-      const data = {
-        folderName: folder,
-        uploads: up.map(({ handle, ...rest }) => rest),
-        ignored: ig.map(({ handle, ...rest }) => rest),
-      };
-      localStorage.setItem(FOLDER_STATE_KEY, JSON.stringify(data));
+      localStorage.setItem(
+        FOLDER_STATE_KEY,
+        JSON.stringify(buildSessionData(partial)),
+      );
     } catch {
       // ignore
+    }
+  }
+
+  function getSessionNames() {
+    try {
+      const parsed = JSON.parse(localStorage.getItem(SESSIONS_KEY) || '[]');
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+
+  function saveSession() {
+    const name = prompt('Session name?', folderName || new Date().toISOString());
+    if (!name) return;
+    try {
+      const data = buildSessionData();
+      localStorage.setItem(SESSION_PREFIX + name, JSON.stringify(data));
+      const names = new Set(getSessionNames());
+      names.add(name);
+      localStorage.setItem(SESSIONS_KEY, JSON.stringify([...names]));
+      persistState(data);
+      setSessionNames([...names]);
+      setSelectedSession(name);
+      addToast('State saved', 'success');
+    } catch {
+      addToast('Failed to save state', 'error');
+    }
+  }
+
+  function loadSession(name = selectedSession) {
+    if (!name) {
+      addToast('No session selected', 'error');
+      return;
+    }
+    try {
+      const raw = localStorage.getItem(SESSION_PREFIX + name);
+      if (!raw) {
+        addToast('No saved sessions', 'error');
+        return;
+      }
+      const data = JSON.parse(raw);
+      setFolderName(data.folderName || '');
+      setUploads(
+        Array.isArray(data.uploads)
+          ? data.uploads.map((u) => ({
+              ...u,
+              id: u.originalName,
+              description: extractDateFromName(u.originalName),
+              processed: !!u.processed,
+            }))
+          : [],
+      );
+      setIgnored(
+        Array.isArray(data.ignored)
+          ? data.ignored.map((u) => ({
+              ...u,
+              id: u.originalName,
+              description: extractDateFromName(u.originalName),
+              processed: !!u.processed,
+            }))
+          : [],
+      );
+      setPending(
+        Array.isArray(data.pending)
+          ? data.pending.map((u) => ({ ...u, processed: !!u.processed }))
+          : [],
+      );
+      setHostIgnored(
+        Array.isArray(data.hostIgnored)
+          ? data.hostIgnored.map((u) => ({ ...u, processed: !!u.processed }))
+          : [],
+      );
+      setSelected([]);
+      setHostIgnoredSel([]);
+      setUploadSel([]);
+      setUploadPage(1);
+      setIgnoredPage(1);
+      setHostIgnoredPage(1);
+      setPendingPage(1);
+      persistState(data);
+      addToast('State loaded', 'success');
+    } catch {
+      addToast('Failed to load session', 'error');
+    }
+  }
+
+  function deleteSession(name = selectedSession) {
+    if (!name) return;
+    try {
+      localStorage.removeItem(SESSION_PREFIX + name);
+      const names = getSessionNames().filter((n) => n !== name);
+      localStorage.setItem(SESSIONS_KEY, JSON.stringify(names));
+      setSessionNames(names);
+      if (selectedSession === name) setSelectedSession('');
+      addToast('State deleted', 'success');
+    } catch {
+      addToast('Failed to delete session', 'error');
     }
   }
 
@@ -91,11 +272,23 @@ export default function ImageManagement() {
   }
 
   function toggleAll() {
-    if (selected.length === pending.length) {
-      setSelected([]);
-    } else {
-      setSelected(pending.map((p) => p.currentName));
+    const withNew = pending
+      .filter((p) => p.newName && !p.processed)
+      .map((p) => p.currentName);
+    const unprocessed = pending.filter((p) => !p.processed).map((p) => p.currentName);
+    const all = pending.map((p) => p.currentName);
+    const setEq = (arr) =>
+      arr.length === selected.length && arr.every((id) => selected.includes(id));
+    if (withNew.length === 0) {
+      if (setEq(all)) setSelected([]);
+      else if (setEq(unprocessed)) setSelected(all);
+      else setSelected(unprocessed);
+      return;
     }
+    if (setEq(withNew)) setSelected(unprocessed);
+    else if (setEq(unprocessed)) setSelected(all);
+    else if (setEq(all)) setSelected([]);
+    else setSelected(withNew);
   }
 
   function toggleHostIgnored(id) {
@@ -105,13 +298,28 @@ export default function ImageManagement() {
   }
 
   function toggleHostIgnoredAll(list) {
-    const ids = list.map((p) => p.currentName);
-    const allSelected = ids.every((id) => hostIgnoredSel.includes(id));
-    if (allSelected) {
-      setHostIgnoredSel((prev) => prev.filter((id) => !ids.includes(id)));
-    } else {
-      setHostIgnoredSel((prev) => [...prev, ...ids.filter((id) => !prev.includes(id))]);
+    const allIds = list.map((p) => p.currentName);
+    const unprocessedIds = list.filter((p) => !p.processed).map((p) => p.currentName);
+    const newIds = list
+      .filter((p) => p.newName && !p.processed)
+      .map((p) => p.currentName);
+    const current = hostIgnoredSel.filter((id) => allIds.includes(id));
+    const setEq = (arr) => arr.length === current.length && arr.every((id) => current.includes(id));
+    const removePage = (prev) => prev.filter((id) => !allIds.includes(id));
+    if (newIds.length === 0) {
+      if (setEq(allIds)) setHostIgnoredSel(removePage);
+      else if (setEq(unprocessedIds))
+        setHostIgnoredSel((prev) => [...removePage(prev), ...allIds.filter((id) => !prev.includes(id))]);
+      else setHostIgnoredSel((prev) => [...removePage(prev), ...unprocessedIds.filter((id) => !prev.includes(id))]);
+      return;
     }
+    if (setEq(newIds))
+      setHostIgnoredSel((prev) => [...removePage(prev), ...unprocessedIds.filter((id) => !prev.includes(id))]);
+    else if (setEq(unprocessedIds))
+      setHostIgnoredSel((prev) => [...removePage(prev), ...allIds.filter((id) => !prev.includes(id))]);
+    else if (setEq(allIds)) setHostIgnoredSel(removePage);
+    else
+      setHostIgnoredSel((prev) => [...removePage(prev), ...newIds.filter((id) => !prev.includes(id))]);
   }
 
   function toggleUpload(id) {
@@ -121,13 +329,25 @@ export default function ImageManagement() {
   }
 
   function toggleUploadAll(list) {
-    const ids = list.filter((u) => !u.processed).map((u) => u.id);
-    const allSelected = ids.every((id) => uploadSel.includes(id));
-    if (allSelected) {
-      setUploadSel((prev) => prev.filter((id) => !ids.includes(id)));
-    } else {
-      setUploadSel((prev) => [...prev, ...ids.filter((id) => !prev.includes(id))]);
+    const allIds = list.map((u) => u.id);
+    const unprocessedIds = list.filter((u) => !u.processed).map((u) => u.id);
+    const newIds = list.filter((u) => u.newName && !u.processed).map((u) => u.id);
+    const current = uploadSel.filter((id) => allIds.includes(id));
+    const setEq = (arr) => arr.length === current.length && arr.every((id) => current.includes(id));
+    const removePage = (prev) => prev.filter((id) => !allIds.includes(id));
+    if (newIds.length === 0) {
+      if (setEq(allIds)) setUploadSel(removePage);
+      else if (setEq(unprocessedIds))
+        setUploadSel((prev) => [...removePage(prev), ...allIds.filter((id) => !prev.includes(id))]);
+      else setUploadSel((prev) => [...removePage(prev), ...unprocessedIds.filter((id) => !prev.includes(id))]);
+      return;
     }
+    if (setEq(newIds))
+      setUploadSel((prev) => [...removePage(prev), ...unprocessedIds.filter((id) => !prev.includes(id))]);
+    else if (setEq(unprocessedIds))
+      setUploadSel((prev) => [...removePage(prev), ...allIds.filter((id) => !prev.includes(id))]);
+    else if (setEq(allIds)) setUploadSel(removePage);
+    else setUploadSel((prev) => [...removePage(prev), ...newIds.filter((id) => !prev.includes(id))]);
   }
 
   useEffect(() => {
@@ -222,10 +442,20 @@ export default function ImageManagement() {
       setUploadSel([]);
       setUploadPage(1);
       setIgnoredPage(1);
+      setPending([]);
+      setHostIgnored([]);
+      setSelected([]);
+      setHostIgnoredSel([]);
       setReport(
         `Scanned ${names.length} file(s), found ${processed} incomplete name(s), ${skipped.length} unflagged.`,
       );
-      persistState(uploadsList, ignoredList, dirHandle.name || '');
+      persistState({
+        uploads: uploadsList,
+        ignored: ignoredList,
+        folderName: dirHandle.name || '',
+        pending: [],
+        hostIgnored: [],
+      });
     } catch {
       // ignore
     } finally {
@@ -251,7 +481,7 @@ export default function ImageManagement() {
     }
   }
 
-  async function detectFromHost(p = page) {
+  async function detectFromHost(p = pendingPage) {
     const controller = new AbortController();
     detectAbortRef.current = controller;
     setActiveOp('detect');
@@ -266,7 +496,11 @@ export default function ImageManagement() {
           ? data.list
               .slice()
               .sort((a, b) => a.currentName.localeCompare(b.currentName))
-              .map((p) => ({ ...p, description: extractDateFromName(p.currentName) }))
+              .map((p) => ({
+                ...p,
+                description: extractDateFromName(p.currentName),
+                processed: false,
+              }))
           : [];
         const miss = Array.isArray(data.skipped)
           ? data.skipped
@@ -275,6 +509,7 @@ export default function ImageManagement() {
               .map((p) => ({
                 ...p,
                 description: extractDateFromName(p.currentName),
+                processed: false,
               }))
           : [];
         setPending(list);
@@ -288,14 +523,22 @@ export default function ImageManagement() {
         setReport(
           `Scanned ${sum.totalFiles || 0} file(s), found ${sum.incompleteFound || 0} incomplete name(s), ${sum.skipped || 0} not incomplete.`,
         );
+        persistState({
+          uploads,
+          ignored,
+          folderName,
+          pending: list,
+          hostIgnored: miss,
+        });
       } else {
         setPending([]);
         setHostIgnored([]);
         setHostIgnoredPage(1);
         setPendingSummary(null);
         setHasMore(false);
+        persistState({ uploads, ignored, folderName, pending: [], hostIgnored: [] });
       }
-      setPage(p);
+      setPendingPage(p);
     } catch (e) {
       if (e.name !== 'AbortError') {
         setPending([]);
@@ -303,17 +546,18 @@ export default function ImageManagement() {
         setHostIgnoredPage(1);
         setPendingSummary(null);
         setHasMore(false);
+        persistState({ uploads, ignored, folderName, pending: [], hostIgnored: [] });
       }
     } finally {
       detectAbortRef.current = null;
       setActiveOp(null);
     }
-    setPage(p);
+      setPendingPage(p);
   }
 
   async function applyFixesSelection(list, sel) {
-    const items = list.filter((p) => sel.includes(p.currentName));
-    if (items.length === 0) return;
+    const items = list.filter((p) => sel.includes(p.currentName) && !p.processed);
+    if (items.length === 0) return null;
     const res = await fetch('/api/transaction_images/fix_incomplete', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -324,18 +568,32 @@ export default function ImageManagement() {
       const data = await res.json().catch(() => ({}));
       addToast(`Renamed ${data.fixed || 0} file(s)`, 'success');
       setReport(`Renamed ${data.fixed || 0} file(s)`);
-      detectFromHost(page);
+      const newList = list.map((p) =>
+        sel.includes(p.currentName) ? { ...p, processed: true } : p,
+      );
+      return newList;
     } else {
       addToast('Rename failed', 'error');
+      return null;
     }
   }
 
   async function applyFixes() {
-    await applyFixesSelection(pending, selected);
+    const newPending = await applyFixesSelection(pending, selected);
+    if (newPending) {
+      setPending(newPending);
+      setSelected([]);
+      persistState({ uploads, ignored, folderName, pending: newPending, hostIgnored });
+    }
   }
 
   async function applyFixesHostIgnored() {
-    await applyFixesSelection(hostIgnored, hostIgnoredSel);
+    const newHostIgnored = await applyFixesSelection(hostIgnored, hostIgnoredSel);
+    if (newHostIgnored) {
+      setHostIgnored(newHostIgnored);
+      setHostIgnoredSel([]);
+      persistState({ uploads, ignored, folderName, pending, hostIgnored: newHostIgnored });
+    }
   }
 
   async function renameSelected() {
@@ -381,7 +639,7 @@ export default function ImageManagement() {
         .sort((a, b) => a.originalName.localeCompare(b.originalName));
       setUploads(newUploads);
       setIgnored(newIgnored);
-      persistState(newUploads, newIgnored);
+      persistState({ uploads: newUploads, ignored: newIgnored });
       setReport(`Renamed ${list.length} file(s)`);
     } catch {
       addToast('Rename failed', 'error');
@@ -411,7 +669,7 @@ export default function ImageManagement() {
       setUploads(newUploads);
       setIgnored(newIgnored);
       setUploadSel([]);
-      persistState(newUploads, newIgnored);
+      persistState({ uploads: newUploads, ignored: newIgnored });
       setReport(`Uploaded ${data.uploaded || 0} file(s)`);
     } else {
       addToast('Upload failed', 'error');
@@ -457,6 +715,31 @@ export default function ImageManagement() {
               Select Folder
             </button>
             {folderName && <span style={{ marginRight: '0.5rem' }}>{folderName}</span>}
+            <button
+              type="button"
+              onClick={saveSession}
+              style={{ marginRight: '0.5rem' }}
+            >
+              Save
+            </button>
+            <select
+              value={selectedSession}
+              onChange={(e) => setSelectedSession(e.target.value)}
+              style={{ marginRight: '0.5rem' }}
+            >
+              <option value="">Select session</option>
+              {sessionNames.map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+            <button type="button" onClick={() => loadSession()} disabled={!selectedSession} style={{ marginRight: '0.5rem' }}>
+              Load
+            </button>
+            <button type="button" onClick={() => deleteSession()} disabled={!selectedSession}>
+              Delete
+            </button>
           </div>
           {uploadSummary && (
             <p style={{ marginBottom: '0.5rem' }}>
@@ -494,7 +777,7 @@ export default function ImageManagement() {
                   setIgnored(remainingIgnored);
                   setUploadSel([]);
                   setReport(`Deleted ${uploadSel.length} file(s)`);
-                  persistState(remainingUploads, remainingIgnored);
+                  persistState({ uploads: remainingUploads, ignored: remainingIgnored });
                 }}
                 style={{ marginBottom: '0.5rem', marginLeft: '0.5rem' }}
                 disabled={uploadSel.length === 0}
@@ -565,6 +848,7 @@ export default function ImageManagement() {
                         <th className="border px-2 py-1">New Name</th>
                         <th className="border px-2 py-1">Folder</th>
                         <th className="border px-2 py-1">Description</th>
+                        <th className="border px-2 py-1">State</th>
                         <th className="border px-2 py-1">Delete</th>
                       </tr>
                     </thead>
@@ -578,6 +862,7 @@ export default function ImageManagement() {
                           <td className="border px-2 py-1">{u.newName}</td>
                           <td className="border px-2 py-1">{u.folderDisplay}</td>
                           <td className="border px-2 py-1">{u.description}</td>
+                          <td className="border px-2 py-1">{stateLabel(u)}</td>
                           <td className="border px-2 py-1 text-center">
                             <button
                               type="button"
@@ -585,7 +870,7 @@ export default function ImageManagement() {
                                 const remainingUploads = uploads.filter((x) => x.id !== u.id);
                                 setUploads(remainingUploads);
                                 setUploadSel((s) => s.filter((id) => id !== u.id));
-                                persistState(remainingUploads, ignored);
+                                persistState({ uploads: remainingUploads, ignored });
                               }}
                             >
                               Delete
@@ -647,6 +932,7 @@ export default function ImageManagement() {
                         <th className="border px-2 py-1">New Name</th>
                         <th className="border px-2 py-1">Folder</th>
                         <th className="border px-2 py-1">Description</th>
+                        <th className="border px-2 py-1">State</th>
                         <th className="border px-2 py-1">Delete</th>
                       </tr>
                     </thead>
@@ -660,6 +946,7 @@ export default function ImageManagement() {
                           <td className="border px-2 py-1">{u.newName}</td>
                           <td className="border px-2 py-1">{u.folderDisplay}</td>
                           <td className="border px-2 py-1">{u.reason}</td>
+                          <td className="border px-2 py-1">{stateLabel(u)}</td>
                           <td className="border px-2 py-1 text-center">
                             <button
                               type="button"
@@ -667,7 +954,7 @@ export default function ImageManagement() {
                                 const remainingIgnored = ignored.filter((x) => x.id !== u.id);
                                 setIgnored(remainingIgnored);
                                 setUploadSel((s) => s.filter((id) => id !== u.id));
-                                persistState(uploads, remainingIgnored);
+                                persistState({ uploads, ignored: remainingIgnored });
                               }}
                             >
                               Delete
@@ -696,7 +983,7 @@ export default function ImageManagement() {
             </label>
             <button
               type="button"
-              disabled={page === 1}
+              disabled={pendingPage === 1}
               onClick={() => detectFromHost(1)}
               style={{ marginRight: '0.5rem' }}
             >
@@ -704,8 +991,8 @@ export default function ImageManagement() {
             </button>
             <button
               type="button"
-              disabled={page === 1}
-              onClick={() => detectFromHost(page - 1)}
+              disabled={pendingPage === 1}
+              onClick={() => detectFromHost(pendingPage - 1)}
               style={{ marginRight: '0.5rem' }}
             >
               Prev
@@ -713,14 +1000,14 @@ export default function ImageManagement() {
             <button
               type="button"
               disabled={!hasMore}
-              onClick={() => detectFromHost(page + 1)}
+              onClick={() => detectFromHost(pendingPage + 1)}
               style={{ marginRight: '0.5rem' }}
             >
               Next
             </button>
             <button
               type="button"
-              disabled={page === lastPage}
+              disabled={pendingPage === lastPage}
               onClick={() => detectFromHost(lastPage)}
             >
               Last
@@ -748,8 +1035,10 @@ export default function ImageManagement() {
               <button
                 type="button"
                 onClick={() => {
-                  setPending((prev) => prev.filter((p) => !selected.includes(p.currentName)));
+                  const remaining = pending.filter((p) => !selected.includes(p.currentName));
+                  setPending(remaining);
                   setSelected([]);
+                  persistState({ uploads, ignored, folderName, pending: remaining, hostIgnored });
                 }}
                 style={{ marginBottom: '0.5rem', marginLeft: '0.5rem' }}
                 disabled={selected.length === 0}
@@ -766,6 +1055,7 @@ export default function ImageManagement() {
                     <th className="border px-2 py-1">New Name</th>
                     <th className="border px-2 py-1">Folder</th>
                     <th className="border px-2 py-1">Description</th>
+                    <th className="border px-2 py-1">State</th>
                     <th className="border px-2 py-1">Delete</th>
                   </tr>
                 </thead>
@@ -779,6 +1069,7 @@ export default function ImageManagement() {
                       <td className="border px-2 py-1">{p.newName}</td>
                       <td className="border px-2 py-1">{p.folderDisplay}</td>
                       <td className="border px-2 py-1">{p.description}</td>
+                      <td className="border px-2 py-1">{stateLabel(p)}</td>
                       <td className="border px-2 py-1 text-center">
                         <button
                           type="button"
@@ -810,8 +1101,12 @@ export default function ImageManagement() {
               <button
                 type="button"
                 onClick={() => {
-                  setHostIgnored((prev) => prev.filter((p) => !hostIgnoredSel.includes(p.currentName)));
+                  const remaining = hostIgnored.filter(
+                    (p) => !hostIgnoredSel.includes(p.currentName),
+                  );
+                  setHostIgnored(remaining);
                   setHostIgnoredSel([]);
+                  persistState({ uploads, ignored, folderName, pending, hostIgnored: remaining });
                 }}
                 style={{ marginBottom: '0.5rem', marginLeft: '0.5rem' }}
                 disabled={hostIgnoredSel.length === 0}
@@ -868,6 +1163,7 @@ export default function ImageManagement() {
                     <th className="border px-2 py-1">New Name</th>
                     <th className="border px-2 py-1">Folder</th>
                     <th className="border px-2 py-1">Description</th>
+                    <th className="border px-2 py-1">State</th>
                     <th className="border px-2 py-1">Delete</th>
                   </tr>
                 </thead>
@@ -889,6 +1185,7 @@ export default function ImageManagement() {
                         {p.description && p.reason ? ' - ' : ''}
                         {p.reason}
                       </td>
+                      <td className="border px-2 py-1">{stateLabel(p)}</td>
                       <td className="border px-2 py-1 text-center">
                         <button
                           type="button"


### PR DESCRIPTION
## Summary
- sanitize session data and persist all tables including folder name
- add dropdown to load or delete any saved image management session
- isolate pending results pagination so one table's navigation doesn't affect others
- prevent save errors by filtering out sparse table entries before persisting
- sanitize saved image sessions to remove non-serializable values
- store each image-management session under its own key to avoid save failures when only folder tables are present
- strip non-primitive fields and rewrite save logic so folder and host tables all persist without errors
- standardize session serialization so Save captures every table's primitive fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f57e307d08331a63cd197f95ea8b7