### PR TITLE
feat: add stored procedure reports

### DIFF
--- a/api-server/routes/procedures.js
+++ b/api-server/routes/procedures.js
@@ -1,8 +1,32 @@
 import express from 'express';
 import { requireAuth } from '../middlewares/auth.js';
-import { callStoredProcedure } from '../../db/index.js';
+import {
+  callStoredProcedure,
+  listStoredProcedures,
+  getProcedureParams,
+} from '../../db/index.js';
 
 const router = express.Router();
+
+router.get('/', requireAuth, async (req, res, next) => {
+  try {
+    const procedures = (await listStoredProcedures()).filter((p) =>
+      typeof p === 'string' && p.toLowerCase().includes('report'),
+    );
+    res.json({ procedures });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/:name/params', requireAuth, async (req, res, next) => {
+  try {
+    const parameters = await getProcedureParams(req.params.name);
+    res.json({ parameters });
+  } catch (err) {
+    next(err);
+  }
+});
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {

--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -83,6 +83,7 @@ function parseEntry(raw = {}) {
       ? raw.allowedDepartments.map((v) => Number(v)).filter((v) => !Number.isNaN(v))
       : [],
     moduleLabel: typeof raw.moduleLabel === 'string' ? raw.moduleLabel : '',
+    procedures: arrify(raw.procedures || raw.procedure),
   };
 }
 
@@ -171,6 +172,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     viewSource = {},
     transactionTypeField = '',
     transactionTypeValue = '',
+    procedures = [],
   } = config || {};
   const uid = arrify(userIdFields.length ? userIdFields : userIdField ? [userIdField] : []);
   const bid = arrify(
@@ -216,6 +218,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     moduleLabel: moduleLabel || undefined,
     allowedBranches: ab,
     allowedDepartments: ad,
+    procedures: arrify(procedures),
   };
   if (editableFields !== undefined) {
     cfg[table][name].editableFields = arrify(editableFields);

--- a/db/index.js
+++ b/db/index.js
@@ -1035,3 +1035,24 @@ export async function callStoredProcedure(name, params = [], aliases = []) {
     conn.release();
   }
 }
+
+export async function listStoredProcedures() {
+  const [rows] = await pool.query(
+    'SHOW PROCEDURE STATUS WHERE Db = DATABASE()'
+  );
+  return rows
+    .map((r) => r.Name)
+    .filter((n) => typeof n === 'string' && n.toLowerCase().includes('report'));
+}
+
+export async function getProcedureParams(name) {
+  const [rows] = await pool.query(
+    `SELECT PARAMETER_NAME AS name
+       FROM information_schema.parameters
+      WHERE SPECIFIC_NAME = ?
+        AND ROUTINE_TYPE = 'PROCEDURE'
+      ORDER BY ORDINAL_POSITION`,
+    [name],
+  );
+  return rows.map((r) => r.name).filter(Boolean);
+}

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -208,10 +208,18 @@ function Sidebar({ onOpen, open, isMobile }) {
 
   const map = {};
   modules.forEach((m) => {
-    if (!perms[m.module_key] || !licensed[m.module_key] || !m.show_in_sidebar)
-      return;
-    if (isFormsDescendant(m) && txnModuleKeys && !txnModuleKeys.has(m.module_key))
-      return;
+    const isProc =
+      m.parent_key === 'reports' && m.module_key.startsWith('proc_');
+    if (!isProc) {
+      if (
+        !perms[m.module_key] ||
+        !licensed[m.module_key] ||
+        !m.show_in_sidebar
+      )
+        return;
+      if (isFormsDescendant(m) && txnModuleKeys && !txnModuleKeys.has(m.module_key))
+        return;
+    }
     map[m.module_key] = { ...m, children: [] };
   });
 

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1475,36 +1475,62 @@ const TableManager = forwardRef(function TableManager({
               const val = e.target.value;
               setDatePreset(val);
               const now = new Date();
+              const y = now.getFullYear();
+              const m = now.getMonth();
+              const fmt = (d) => formatTimestamp(d).slice(0, 10);
               if (val === 'custom') {
                 setCustomStartDate('');
                 setCustomEndDate('');
                 setDateFilter('');
                 return;
               }
-              if (val === 'month') {
-                const m = String(now.getMonth() + 1).padStart(2, '0');
-                setDateFilter(`${now.getFullYear()}-${m}`);
-                return;
+              let start;
+              let end;
+              switch (val) {
+                case 'month':
+                  start = new Date(y, m, 1);
+                  end = new Date(y, m + 1, 1);
+                  break;
+                case 'q1':
+                  start = new Date(y, 0, 1);
+                  end = new Date(y, 3, 1);
+                  break;
+                case 'q2':
+                  start = new Date(y, 3, 1);
+                  end = new Date(y, 6, 1);
+                  break;
+                case 'q3':
+                  start = new Date(y, 6, 1);
+                  end = new Date(y, 9, 1);
+                  break;
+                case 'q4':
+                  start = new Date(y, 9, 1);
+                  end = new Date(y + 1, 0, 1);
+                  break;
+                case 'quarter': {
+                  const q = Math.floor(m / 3);
+                  start = new Date(y, q * 3, 1);
+                  end = new Date(y, q * 3 + 3, 1);
+                  break;
+                }
+                case 'year':
+                  start = new Date(y, 0, 1);
+                  end = new Date(y + 1, 0, 1);
+                  break;
+                default:
+                  setDateFilter('');
+                  return;
               }
-              if (val === 'year') {
-                setDateFilter(String(now.getFullYear()));
-                return;
-              }
-              if (val === 'quarter') {
-                const q = Math.floor(now.getMonth() / 3);
-                const start = new Date(now.getFullYear(), q * 3, 1);
-                const end = new Date(now.getFullYear(), q * 3 + 3, 0);
-                setDateFilter(
-                  `${formatTimestamp(start).slice(0, 10)}-${formatTimestamp(end).slice(0, 10)}`,
-                );
-                return;
-              }
-              setDateFilter('');
-            }}
+              setDateFilter(`${fmt(start)}-${fmt(end)}`);
+              }}
             style={{ marginRight: '0.5rem' }}
           >
             <option value="custom">Custom</option>
             <option value="month">This Month</option>
+            <option value="q1">Quarter #1</option>
+            <option value="q2">Quarter #2</option>
+            <option value="q3">Quarter #3</option>
+            <option value="q4">Quarter #4</option>
             <option value="quarter">This Quarter</option>
             <option value="year">This Year</option>
           </select>

--- a/src/erp.mgt.mn/hooks/useModules.js
+++ b/src/erp.mgt.mn/hooks/useModules.js
@@ -16,6 +16,25 @@ export function useModules() {
     try {
       const res = await fetch('/api/modules', { credentials: 'include' });
       const rows = res.ok ? await res.json() : [];
+      try {
+        const pres = await fetch('/api/procedures', { credentials: 'include' });
+        if (pres.ok) {
+          const data = await pres.json();
+          const list = Array.isArray(data.procedures) ? data.procedures : [];
+          list.forEach((p) => {
+            const key = `proc_${p.toLowerCase().replace(/[^a-z0-9_]/g, '_')}`;
+            rows.push({
+              module_key: key,
+              label: p,
+              parent_key: 'reports',
+              show_in_sidebar: true,
+              show_in_header: false,
+            });
+          });
+        }
+      } catch (e) {
+        console.error('Failed to load procedures', e);
+      }
       cache.data = rows;
       setModules(rows);
     } catch (err) {

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -15,6 +15,7 @@ export default function FormsManagement() {
   const [txnTypes, setTxnTypes] = useState([]);
   const [columns, setColumns] = useState([]);
   const [views, setViews] = useState([]);
+  const [procedureOptions, setProcedureOptions] = useState([]);
   const modules = useModules();
   useEffect(() => {
     debugLog('Component mounted: FormsManagement');
@@ -47,6 +48,7 @@ export default function FormsManagement() {
     transactionTypeValue: '',
     allowedBranches: [],
     allowedDepartments: [],
+    procedures: [],
   });
 
   useEffect(() => {
@@ -74,6 +76,17 @@ export default function FormsManagement() {
       .then((res) => (res.ok ? res.json() : { rows: [] }))
       .then((data) => setTxnTypes(data.rows || []))
       .catch(() => setTxnTypes([]));
+
+    fetch('/api/procedures', { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : { procedures: [] }))
+      .then((data) =>
+        setProcedureOptions(
+          (data.procedures || []).filter((p) =>
+            String(p).toLowerCase().includes('report'),
+          )
+        )
+      )
+      .catch(() => setProcedureOptions([]));
   }, []);
 
   useEffect(() => {
@@ -123,6 +136,7 @@ export default function FormsManagement() {
             transactionTypeValue: filtered[name].transactionTypeValue || '',
             allowedBranches: (filtered[name].allowedBranches || []).map(String),
             allowedDepartments: (filtered[name].allowedDepartments || []).map(String),
+            procedures: filtered[name].procedures || [],
           });
         } else {
           setName('');
@@ -154,6 +168,7 @@ export default function FormsManagement() {
             transactionTypeValue: '',
             allowedBranches: [],
             allowedDepartments: [],
+            procedures: [],
           });
         }
       })
@@ -188,6 +203,7 @@ export default function FormsManagement() {
           transactionTypeValue: '',
           allowedBranches: [],
           allowedDepartments: [],
+          procedures: [],
         });
         setModuleKey('');
       });
@@ -227,6 +243,7 @@ export default function FormsManagement() {
           transactionTypeValue: cfg.transactionTypeValue || '',
           allowedBranches: (cfg.allowedBranches || []).map(String),
           allowedDepartments: (cfg.allowedDepartments || []).map(String),
+          procedures: cfg.procedures || [],
         });
       })
       .catch(() => {
@@ -258,6 +275,7 @@ export default function FormsManagement() {
           transactionTypeValue: '',
           allowedBranches: [],
           allowedDepartments: [],
+          procedures: [],
         });
         setModuleKey('');
       });
@@ -381,6 +399,7 @@ export default function FormsManagement() {
       transactionTypeValue: '',
       allowedBranches: [],
       allowedDepartments: [],
+      procedures: [],
     });
     setModuleKey('');
   }
@@ -414,6 +433,7 @@ export default function FormsManagement() {
       transactionTypeValue: cfg.transactionTypeValue || '',
       allowedBranches: (cfg.allowedBranches || []).map(String),
       allowedDepartments: (cfg.allowedDepartments || []).map(String),
+      procedures: cfg.procedures || [],
     });
   }
 
@@ -739,7 +759,7 @@ export default function FormsManagement() {
             </tbody>
           </table>
           </div>
-          <div style={{ marginTop: '1rem' }}>
+          <div style={{ marginTop: '1rem', display: 'flex', alignItems: 'flex-start' }}>
             <label style={{ marginLeft: '1rem' }}>
               Allowed branches:{' '}
               <select
@@ -784,6 +804,31 @@ export default function FormsManagement() {
               <button type="button" onClick={() => setConfig((c) => ({ ...c, allowedDepartments: departments.map((d) => String(d.id)) }))}>All</button>
               <button type="button" onClick={() => setConfig((c) => ({ ...c, allowedDepartments: [] }))}>None</button>
             </label>
+            {procedureOptions.length > 0 && (
+              <label style={{ marginLeft: '1rem' }}>
+                Procedures:{' '}
+                <select
+                  multiple
+                  size={8}
+                  value={config.procedures}
+                  onChange={(e) =>
+                    setConfig((c) => ({
+                      ...c,
+                      procedures: Array.from(
+                        e.target.selectedOptions,
+                        (o) => o.value,
+                      ),
+                    }))
+                  }
+                >
+                  {procedureOptions.map((p) => (
+                    <option key={p} value={p}>
+                      {p}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
           </div>
           <div style={{ marginTop: '1rem' }}>
             <button onClick={handleSave}>Save Configuration</button>


### PR DESCRIPTION
## Summary
- persist stored procedure selections in transaction form config
- filter available procedures to names containing "report" and move selector beside allowed branch/department options
- limit backend procedure listing to report routines
- display stored procedure report results with toasts and a table showing parameters
- place date pickers beneath the report dropdown and pass branch id when calling procedures
- add date range presets (this month/quarter/year) that auto-fill report pickers
- expand date presets with quarterly options and adjusted ranges
- format preset ranges to use local first-of-month boundaries
- surface report procedures under the Reports module in the sidebar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68937c0dbd10833198d2df90e5f939a2