### PR TITLE
feat: archive images and search via context menu

### DIFF
--- a/api-server/routes/transaction_images.js
+++ b/api-server/routes/transaction_images.js
@@ -13,6 +13,7 @@ import {
   checkUploadedImages,
   commitUploadedImages,
   detectIncompleteFromNames,
+  searchImages,
 } from '../services/transactionImageService.js';
 import { getGeneralConfig } from '../services/generalConfig.js';
 
@@ -102,6 +103,17 @@ router.post('/upload_commit', requireAuth, async (req, res, next) => {
     const arr = Array.isArray(req.body?.list) ? req.body.list : [];
     const uploaded = await commitUploadedImages(arr);
     res.json({ uploaded });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/search/:value', requireAuth, async (req, res, next) => {
+  try {
+    const page = parseInt(req.query.page, 10) || 1;
+    const perPage = parseInt(req.query.pageSize, 10) || 20;
+    const { files, total } = await searchImages(req.params.value, page, perPage);
+    res.json({ files: toAbsolute(req, files), total, page, perPage });
   } catch (err) {
     next(err);
   }

--- a/src/erp.mgt.mn/components/ImageSearchModal.jsx
+++ b/src/erp.mgt.mn/components/ImageSearchModal.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import Modal from './Modal.jsx';
+
+export default function ImageSearchModal({
+  visible,
+  term,
+  images = [],
+  page = 1,
+  total = 0,
+  perPage = 20,
+  onClose,
+  onPrev,
+  onNext,
+}) {
+  const totalPages = Math.ceil(total / perPage);
+  return (
+    <Modal visible={visible} title={`Images for "${term}"`} onClose={onClose} width="80%">
+      {images.length === 0 ? (
+        <div>No images found.</div>
+      ) : (
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))',
+            gap: '0.5rem',
+          }}
+        >
+          {images.map((src) => (
+            <img key={src} src={src} style={{ width: '100%', height: 'auto', objectFit: 'cover' }} />
+          ))}
+        </div>
+      )}
+      {totalPages > 1 && (
+        <div
+          style={{
+            marginTop: '0.5rem',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <button onClick={onPrev} disabled={page <= 1}>
+            Prev
+          </button>
+          <span>
+            Page {page} of {totalPages}
+          </span>
+          <button onClick={onNext} disabled={page >= totalPages}>
+            Next
+          </button>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/src/erp.mgt.mn/components/RowImageViewModal.jsx
+++ b/src/erp.mgt.mn/components/RowImageViewModal.jsx
@@ -238,6 +238,26 @@ export default function RowImageViewModal({
     setFullscreen(src);
   };
 
+  const handleDelete = async (file) => {
+    if (!window.confirm('Delete this image?')) return;
+    const safeTable = encodeURIComponent(table);
+    const params = new URLSearchParams();
+    if (folder) params.set('folder', folder);
+    const name = row._imageName || 'unused';
+    const url = `${API_BASE}/transaction_images/${safeTable}/${encodeURIComponent(name)}/${encodeURIComponent(file.name)}?${params.toString()}`;
+    try {
+      const res = await fetch(url, { method: 'DELETE', credentials: 'include' });
+      if (res.ok) {
+        setFiles((prev) => prev.filter((f) => f.path !== file.path));
+        toast('Image deleted', 'info');
+      } else {
+        toast('Failed to delete image', 'error');
+      }
+    } catch {
+      toast('Failed to delete image', 'error');
+    }
+  };
+
   const listView = (
     <div style={{ maxHeight: '40vh', overflowY: 'auto' }}>
       {files.map((f) => (
@@ -310,17 +330,39 @@ export default function RowImageViewModal({
               }}
             >
               {files.map((f) => (
-                <img
-                  key={f.path}
-                  src={f.src}
-                  alt=""
-                  onError={(e) => {
-                    e.currentTarget.onerror = null;
-                    e.currentTarget.src = placeholder;
-                  }}
-                  style={{ width: '100%', height: '100%', objectFit: 'contain', cursor: 'pointer' }}
-                  onClick={() => handleView(f.src)}
-                />
+                <div key={f.path} style={{ position: 'relative' }}>
+                  <img
+                    src={f.src}
+                    alt=""
+                    onError={(e) => {
+                      e.currentTarget.onerror = null;
+                      e.currentTarget.src = placeholder;
+                    }}
+                    style={{ width: '100%', height: '100%', objectFit: 'contain', cursor: 'pointer' }}
+                    onClick={() => handleView(f.src)}
+                  />
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDelete(f);
+                    }}
+                    style={{
+                      position: 'absolute',
+                      top: '0.25rem',
+                      right: '0.25rem',
+                      background: 'red',
+                      color: 'white',
+                      border: 'none',
+                      borderRadius: '0.25rem',
+                      padding: '0.25rem 0.5rem',
+                      cursor: 'pointer',
+                      fontSize: '0.75rem',
+                    }}
+                  >
+                    delete
+                  </button>
+                </div>
               ))}
             </div>
           </div>,

--- a/tests/api/deleteImageMovesFile.test.js
+++ b/tests/api/deleteImageMovesFile.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import path from 'path';
+import { deleteImage } from '../../api-server/services/transactionImageService.js';
+
+const baseDir = path.join(process.cwd(), 'uploads', 'txn_images');
+const srcDir = path.join(baseDir, 'delete_image_test');
+const deletedDir = path.join(baseDir, 'deleted_images');
+
+await test('deleteImage moves file to deleted_images', async () => {
+  await fs.rm(srcDir, { recursive: true, force: true });
+  await fs.rm(deletedDir, { recursive: true, force: true });
+  await fs.mkdir(srcDir, { recursive: true });
+  const fileName = 'img001_123.jpg';
+  await fs.writeFile(path.join(srcDir, fileName), 'x');
+
+  const ok = await deleteImage('delete_image_test', fileName, 'delete_image_test');
+  assert.equal(ok, true);
+  const files = await fs.readdir(deletedDir);
+  assert.ok(files.includes(fileName));
+  const origFiles = await fs.readdir(srcDir).catch(() => []);
+  assert.equal(origFiles.length, 0);
+  await fs.rm(srcDir, { recursive: true, force: true });
+  await fs.rm(deletedDir, { recursive: true, force: true });
+});

--- a/tests/api/searchImagesByValue.test.js
+++ b/tests/api/searchImagesByValue.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import path from 'path';
+import { searchImages } from '../../api-server/services/transactionImageService.js';
+
+const baseDir = path.join(process.cwd(), 'uploads', 'txn_images', 'search_images_test');
+
+await test('searchImages finds files by field value', async () => {
+  await fs.rm(baseDir, { recursive: true, force: true });
+  await fs.mkdir(baseDir, { recursive: true });
+  await fs.writeFile(path.join(baseDir, 'a_123_b.jpg'), 'x');
+  await fs.mkdir(path.join(baseDir, 'sub'), { recursive: true });
+  await fs.writeFile(path.join(baseDir, 'sub', 'c-123-d.png'), 'x');
+  await fs.writeFile(path.join(baseDir, 'sub', 'e~123~f.jpeg'), 'x');
+  await fs.writeFile(path.join(baseDir, 'nomatch.jpg'), 'x');
+
+  const { files, total } = await searchImages('123', 1, 10);
+  assert.equal(total, 3);
+  const joined = files.join('\n');
+  assert.ok(joined.includes('a_123_b.jpg'));
+  assert.ok(joined.includes('c-123-d.png'));
+  assert.ok(joined.includes('e~123~f.jpeg'));
+
+  await fs.rm(baseDir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- add delete controls to gallery and confirm before moving images
- archive images in deleted_images instead of removing
- search for image files by field value via table cell context menu
- display found images in a paginated modal
- cover image archiving and searching with automated tests
- color gallery delete buttons red with a delete label

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fa8838e88833194a805873557620e