### PR TITLE
feat: add stored procedure reports

### DIFF
--- a/api-server/routes/procedures.js
+++ b/api-server/routes/procedures.js
@@ -1,8 +1,30 @@
 import express from 'express';
 import { requireAuth } from '../middlewares/auth.js';
-import { callStoredProcedure } from '../../db/index.js';
+import {
+  callStoredProcedure,
+  listStoredProcedures,
+  getProcedureParams,
+} from '../../db/index.js';
 
 const router = express.Router();
+
+router.get('/', requireAuth, async (req, res, next) => {
+  try {
+    const procedures = await listStoredProcedures();
+    res.json({ procedures });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/:name/params', requireAuth, async (req, res, next) => {
+  try {
+    const parameters = await getProcedureParams(req.params.name);
+    res.json({ parameters });
+  } catch (err) {
+    next(err);
+  }
+});
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {

--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -83,6 +83,7 @@ function parseEntry(raw = {}) {
       ? raw.allowedDepartments.map((v) => Number(v)).filter((v) => !Number.isNaN(v))
       : [],
     moduleLabel: typeof raw.moduleLabel === 'string' ? raw.moduleLabel : '',
+    procedures: arrify(raw.procedures),
   };
 }
 
@@ -171,6 +172,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     viewSource = {},
     transactionTypeField = '',
     transactionTypeValue = '',
+    procedures = [],
   } = config || {};
   const uid = arrify(userIdFields.length ? userIdFields : userIdField ? [userIdField] : []);
   const bid = arrify(
@@ -216,6 +218,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     moduleLabel: moduleLabel || undefined,
     allowedBranches: ab,
     allowedDepartments: ad,
+    procedures: arrify(procedures),
   };
   if (editableFields !== undefined) {
     cfg[table][name].editableFields = arrify(editableFields);

--- a/db/index.js
+++ b/db/index.js
@@ -1035,3 +1035,24 @@ export async function callStoredProcedure(name, params = [], aliases = []) {
     conn.release();
   }
 }
+
+export async function listStoredProcedures() {
+  const [rows] = await pool.query(
+    'SHOW PROCEDURE STATUS WHERE Db = DATABASE()'
+  );
+  return rows
+    .map((r) => r.Name)
+    .filter((n) => typeof n === 'string' && n.toLowerCase().includes('report'));
+}
+
+export async function getProcedureParams(name) {
+  const [rows] = await pool.query(
+    `SELECT PARAMETER_NAME AS name
+       FROM information_schema.parameters
+      WHERE SPECIFIC_NAME = ?
+        AND ROUTINE_TYPE = 'PROCEDURE'
+      ORDER BY ORDINAL_POSITION`,
+    [name],
+  );
+  return rows.map((r) => r.name).filter(Boolean);
+}

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -15,6 +15,7 @@ export default function FormsManagement() {
   const [txnTypes, setTxnTypes] = useState([]);
   const [columns, setColumns] = useState([]);
   const [views, setViews] = useState([]);
+  const [procedureOptions, setProcedureOptions] = useState([]);
   const modules = useModules();
   useEffect(() => {
     debugLog('Component mounted: FormsManagement');
@@ -47,6 +48,7 @@ export default function FormsManagement() {
     transactionTypeValue: '',
     allowedBranches: [],
     allowedDepartments: [],
+    procedures: [],
   });
 
   useEffect(() => {
@@ -74,6 +76,17 @@ export default function FormsManagement() {
       .then((res) => (res.ok ? res.json() : { rows: [] }))
       .then((data) => setTxnTypes(data.rows || []))
       .catch(() => setTxnTypes([]));
+
+    fetch('/api/procedures', { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : { procedures: [] }))
+      .then((data) =>
+        setProcedureOptions(
+          (data.procedures || []).filter((p) =>
+            String(p).toLowerCase().includes('report'),
+          )
+        )
+      )
+      .catch(() => setProcedureOptions([]));
   }, []);
 
   useEffect(() => {
@@ -123,6 +136,7 @@ export default function FormsManagement() {
             transactionTypeValue: filtered[name].transactionTypeValue || '',
             allowedBranches: (filtered[name].allowedBranches || []).map(String),
             allowedDepartments: (filtered[name].allowedDepartments || []).map(String),
+            procedures: filtered[name].procedures || [],
           });
         } else {
           setName('');
@@ -154,6 +168,7 @@ export default function FormsManagement() {
             transactionTypeValue: '',
             allowedBranches: [],
             allowedDepartments: [],
+            procedures: [],
           });
         }
       })
@@ -188,6 +203,7 @@ export default function FormsManagement() {
           transactionTypeValue: '',
           allowedBranches: [],
           allowedDepartments: [],
+          procedures: [],
         });
         setModuleKey('');
       });
@@ -227,6 +243,7 @@ export default function FormsManagement() {
           transactionTypeValue: cfg.transactionTypeValue || '',
           allowedBranches: (cfg.allowedBranches || []).map(String),
           allowedDepartments: (cfg.allowedDepartments || []).map(String),
+          procedures: cfg.procedures || [],
         });
       })
       .catch(() => {
@@ -258,6 +275,7 @@ export default function FormsManagement() {
           transactionTypeValue: '',
           allowedBranches: [],
           allowedDepartments: [],
+          procedures: [],
         });
         setModuleKey('');
       });
@@ -381,6 +399,7 @@ export default function FormsManagement() {
       transactionTypeValue: '',
       allowedBranches: [],
       allowedDepartments: [],
+      procedures: [],
     });
     setModuleKey('');
   }
@@ -414,6 +433,7 @@ export default function FormsManagement() {
       transactionTypeValue: cfg.transactionTypeValue || '',
       allowedBranches: (cfg.allowedBranches || []).map(String),
       allowedDepartments: (cfg.allowedDepartments || []).map(String),
+      procedures: cfg.procedures || [],
     });
   }
 
@@ -784,6 +804,31 @@ export default function FormsManagement() {
               <button type="button" onClick={() => setConfig((c) => ({ ...c, allowedDepartments: departments.map((d) => String(d.id)) }))}>All</button>
               <button type="button" onClick={() => setConfig((c) => ({ ...c, allowedDepartments: [] }))}>None</button>
             </label>
+            {procedureOptions.length > 0 && (
+              <label style={{ marginLeft: '1rem' }}>
+                Procedures:{' '}
+                <select
+                  multiple
+                  size={8}
+                  value={config.procedures}
+                  onChange={(e) =>
+                    setConfig((c) => ({
+                      ...c,
+                      procedures: Array.from(
+                        e.target.selectedOptions,
+                        (o) => o.value,
+                      ),
+                    }))
+                  }
+                >
+                  {procedureOptions.map((p) => (
+                    <option key={p} value={p}>
+                      {p}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
           </div>
           <div style={{ marginTop: '1rem' }}>
             <button onClick={handleSave}>Save Configuration</button>


### PR DESCRIPTION
## Summary
- persist stored procedure selections in transaction form config
- filter available procedures to names containing "report" and move selector beside allowed branch/department options
- limit backend procedure listing to report routines

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68937c0dbd10833198d2df90e5f939a2