### PR TITLE
feat: allow configurable API base for auth

### DIFF
--- a/src/erp.mgt.mn/context/AuthContext.jsx
+++ b/src/erp.mgt.mn/context/AuthContext.jsx
@@ -1,6 +1,7 @@
 // src/erp.mgt.mn/context/AuthContext.jsx
 import React, { createContext, useState, useEffect, useContext, useMemo } from 'react';
 import { debugLog, trackSetState } from '../utils/debug.js';
+import { API_BASE } from '../utils/apiBase.js';
 
 // Create the AuthContext
 export const AuthContext = createContext({
@@ -42,7 +43,7 @@ export default function AuthContextProvider({ children }) {
     debugLog('AuthContext: load profile');
     async function loadProfile() {
       try {
-        const res = await fetch('/api/auth/me', {
+        const res = await fetch(`${API_BASE}/auth/me`, {
           credentials: 'include',
         });
 

--- a/src/erp.mgt.mn/hooks/useAuth.jsx
+++ b/src/erp.mgt.mn/hooks/useAuth.jsx
@@ -1,6 +1,7 @@
 // src/erp.mgt.mn/hooks/useAuth.jsx
 import { useContext } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
+import { API_BASE } from '../utils/apiBase.js';
 
 // src/erp.mgt.mn/hooks/useAuth.jsx
 
@@ -10,7 +11,7 @@ import { AuthContext } from '../context/AuthContext.jsx';
  * @returns {Promise<{id: number, empid: string, role: string}>}
 */
 export async function login({ empid, password }) {
-  const res = await fetch('/api/auth/login', {
+  const res = await fetch(`${API_BASE}/auth/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include', // Ensures cookie is stored
@@ -27,7 +28,7 @@ export async function login({ empid, password }) {
  * Calls logout endpoint to clear the JWT cookie.
  */
 export async function logout() {
-  await fetch('/api/auth/logout', {
+  await fetch(`${API_BASE}/auth/logout`, {
     method: 'POST',
     credentials: 'include',
   });
@@ -38,7 +39,7 @@ export async function logout() {
  * @returns {Promise<{id: number, empid: string, role: string}>}
 */
 export async function fetchProfile() {
-  const res = await fetch('/api/auth/me', { credentials: 'include' });
+  const res = await fetch(`${API_BASE}/auth/me`, { credentials: 'include' });
   if (!res.ok) throw new Error('Not authenticated');
   return res.json();
 }

--- a/src/erp.mgt.mn/hooks/useFetchProfile.js
+++ b/src/erp.mgt.mn/hooks/useFetchProfile.js
@@ -1,6 +1,8 @@
 // (for example) src/erp.mgt.mn/hooks/useFetchProfile.js
+import { API_BASE } from '../utils/apiBase.js';
+
 export async function fetchProfile() {
-  const res = await fetch('/api/auth/me', { credentials: 'include' });
+  const res = await fetch(`${API_BASE}/auth/me`, { credentials: 'include' });
   if (!res.ok) throw new Error('Failed to fetch profile');
   return res.json();
 }

--- a/src/erp.mgt.mn/utils/csrfFetch.js
+++ b/src/erp.mgt.mn/utils/csrfFetch.js
@@ -1,3 +1,5 @@
+import { API_BASE } from './apiBase.js';
+
 let tokenPromise;
 
 function dispatchStart(key) {
@@ -14,7 +16,7 @@ function currentKey() {
 
 async function getToken() {
   if (!tokenPromise) {
-    tokenPromise = fetch('/api/csrf-token', { credentials: 'include' })
+    tokenPromise = fetch(`${API_BASE}/csrf-token`, { credentials: 'include' })
       .then(res => res.json())
       .then(data => data.csrfToken)
       .catch(() => undefined);
@@ -45,7 +47,7 @@ window.fetch = async (url, options = {}, _retry) => {
       msg = data.message;
     } catch {}
     if (msg && msg.toLowerCase().includes('expired')) {
-      const refreshRes = await originalFetch('/api/auth/refresh', {
+      const refreshRes = await originalFetch(`${API_BASE}/auth/refresh`, {
         method: 'POST',
         credentials: 'include',
         headers: { 'X-CSRF-Token': await getToken() },


### PR DESCRIPTION
## Summary
- use VITE_API_BASE for auth requests
- wire CSRF helper to configurable API base

## Testing
- `npm test`
- `npm run build:erp`


------
https://chatgpt.com/codex/tasks/task_e_6891b3c4927483319136f2fddce0a5c1