### PR TITLE
Include user info in refresh token and rotate on refresh

### DIFF
--- a/api-server/controllers/authController.js
+++ b/api-server/controllers/authController.js
@@ -16,7 +16,11 @@ export async function login(req, res, next) {
       role: user.role,
     });
 
-    const refreshToken = jwtService.signRefresh({ id: user.id });
+    const refreshToken = jwtService.signRefresh({
+      id: user.id,
+      empid: user.empid,
+      role: user.role,
+    });
 
     res.cookie(getCookieName(), token, {
       httpOnly: true,
@@ -87,11 +91,22 @@ export async function refresh(req, res) {
       empid: user.empid,
       role: user.role,
     });
+    const newRefresh = jwtService.signRefresh({
+      id: user.id,
+      empid: user.empid,
+      role: user.role,
+    });
     res.cookie(getCookieName(), newAccess, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
       maxAge: jwtService.getExpiryMillis(),
+    });
+    res.cookie(getRefreshCookieName(), newRefresh, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: jwtService.getRefreshExpiryMillis(),
     });
     res.json({
       id: user.id,

--- a/api-server/middlewares/auth.js
+++ b/api-server/middlewares/auth.js
@@ -26,11 +26,22 @@ export function requireAuth(req, res, next) {
             empid: rPayload.empid,
             role: rPayload.role,
           });
+          const newRefresh = jwtService.signRefresh({
+            id: rPayload.id,
+            empid: rPayload.empid,
+            role: rPayload.role,
+          });
           res.cookie(getCookieName(), newAccess, {
             httpOnly: true,
             secure: process.env.NODE_ENV === 'production',
             sameSite: 'lax',
             maxAge: jwtService.getExpiryMillis(),
+          });
+          res.cookie(getRefreshCookieName(), newRefresh, {
+            httpOnly: true,
+            secure: process.env.NODE_ENV === 'production',
+            sameSite: 'lax',
+            maxAge: jwtService.getRefreshExpiryMillis(),
           });
           req.user = jwtService.verify(newAccess);
           refreshed = true;


### PR DESCRIPTION
## Summary
- ensure refresh tokens carry id, empid and role
- rotate refresh token alongside access token during automatic and manual refresh

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897037a74cc83319682d356b549780f