### PR TITLE
Persist transformed report SQL and display toast notifications

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -1106,10 +1106,7 @@ export async function getProcedureRawRows(
     } catch {}
   }
   if (!createSql) {
-    const callSql = `CALL ${name}`;
-    const file = `${name.replace(/[^a-z0-9_]/gi, '_')}_rows.sql`;
-    await fs.writeFile(path.join(process.cwd(), 'config', file), callSql);
-    return { rows: [], sql: callSql, file };
+    createSql = `CALL ${name}`;
   }
   const bodyMatch = createSql.match(/BEGIN\s*([\s\S]*)END/i);
   const body = bodyMatch ? bodyMatch[1] : createSql;
@@ -1129,9 +1126,7 @@ export async function getProcedureRawRows(
     sql = selectMatches[selectMatches.length - 1][0];
   }
   if (!sql) {
-    const file = `${name.replace(/[^a-z0-9_]/gi, '_')}_rows.sql`;
-    await fs.writeFile(path.join(process.cwd(), 'config', file), createSql);
-    return { rows: [], sql: createSql, file };
+    sql = createSql;
   }
   const colRe = escapeRegExp(column);
   const sumRegex = new RegExp(

--- a/src/erp.mgt.mn/components/ReportTable.jsx
+++ b/src/erp.mgt.mn/components/ReportTable.jsx
@@ -173,69 +173,62 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
           data: data.rows || [],
           sql: data.sql || '',
         });
-        if (general.reportRowToastEnabled) {
-          if (data.sql) {
-            const preview =
-              data.sql.length > 200 ? `${data.sql.slice(0, 200)}…` : data.sql;
-            window.dispatchEvent(
-              new CustomEvent('toast', {
-                detail: {
-                  message: `SQL saved to ${data.file || ''}: ${preview}`,
-                  type: 'info',
-                },
-              }),
-            );
-          } else {
-            window.dispatchEvent(
-              new CustomEvent('toast', {
-                detail: {
-                  message: 'No SQL generated',
-                  type: 'error',
-                },
-              }),
-            );
-          }
+        if (data.sql) {
+          const preview =
+            data.sql.length > 200 ? `${data.sql.slice(0, 200)}…` : data.sql;
           window.dispatchEvent(
             new CustomEvent('toast', {
               detail: {
-                message: `Rows fetched: ${data.rows ? data.rows.length : 0}`,
-                type: data.rows && data.rows.length ? 'success' : 'error',
+                message: `SQL saved to ${data.file || ''}: ${preview}`,
+                type: 'info',
               },
             }),
           );
+        } else {
+          window.dispatchEvent(
+            new CustomEvent('toast', {
+              detail: { message: 'No SQL generated', type: 'error' },
+            }),
+          );
         }
+        window.dispatchEvent(
+          new CustomEvent('toast', {
+            detail: {
+              message: `Rows fetched: ${data.rows ? data.rows.length : 0}`,
+              type: data.rows && data.rows.length ? 'success' : 'error',
+            },
+          }),
+        );
       })
       .catch((err) => {
         const sql = err && typeof err === 'object' ? err.sql || '' : '';
         const file = err && typeof err === 'object' ? err.file || '' : '';
         setTxnInfo({ loading: false, col, value, data: [], sql });
-        if (general.reportRowToastEnabled) {
-          if (sql) {
-            const preview = sql.length > 200 ? `${sql.slice(0, 200)}…` : sql;
-            window.dispatchEvent(
-              new CustomEvent('toast', {
-                detail: {
-                  message: `SQL saved to ${file}: ${preview}`,
-                  type: 'info',
-                },
-              }),
-            );
-          } else {
-            window.dispatchEvent(
-              new CustomEvent('toast', {
-                detail: { message: 'No SQL generated', type: 'error' },
-              }),
-            );
-          }
+        if (sql) {
+          const preview = sql.length > 200 ? `${sql.slice(0, 200)}…` : sql;
           window.dispatchEvent(
             new CustomEvent('toast', {
               detail: {
-                message: err && err.message ? err.message : 'Row fetch failed',
-                type: 'error',
+                message: `SQL saved to ${file}: ${preview}`,
+                type: 'info',
               },
             }),
           );
+        } else {
+          window.dispatchEvent(
+            new CustomEvent('toast', {
+              detail: { message: 'No SQL generated', type: 'error' },
+            }),
+          );
         }
+        window.dispatchEvent(
+          new CustomEvent('toast', {
+            detail: {
+              message: err && err.message ? err.message : 'Row fetch failed',
+              type: 'error',
+            },
+          }),
+        );
       });
   }
 


### PR DESCRIPTION
## Summary
- Ensure stored procedure fallbacks default to `CALL` and persist transformed SQL to a config file
- Always toast SQL save info and row counts when previewing report rows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894f17dd6f8833191b78dc3e374e70f