### PR TITLE
Persist transformed report SQL and display toast notifications

### DIFF
--- a/api-server/routes/procedures.js
+++ b/api-server/routes/procedures.js
@@ -49,7 +49,7 @@ router.post('/raw', requireAuth, async (req, res, next) => {
     const { name, params, column, groupField, groupValue, session } = req.body || {};
     if (!name || !column)
       return res.status(400).json({ message: 'name and column required' });
-    const { rows, sql, file } = await getProcedureRawRows(
+    const { rows, sql, original, file } = await getProcedureRawRows(
       name,
       params || {},
       column,
@@ -57,7 +57,7 @@ router.post('/raw', requireAuth, async (req, res, next) => {
       groupValue,
       { ...(session || {}), empid: req.user?.empid },
     );
-    res.json({ rows, sql, file });
+    res.json({ rows, sql, original, file });
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
## Summary
- Add robust stored procedure extraction with database-qualified `SHOW CREATE PROCEDURE`, unqualified fallback, and `information_schema` lookup
- Replace `SUM(CASE ...)` aggregates with raw `CASE` expressions to return transaction-level rows

## Testing
- `npm test` *(fails: 17, passes: 19)*

------
https://chatgpt.com/codex/tasks/task_e_6894f17dd6f8833191b78dc3e374e70f