### PR TITLE
Filter unrelated aggregates when drilling into report cells

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -1150,14 +1150,21 @@ export async function getProcedureRawRows(
 
   if (/^SELECT/i.test(sql)) {
     const colRe = escapeRegExp(column);
-    const sumRegex = new RegExp(
-      `SUM\\(([^)]*)\\)\\s*(?:AS\\s+)?` + '`?' + colRe + '`?',
+
+    const keepRegex = new RegExp(
+      'SUM\\(([^)]*)\\)\\s*(?:AS\\s+)?`?' + colRe + '`?',
       'i',
     );
-    const sumMatch = sql.match(sumRegex);
-    if (sumMatch) {
-      sql = sql.replace(sumRegex, `${sumMatch[1]} AS ${column}`);
-    }
+    sql = sql.replace(keepRegex, (_, inner) => `${inner} AS ${column}`);
+
+    sql = sql.replace(
+      /,\s*SUM\([^)]*\)\s*(?:AS\s+)?`?[a-z0-9_]+`?/gi,
+      '',
+    );
+    sql = sql.replace(
+      /SELECT\s*SUM\([^)]*\)\s*(?:AS\s+)?`?[a-z0-9_]+`?\s*,/i,
+      'SELECT ',
+    );
 
     sql = sql.replace(/GROUP BY[\s\S]*?(HAVING|ORDER BY|$)/i, '$1');
     sql = sql.replace(/HAVING[\s\S]*?(ORDER BY|$)/i, '$1');
@@ -1188,34 +1195,13 @@ export async function getProcedureRawRows(
       }
     }
 
+    sql = sql.replace(/;\s*$/, '');
     if (groupValue !== undefined) {
-      let condField = groupField;
-      const sel = sql.match(/SELECT\s+([\s\S]+?)\s+FROM/i);
-      if (sel) {
-        const firstField = sel[1].split(/,(?![^()]*\))/)[0]?.trim();
-        const m = firstField?.match(/^(.+?)\s+(?:AS\s+)?`?([a-z0-9_]+)`?$/i);
-        if (m) {
-          const expr = m[1].trim();
-          const alias = m[2];
-          if (!groupField || alias === groupField) condField = expr;
-        } else if (!groupField) {
-          condField = firstField;
-        }
-      }
-      if (condField) {
-        const rep =
-          typeof groupValue === 'number' ? String(groupValue) : `'${groupValue}'`;
-        const clause = `${condField} = ${rep}`;
-        if (/WHERE/i.test(sql)) {
-          sql = sql.replace(/WHERE/i, `WHERE ${clause} AND `);
-        } else {
-          sql += ` WHERE ${clause}`;
-        }
-      }
+      const rep =
+        typeof groupValue === 'number' ? String(groupValue) : `'${groupValue}'`;
+      sql = `SELECT * FROM (${sql}) AS _raw WHERE ${groupField} = ${rep}`;
     }
 
-    // Trim trailing statement terminators to avoid MySQL complaining when
-    // executing the reconstructed query.
     sql = sql.replace(/;\s*$/, '');
   }
 

--- a/tests/db/procedureRawRows.test.js
+++ b/tests/db/procedureRawRows.test.js
@@ -23,7 +23,7 @@ function mockPool(createSql) {
 test('getProcedureRawRows expands alias and removes aggregates', async () => {
   const createSql = `CREATE PROCEDURE \`sp_test\`()
 BEGIN
-  SELECT c.name AS category, SUM(t.amount) AS total
+  SELECT c.name AS category, SUM(t.amount) AS total, SUM(t.count) AS cnt
   FROM trans t
   JOIN categories c ON c.id = t.category_id
   WHERE t.date BETWEEN start_date AND end_date
@@ -39,10 +39,12 @@ END`;
   );
   restore();
   assert.ok(sql.includes('t.amount AS total'));
-  assert.ok(sql.includes("c.name = 'Phones'"));
+  assert.ok(!/\bcnt\b/i.test(sql));
+  assert.ok(sql.includes("category = 'Phones'"));
   assert.ok(sql.includes("'2024-01-01'"));
   assert.ok(!/GROUP BY/i.test(sql));
   assert.ok(!/HAVING/i.test(sql));
   assert.ok(!/SUM\(/i.test(sql));
+  assert.ok(/^SELECT \* FROM \(/i.test(sql));
   await fs.unlink(path.join(process.cwd(), 'config', 'sp_test_rows.sql')).catch(() => {});
 });


### PR DESCRIPTION
## Summary
- Use regex on full procedure SQL to drop unclicked SUM fields and remove grouping
- Wrap raw query and filter by leftmost column alias

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897394edf648331a1d4547fbec136e6