### PR TITLE
feat: store table label edits in header mappings

### DIFF
--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -9,11 +9,11 @@ import {
   listTableRelationships,
   listTableColumns,
   listTableColumnMeta,
-  saveTableColumnLabels,
   pool,
   getPrimaryKeyColumns,
 } from '../../db/index.js';
 import { moveImagesToDeleted } from '../services/transactionImageService.js';
+import { addMappings } from '../services/headerMappings.js';
 let bcrypt;
 try {
   const mod = await import('bcryptjs');
@@ -158,7 +158,7 @@ export async function saveColumnLabels(req, res, next) {
   try {
     if (req.user.role !== 'admin') return res.sendStatus(403);
     const labels = req.body.labels || {};
-    await saveTableColumnLabels(req.params.table, labels);
+    await addMappings(labels);
     res.sendStatus(204);
   } catch (err) {
     next(err);

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -2197,11 +2197,11 @@ const TableManager = forwardRef(function TableManager({
             <div style={{ textAlign: 'right' }}>
               <button onClick={() => setEditLabels(false)} style={{ marginRight: '0.5rem' }}>Cancel</button>
               <button onClick={async () => {
-                await fetch(`/api/tables/${encodeURIComponent(table)}/labels`, {
-                  method: 'PUT',
+                await fetch('/api/header_mappings', {
+                  method: 'POST',
                   headers: { 'Content-Type': 'application/json' },
                   credentials: 'include',
-                  body: JSON.stringify({ labels: labelEdits }),
+                  body: JSON.stringify({ mappings: labelEdits }),
                 });
                 const res = await fetch(`/api/tables/${encodeURIComponent(table)}/columns`, { credentials: 'include' });
                 if (res.ok) {


### PR DESCRIPTION
## Summary
- Save field label edits to headerMappings.json instead of database
- Route controller writes table labels directly to headerMappings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893a9900cd08331b37ad7657c2ccef1