### PR TITLE
Add POST view and procedure actions in Report Builder

### DIFF
--- a/api-server/routes/report_builder.js
+++ b/api-server/routes/report_builder.js
@@ -6,6 +6,7 @@ import {
   listDatabaseTables,
   listTableColumns,
   saveStoredProcedure,
+  saveView,
 } from '../../db/index.js';
 
 const router = express.Router();
@@ -40,6 +41,18 @@ router.post('/procedures', requireAuth, async (req, res, next) => {
     const { sql } = req.body || {};
     if (!sql) return res.status(400).json({ message: 'sql required' });
     await saveStoredProcedure(sql);
+    res.json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Save a view
+router.post('/views', requireAuth, async (req, res, next) => {
+  try {
+    const { sql } = req.body || {};
+    if (!sql) return res.status(400).json({ message: 'sql required' });
+    await saveView(sql);
     res.json({ ok: true });
   } catch (err) {
     next(err);

--- a/db/index.js
+++ b/db/index.js
@@ -581,6 +581,10 @@ export async function saveStoredProcedure(sql) {
   }
 }
 
+export async function saveView(sql) {
+  await pool.query(sql);
+}
+
 export async function getTableColumnLabels(tableName) {
   const [rows] = await pool.query(
     'SELECT column_name, mn_label FROM table_column_labels WHERE table_name = ?',


### PR DESCRIPTION
## Summary
- Clear generated SQL areas before inserting new scripts
- Add POST View/Procedure buttons with confirmation prompts
- Support persisting views via new API and DB helper

## Testing
- `npm test` *(fails: cleanupOldImages removes old files, deleteImage moves file to deleted_images)*

------
https://chatgpt.com/codex/tasks/task_e_689735d34a04833180d1cf6b2c1ef6ec