### PR TITLE
Include user info in refresh token and rotate on refresh

### DIFF
--- a/api-server/controllers/authController.js
+++ b/api-server/controllers/authController.js
@@ -16,7 +16,11 @@ export async function login(req, res, next) {
       role: user.role,
     });
 
-    const refreshToken = jwtService.signRefresh({ id: user.id });
+    const refreshToken = jwtService.signRefresh({
+      id: user.id,
+      empid: user.empid,
+      role: user.role,
+    });
 
     res.cookie(getCookieName(), token, {
       httpOnly: true,
@@ -87,11 +91,22 @@ export async function refresh(req, res) {
       empid: user.empid,
       role: user.role,
     });
+    const newRefresh = jwtService.signRefresh({
+      id: user.id,
+      empid: user.empid,
+      role: user.role,
+    });
     res.cookie(getCookieName(), newAccess, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
       maxAge: jwtService.getExpiryMillis(),
+    });
+    res.cookie(getRefreshCookieName(), newRefresh, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: jwtService.getRefreshExpiryMillis(),
     });
     res.json({
       id: user.id,

--- a/api-server/middlewares/auth.js
+++ b/api-server/middlewares/auth.js
@@ -5,7 +5,42 @@ import { getCookieName, getRefreshCookieName } from '../utils/cookieNames.js';
 export function requireAuth(req, res, next) {
   // Read from req.cookies (not req.signedCookies) because we didn't sign it
   const token = req.cookies?.[getCookieName()];
+  const rToken = req.cookies?.[getRefreshCookieName()];
+
+  function issueTokens(payload) {
+    const newAccess = jwtService.sign({
+      id: payload.id,
+      empid: payload.empid,
+      role: payload.role,
+    });
+    const newRefresh = jwtService.signRefresh({
+      id: payload.id,
+      empid: payload.empid,
+      role: payload.role,
+    });
+    res.cookie(getCookieName(), newAccess, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: jwtService.getExpiryMillis(),
+    });
+    res.cookie(getRefreshCookieName(), newRefresh, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: jwtService.getRefreshExpiryMillis(),
+    });
+    req.user = jwtService.verify(newAccess);
+  }
+
   if (!token) {
+    if (rToken) {
+      try {
+        const payload = jwtService.verifyRefresh(rToken);
+        issueTokens(payload);
+        return next();
+      } catch {}
+    }
     return res.status(401).json({ message: 'Authentication required' });
   }
 
@@ -13,31 +48,15 @@ export function requireAuth(req, res, next) {
     // Verify the JWT
     const payload = jwtService.verify(token);
     req.user = payload; // { id, empid, role, iat, exp }
-    next();
+    return next();
   } catch (err) {
-    let refreshed = false;
-    if (err.name === 'TokenExpiredError') {
-      const rToken = req.cookies?.[getRefreshCookieName()];
-      if (rToken) {
-        try {
-          const rPayload = jwtService.verifyRefresh(rToken);
-          const newAccess = jwtService.sign({
-            id: rPayload.id,
-            empid: rPayload.empid,
-            role: rPayload.role,
-          });
-          res.cookie(getCookieName(), newAccess, {
-            httpOnly: true,
-            secure: process.env.NODE_ENV === 'production',
-            sameSite: 'lax',
-            maxAge: jwtService.getExpiryMillis(),
-          });
-          req.user = jwtService.verify(newAccess);
-          refreshed = true;
-        } catch {}
-      }
+    if (err.name === 'TokenExpiredError' && rToken) {
+      try {
+        const payload = jwtService.verifyRefresh(rToken);
+        issueTokens(payload);
+        return next();
+      } catch {}
     }
-    if (refreshed) return next();
 
     console.error('JWT verification failed:', err);
     const opts = {


### PR DESCRIPTION
## Summary
- ensure refresh tokens carry id, empid and role
- rotate refresh token alongside access token during automatic and manual refresh
- refresh session when access token cookie has expired

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897037a74cc83319682d356b549780f