### PR TITLE
Filter unrelated aggregates when drilling into report cells

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -1130,34 +1130,78 @@ export async function getProcedureRawRows(
   function escapeRegExp(s) {
     return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
-  const selectMatches = [...body.matchAll(/SELECT[\s\S]*?(?=;|END|$)/gi)];
-  const colRegex = new RegExp(`\\b${escapeRegExp(column)}\\b`, 'i');
-  let sql = '';
-  for (const m of selectMatches) {
-    if (colRegex.test(m[0])) {
-      sql = m[0];
-      break;
-    }
-  }
-  if (!sql && selectMatches.length) {
-    sql = selectMatches[selectMatches.length - 1][0];
-  }
-  if (!sql) {
-    sql = createSql;
-  }
-
+  const firstSelectIdx = body.search(/SELECT/i);
+  let sql = firstSelectIdx === -1 ? createSql : body.slice(firstSelectIdx);
   const originalSql = sql;
+  let remainder = '';
+  const firstSemi = sql.indexOf(';');
+  if (firstSemi !== -1) {
+    remainder = sql.slice(firstSemi);
+    sql = sql.slice(0, firstSemi);
+  }
 
   if (/^SELECT/i.test(sql)) {
-    const colRe = escapeRegExp(column);
-    const sumRegex = new RegExp(
-      `SUM\\(([^)]*)\\)\\s*(?:AS\\s+)?` + '`?' + colRe + '`?',
-      'i',
-    );
-    const sumMatch = sql.match(sumRegex);
-    if (sumMatch) {
-      sql = sql.replace(sumRegex, `${sumMatch[1]} AS ${column}`);
+    function filterAggregates(input, aliasToKeep) {
+      const upper = input.toUpperCase();
+      // find FROM at top level
+      let depth = 0;
+      let fromIdx = -1;
+      for (let i = 0; i < upper.length; i++) {
+        const ch = upper[i];
+        if (ch === '(') depth++;
+        else if (ch === ')') depth--;
+        else if (depth === 0 && upper.startsWith('FROM', i)) {
+          fromIdx = i;
+          break;
+        }
+      }
+      if (fromIdx === -1) return input;
+      const fieldsPart = input.slice(6, fromIdx);
+      const rest = input.slice(fromIdx);
+      const fields = [];
+      let buf = '';
+      depth = 0;
+      for (let i = 0; i < fieldsPart.length; i++) {
+        const ch = fieldsPart[i];
+        if (ch === '(') depth++;
+        else if (ch === ')') depth--;
+        if (ch === ',' && depth === 0) {
+          fields.push(buf.trim());
+          buf = '';
+        } else {
+          buf += ch;
+        }
+      }
+      if (buf.trim()) fields.push(buf.trim());
+      const kept = [];
+      for (let field of fields) {
+        const sumIdx = field.toUpperCase().indexOf('SUM(');
+        if (sumIdx === -1) {
+          kept.push(field);
+          continue;
+        }
+        const aliasMatch = field.match(/(?:AS\s+)?`?([a-zA-Z0-9_]+)`?\s*$/i);
+        const alias = aliasMatch ? aliasMatch[1] : null;
+        if (alias && alias.toLowerCase() === String(aliasToKeep).toLowerCase()) {
+          let start = sumIdx + 4;
+          let depth2 = 1;
+          let j = start;
+          while (j < field.length && depth2 > 0) {
+            const ch2 = field[j];
+            if (ch2 === '(') depth2++;
+            else if (ch2 === ')') depth2--;
+            j++;
+          }
+          const inner = field.slice(start, j - 1);
+          field = field.slice(0, sumIdx) + inner + field.slice(j);
+          kept.push(field.trim());
+        }
+      }
+      if (!kept.length) return input;
+      return 'SELECT ' + kept.join(', ') + ' ' + rest;
     }
+
+    sql = filterAggregates(sql, column);
 
     sql = sql.replace(/GROUP BY[\s\S]*?(HAVING|ORDER BY|$)/i, '$1');
     sql = sql.replace(/HAVING[\s\S]*?(ORDER BY|$)/i, '$1');
@@ -1188,36 +1232,18 @@ export async function getProcedureRawRows(
       }
     }
 
+    sql = sql.replace(/;\s*$/, '');
     if (groupValue !== undefined) {
-      let condField = groupField;
-      const sel = sql.match(/SELECT\s+([\s\S]+?)\s+FROM/i);
-      if (sel) {
-        const firstField = sel[1].split(/,(?![^()]*\))/)[0]?.trim();
-        const m = firstField?.match(/^(.+?)\s+(?:AS\s+)?`?([a-z0-9_]+)`?$/i);
-        if (m) {
-          const expr = m[1].trim();
-          const alias = m[2];
-          if (!groupField || alias === groupField) condField = expr;
-        } else if (!groupField) {
-          condField = firstField;
-        }
-      }
-      if (condField) {
-        const rep =
-          typeof groupValue === 'number' ? String(groupValue) : `'${groupValue}'`;
-        const clause = `${condField} = ${rep}`;
-        if (/WHERE/i.test(sql)) {
-          sql = sql.replace(/WHERE/i, `WHERE ${clause} AND `);
-        } else {
-          sql += ` WHERE ${clause}`;
-        }
-      }
+      const rep =
+        typeof groupValue === 'number' ? String(groupValue) : `'${groupValue}'`;
+      sql = `SELECT * FROM (${sql}) AS _raw WHERE ${groupField} = ${rep}`;
     }
 
-    // Trim trailing statement terminators to avoid MySQL complaining when
-    // executing the reconstructed query.
     sql = sql.replace(/;\s*$/, '');
   }
+
+  sql += remainder;
+  sql = sql.replace(/;\s*$/, '');
 
   const file = `${name.replace(/[^a-z0-9_]/gi, '_')}_rows.sql`;
   let content = `-- Original SQL for ${name}\n${originalSql}\n`;

--- a/tests/db/procedureRawRows.test.js
+++ b/tests/db/procedureRawRows.test.js
@@ -23,11 +23,12 @@ function mockPool(createSql) {
 test('getProcedureRawRows expands alias and removes aggregates', async () => {
   const createSql = `CREATE PROCEDURE \`sp_test\`()
 BEGIN
-  SELECT c.name AS category, SUM(t.amount) AS total
+  SELECT c.name AS category, SUM(t.amount) AS total, SUM(t.count) AS cnt
   FROM trans t
   JOIN categories c ON c.id = t.category_id
   WHERE t.date BETWEEN start_date AND end_date
   GROUP BY c.name;
+  SELECT 'after';
 END`;
   const restore = mockPool(createSql);
   const { sql } = await db.getProcedureRawRows(
@@ -39,10 +40,39 @@ END`;
   );
   restore();
   assert.ok(sql.includes('t.amount AS total'));
-  assert.ok(sql.includes("c.name = 'Phones'"));
+  assert.ok(!/\bcnt\b/i.test(sql));
+  assert.ok(sql.includes("category = 'Phones'"));
   assert.ok(sql.includes("'2024-01-01'"));
   assert.ok(!/GROUP BY/i.test(sql));
   assert.ok(!/HAVING/i.test(sql));
   assert.ok(!/SUM\(/i.test(sql));
+  assert.ok(/^SELECT \* FROM \(/i.test(sql));
+  assert.ok(/after/i.test(sql));
   await fs.unlink(path.join(process.cwd(), 'config', 'sp_test_rows.sql')).catch(() => {});
+});
+
+test('getProcedureRawRows handles nested SUM expressions', async () => {
+  const createSql = `CREATE PROCEDURE \`sp_case\`()
+BEGIN
+  SELECT t.id, t.name,
+         SUM(CASE WHEN t.type = 'a' THEN IFNULL(t.val,0) ELSE 0 END) AS a_val,
+         SUM(CASE WHEN t.type = 'b' THEN IFNULL(t.val,0) ELSE 0 END) AS b_val
+  FROM trans t;
+END`;
+  const restore = mockPool(createSql);
+  const { sql } = await db.getProcedureRawRows(
+    'sp_case',
+    {},
+    'b_val',
+    'id',
+    5,
+  );
+  restore();
+  assert.ok(
+    sql.includes("CASE WHEN t.type = 'b' THEN IFNULL(t.val,0) ELSE 0 END AS b_val"),
+  );
+  assert.ok(!/\ba_val\b/i.test(sql));
+  assert.ok(!/SUM\(/i.test(sql));
+  assert.ok(sql.includes("id = 5"));
+  await fs.unlink(path.join(process.cwd(), 'config', 'sp_case_rows.sql')).catch(() => {});
 });


### PR DESCRIPTION
## Summary
- Remove all SUM fields except the clicked column during report drilldown
- Expand the selected aggregate's inner expression while handling nested cases
- Add regression test covering nested SUM(CASE ...) scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897394edf648331a1d4547fbec136e6