### PR TITLE
fix: persist all tables in image management

### DIFF
--- a/src/erp.mgt.mn/pages/ImageManagement.jsx
+++ b/src/erp.mgt.mn/pages/ImageManagement.jsx
@@ -216,7 +216,7 @@ export default function ImageManagement() {
     );
   }
 
-  function persistSnapshot(partial) {
+  function persistSnapshot(partial = {}) {
     try {
       const data = buildSession(partial);
       localStorage.setItem(FOLDER_STATE_KEY, JSON.stringify(data));
@@ -224,6 +224,15 @@ export default function ImageManagement() {
     } catch {
       // ignore
     }
+  }
+
+  function getTables() {
+    return { uploads, ignored, pending, hostIgnored };
+  }
+
+  function persistAll(partial = {}) {
+    const tables = getTables();
+    persistSnapshot({ ...tables, folderName, ...partial });
   }
 
   function getSessionNames() {
@@ -251,7 +260,7 @@ export default function ImageManagement() {
       names.add(name);
       localStorage.setItem(SESSIONS_KEY, JSON.stringify([...names]));
       await saveDirHandle(name, dirHandleRef.current);
-      persistSnapshot(data);
+      persistAll(data);
       setSessionNames([...names]);
       setSelectedSession(name);
       addToast('State saved', 'success');
@@ -290,7 +299,7 @@ export default function ImageManagement() {
       setIgnoredPage(1);
       setHostIgnoredPage(1);
       setPendingPage(1);
-      persistSnapshot(data);
+      persistAll(data);
       addToast('State loaded', 'success');
     } catch (err) {
       console.error(err);
@@ -329,8 +338,12 @@ export default function ImageManagement() {
     ? Math.max(1, Math.ceil((pendingSummary.incompleteFound || 0) / pageSize))
     : 1;
 
-  const canRenameSelected = [...uploads, ...ignored].some(
+  const allTables = Object.values(getTables()).flat();
+  const canRenameSelected = allTables.some(
     (u) => uploadSel.includes(u.id) && u.handle && !u.processed,
+  );
+  const canUploadSelected = allTables.some(
+    (u) => uploadSel.includes(u.id) && u.tmpPath && !u.processed,
   );
 
   function toggle(id) {
@@ -518,7 +531,7 @@ export default function ImageManagement() {
       setReport(
         `Scanned ${names.length} file(s), found ${processed} incomplete name(s), ${skipped.length} unflagged.`,
       );
-      persistSnapshot({
+      persistAll({
         uploads: uploadsList,
         ignored: ignoredList,
         folderName: dirHandle.name || '',
@@ -592,7 +605,7 @@ export default function ImageManagement() {
         setReport(
           `Scanned ${sum.totalFiles || 0} file(s), found ${sum.incompleteFound || 0} incomplete name(s), ${sum.skipped || 0} not incomplete.`,
         );
-        persistSnapshot({
+        persistAll({
           uploads,
           ignored,
           folderName,
@@ -605,7 +618,7 @@ export default function ImageManagement() {
         setHostIgnoredPage(1);
         setPendingSummary(null);
         setHasMore(false);
-        persistSnapshot({ uploads, ignored, folderName, pending: [], hostIgnored: [] });
+        persistAll({ uploads, ignored, folderName, pending: [], hostIgnored: [] });
       }
       setPendingPage(p);
     } catch (e) {
@@ -615,7 +628,7 @@ export default function ImageManagement() {
         setHostIgnoredPage(1);
         setPendingSummary(null);
         setHasMore(false);
-        persistSnapshot({ uploads, ignored, folderName, pending: [], hostIgnored: [] });
+        persistAll({ uploads, ignored, folderName, pending: [], hostIgnored: [] });
       }
     } finally {
       detectAbortRef.current = null;
@@ -652,7 +665,7 @@ export default function ImageManagement() {
     if (newPending) {
       setPending(newPending);
       setSelected([]);
-      persistSnapshot({ uploads, ignored, folderName, pending: newPending, hostIgnored });
+      persistAll({ uploads, ignored, folderName, pending: newPending, hostIgnored });
     }
   }
 
@@ -661,12 +674,14 @@ export default function ImageManagement() {
     if (newHostIgnored) {
       setHostIgnored(newHostIgnored);
       setHostIgnoredSel([]);
-      persistSnapshot({ uploads, ignored, folderName, pending, hostIgnored: newHostIgnored });
+      persistAll({ uploads, ignored, folderName, pending, hostIgnored: newHostIgnored });
     }
   }
 
   async function renameSelected() {
-    const items = [...uploads, ...ignored].filter(
+    const tables = getTables();
+    const allItems = Object.values(tables).flat();
+    const items = allItems.filter(
       (u) => uploadSel.includes(u.id) && u.handle && !u.processed,
     );
     if (items.length === 0) {
@@ -695,23 +710,25 @@ export default function ImageManagement() {
       }
       const data = await res.json().catch(() => ({}));
       const list = Array.isArray(data.list) ? data.list : [];
-      const newUploads = uploads
-        .map((u) => {
-          const found = list.find((x) => x.originalName === u.originalName);
-          const merged = found ? { ...u, ...found, id: u.id } : u;
-          return { ...merged, description: extractDateFromName(merged.originalName) };
-        })
-        .sort((a, b) => a.originalName.localeCompare(b.originalName));
-      const newIgnored = ignored
-        .map((u) => {
-          const found = list.find((x) => x.originalName === u.originalName);
-          const merged = found ? { ...u, ...found, id: u.id } : u;
-          return { ...merged, description: extractDateFromName(merged.originalName) };
-        })
-        .sort((a, b) => a.originalName.localeCompare(b.originalName));
-      setUploads(newUploads);
-      setIgnored(newIgnored);
-      persistSnapshot({ uploads: newUploads, ignored: newIgnored });
+      const updated = {};
+      for (const [key, arr] of Object.entries(tables)) {
+        if (arr.some((u) => 'originalName' in u)) {
+          updated[key] = arr
+            .map((u) => {
+              const found = list.find((x) => x.originalName === u.originalName);
+              const merged = found ? { ...u, ...found, id: u.id } : u;
+              return { ...merged, description: extractDateFromName(merged.originalName) };
+            })
+            .sort((a, b) => a.originalName.localeCompare(b.originalName));
+        } else {
+          updated[key] = arr;
+        }
+      }
+      setUploads(updated.uploads);
+      setIgnored(updated.ignored);
+      setPending(updated.pending);
+      setHostIgnored(updated.hostIgnored);
+      persistAll(updated);
       setReport(`Renamed ${list.length} file(s)`);
     } catch {
       addToast('Rename failed', 'error');
@@ -719,7 +736,9 @@ export default function ImageManagement() {
   }
 
   async function commitUploads() {
-    const items = [...uploads, ...ignored].filter(
+    const tables = getTables();
+    const allItems = Object.values(tables).flat();
+    const items = allItems.filter(
       (u) => uploadSel.includes(u.id) && u.tmpPath && !u.processed,
     );
     if (items.length === 0) return;
@@ -732,16 +751,18 @@ export default function ImageManagement() {
     if (res.ok) {
       const data = await res.json().catch(() => ({}));
       addToast(`Uploaded ${data.uploaded || 0} file(s)`, 'success');
-      const newUploads = uploads.map((u) =>
-        uploadSel.includes(u.id) && u.tmpPath ? { ...u, processed: true } : u,
-      );
-      const newIgnored = ignored.map((u) =>
-        uploadSel.includes(u.id) && u.tmpPath ? { ...u, processed: true } : u,
-      );
-      setUploads(newUploads);
-      setIgnored(newIgnored);
+      const updated = {};
+      for (const [key, arr] of Object.entries(tables)) {
+        updated[key] = arr.map((u) =>
+          uploadSel.includes(u.id) && u.tmpPath ? { ...u, processed: true } : u,
+        );
+      }
+      setUploads(updated.uploads);
+      setIgnored(updated.ignored);
+      setPending(updated.pending);
+      setHostIgnored(updated.hostIgnored);
       setUploadSel([]);
-      persistSnapshot({ uploads: newUploads, ignored: newIgnored });
+      persistAll(updated);
       setReport(`Uploaded ${data.uploaded || 0} file(s)`);
     } else {
       addToast('Upload failed', 'error');
@@ -834,8 +855,7 @@ export default function ImageManagement() {
                 onClick={commitUploads}
                 style={{ marginBottom: '0.5rem' }}
                 disabled={
-                  uploadSel.length === 0 ||
-                  ![...uploads, ...ignored].some((u) => uploadSel.includes(u.id) && u.tmpPath)
+                  uploadSel.length === 0 || !canUploadSelected
                 }
               >
                 Upload Selected
@@ -849,7 +869,7 @@ export default function ImageManagement() {
                   setIgnored(remainingIgnored);
                   setUploadSel([]);
                   setReport(`Deleted ${uploadSel.length} file(s)`);
-                  persistSnapshot({ uploads: remainingUploads, ignored: remainingIgnored });
+                  persistAll({ uploads: remainingUploads, ignored: remainingIgnored });
                 }}
                 style={{ marginBottom: '0.5rem', marginLeft: '0.5rem' }}
                 disabled={uploadSel.length === 0}
@@ -942,7 +962,7 @@ export default function ImageManagement() {
                                 const remainingUploads = uploads.filter((x) => x.id !== u.id);
                                 setUploads(remainingUploads);
                                 setUploadSel((s) => s.filter((id) => id !== u.id));
-                                persistSnapshot({ uploads: remainingUploads, ignored });
+                                persistAll({ uploads: remainingUploads, ignored });
                               }}
                             >
                               Delete
@@ -1026,7 +1046,7 @@ export default function ImageManagement() {
                                 const remainingIgnored = ignored.filter((x) => x.id !== u.id);
                                 setIgnored(remainingIgnored);
                                 setUploadSel((s) => s.filter((id) => id !== u.id));
-                                persistSnapshot({ uploads, ignored: remainingIgnored });
+                                persistAll({ uploads, ignored: remainingIgnored });
                               }}
                             >
                               Delete
@@ -1110,7 +1130,7 @@ export default function ImageManagement() {
                   const remaining = pending.filter((p) => !selected.includes(p.currentName));
                   setPending(remaining);
                   setSelected([]);
-                  persistSnapshot({ uploads, ignored, folderName, pending: remaining, hostIgnored });
+                  persistAll({ uploads, ignored, folderName, pending: remaining, hostIgnored });
                 }}
                 style={{ marginBottom: '0.5rem', marginLeft: '0.5rem' }}
                 disabled={selected.length === 0}
@@ -1178,7 +1198,7 @@ export default function ImageManagement() {
                   );
                   setHostIgnored(remaining);
                   setHostIgnoredSel([]);
-                  persistSnapshot({ uploads, ignored, folderName, pending, hostIgnored: remaining });
+                  persistAll({ uploads, ignored, folderName, pending, hostIgnored: remaining });
                 }}
                 style={{ marginBottom: '0.5rem', marginLeft: '0.5rem' }}
                 disabled={hostIgnoredSel.length === 0}


### PR DESCRIPTION
## Summary
- centralize table collection and snapshotting for image management
- handle rename and upload operations across all tables in Fix Names tab
- enable Rename/Upload buttons to recognize selections from any table

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891bed300688331be96cccd8fc91038