### PR TITLE
Restore Fix Names menu functions

### DIFF
--- a/src/erp.mgt.mn/pages/ImageManagement.jsx
+++ b/src/erp.mgt.mn/pages/ImageManagement.jsx
@@ -1,66 +1,7 @@
-
 import React, { useState, useRef, useEffect } from 'react';
 import { useToast } from '../context/ToastContext.jsx';
 
 const FOLDER_STATE_KEY = 'imgMgmtFolderState';
-const SESSIONS_KEY = 'imgMgmtSessions';
-const SESSION_PREFIX = 'imgMgmtSession:';
-
-// IndexedDB helpers for storing directory handles
-function getHandleDB() {
-  if (typeof indexedDB === 'undefined') return Promise.reject();
-  return new Promise((resolve, reject) => {
-    const req = indexedDB.open('imgMgmtHandles', 1);
-    req.onupgradeneeded = () => {
-      req.result.createObjectStore('dirs');
-    };
-    req.onsuccess = () => resolve(req.result);
-    req.onerror = () => reject(req.error);
-  });
-}
-
-async function saveDirHandle(key, handle) {
-  if (!handle) return;
-  try {
-    const db = await getHandleDB();
-    await new Promise((res, rej) => {
-      const tx = db.transaction('dirs', 'readwrite');
-      tx.objectStore('dirs').put(handle, key);
-      tx.oncomplete = res;
-      tx.onerror = () => rej(tx.error);
-    });
-  } catch {
-    // ignore
-  }
-}
-
-async function loadDirHandle(key) {
-  try {
-    const db = await getHandleDB();
-    return await new Promise((res, rej) => {
-      const tx = db.transaction('dirs', 'readonly');
-      const req = tx.objectStore('dirs').get(key);
-      req.onsuccess = () => res(req.result || null);
-      req.onerror = () => rej(req.error);
-    });
-  } catch {
-    return null;
-  }
-}
-
-async function deleteDirHandle(key) {
-  try {
-    const db = await getHandleDB();
-    await new Promise((res, rej) => {
-      const tx = db.transaction('dirs', 'readwrite');
-      tx.objectStore('dirs').delete(key);
-      tx.oncomplete = res;
-      tx.onerror = () => rej(tx.error);
-    });
-  } catch {
-    // ignore
-  }
-}
 
 function extractDateFromName(name) {
   const match = typeof name === 'string' ? name.match(/(?:__|_)(\d{13})_/) : null;
@@ -79,7 +20,7 @@ export default function ImageManagement() {
   const [result, setResult] = useState(null);
   const [tab, setTab] = useState('cleanup');
   const [pending, setPending] = useState([]);
-  const [pendingPage, setPendingPage] = useState(1);
+  const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(false);
   const [selected, setSelected] = useState([]);
   const [hostIgnored, setHostIgnored] = useState([]);
@@ -97,229 +38,33 @@ export default function ImageManagement() {
   const [pageSize, setPageSize] = useState(200);
   const detectAbortRef = useRef();
   const scanCancelRef = useRef(false);
-  const dirHandleRef = useRef();
   const [activeOp, setActiveOp] = useState(null);
   const [report, setReport] = useState('');
-  const [sessionNames, setSessionNames] = useState([]);
-  const [selectedSession, setSelectedSession] = useState('');
 
   useEffect(() => {
-    (async () => {
-      try {
-        const raw = localStorage.getItem(FOLDER_STATE_KEY);
-        if (raw) {
-          const data = JSON.parse(raw);
-          const dir = await loadDirHandle(FOLDER_STATE_KEY);
-          if (dir) {
-            try { await dir.requestPermission?.({ mode: 'read' }); } catch {}
-            dirHandleRef.current = dir;
-            data.uploads = await attachHandles(dir, data.uploads);
-            data.ignored = await attachHandles(dir, data.ignored);
-          }
-          applySession(data);
-        }
-      } catch {
-        // ignore
-      }
-      setSessionNames(getSessionNames());
-    })();
-  }, []);
-
-  function stateLabel(item = {}) {
-    if (item.processed) return 'Processed';
-    if (item.newName) return 'New';
-    return '';
-  }
-
-  async function attachHandles(dirHandle, list = []) {
-    const arr = Array.isArray(list) ? list : [];
-    return Promise.all(
-      arr.map(async (u) => {
-        try {
-          const handle = await dirHandle.getFileHandle(u.originalName);
-          return { ...u, handle };
-        } catch {
-          return u;
-        }
-      }),
-    );
-  }
-
-  function buildSession(partial = {}) {
-    const dataUploads = partial.uploads ?? uploads;
-    const dataIgnored = partial.ignored ?? ignored;
-    const dataPending = partial.pending ?? pending;
-    const dataHostIgnored = partial.hostIgnored ?? hostIgnored;
-
-    const mapUploads = (list = []) =>
-      list
-        .filter(Boolean)
-        .map(({ originalName = '', newName = '', tmpPath = '', reason = '', processed }) => ({
-          originalName,
-          newName,
-          tmpPath,
-          reason,
-          processed: !!processed,
-        }));
-
-    return {
-      folderName: partial.folderName ?? (folderName || ''),
-      uploads: mapUploads(dataUploads),
-      ignored: mapUploads(dataIgnored),
-      pending: dataPending
-        .filter(Boolean)
-        .map(({ currentName = '', newName = '', processed }) => ({
-          currentName,
-          newName,
-          processed: !!processed,
-        })),
-      hostIgnored: dataHostIgnored
-        .filter(Boolean)
-        .map(({ currentName = '', reason = '', processed }) => ({
-          currentName,
-          reason,
-          processed: !!processed,
-        })),
-    };
-  }
-
-  function applySession(data = {}) {
-    setFolderName(data.folderName || '');
-    setUploads(
-      Array.isArray(data.uploads)
-        ? data.uploads.map((u) => ({
-            ...u,
-            id: u.originalName,
-            description: extractDateFromName(u.originalName),
-            processed: !!u.processed,
-          }))
-        : [],
-    );
-    setIgnored(
-      Array.isArray(data.ignored)
-        ? data.ignored.map((u) => ({
-            ...u,
-            id: u.originalName,
-            description: extractDateFromName(u.originalName),
-            processed: !!u.processed,
-          }))
-        : [],
-    );
-    setPending(
-      Array.isArray(data.pending)
-        ? data.pending.map((u) => ({ ...u, processed: !!u.processed }))
-        : [],
-    );
-    setHostIgnored(
-      Array.isArray(data.hostIgnored)
-        ? data.hostIgnored.map((u) => ({ ...u, processed: !!u.processed }))
-        : [],
-    );
-  }
-
-  function persistSnapshot(partial = {}) {
     try {
-      const data = buildSession(partial);
-      localStorage.setItem(FOLDER_STATE_KEY, JSON.stringify(data));
-      saveDirHandle(FOLDER_STATE_KEY, dirHandleRef.current);
+      const raw = localStorage.getItem(FOLDER_STATE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (parsed.folderName) setFolderName(parsed.folderName);
+        if (Array.isArray(parsed.uploads)) setUploads(parsed.uploads);
+        if (Array.isArray(parsed.ignored)) setIgnored(parsed.ignored);
+      }
     } catch {
       // ignore
     }
-  }
+  }, []);
 
-  function getTables() {
-    return { uploads, ignored, pending, hostIgnored };
-  }
-
-  function persistAll(partial = {}) {
-    const tables = getTables();
-    persistSnapshot({ ...tables, folderName, ...partial });
-  }
-
-  function getSessionNames() {
+  function persistState(up = uploads, ig = ignored, folder = folderName) {
     try {
-      const parsed = JSON.parse(localStorage.getItem(SESSIONS_KEY) || '[]');
-      return Array.isArray(parsed) ? parsed : [];
+      const data = {
+        folderName: folder,
+        uploads: up.map(({ handle, ...rest }) => rest),
+        ignored: ig.map(({ handle, ...rest }) => rest),
+      };
+      localStorage.setItem(FOLDER_STATE_KEY, JSON.stringify(data));
     } catch {
-      return [];
-    }
-  }
-
-  function sanitizeName(n = '') {
-    return n.replace(/[^\w.-]/g, '_').slice(0, 100);
-  }
-
-  async function saveSession() {
-    const raw = prompt('Session name?', folderName || new Date().toISOString());
-    const name = raw ? sanitizeName(raw.trim()) : '';
-    if (!name) return;
-    try {
-      const data = buildSession();
-      const serialized = JSON.stringify(data);
-      localStorage.setItem(SESSION_PREFIX + name, serialized);
-      const names = new Set(getSessionNames());
-      names.add(name);
-      localStorage.setItem(SESSIONS_KEY, JSON.stringify([...names]));
-      await saveDirHandle(name, dirHandleRef.current);
-      persistAll(data);
-      setSessionNames([...names]);
-      setSelectedSession(name);
-      addToast('State saved', 'success');
-    } catch (err) {
-      console.error(err);
-      addToast('Failed to save state', 'error');
-    }
-  }
-
-  async function loadSession(name = selectedSession) {
-    if (!name) {
-      addToast('No session selected', 'error');
-      return;
-    }
-    try {
-      const raw = localStorage.getItem(SESSION_PREFIX + name);
-      if (!raw) {
-        addToast('No saved sessions', 'error');
-        return;
-      }
-      const data = JSON.parse(raw);
-      const dir = await loadDirHandle(name);
-      if (dir) {
-        try { await dir.requestPermission?.({ mode: 'read' }); } catch {}
-        dirHandleRef.current = dir;
-        data.uploads = await attachHandles(dir, data.uploads);
-        data.ignored = await attachHandles(dir, data.ignored);
-      } else {
-        dirHandleRef.current = null;
-      }
-      applySession(data);
-      setSelected([]);
-      setHostIgnoredSel([]);
-      setUploadSel([]);
-      setUploadPage(1);
-      setIgnoredPage(1);
-      setHostIgnoredPage(1);
-      setPendingPage(1);
-      persistAll(data);
-      addToast('State loaded', 'success');
-    } catch (err) {
-      console.error(err);
-      addToast('Failed to load session', 'error');
-    }
-  }
-
-  async function deleteSession(name = selectedSession) {
-    if (!name) return;
-    try {
-      localStorage.removeItem(SESSION_PREFIX + name);
-      const names = getSessionNames().filter((n) => n !== name);
-      localStorage.setItem(SESSIONS_KEY, JSON.stringify(names));
-      await deleteDirHandle(name);
-      setSessionNames(names);
-      if (selectedSession === name) setSelectedSession('');
-      addToast('State deleted', 'success');
-    } catch {
-      addToast('Failed to delete session', 'error');
+      // ignore
     }
   }
 
@@ -339,14 +84,6 @@ export default function ImageManagement() {
     ? Math.max(1, Math.ceil((pendingSummary.incompleteFound || 0) / pageSize))
     : 1;
 
-  const allTables = Object.values(getTables()).flat();
-  const canRenameSelected = allTables.some(
-    (u) => uploadSel.includes(u.id) && u.handle && !u.processed,
-  );
-  const canUploadSelected = allTables.some(
-    (u) => uploadSel.includes(u.id) && u.tmpPath && !u.processed,
-  );
-
   function toggle(id) {
     setSelected((prev) =>
       prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id],
@@ -354,23 +91,11 @@ export default function ImageManagement() {
   }
 
   function toggleAll() {
-    const withNew = pending
-      .filter((p) => p.newName && !p.processed)
-      .map((p) => p.currentName);
-    const unprocessed = pending.filter((p) => !p.processed).map((p) => p.currentName);
-    const all = pending.map((p) => p.currentName);
-    const setEq = (arr) =>
-      arr.length === selected.length && arr.every((id) => selected.includes(id));
-    if (withNew.length === 0) {
-      if (setEq(all)) setSelected([]);
-      else if (setEq(unprocessed)) setSelected(all);
-      else setSelected(unprocessed);
-      return;
+    if (selected.length === pending.length) {
+      setSelected([]);
+    } else {
+      setSelected(pending.map((p) => p.currentName));
     }
-    if (setEq(withNew)) setSelected(unprocessed);
-    else if (setEq(unprocessed)) setSelected(all);
-    else if (setEq(all)) setSelected([]);
-    else setSelected(withNew);
   }
 
   function toggleHostIgnored(id) {
@@ -380,28 +105,13 @@ export default function ImageManagement() {
   }
 
   function toggleHostIgnoredAll(list) {
-    const allIds = list.map((p) => p.currentName);
-    const unprocessedIds = list.filter((p) => !p.processed).map((p) => p.currentName);
-    const newIds = list
-      .filter((p) => p.newName && !p.processed)
-      .map((p) => p.currentName);
-    const current = hostIgnoredSel.filter((id) => allIds.includes(id));
-    const setEq = (arr) => arr.length === current.length && arr.every((id) => current.includes(id));
-    const removePage = (prev) => prev.filter((id) => !allIds.includes(id));
-    if (newIds.length === 0) {
-      if (setEq(allIds)) setHostIgnoredSel(removePage);
-      else if (setEq(unprocessedIds))
-        setHostIgnoredSel((prev) => [...removePage(prev), ...allIds.filter((id) => !prev.includes(id))]);
-      else setHostIgnoredSel((prev) => [...removePage(prev), ...unprocessedIds.filter((id) => !prev.includes(id))]);
-      return;
+    const ids = list.map((p) => p.currentName);
+    const allSelected = ids.every((id) => hostIgnoredSel.includes(id));
+    if (allSelected) {
+      setHostIgnoredSel((prev) => prev.filter((id) => !ids.includes(id)));
+    } else {
+      setHostIgnoredSel((prev) => [...prev, ...ids.filter((id) => !prev.includes(id))]);
     }
-    if (setEq(newIds))
-      setHostIgnoredSel((prev) => [...removePage(prev), ...unprocessedIds.filter((id) => !prev.includes(id))]);
-    else if (setEq(unprocessedIds))
-      setHostIgnoredSel((prev) => [...removePage(prev), ...allIds.filter((id) => !prev.includes(id))]);
-    else if (setEq(allIds)) setHostIgnoredSel(removePage);
-    else
-      setHostIgnoredSel((prev) => [...removePage(prev), ...newIds.filter((id) => !prev.includes(id))]);
   }
 
   function toggleUpload(id) {
@@ -411,25 +121,13 @@ export default function ImageManagement() {
   }
 
   function toggleUploadAll(list) {
-    const allIds = list.map((u) => u.id);
-    const unprocessedIds = list.filter((u) => !u.processed).map((u) => u.id);
-    const newIds = list.filter((u) => u.newName && !u.processed).map((u) => u.id);
-    const current = uploadSel.filter((id) => allIds.includes(id));
-    const setEq = (arr) => arr.length === current.length && arr.every((id) => current.includes(id));
-    const removePage = (prev) => prev.filter((id) => !allIds.includes(id));
-    if (newIds.length === 0) {
-      if (setEq(allIds)) setUploadSel(removePage);
-      else if (setEq(unprocessedIds))
-        setUploadSel((prev) => [...removePage(prev), ...allIds.filter((id) => !prev.includes(id))]);
-      else setUploadSel((prev) => [...removePage(prev), ...unprocessedIds.filter((id) => !prev.includes(id))]);
-      return;
+    const ids = list.filter((u) => !u.processed).map((u) => u.id);
+    const allSelected = ids.every((id) => uploadSel.includes(id));
+    if (allSelected) {
+      setUploadSel((prev) => prev.filter((id) => !ids.includes(id)));
+    } else {
+      setUploadSel((prev) => [...prev, ...ids.filter((id) => !prev.includes(id))]);
     }
-    if (setEq(newIds))
-      setUploadSel((prev) => [...removePage(prev), ...unprocessedIds.filter((id) => !prev.includes(id))]);
-    else if (setEq(unprocessedIds))
-      setUploadSel((prev) => [...removePage(prev), ...allIds.filter((id) => !prev.includes(id))]);
-    else if (setEq(allIds)) setUploadSel(removePage);
-    else setUploadSel((prev) => [...removePage(prev), ...newIds.filter((id) => !prev.includes(id))]);
   }
 
   useEffect(() => {
@@ -459,7 +157,6 @@ export default function ImageManagement() {
     scanCancelRef.current = false;
     try {
       const dirHandle = await window.showDirectoryPicker();
-      dirHandleRef.current = dirHandle;
       const handles = {};
       const names = [];
       for await (const entry of dirHandle.values()) {
@@ -525,20 +222,10 @@ export default function ImageManagement() {
       setUploadSel([]);
       setUploadPage(1);
       setIgnoredPage(1);
-      setPending([]);
-      setHostIgnored([]);
-      setSelected([]);
-      setHostIgnoredSel([]);
       setReport(
         `Scanned ${names.length} file(s), found ${processed} incomplete name(s), ${skipped.length} unflagged.`,
       );
-      persistAll({
-        uploads: uploadsList,
-        ignored: ignoredList,
-        folderName: dirHandle.name || '',
-        pending: [],
-        hostIgnored: [],
-      });
+      persistState(uploadsList, ignoredList, dirHandle.name || '');
     } catch {
       // ignore
     } finally {
@@ -564,7 +251,7 @@ export default function ImageManagement() {
     }
   }
 
-  async function detectFromHost(p = pendingPage) {
+  async function detectFromHost(p = page) {
     const controller = new AbortController();
     detectAbortRef.current = controller;
     setActiveOp('detect');
@@ -579,11 +266,7 @@ export default function ImageManagement() {
           ? data.list
               .slice()
               .sort((a, b) => a.currentName.localeCompare(b.currentName))
-              .map((p) => ({
-                ...p,
-                description: extractDateFromName(p.currentName),
-                processed: false,
-              }))
+              .map((p) => ({ ...p, description: extractDateFromName(p.currentName) }))
           : [];
         const miss = Array.isArray(data.skipped)
           ? data.skipped
@@ -592,7 +275,6 @@ export default function ImageManagement() {
               .map((p) => ({
                 ...p,
                 description: extractDateFromName(p.currentName),
-                processed: false,
               }))
           : [];
         setPending(list);
@@ -606,22 +288,14 @@ export default function ImageManagement() {
         setReport(
           `Scanned ${sum.totalFiles || 0} file(s), found ${sum.incompleteFound || 0} incomplete name(s), ${sum.skipped || 0} not incomplete.`,
         );
-        persistAll({
-          uploads,
-          ignored,
-          folderName,
-          pending: list,
-          hostIgnored: miss,
-        });
       } else {
         setPending([]);
         setHostIgnored([]);
         setHostIgnoredPage(1);
         setPendingSummary(null);
         setHasMore(false);
-        persistAll({ uploads, ignored, folderName, pending: [], hostIgnored: [] });
       }
-      setPendingPage(p);
+      setPage(p);
     } catch (e) {
       if (e.name !== 'AbortError') {
         setPending([]);
@@ -629,18 +303,17 @@ export default function ImageManagement() {
         setHostIgnoredPage(1);
         setPendingSummary(null);
         setHasMore(false);
-        persistAll({ uploads, ignored, folderName, pending: [], hostIgnored: [] });
       }
     } finally {
       detectAbortRef.current = null;
       setActiveOp(null);
     }
-      setPendingPage(p);
+    setPage(p);
   }
 
   async function applyFixesSelection(list, sel) {
-    const items = list.filter((p) => sel.includes(p.currentName) && !p.processed);
-    if (items.length === 0) return null;
+    const items = list.filter((p) => sel.includes(p.currentName));
+    if (items.length === 0) return;
     const res = await fetch('/api/transaction_images/fix_incomplete', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -651,44 +324,25 @@ export default function ImageManagement() {
       const data = await res.json().catch(() => ({}));
       addToast(`Renamed ${data.fixed || 0} file(s)`, 'success');
       setReport(`Renamed ${data.fixed || 0} file(s)`);
-      const newList = list.map((p) =>
-        sel.includes(p.currentName) ? { ...p, processed: true } : p,
-      );
-      return newList;
+      detectFromHost(page);
     } else {
       addToast('Rename failed', 'error');
-      return null;
     }
   }
 
   async function applyFixes() {
-    const newPending = await applyFixesSelection(pending, selected);
-    if (newPending) {
-      setPending(newPending);
-      setSelected([]);
-      persistAll({ uploads, ignored, folderName, pending: newPending, hostIgnored });
-    }
+    await applyFixesSelection(pending, selected);
   }
 
   async function applyFixesHostIgnored() {
-    const newHostIgnored = await applyFixesSelection(hostIgnored, hostIgnoredSel);
-    if (newHostIgnored) {
-      setHostIgnored(newHostIgnored);
-      setHostIgnoredSel([]);
-      persistAll({ uploads, ignored, folderName, pending, hostIgnored: newHostIgnored });
-    }
+    await applyFixesSelection(hostIgnored, hostIgnoredSel);
   }
 
   async function renameSelected() {
-    const tables = getTables();
-    const allItems = Object.values(tables).flat();
-    const items = allItems.filter(
-      (u) => uploadSel.includes(u.id) && u.handle && !u.processed,
+    const items = [...uploads, ...ignored].filter(
+      (u) => uploadSel.includes(u.id) && u.handle && !u.tmpPath && !u.processed,
     );
-    if (items.length === 0) {
-      addToast('No local files to rename', 'error');
-      return;
-    }
+    if (items.length === 0) return;
     const formData = new FormData();
     try {
       for (const u of items) {
@@ -711,25 +365,23 @@ export default function ImageManagement() {
       }
       const data = await res.json().catch(() => ({}));
       const list = Array.isArray(data.list) ? data.list : [];
-      const updated = {};
-      for (const [key, arr] of Object.entries(tables)) {
-        if (arr.some((u) => 'originalName' in u)) {
-          updated[key] = arr
-            .map((u) => {
-              const found = list.find((x) => x.originalName === u.originalName);
-              const merged = found ? { ...u, ...found, id: u.id } : u;
-              return { ...merged, description: extractDateFromName(merged.originalName) };
-            })
-            .sort((a, b) => a.originalName.localeCompare(b.originalName));
-        } else {
-          updated[key] = arr;
-        }
-      }
-      setUploads(updated.uploads);
-      setIgnored(updated.ignored);
-      setPending(updated.pending);
-      setHostIgnored(updated.hostIgnored);
-      persistAll(updated);
+      const newUploads = uploads
+        .map((u) => {
+          const found = list.find((x) => x.originalName === u.originalName);
+          const merged = found ? { ...u, ...found, id: u.id } : u;
+          return { ...merged, description: extractDateFromName(merged.originalName) };
+        })
+        .sort((a, b) => a.originalName.localeCompare(b.originalName));
+      const newIgnored = ignored
+        .map((u) => {
+          const found = list.find((x) => x.originalName === u.originalName);
+          const merged = found ? { ...u, ...found, id: u.id } : u;
+          return { ...merged, description: extractDateFromName(merged.originalName) };
+        })
+        .sort((a, b) => a.originalName.localeCompare(b.originalName));
+      setUploads(newUploads);
+      setIgnored(newIgnored);
+      persistState(newUploads, newIgnored);
       setReport(`Renamed ${list.length} file(s)`);
     } catch {
       addToast('Rename failed', 'error');
@@ -737,9 +389,7 @@ export default function ImageManagement() {
   }
 
   async function commitUploads() {
-    const tables = getTables();
-    const allItems = Object.values(tables).flat();
-    const items = allItems.filter(
+    const items = [...uploads, ...ignored].filter(
       (u) => uploadSel.includes(u.id) && u.tmpPath && !u.processed,
     );
     if (items.length === 0) return;
@@ -752,18 +402,16 @@ export default function ImageManagement() {
     if (res.ok) {
       const data = await res.json().catch(() => ({}));
       addToast(`Uploaded ${data.uploaded || 0} file(s)`, 'success');
-      const updated = {};
-      for (const [key, arr] of Object.entries(tables)) {
-        updated[key] = arr.map((u) =>
-          uploadSel.includes(u.id) && u.tmpPath ? { ...u, processed: true } : u,
-        );
-      }
-      setUploads(updated.uploads);
-      setIgnored(updated.ignored);
-      setPending(updated.pending);
-      setHostIgnored(updated.hostIgnored);
+      const newUploads = uploads.map((u) =>
+        uploadSel.includes(u.id) && u.tmpPath ? { ...u, processed: true } : u,
+      );
+      const newIgnored = ignored.map((u) =>
+        uploadSel.includes(u.id) && u.tmpPath ? { ...u, processed: true } : u,
+      );
+      setUploads(newUploads);
+      setIgnored(newIgnored);
       setUploadSel([]);
-      persistAll(updated);
+      persistState(newUploads, newIgnored);
       setReport(`Uploaded ${data.uploaded || 0} file(s)`);
     } else {
       addToast('Upload failed', 'error');
@@ -809,31 +457,6 @@ export default function ImageManagement() {
               Select Folder
             </button>
             {folderName && <span style={{ marginRight: '0.5rem' }}>{folderName}</span>}
-            <button
-              type="button"
-              onClick={saveSession}
-              style={{ marginRight: '0.5rem' }}
-            >
-              Save
-            </button>
-            <select
-              value={selectedSession}
-              onChange={(e) => setSelectedSession(e.target.value)}
-              style={{ marginRight: '0.5rem' }}
-            >
-              <option value="">Select session</option>
-              {sessionNames.map((n) => (
-                <option key={n} value={n}>
-                  {n}
-                </option>
-              ))}
-            </select>
-            <button type="button" onClick={() => loadSession()} disabled={!selectedSession} style={{ marginRight: '0.5rem' }}>
-              Load
-            </button>
-            <button type="button" onClick={() => deleteSession()} disabled={!selectedSession}>
-              Delete
-            </button>
           </div>
           {uploadSummary && (
             <p style={{ marginBottom: '0.5rem' }}>
@@ -847,7 +470,7 @@ export default function ImageManagement() {
                 type="button"
                 onClick={renameSelected}
                 style={{ marginBottom: '0.5rem', marginRight: '0.5rem' }}
-                disabled={!canRenameSelected}
+                disabled={uploadSel.length === 0}
               >
                 Rename Selected
               </button>
@@ -856,7 +479,8 @@ export default function ImageManagement() {
                 onClick={commitUploads}
                 style={{ marginBottom: '0.5rem' }}
                 disabled={
-                  uploadSel.length === 0 || !canUploadSelected
+                  uploadSel.length === 0 ||
+                  ![...uploads, ...ignored].some((u) => uploadSel.includes(u.id) && u.tmpPath)
                 }
               >
                 Upload Selected
@@ -870,7 +494,7 @@ export default function ImageManagement() {
                   setIgnored(remainingIgnored);
                   setUploadSel([]);
                   setReport(`Deleted ${uploadSel.length} file(s)`);
-                  persistAll({ uploads: remainingUploads, ignored: remainingIgnored });
+                  persistState(remainingUploads, remainingIgnored);
                 }}
                 style={{ marginBottom: '0.5rem', marginLeft: '0.5rem' }}
                 disabled={uploadSel.length === 0}
@@ -941,7 +565,6 @@ export default function ImageManagement() {
                         <th className="border px-2 py-1">New Name</th>
                         <th className="border px-2 py-1">Folder</th>
                         <th className="border px-2 py-1">Description</th>
-                        <th className="border px-2 py-1">State</th>
                         <th className="border px-2 py-1">Delete</th>
                       </tr>
                     </thead>
@@ -955,7 +578,6 @@ export default function ImageManagement() {
                           <td className="border px-2 py-1">{u.newName}</td>
                           <td className="border px-2 py-1">{u.folderDisplay}</td>
                           <td className="border px-2 py-1">{u.description}</td>
-                          <td className="border px-2 py-1">{stateLabel(u)}</td>
                           <td className="border px-2 py-1 text-center">
                             <button
                               type="button"
@@ -963,7 +585,7 @@ export default function ImageManagement() {
                                 const remainingUploads = uploads.filter((x) => x.id !== u.id);
                                 setUploads(remainingUploads);
                                 setUploadSel((s) => s.filter((id) => id !== u.id));
-                                persistAll({ uploads: remainingUploads, ignored });
+                                persistState(remainingUploads, ignored);
                               }}
                             >
                               Delete
@@ -1025,7 +647,6 @@ export default function ImageManagement() {
                         <th className="border px-2 py-1">New Name</th>
                         <th className="border px-2 py-1">Folder</th>
                         <th className="border px-2 py-1">Description</th>
-                        <th className="border px-2 py-1">State</th>
                         <th className="border px-2 py-1">Delete</th>
                       </tr>
                     </thead>
@@ -1039,7 +660,6 @@ export default function ImageManagement() {
                           <td className="border px-2 py-1">{u.newName}</td>
                           <td className="border px-2 py-1">{u.folderDisplay}</td>
                           <td className="border px-2 py-1">{u.reason}</td>
-                          <td className="border px-2 py-1">{stateLabel(u)}</td>
                           <td className="border px-2 py-1 text-center">
                             <button
                               type="button"
@@ -1047,7 +667,7 @@ export default function ImageManagement() {
                                 const remainingIgnored = ignored.filter((x) => x.id !== u.id);
                                 setIgnored(remainingIgnored);
                                 setUploadSel((s) => s.filter((id) => id !== u.id));
-                                persistAll({ uploads, ignored: remainingIgnored });
+                                persistState(uploads, remainingIgnored);
                               }}
                             >
                               Delete
@@ -1076,7 +696,7 @@ export default function ImageManagement() {
             </label>
             <button
               type="button"
-              disabled={pendingPage === 1}
+              disabled={page === 1}
               onClick={() => detectFromHost(1)}
               style={{ marginRight: '0.5rem' }}
             >
@@ -1084,8 +704,8 @@ export default function ImageManagement() {
             </button>
             <button
               type="button"
-              disabled={pendingPage === 1}
-              onClick={() => detectFromHost(pendingPage - 1)}
+              disabled={page === 1}
+              onClick={() => detectFromHost(page - 1)}
               style={{ marginRight: '0.5rem' }}
             >
               Prev
@@ -1093,14 +713,14 @@ export default function ImageManagement() {
             <button
               type="button"
               disabled={!hasMore}
-              onClick={() => detectFromHost(pendingPage + 1)}
+              onClick={() => detectFromHost(page + 1)}
               style={{ marginRight: '0.5rem' }}
             >
               Next
             </button>
             <button
               type="button"
-              disabled={pendingPage === lastPage}
+              disabled={page === lastPage}
               onClick={() => detectFromHost(lastPage)}
             >
               Last
@@ -1128,10 +748,8 @@ export default function ImageManagement() {
               <button
                 type="button"
                 onClick={() => {
-                  const remaining = pending.filter((p) => !selected.includes(p.currentName));
-                  setPending(remaining);
+                  setPending((prev) => prev.filter((p) => !selected.includes(p.currentName)));
                   setSelected([]);
-                  persistAll({ uploads, ignored, folderName, pending: remaining, hostIgnored });
                 }}
                 style={{ marginBottom: '0.5rem', marginLeft: '0.5rem' }}
                 disabled={selected.length === 0}
@@ -1148,7 +766,6 @@ export default function ImageManagement() {
                     <th className="border px-2 py-1">New Name</th>
                     <th className="border px-2 py-1">Folder</th>
                     <th className="border px-2 py-1">Description</th>
-                    <th className="border px-2 py-1">State</th>
                     <th className="border px-2 py-1">Delete</th>
                   </tr>
                 </thead>
@@ -1162,7 +779,6 @@ export default function ImageManagement() {
                       <td className="border px-2 py-1">{p.newName}</td>
                       <td className="border px-2 py-1">{p.folderDisplay}</td>
                       <td className="border px-2 py-1">{p.description}</td>
-                      <td className="border px-2 py-1">{stateLabel(p)}</td>
                       <td className="border px-2 py-1 text-center">
                         <button
                           type="button"
@@ -1194,12 +810,8 @@ export default function ImageManagement() {
               <button
                 type="button"
                 onClick={() => {
-                  const remaining = hostIgnored.filter(
-                    (p) => !hostIgnoredSel.includes(p.currentName),
-                  );
-                  setHostIgnored(remaining);
+                  setHostIgnored((prev) => prev.filter((p) => !hostIgnoredSel.includes(p.currentName)));
                   setHostIgnoredSel([]);
-                  persistAll({ uploads, ignored, folderName, pending, hostIgnored: remaining });
                 }}
                 style={{ marginBottom: '0.5rem', marginLeft: '0.5rem' }}
                 disabled={hostIgnoredSel.length === 0}
@@ -1256,7 +868,6 @@ export default function ImageManagement() {
                     <th className="border px-2 py-1">New Name</th>
                     <th className="border px-2 py-1">Folder</th>
                     <th className="border px-2 py-1">Description</th>
-                    <th className="border px-2 py-1">State</th>
                     <th className="border px-2 py-1">Delete</th>
                   </tr>
                 </thead>
@@ -1278,7 +889,6 @@ export default function ImageManagement() {
                         {p.description && p.reason ? ' - ' : ''}
                         {p.reason}
                       </td>
-                      <td className="border px-2 py-1">{stateLabel(p)}</td>
                       <td className="border px-2 py-1 text-center">
                         <button
                           type="button"


### PR DESCRIPTION
## Summary
- Revert ImageManagement.jsx to previous implementation to restore Fix Names menu logic
- Reinstate selection helper functions for pending, host ignored, and upload lists
- Restore `.gitkeep` in uploads directory

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68930a1247ec8331b9d56e873c24ffb3