### PR TITLE
feat: improve report tables and translations

### DIFF
--- a/api-server/controllers/transactionController.js
+++ b/api-server/controllers/transactionController.js
@@ -1,14 +1,26 @@
-import { listInventoryTransactions } from '../../db/index.js';
+import { listTransactions } from '../../db/index.js';
 
-export async function getInventoryTransactions(req, res, next) {
+export async function getTransactions(req, res, next) {
   try {
-    const { startDate, endDate, branchId, page, perPage } = req.query;
-    const result = await listInventoryTransactions({
+    const {
+      table,
+      startDate,
+      endDate,
+      branchId,
+      page,
+      perPage,
+      refCol,
+      refVal,
+    } = req.query;
+    const result = await listTransactions({
+      table,
       branchId,
       startDate,
       endDate,
       page: Number(page) || 1,
       perPage: Number(perPage) || 50,
+      refCol,
+      refVal,
     });
     res.json(result);
   } catch (err) {

--- a/api-server/routes/procedures.js
+++ b/api-server/routes/procedures.js
@@ -4,6 +4,7 @@ import {
   callStoredProcedure,
   listStoredProcedures,
   getProcedureParams,
+  getProcedureRawRows,
 } from '../../db/index.js';
 
 const router = express.Router();
@@ -38,6 +39,25 @@ router.post('/', requireAuth, async (req, res, next) => {
       Array.isArray(aliases) ? aliases : [],
     );
     res.json({ row });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/raw', requireAuth, async (req, res, next) => {
+  try {
+    const { name, params, column, groupField, groupValue, session } = req.body || {};
+    if (!name || !column)
+      return res.status(400).json({ message: 'name and column required' });
+    const { rows, sql, file } = await getProcedureRawRows(
+      name,
+      params || {},
+      column,
+      groupField,
+      groupValue,
+      { ...(session || {}), empid: req.user?.empid },
+    );
+    res.json({ rows, sql, file });
   } catch (err) {
     next(err);
   }

--- a/api-server/routes/transaction_forms.js
+++ b/api-server/routes/transaction_forms.js
@@ -5,6 +5,7 @@ import {
   listTransactionNames,
   setFormConfig,
   deleteFormConfig,
+  findTableByProcedure,
 } from '../services/transactionFormConfig.js';
 import { requireAuth } from '../middlewares/auth.js';
 
@@ -12,8 +13,12 @@ const router = express.Router();
 
 router.get('/', requireAuth, async (req, res, next) => {
   try {
-    const { table, name, moduleKey, branchId, departmentId } = req.query;
-    if (table && name) {
+    const { table, name, moduleKey, branchId, departmentId, proc } = req.query;
+    if (proc) {
+      const tbl = await findTableByProcedure(proc);
+      if (tbl) res.json({ table: tbl });
+      else res.status(404).json({ message: 'Table not found' });
+    } else if (table && name) {
       const cfg = await getFormConfig(table, name);
       res.json(cfg);
     } else if (table) {

--- a/api-server/routes/transactions.js
+++ b/api-server/routes/transactions.js
@@ -1,9 +1,8 @@
 import express from 'express';
-import { requireAuth } from '../middlewares/auth.js';
-import { getInventoryTransactions } from '../controllers/transactionController.js';
+import { getTransactions } from '../controllers/transactionController.js';
 
 const router = express.Router();
 
-router.get('/', requireAuth, getInventoryTransactions);
+router.get('/', getTransactions);
 
 export default router;

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -97,7 +97,7 @@ app.use("/api/views", viewsRoutes);
 app.use("/api/procedures", requireAuth, procedureRoutes);
 app.use("/api/proc_triggers", requireAuth, procTriggerRoutes);
 app.use("/api/report_procedures", reportProcedureRoutes);
-app.use("/api/inventory_transactions", requireAuth, transactionRoutes);
+app.use("/api/transactions", requireAuth, transactionRoutes);
 app.use("/api/transaction_images", transactionImageRoutes);
 app.use("/api/tables", requireAuth, tableRoutes);
 app.use("/api/general_config", requireAuth, generalConfigRoutes);

--- a/api-server/services/generalConfig.js
+++ b/api-server/services/generalConfig.js
@@ -24,6 +24,7 @@ const defaults = {
     triggerToastEnabled: true,
     procToastEnabled: true,
     viewToastEnabled: true,
+    reportRowToastEnabled: true,
     imageToastEnabled: false,
     debugLoggingEnabled: false,
     editLabelsEnabled: false,

--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -121,6 +121,18 @@ export async function getConfigsByTransTypeValue(val) {
   return result;
 }
 
+export async function findTableByProcedure(proc) {
+  if (!proc) return null;
+  const cfg = await readConfig();
+  for (const [tbl, names] of Object.entries(cfg)) {
+    for (const info of Object.values(names)) {
+      const parsed = parseEntry(info);
+      if (parsed.procedures.includes(proc)) return tbl;
+    }
+  }
+  return null;
+}
+
 export async function listTransactionNames({ moduleKey, branchId, departmentId } = {}) {
   const cfg = await readConfig();
   const result = {};

--- a/config/generalConfig.json
+++ b/config/generalConfig.json
@@ -19,8 +19,13 @@
     "triggerToastEnabled": false,
     "procToastEnabled": false,
     "viewToastEnabled": false,
+    "reportRowToastEnabled": false,
     "imageToastEnabled": false,
     "debugLoggingEnabled": false,
+    "editLabelsEnabled": false,
+    "showReportParams": false,
+    "procLabels": {},
+    "procFieldLabels": {},
     "imageDir": "txn_images"
   },
   "images": {

--- a/db/index.js
+++ b/db/index.js
@@ -36,6 +36,8 @@ try {
 }
 import defaultModules from "./defaultModules.js";
 import { logDb } from "./debugLog.js";
+import fs from "fs/promises";
+import path from "path";
 
 const tableColumnsCache = new Map();
 
@@ -949,13 +951,19 @@ export async function deleteTableRowCascade(tableName, id) {
   }
 }
 
-export async function listInventoryTransactions({
+export async function listTransactions({
+  table,
   branchId,
   startDate,
   endDate,
   page = 1,
   perPage = 50,
+  refCol,
+  refVal,
 } = {}) {
+  if (!table || !/^[a-zA-Z0-9_]+$/.test(table)) {
+    throw new Error('Invalid table');
+  }
   const clauses = [];
   const params = [];
   if (branchId !== undefined && branchId !== '') {
@@ -970,15 +978,19 @@ export async function listInventoryTransactions({
     clauses.push('transaction_date <= ?');
     params.push(endDate);
   }
+  if (refCol && /^[a-zA-Z0-9_]+$/.test(refCol)) {
+    clauses.push(`${refCol} = ?`);
+    params.push(refVal);
+  }
   const where = clauses.length > 0 ? 'WHERE ' + clauses.join(' AND ') : '';
 
   const [countRows] = await pool.query(
-    `SELECT COUNT(*) AS count FROM inventory_transactions ${where}`,
+    `SELECT COUNT(*) AS count FROM \`${table}\` ${where}`,
     params,
   );
   const count = countRows[0].count;
 
-  let sql = `SELECT * FROM inventory_transactions ${where} ORDER BY id DESC`;
+  let sql = `SELECT * FROM \`${table}\` ${where} ORDER BY id DESC`;
   const qParams = [...params];
   if (count > 100) {
     const limit = Math.min(Number(perPage) || 50, 500);
@@ -1055,4 +1067,134 @@ export async function getProcedureParams(name) {
     [name],
   );
   return rows.map((r) => r.name).filter(Boolean);
+}
+
+export async function getProcedureRawRows(
+  name,
+  params = {},
+  column,
+  groupField,
+  groupValue,
+  sessionVars = {},
+) {
+  let createSql = '';
+  try {
+    const [rows] = await pool.query(`SHOW CREATE PROCEDURE \`${name}\``);
+    createSql = rows && rows[0] && rows[0]['Create Procedure'];
+  } catch {}
+  if (!createSql) {
+    try {
+      const [rows] = await pool.query(
+        `SELECT ROUTINE_DEFINITION AS def
+           FROM information_schema.routines
+          WHERE ROUTINE_SCHEMA = DATABASE() AND ROUTINE_NAME = ?`,
+        [name],
+      );
+      createSql = rows && rows[0] && rows[0].def;
+    } catch {}
+  }
+  // Final fallback: try mysql.proc for environments where information_schema
+  // access is restricted. This still may fail, but ensures we return some SQL
+  // text when possible so the frontend can display it for debugging.
+  if (!createSql) {
+    try {
+      const [rows] = await pool.query(
+        `SELECT body FROM mysql.proc WHERE db = DATABASE() AND name = ?`,
+        [name],
+      );
+      createSql = rows && rows[0] && rows[0].body;
+    } catch {}
+  }
+
+  // default to CALL statement when definition cannot be retrieved
+  let sql = createSql ? '' : `CALL ${name}`;
+  let transformed = false;
+
+  if (createSql) {
+    const bodyMatch = createSql.match(/BEGIN\s*([\s\S]*)END/i);
+    const body = bodyMatch ? bodyMatch[1] : createSql;
+    function escapeRegExp(s) {
+      return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+    const selectMatches = [...body.matchAll(/SELECT[\s\S]*?(?=;|END|$)/gi)];
+    const colRegex = new RegExp(`\\b${escapeRegExp(column)}\\b`, 'i');
+    for (const m of selectMatches) {
+      if (colRegex.test(m[0])) {
+        sql = m[0];
+        break;
+      }
+    }
+    if (!sql && selectMatches.length) {
+      sql = selectMatches[selectMatches.length - 1][0];
+    }
+    if (sql) {
+      const colRe = escapeRegExp(column);
+      const sumRegex = new RegExp(
+        `SUM\\(([^)]*)\\)\\s*(?:AS\\s+)?` + '`?' + colRe + '`?`,
+        'i',
+      );
+      const sumMatch = sql.match(sumRegex);
+      if (sumMatch) {
+        sql = sql.replace(sumRegex, `${sumMatch[1]} AS ${column}`);
+      }
+
+      sql = sql.replace(/GROUP BY[\s\S]*?(HAVING|ORDER BY|$)/i, '$1');
+      sql = sql.replace(/HAVING[\s\S]*?(ORDER BY|$)/i, '$1');
+
+      if (params && typeof params === 'object') {
+        for (const [key, val] of Object.entries(params)) {
+          const re = new RegExp(`\\b${escapeRegExp(key)}\\b`, 'gi');
+          const rep =
+            val === null || val === undefined
+              ? 'NULL'
+              : typeof val === 'number'
+              ? String(val)
+              : `'${val}'`;
+          sql = sql.replace(re, rep);
+        }
+      }
+
+      if (sessionVars && typeof sessionVars === 'object') {
+        for (const [key, val] of Object.entries(sessionVars)) {
+          const re = new RegExp(`@session_${escapeRegExp(key)}\\b`, 'gi');
+          const rep =
+            val === null || val === undefined
+              ? 'NULL'
+              : typeof val === 'number'
+              ? String(val)
+              : `'${val}'`;
+          sql = sql.replace(re, rep);
+        }
+      }
+
+      if (groupField && groupValue !== undefined) {
+        const rep =
+          typeof groupValue === 'number' ? String(groupValue) : `'${groupValue}'`;
+        if (/WHERE/i.test(sql)) {
+          sql = sql.replace(/WHERE/i, `WHERE ${groupField} = ${rep} AND `);
+        } else {
+          sql += ` WHERE ${groupField} = ${rep}`;
+        }
+      }
+
+      sql = sql.replace(/;\s*$/, '');
+      transformed = true;
+    } else {
+      // fall back to the full procedure definition if no SELECT match
+      sql = createSql;
+    }
+  }
+
+  const file = `${name.replace(/[^a-z0-9_]/gi, '_')}_rows.sql`;
+  await fs.writeFile(path.join(process.cwd(), 'config', file), sql);
+
+  if (transformed) {
+    try {
+      const [out] = await pool.query(sql);
+      return { rows: out, sql, file };
+    } catch {
+      return { rows: [], sql, file };
+    }
+  }
+  return { rows: [], sql, file };
 }

--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -28,6 +28,7 @@ import GeneralConfigurationPage from './pages/GeneralConfiguration.jsx';
 import SettingsPage, { GeneralSettings } from './pages/Settings.jsx';
 import ChangePasswordPage from './pages/ChangePassword.jsx';
 import BlueLinkPage from './pages/BlueLinkPage.jsx';
+import useHeaderMappings from './hooks/useHeaderMappings.js';
 import InventoryPage from './pages/InventoryPage.jsx';
 import ImageManagementPage from './pages/ImageManagement.jsx';
 import FinanceTransactionsPage from './pages/FinanceTransactions.jsx';
@@ -39,6 +40,7 @@ export default function App() {
   const modules = useModules();
   const txnModules = useTxnModules();
   const generalConfig = useGeneralConfig();
+  const headerMap = useHeaderMappings(modules.map((m) => m.module_key));
 
   useEffect(() => {
     debugLog('Component mounted: App');
@@ -46,7 +48,10 @@ export default function App() {
 
   const moduleMap = {};
   modules.forEach((m) => {
-    const label = generalConfig.general?.procLabels?.[m.module_key] || m.label;
+    const label =
+      generalConfig.general?.procLabels?.[m.module_key] ||
+      headerMap[m.module_key] ||
+      m.label;
     moduleMap[m.module_key] = { ...m, label, children: [] };
   });
   modules.forEach((m) => {

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -15,6 +15,7 @@ import useGeneralConfig from "../hooks/useGeneralConfig.js";
 import { useTabs } from "../context/TabContext.jsx";
 import { useIsLoading } from "../context/LoadingContext.jsx";
 import Spinner from "./Spinner.jsx";
+import useHeaderMappings from "../hooks/useHeaderMappings.js";
 
 /**
  * A desktop‐style “ERPLayout” with:
@@ -47,6 +48,7 @@ export default function ERPLayout() {
   }, []);
 
   const modules = useModules();
+  const headerMap = useHeaderMappings(modules.map((m) => m.module_key));
   const titleMap = {
     "/": "Blue Link демо",
     "/forms": "Маягтууд",
@@ -70,7 +72,11 @@ export default function ERPLayout() {
       (m) => m.module_key.replace(/_/g, '-') === seg,
     );
     if (!mod) return 'ERP';
-    return generalConfig.general?.procLabels?.[mod.module_key] || mod.label;
+    return (
+      generalConfig.general?.procLabels?.[mod.module_key] ||
+      headerMap[mod.module_key] ||
+      mod.label
+    );
   }
 
   const windowTitle = titleForPath(location.pathname);
@@ -191,12 +197,16 @@ function Sidebar({ onOpen, open, isMobile }) {
   const modules = useModules();
   const txnModuleKeys = useTxnModules();
   const generalConfig = useGeneralConfig();
+  const headerMap = useHeaderMappings(modules.map((m) => m.module_key));
 
   if (!perms || !licensed) return null;
 
   const allMap = {};
   modules.forEach((m) => {
-    const label = generalConfig.general?.procLabels?.[m.module_key] || m.label;
+    const label =
+      generalConfig.general?.procLabels?.[m.module_key] ||
+      headerMap[m.module_key] ||
+      m.label;
     allMap[m.module_key] = { ...m, label };
   });
 
@@ -219,7 +229,10 @@ function Sidebar({ onOpen, open, isMobile }) {
       return;
     if (isFormsDescendant(m) && txnModuleKeys && !txnModuleKeys.has(m.module_key))
       return;
-    const label = generalConfig.general?.procLabels?.[m.module_key] || m.label;
+    const label =
+      generalConfig.general?.procLabels?.[m.module_key] ||
+      headerMap[m.module_key] ||
+      m.label;
     map[m.module_key] = { ...m, label, children: [] };
   });
 

--- a/src/erp.mgt.mn/components/HeaderMenu.jsx
+++ b/src/erp.mgt.mn/components/HeaderMenu.jsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { useRolePermissions } from '../hooks/useRolePermissions.js';
 import { useModules } from '../hooks/useModules.js';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
+import useHeaderMappings from '../hooks/useHeaderMappings.js';
 
 export default function HeaderMenu({ onOpen }) {
   const perms = useRolePermissions();
   const modules = useModules();
   const generalConfig = useGeneralConfig();
   const items = modules.filter((r) => r.show_in_header);
+  const headerMap = useHeaderMappings(items.map((m) => m.module_key));
 
   if (!perms) return null;
 
@@ -21,7 +23,9 @@ export default function HeaderMenu({ onOpen }) {
               style={styles.btn}
               onClick={() => onOpen(m.module_key)}
             >
-              {generalConfig.general?.procLabels?.[m.module_key] || m.label}
+              {generalConfig.general?.procLabels?.[m.module_key] ||
+                headerMap[m.module_key] ||
+                m.label}
             </button>
           ),
       )}

--- a/src/erp.mgt.mn/components/ReportTable.jsx
+++ b/src/erp.mgt.mn/components/ReportTable.jsx
@@ -1,9 +1,38 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
 import useGeneralConfig, { updateCache } from '../hooks/useGeneralConfig.js';
+import useHeaderMappings from '../hooks/useHeaderMappings.js';
+import Modal from './Modal.jsx';
+
+function ch(n) {
+  return Math.round(n * 8);
+}
+
+function getAverageLength(columnKey, data) {
+  const values = data
+    .slice(0, 20)
+    .map((r) => (r[columnKey] ?? '').toString());
+  if (values.length === 0) return 0;
+  return Math.round(
+    values.reduce((sum, val) => sum + val.length, 0) / values.length,
+  );
+}
+
+const MAX_WIDTH = ch(40);
+
+const numberFmt = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function formatNumber(val) {
+  if (val === null || val === undefined || val === '') return '';
+  const num = Number(String(val).replace(',', '.'));
+  return Number.isNaN(num) ? '' : numberFmt.format(num);
+}
 
 export default function ReportTable({ procedure = '', params = {}, rows = [] }) {
-  const { user } = useContext(AuthContext);
+  const { user, company } = useContext(AuthContext);
   const generalConfig = useGeneralConfig();
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
@@ -11,14 +40,18 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
   const [search, setSearch] = useState('');
   const [editLabels, setEditLabels] = useState(false);
   const [labelEdits, setLabelEdits] = useState({});
+  const [txnInfo, setTxnInfo] = useState(null);
 
   useEffect(() => {
     setPage(1);
   }, [rows]);
 
+
   const procLabels = generalConfig.general?.procLabels || {};
   const procFieldLabels = generalConfig.general?.procFieldLabels || {};
   const fieldLabels = procFieldLabels[procedure] || {};
+  const headerMap = useHeaderMappings([procedure]);
+  const general = generalConfig.general || {};
 
   const columns = rows && rows.length ? Object.keys(rows[0]) : [];
 
@@ -45,6 +78,50 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
     });
   }, [filtered, sort]);
 
+  const columnAlign = useMemo(() => {
+    const map = {};
+    columns.forEach((c) => {
+      const sample = sorted.find((r) => r[c] !== null && r[c] !== undefined);
+      map[c] = typeof sample?.[c] === 'number' ? 'right' : 'left';
+    });
+    return map;
+  }, [columns, sorted]);
+
+  const columnWidths = useMemo(() => {
+    const map = {};
+    if (sorted.length === 0) return map;
+    columns.forEach((c) => {
+      const avg = getAverageLength(c, sorted);
+      let w;
+      if (avg <= 4) w = ch(Math.max(avg + 1, 5));
+      else if (avg <= 10) w = ch(12);
+      else w = ch(20);
+      map[c] = Math.min(w, MAX_WIDTH);
+    });
+    return map;
+  }, [columns, sorted]);
+
+  const numericColumns = useMemo(
+    () =>
+      columns.filter((c) =>
+        sorted.some(
+          (r) => r[c] !== null && r[c] !== '' && !isNaN(Number(String(r[c]).replace(',', '.'))),
+        ),
+      ),
+    [columns, sorted],
+  );
+
+  const totals = useMemo(() => {
+    const sums = {};
+    numericColumns.forEach((c) => {
+      sums[c] = sorted.reduce((sum, r) => {
+        const val = Number(String(r[c] ?? 0).replace(',', '.'));
+        return sum + (isNaN(val) ? 0 : val);
+      }, 0);
+    });
+    return sums;
+  }, [numericColumns, sorted]);
+
   const totalPages = Math.max(1, Math.ceil(sorted.length / perPage));
   const pageRows = useMemo(
     () => sorted.slice((page - 1) * perPage, page * perPage),
@@ -57,6 +134,109 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
         ? { col, dir: prev.dir === 'asc' ? 'desc' : 'asc' }
         : { col, dir: 'asc' },
     );
+  }
+
+  function handleCellClick(col, value, row) {
+    const num = Number(String(value).replace(',', '.'));
+    if (!procedure || Number.isNaN(num) || num <= 0) return;
+    const firstField = columns[0];
+    const payload = {
+      name: procedure,
+      column: col,
+      params,
+      groupField: firstField,
+      groupValue: row[firstField],
+      session: {
+        empid: user?.empid,
+        company_id: company?.company_id,
+        branch_id: company?.branch_id,
+        department_id: company?.department_id,
+      },
+    };
+    setTxnInfo({ loading: true, col, value, data: [], sql: '' });
+    fetch('/api/procedures/raw', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(payload),
+    })
+      .then(async (res) => {
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) throw data;
+        return data;
+      })
+      .then((data) => {
+        setTxnInfo({
+          loading: false,
+          col,
+          value,
+          data: data.rows || [],
+          sql: data.sql || '',
+        });
+        if (general.reportRowToastEnabled) {
+          if (data.sql) {
+            const preview =
+              data.sql.length > 200 ? `${data.sql.slice(0, 200)}…` : data.sql;
+            window.dispatchEvent(
+              new CustomEvent('toast', {
+                detail: {
+                  message: `SQL saved to ${data.file || ''}: ${preview}`,
+                  type: 'info',
+                },
+              }),
+            );
+          } else {
+            window.dispatchEvent(
+              new CustomEvent('toast', {
+                detail: {
+                  message: 'No SQL generated',
+                  type: 'error',
+                },
+              }),
+            );
+          }
+          window.dispatchEvent(
+            new CustomEvent('toast', {
+              detail: {
+                message: `Rows fetched: ${data.rows ? data.rows.length : 0}`,
+                type: data.rows && data.rows.length ? 'success' : 'error',
+              },
+            }),
+          );
+        }
+      })
+      .catch((err) => {
+        const sql = err && typeof err === 'object' ? err.sql || '' : '';
+        const file = err && typeof err === 'object' ? err.file || '' : '';
+        setTxnInfo({ loading: false, col, value, data: [], sql });
+        if (general.reportRowToastEnabled) {
+          if (sql) {
+            const preview = sql.length > 200 ? `${sql.slice(0, 200)}…` : sql;
+            window.dispatchEvent(
+              new CustomEvent('toast', {
+                detail: {
+                  message: `SQL saved to ${file}: ${preview}`,
+                  type: 'info',
+                },
+              }),
+            );
+          } else {
+            window.dispatchEvent(
+              new CustomEvent('toast', {
+                detail: { message: 'No SQL generated', type: 'error' },
+              }),
+            );
+          }
+          window.dispatchEvent(
+            new CustomEvent('toast', {
+              detail: {
+                message: err && err.message ? err.message : 'Row fetch failed',
+                type: 'error',
+              },
+            }),
+          );
+        }
+      });
   }
 
   function handleSaveFieldLabels() {
@@ -97,14 +277,14 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
       .then((data) => data && updateCache(data));
   }
 
-  const procLabel = procLabels[procedure] || procedure;
+  const procLabel = procLabels[procedure] || headerMap[procedure] || procedure;
   const paramText =
     generalConfig.general?.showReportParams &&
     params &&
     Object.keys(params).length > 0
-      ? ` (${Object.entries(params)
+      ? Object.entries(params)
           .map(([k, v]) => `${k}=${v}`)
-          .join(', ')})`
+          .join(', ')
       : '';
 
   if (!rows || rows.length === 0) {
@@ -121,6 +301,7 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
             </button>
           )}
         </h4>
+        {paramText && <div style={{ marginTop: '0.25rem' }}>{paramText}</div>}
         <p>No data</p>
       </div>
     );
@@ -130,13 +311,13 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
     <div style={{ marginTop: '1rem' }}>
       <h4>
         {procLabel}
-        {paramText}
         {user?.role === 'admin' && generalConfig.general?.editLabelsEnabled && (
           <button onClick={handleEditProcLabel} style={{ marginLeft: '0.5rem' }}>
             Edit label
           </button>
         )}
       </h4>
+      {paramText && <div style={{ marginTop: '0.25rem' }}>{paramText}</div>}
       <div style={{ marginBottom: '0.5rem', display: 'flex', alignItems: 'center' }}>
         <input
           type="text"
@@ -145,23 +326,6 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
           placeholder="Search"
           style={{ marginRight: '0.5rem' }}
         />
-        <label>
-          Page size:
-          <select
-            value={perPage}
-            onChange={(e) => {
-              setPerPage(Number(e.target.value));
-              setPage(1);
-            }}
-            style={{ marginLeft: '0.25rem' }}
-          >
-            {[10, 25, 50, 100, 250, 500, 1000].map((n) => (
-              <option key={n} value={n}>
-                {n}
-              </option>
-            ))}
-          </select>
-        </label>
       </div>
       <div style={{ overflowX: 'auto' }}>
         <table
@@ -181,11 +345,26 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
                   style={{
                     padding: '0.5rem',
                     border: '1px solid #d1d5db',
-                    textAlign: 'left',
-                    whiteSpace: 'nowrap',
-                    cursor: 'pointer',
+                    whiteSpace: 'normal',
+                    wordBreak: 'break-word',
+                    lineHeight: 1.2,
+                    fontSize: '0.75rem',
+                    textAlign: columnAlign[col],
+                    width: columnWidths[col],
+                    minWidth: columnWidths[col],
+                    maxWidth: MAX_WIDTH,
                     resize: 'horizontal',
-                    overflow: 'auto',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    cursor: 'pointer',
+                    ...(columnWidths[col] <= ch(8)
+                      ? {
+                          writingMode: 'vertical-rl',
+                          transform: 'rotate(180deg)',
+                          overflowWrap: 'break-word',
+                          maxHeight: '15ch',
+                        }
+                      : {}),
                   }}
                 >
                   {fieldLabels[col] || col}
@@ -197,21 +376,57 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
           <tbody>
             {pageRows.map((row, idx) => (
               <tr key={idx}>
-                {columns.map((col) => (
+                {columns.map((col) => {
+                  const w = columnWidths[col];
+                  const style = {
+                    padding: '0.5rem',
+                    border: '1px solid #d1d5db',
+                    textAlign: columnAlign[col],
+                  };
+                  if (w) {
+                    style.width = w;
+                    style.minWidth = w;
+                    style.maxWidth = MAX_WIDTH;
+                    style.whiteSpace = 'nowrap';
+                    style.overflow = 'hidden';
+                    style.textOverflow = 'ellipsis';
+                  }
+                  return (
+                    <td
+                      key={col}
+                      style={{ ...style, cursor: row[col] ? 'pointer' : 'default' }}
+                      onClick={() => handleCellClick(col, row[col], row)}
+                    >
+                      {numericColumns.includes(col) ? formatNumber(row[col]) : row[col]}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+          {numericColumns.length > 0 && (
+            <tfoot>
+              <tr>
+                {columns.map((col, idx) => (
                   <td
                     key={col}
                     style={{
                       padding: '0.5rem',
                       border: '1px solid #d1d5db',
-                      whiteSpace: 'nowrap',
+                      textAlign: columnAlign[col],
+                      fontWeight: 'bold',
                     }}
                   >
-                    {row[col]}
+                    {idx === 0
+                      ? 'TOTAL'
+                      : numericColumns.includes(col)
+                      ? formatNumber(totals[col])
+                      : ''}
                   </td>
                 ))}
               </tr>
-            ))}
-          </tbody>
+            </tfoot>
+          )}
         </table>
       </div>
       <div style={{ marginTop: '0.5rem', display: 'flex', alignItems: 'center' }}>
@@ -226,7 +441,21 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
           {'<'}
         </button>
         <span style={{ margin: '0 0.5rem' }}>
-          Page {page} of {totalPages}
+          Page
+          <input
+            type="number"
+            value={page}
+            onChange={(e) => {
+              let val = Number(e.target.value) || 1;
+              if (val < 1) val = 1;
+              if (val > totalPages) val = totalPages;
+              setPage(val);
+            }}
+            style={{ width: '3rem', margin: '0 0.25rem', textAlign: 'center' }}
+            min="1"
+            max={totalPages}
+          />
+          of {totalPages}
         </span>
         <button
           onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
@@ -238,7 +467,92 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
         <button onClick={() => setPage(totalPages)} disabled={page === totalPages}>
           {'>>'}
         </button>
+        <label style={{ marginLeft: '1rem' }}>
+          Page size:
+          <input
+            type="number"
+            value={perPage}
+            onChange={(e) => {
+              setPerPage(Number(e.target.value) || 1);
+              setPage(1);
+            }}
+            min="1"
+            style={{ marginLeft: '0.25rem', width: '4rem' }}
+          />
+        </label>
       </div>
+      {txnInfo && (
+        <Modal
+          visible
+          title={`Transactions for ${txnInfo.col} = ${txnInfo.value}`}
+          onClose={() => setTxnInfo(null)}
+          width="80%"
+        >
+          {txnInfo.loading ? (
+            <div>Loading...</div>
+          ) : txnInfo.data.length > 0 ? (
+            <div style={{ overflowX: 'auto' }}>
+              <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+                <thead>
+                  <tr>
+                    {Object.keys(txnInfo.data[0]).map((c) => (
+                      <th
+                        key={c}
+                        style={{
+                          padding: '0.25rem',
+                          border: '1px solid #d1d5db',
+                          textAlign: 'left',
+                        }}
+                      >
+                        {c}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {txnInfo.data.map((r, idx) => (
+                    <tr key={idx}>
+                      {Object.keys(txnInfo.data[0]).map((c) => (
+                        <td
+                          key={c}
+                          style={{
+                            padding: '0.25rem',
+                            border: '1px solid #d1d5db',
+                            textAlign: 'left',
+                          }}
+                        >
+                          {typeof r[c] === 'number' ? formatNumber(r[c]) : r[c]}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <div>
+              No transactions
+              {txnInfo.sql ? (
+                <pre
+                  style={{
+                    marginTop: '0.5rem',
+                    whiteSpace: 'pre-wrap',
+                    maxHeight: '200px',
+                    overflow: 'auto',
+                    background: '#f9fafb',
+                    padding: '0.5rem',
+                    border: '1px solid #d1d5db',
+                  }}
+                >
+                  {txnInfo.sql}
+                </pre>
+              ) : (
+                <div style={{ marginTop: '0.5rem' }}>SQL not generated</div>
+              )}
+            </div>
+          )}
+        </Modal>
+      )}
       {user?.role === 'admin' && generalConfig.general?.editLabelsEnabled && (
         <button
           onClick={() => {

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1643,20 +1643,16 @@ const TableManager = forwardRef(function TableManager({
       >
         <div>
           Rows per page:
-          <select
+          <input
+            type="number"
             value={perPage}
             onChange={(e) => {
               setPage(1);
-              setPerPage(Number(e.target.value));
+              setPerPage(Number(e.target.value) || 1);
             }}
-            style={{ marginLeft: '0.25rem' }}
-          >
-            {[10, 25, 50].map((n) => (
-              <option key={n} value={n}>
-                {n}
-              </option>
-            ))}
-          </select>
+            min="1"
+            style={{ marginLeft: '0.25rem', width: '4rem' }}
+          />
         </div>
         <div>
           <button onClick={() => setPage(1)} disabled={page === 1} style={{ marginRight: '0.25rem' }}>
@@ -1670,7 +1666,22 @@ const TableManager = forwardRef(function TableManager({
             {'<'}
           </button>
           <span>
-            Page {page} of {Math.max(1, Math.ceil(count / perPage))}
+            Page
+            <input
+              type="number"
+              value={page}
+              onChange={(e) => {
+                let val = Number(e.target.value) || 1;
+                const max = Math.max(1, Math.ceil(count / perPage));
+                if (val < 1) val = 1;
+                if (val > max) val = max;
+                setPage(val);
+              }}
+              style={{ width: '3rem', margin: '0 0.25rem', textAlign: 'center' }}
+              min="1"
+              max={Math.max(1, Math.ceil(count / perPage))}
+            />
+            of {Math.max(1, Math.ceil(count / perPage))}
           </span>
           <button
             onClick={() => setPage((p) => Math.min(Math.ceil(count / perPage), p + 1))}
@@ -1990,20 +2001,16 @@ const TableManager = forwardRef(function TableManager({
       >
         <div>
           Rows per page:
-          <select
+          <input
+            type="number"
             value={perPage}
             onChange={(e) => {
               setPage(1);
-              setPerPage(Number(e.target.value));
+              setPerPage(Number(e.target.value) || 1);
             }}
-            style={{ marginLeft: '0.25rem' }}
-          >
-            {[10, 25, 50].map((n) => (
-              <option key={n} value={n}>
-                {n}
-              </option>
-            ))}
-          </select>
+            min="1"
+            style={{ marginLeft: '0.25rem', width: '4rem' }}
+          />
         </div>
         <div>
           <button onClick={() => setPage(1)} disabled={page === 1} style={{ marginRight: '0.25rem' }}>
@@ -2017,7 +2024,22 @@ const TableManager = forwardRef(function TableManager({
             {'<'}
           </button>
           <span>
-            Page {page} of {Math.max(1, Math.ceil(count / perPage))}
+            Page
+            <input
+              type="number"
+              value={page}
+              onChange={(e) => {
+                let val = Number(e.target.value) || 1;
+                const max = Math.max(1, Math.ceil(count / perPage));
+                if (val < 1) val = 1;
+                if (val > max) val = max;
+                setPage(val);
+              }}
+              style={{ width: '3rem', margin: '0 0.25rem', textAlign: 'center' }}
+              min="1"
+              max={Math.max(1, Math.ceil(count / perPage))}
+            />
+            of {Math.max(1, Math.ceil(count / perPage))}
           </span>
           <button
             onClick={() => setPage((p) => Math.min(Math.ceil(count / perPage), p + 1))}

--- a/src/erp.mgt.mn/hooks/useAuth.jsx
+++ b/src/erp.mgt.mn/hooks/useAuth.jsx
@@ -11,16 +11,35 @@ import { API_BASE } from '../utils/apiBase.js';
  * @returns {Promise<{id: number, empid: string, role: string}>}
 */
 export async function login({ empid, password }) {
-  const res = await fetch(`${API_BASE}/auth/login`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+  let res;
+  try {
+    res = await fetch(`${API_BASE}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
     credentials: 'include', // Ensures cookie is stored
     body: JSON.stringify({ empid, password }),
-  });
-  if (!res.ok) {
-    const errorBody = await res.json().catch(() => ({}));
-    throw new Error(errorBody.message || 'Login failed');
+    });
+  } catch (err) {
+    // Network errors (e.g. server unreachable)
+    throw new Error('Login request failed');
   }
+
+  if (!res.ok) {
+    let message = 'Login failed';
+    const contentType = res.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) {
+      const data = await res.json().catch(() => ({}));
+      if (data && data.message) message = data.message;
+    } else if (res.status === 503) {
+      message = 'Service unavailable';
+    } else {
+      // Consume text to avoid unhandled promise rejections
+      const text = await res.text().catch(() => '');
+      if (text) message = text;
+    }
+    throw new Error(message);
+  }
+
   return res.json();
 }
 

--- a/src/erp.mgt.mn/hooks/useHeaderMappings.js
+++ b/src/erp.mgt.mn/hooks/useHeaderMappings.js
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+
+const cache = {};
+
+export default function useHeaderMappings(headers = []) {
+  const [map, setMap] = useState({});
+
+  useEffect(() => {
+    const unique = Array.from(new Set(headers.filter(Boolean)));
+    if (unique.length === 0) {
+      setMap({});
+      return;
+    }
+    const missing = unique.filter((h) => cache[h] === undefined);
+    if (missing.length > 0) {
+      const params = new URLSearchParams();
+      params.set('headers', missing.join(','));
+      fetch(`/api/header_mappings?${params.toString()}`, { credentials: 'include' })
+        .then((res) => (res.ok ? res.json() : {}))
+        .then((data) => {
+          Object.assign(cache, data);
+          const result = {};
+          unique.forEach((h) => {
+            if (cache[h] !== undefined) result[h] = cache[h];
+          });
+          setMap(result);
+        })
+        .catch(() => {
+          const result = {};
+          unique.forEach((h) => {
+            if (cache[h] !== undefined) result[h] = cache[h];
+          });
+          setMap(result);
+        });
+    } else {
+      const result = {};
+      unique.forEach((h) => {
+        if (cache[h] !== undefined) result[h] = cache[h];
+      });
+      setMap(result);
+    }
+  }, [headers.join(',')]);
+
+  return map;
+}

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -15,6 +15,7 @@ import { useTxnSession } from '../context/TxnSessionContext.jsx';
 import { useToast } from '../context/ToastContext.jsx';
 import formatTimestamp from '../utils/formatTimestamp.js';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
+import useHeaderMappings from '../hooks/useHeaderMappings.js';
 
 function isEqual(a, b) {
   try {
@@ -61,6 +62,20 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
   const sessionLoaded = useRef(false);
   const prevSessionRef = useRef({});
   const prevConfigRef = useRef(null);
+
+  const procMap = useHeaderMappings(
+    config?.procedures
+      ? [...config.procedures, selectedProc].filter(Boolean)
+      : selectedProc
+      ? [selectedProc]
+      : [],
+  );
+
+  function getProcLabel(name) {
+    return (
+      generalConfig.general?.procLabels?.[name] || procMap[name] || name
+    );
+  }
 
 
   useEffect(() => {
@@ -389,7 +404,7 @@ useEffect(() => {
       acc[p] = finalParams[i];
       return acc;
     }, {});
-    const label = generalConfig.general?.procLabels?.[selectedProc] || selectedProc;
+    const label = getProcLabel(selectedProc);
     addToast(`Calling ${label}`, 'info');
     try {
       const res = await fetch('/api/procedures', {
@@ -464,7 +479,7 @@ useEffect(() => {
                   <option value="">-- select --</option>
                   {config.procedures.map((p) => (
                     <option key={p} value={p}>
-                      {generalConfig.general?.procLabels?.[p] || p}
+                      {getProcLabel(p)}
                     </option>
                   ))}
                 </select>

--- a/src/erp.mgt.mn/pages/FormsIndex.jsx
+++ b/src/erp.mgt.mn/pages/FormsIndex.jsx
@@ -6,6 +6,7 @@ import { useRolePermissions } from '../hooks/useRolePermissions.js';
 import { useCompanyModules } from '../hooks/useCompanyModules.js';
 import { useTxnModules } from '../hooks/useTxnModules.js';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
+import useHeaderMappings from '../hooks/useHeaderMappings.js';
 
 export default function FormsIndex() {
   const [transactions, setTransactions] = useState({});
@@ -16,9 +17,13 @@ export default function FormsIndex() {
   const txnModules = useTxnModules();
   const generalConfig = useGeneralConfig();
 
+  const headerMap = useHeaderMappings(modules.map((m) => m.module_key));
   const moduleMap = {};
   modules.forEach((m) => {
-    const label = generalConfig.general?.procLabels?.[m.module_key] || m.label;
+    const label =
+      generalConfig.general?.procLabels?.[m.module_key] ||
+      headerMap[m.module_key] ||
+      m.label;
     moduleMap[m.module_key] = { ...m, label };
   });
 
@@ -84,7 +89,9 @@ export default function FormsIndex() {
         groups.map(([key]) => {
           const mod = modules.find((m) => m.module_key === key);
           const label = mod
-            ? generalConfig.general?.procLabels?.[mod.module_key] || mod.label
+            ? generalConfig.general?.procLabels?.[mod.module_key] ||
+              headerMap[mod.module_key] ||
+              mod.label
             : key;
           return (
             <div key={key} style={{ marginBottom: '1rem' }}>

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -3,6 +3,7 @@ import { useModules } from '../hooks/useModules.js';
 import { refreshTxnModules } from '../hooks/useTxnModules.js';
 import { debugLog } from '../utils/debug.js';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
+import useHeaderMappings from '../hooks/useHeaderMappings.js';
 
 export default function FormsManagement() {
   const [tables, setTables] = useState([]);
@@ -19,6 +20,10 @@ export default function FormsManagement() {
   const [procedureOptions, setProcedureOptions] = useState([]);
   const generalConfig = useGeneralConfig();
   const modules = useModules();
+  const procMap = useHeaderMappings(procedureOptions);
+  function getProcLabel(name) {
+    return generalConfig.general?.procLabels?.[name] || procMap[name] || name;
+  }
   useEffect(() => {
     debugLog('Component mounted: FormsManagement');
   }, []);
@@ -851,7 +856,7 @@ export default function FormsManagement() {
                 >
                   {procedureOptions.map((p) => (
                     <option key={p} value={p}>
-                      {generalConfig.general?.procLabels?.[p] || p}
+                      {getProcLabel(p)}
                     </option>
                   ))}
                 </select>

--- a/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
+++ b/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
@@ -264,6 +264,17 @@ export default function GeneralConfiguration() {
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
             <label>
+              Show Report Row Toasts{' '}
+              <input
+                name="reportRowToastEnabled"
+                type="checkbox"
+                checked={active.reportRowToastEnabled ?? false}
+                onChange={handleChange}
+              />
+            </label>
+          </div>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <label>
               Show Image Toasts{' '}
               <input
                 name="imageToastEnabled"

--- a/src/erp.mgt.mn/pages/Reports.jsx
+++ b/src/erp.mgt.mn/pages/Reports.jsx
@@ -5,6 +5,7 @@ import { useToast } from '../context/ToastContext.jsx';
 import formatTimestamp from '../utils/formatTimestamp.js';
 import ReportTable from '../components/ReportTable.jsx';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
+import useHeaderMappings from '../hooks/useHeaderMappings.js';
 
 export default function Reports() {
   const { company, user } = useContext(AuthContext);
@@ -18,6 +19,13 @@ export default function Reports() {
   const [datePreset, setDatePreset] = useState('custom');
   const [result, setResult] = useState(null);
   const [manualParams, setManualParams] = useState({});
+  const procMap = useHeaderMappings(procedures);
+
+  function getLabel(name) {
+    return (
+      generalConfig.general?.procLabels?.[name] || procMap[name] || name
+    );
+  }
 
   useEffect(() => {
     const params = new URLSearchParams();
@@ -142,7 +150,7 @@ export default function Reports() {
       acc[p] = finalParams[i];
       return acc;
     }, {});
-    const label = generalConfig.general?.procLabels?.[selectedProc] || selectedProc;
+    const label = getLabel(selectedProc);
     addToast(`Calling ${label}`, 'info');
     try {
       const res = await fetch('/api/procedures', {
@@ -184,7 +192,7 @@ export default function Reports() {
           <option value="">-- select --</option>
           {procedures.map((p) => (
             <option key={p} value={p}>
-              {generalConfig.general?.procLabels?.[p] || p}
+              {getLabel(p)}
             </option>
           ))}
         </select>

--- a/src/erp.mgt.mn/utils/csrfFetch.js
+++ b/src/erp.mgt.mn/utils/csrfFetch.js
@@ -59,10 +59,16 @@ window.fetch = async (url, options = {}, _retry) => {
   }
   if (!res.ok) {
     let errorMsg = res.statusText;
-    try {
-      const data = await res.clone().json();
-      if (data && data.message) errorMsg = data.message;
-    } catch {
+    const contentType = res.headers.get('content-type') || '';
+    if (res.status === 503) {
+      // Some servers return an HTML maintenance page; surface a friendly message instead of raw markup
+      errorMsg = 'Service unavailable';
+    } else if (contentType.includes('application/json')) {
+      try {
+        const data = await res.clone().json();
+        if (data && data.message) errorMsg = data.message;
+      } catch {}
+    } else {
       try {
         const text = await res.clone().text();
         errorMsg = text.slice(0, 200);


### PR DESCRIPTION
## Summary
- derive raw row queries exclusively from stored procedure SQL, writing CALL text when definitions are unavailable
- scan all SELECT statements to locate the one containing the clicked column before removing aggregates and grouping
- always write the transformed query to a reviewable `.sql` file after reconstruction
- gracefully handle 503 Service Unavailable responses so login toasts show a friendly message instead of raw HTML

## Testing
- `npm test` *(fails: 17 failed, 19 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68948559eefc83318dcbd39ca67474e3