### PR TITLE
Filter unrelated aggregates when drilling into report cells

### DIFF
--- a/api-server/routes/procedures.js
+++ b/api-server/routes/procedures.js
@@ -49,7 +49,7 @@ router.post('/raw', requireAuth, async (req, res, next) => {
     const { name, params, column, groupField, groupValue, session } = req.body || {};
     if (!name || !column)
       return res.status(400).json({ message: 'name and column required' });
-    const { rows, sql, original, file } = await getProcedureRawRows(
+    const { rows, sql, original, file, displayFields } = await getProcedureRawRows(
       name,
       params || {},
       column,
@@ -57,7 +57,7 @@ router.post('/raw', requireAuth, async (req, res, next) => {
       groupValue,
       { ...(session || {}), empid: req.user?.empid },
     );
-    res.json({ rows, sql, original, file });
+    res.json({ rows, sql, original, file, displayFields });
   } catch (err) {
     next(err);
   }

--- a/db/index.js
+++ b/db/index.js
@@ -1130,34 +1130,79 @@ export async function getProcedureRawRows(
   function escapeRegExp(s) {
     return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
-  const selectMatches = [...body.matchAll(/SELECT[\s\S]*?(?=;|END|$)/gi)];
-  const colRegex = new RegExp(`\\b${escapeRegExp(column)}\\b`, 'i');
-  let sql = '';
-  for (const m of selectMatches) {
-    if (colRegex.test(m[0])) {
-      sql = m[0];
-      break;
-    }
-  }
-  if (!sql && selectMatches.length) {
-    sql = selectMatches[selectMatches.length - 1][0];
-  }
-  if (!sql) {
-    sql = createSql;
-  }
-
+  const firstSelectIdx = body.search(/SELECT/i);
+  let sql = firstSelectIdx === -1 ? createSql : body.slice(firstSelectIdx);
   const originalSql = sql;
+  let remainder = '';
+  let displayFields = [];
+  const firstSemi = sql.indexOf(';');
+  if (firstSemi !== -1) {
+    remainder = sql.slice(firstSemi);
+    sql = sql.slice(0, firstSemi);
+  }
 
   if (/^SELECT/i.test(sql)) {
-    const colRe = escapeRegExp(column);
-    const sumRegex = new RegExp(
-      `SUM\\(([^)]*)\\)\\s*(?:AS\\s+)?` + '`?' + colRe + '`?',
-      'i',
-    );
-    const sumMatch = sql.match(sumRegex);
-    if (sumMatch) {
-      sql = sql.replace(sumRegex, `${sumMatch[1]} AS ${column}`);
+    function filterAggregates(input, aliasToKeep) {
+      const upper = input.toUpperCase();
+      // find FROM at top level
+      let depth = 0;
+      let fromIdx = -1;
+      for (let i = 0; i < upper.length; i++) {
+        const ch = upper[i];
+        if (ch === '(') depth++;
+        else if (ch === ')') depth--;
+        else if (depth === 0 && upper.startsWith('FROM', i)) {
+          fromIdx = i;
+          break;
+        }
+      }
+      if (fromIdx === -1) return input;
+      const fieldsPart = input.slice(6, fromIdx);
+      const rest = input.slice(fromIdx);
+      const fields = [];
+      let buf = '';
+      depth = 0;
+      for (let i = 0; i < fieldsPart.length; i++) {
+        const ch = fieldsPart[i];
+        if (ch === '(') depth++;
+        else if (ch === ')') depth--;
+        if (ch === ',' && depth === 0) {
+          fields.push(buf.trim());
+          buf = '';
+        } else {
+          buf += ch;
+        }
+      }
+      if (buf.trim()) fields.push(buf.trim());
+      const kept = [];
+      for (let field of fields) {
+        const sumIdx = field.toUpperCase().indexOf('SUM(');
+        if (sumIdx === -1) {
+          kept.push(field);
+          continue;
+        }
+        const aliasMatch = field.match(/(?:AS\s+)?`?([a-zA-Z0-9_]+)`?\s*$/i);
+        const alias = aliasMatch ? aliasMatch[1] : null;
+        if (alias && alias.toLowerCase() === String(aliasToKeep).toLowerCase()) {
+          let start = sumIdx + 4;
+          let depth2 = 1;
+          let j = start;
+          while (j < field.length && depth2 > 0) {
+            const ch2 = field[j];
+            if (ch2 === '(') depth2++;
+            else if (ch2 === ')') depth2--;
+            j++;
+          }
+          const inner = field.slice(start, j - 1);
+          field = field.slice(0, sumIdx) + inner + field.slice(j);
+          kept.push(field.trim());
+        }
+      }
+      if (!kept.length) return input;
+      return 'SELECT ' + kept.join(', ') + ' ' + rest;
     }
+
+    sql = filterAggregates(sql, column);
 
     sql = sql.replace(/GROUP BY[\s\S]*?(HAVING|ORDER BY|$)/i, '$1');
     sql = sql.replace(/HAVING[\s\S]*?(ORDER BY|$)/i, '$1');
@@ -1188,36 +1233,106 @@ export async function getProcedureRawRows(
       }
     }
 
-    if (groupValue !== undefined) {
-      let condField = groupField;
-      const sel = sql.match(/SELECT\s+([\s\S]+?)\s+FROM/i);
-      if (sel) {
-        const firstField = sel[1].split(/,(?![^()]*\))/)[0]?.trim();
-        const m = firstField?.match(/^(.+?)\s+(?:AS\s+)?`?([a-z0-9_]+)`?$/i);
+    sql = sql.replace(/;\s*$/, '');
+
+    const fromIdx = (() => {
+      const upper = sql.toUpperCase();
+      let depth = 0;
+      for (let i = 0; i < upper.length; i++) {
+        const ch = upper[i];
+        if (ch === '(') depth++;
+        else if (ch === ')') depth--;
+        else if (depth === 0 && upper.startsWith('FROM', i)) return i;
+      }
+      return -1;
+    })();
+    if (fromIdx !== -1) {
+      const fieldsPart = sql.slice(6, fromIdx);
+      const rest = sql.slice(fromIdx);
+      const afterFrom = rest.slice(4).trimStart();
+      let table = '';
+      let alias = '';
+      if (afterFrom.startsWith('(')) {
+        let depth = 1;
+        let i = 1;
+        while (i < afterFrom.length && depth > 0) {
+          const ch = afterFrom[i];
+          if (ch === '(') depth++;
+          else if (ch === ')') depth--;
+          i++;
+        }
+        const sub = afterFrom.slice(1, i - 1);
+        const aliasMatch = afterFrom.slice(i).match(/^\s*([a-zA-Z0-9_]+)/);
+        alias = aliasMatch ? aliasMatch[1] : '';
+        const tableMatch = sub.match(/FROM\s+`?([a-zA-Z0-9_]+)`?/i);
+        table = tableMatch ? tableMatch[1] : '';
+      } else {
+        const m = afterFrom.match(/`?([a-zA-Z0-9_]+)`?(?:\s+(?:AS\s+)?([a-zA-Z0-9_]+))?/i);
         if (m) {
-          const expr = m[1].trim();
-          const alias = m[2];
-          if (!groupField || alias === groupField) condField = expr;
-        } else if (!groupField) {
-          condField = firstField;
+          table = m[1];
+          alias = m[2] || m[1];
         }
       }
-      if (condField) {
-        const rep =
-          typeof groupValue === 'number' ? String(groupValue) : `'${groupValue}'`;
-        const clause = `${condField} = ${rep}`;
-        if (/WHERE/i.test(sql)) {
-          sql = sql.replace(/WHERE/i, `WHERE ${clause} AND `);
-        } else {
-          sql += ` WHERE ${clause}`;
-        }
+      if (table) {
+        const prefix = alias ? `${alias}.` : '';
+        try {
+          const txt = await fs.readFile(
+            path.join(process.cwd(), 'config', 'transactionForms.json'),
+            'utf8',
+          );
+          const cfg = JSON.parse(txt);
+          const set = new Set();
+          for (const [tblKey, forms] of Object.entries(cfg)) {
+            for (const info of Object.values(forms || {})) {
+              const main = Array.isArray(info?.mainFields)
+                ? info.mainFields.map(String)
+                : [];
+              if (
+                tblKey === table ||
+                main.some((f) => String(f) === String(table))
+              ) {
+                if (Array.isArray(info.visibleFields)) {
+                  for (const f of info.visibleFields) set.add(String(f));
+                }
+              }
+            }
+          }
+          const add = [];
+          for (const f of set) {
+            if (!new RegExp(`\\b${escapeRegExp(f)}\\b`, 'i').test(fieldsPart)) {
+              add.push(prefix + f);
+            }
+          }
+          if (add.length) {
+            const fp = fieldsPart.trim();
+            const newFields = fp ? fp + ', ' + add.join(', ') : add.join(', ');
+            sql = 'SELECT ' + newFields + ' ' + rest;
+          }
+        } catch {}
+        try {
+          const dfTxt = await fs.readFile(
+            path.join(process.cwd(), 'config', 'tableDisplayFields.json'),
+            'utf8',
+          );
+          const dfCfg = JSON.parse(dfTxt);
+          if (dfCfg[table] && Array.isArray(dfCfg[table].displayFields)) {
+            displayFields = dfCfg[table].displayFields.map(String);
+          }
+        } catch {}
       }
     }
 
-    // Trim trailing statement terminators to avoid MySQL complaining when
-    // executing the reconstructed query.
+    if (groupValue !== undefined) {
+      const rep =
+        typeof groupValue === 'number' ? String(groupValue) : `'${groupValue}'`;
+      sql = `SELECT * FROM (${sql}) AS _raw WHERE ${groupField} = ${rep}`;
+    }
+
     sql = sql.replace(/;\s*$/, '');
   }
+
+  sql += remainder;
+  sql = sql.replace(/;\s*$/, '');
 
   const file = `${name.replace(/[^a-z0-9_]/gi, '_')}_rows.sql`;
   let content = `-- Original SQL for ${name}\n${originalSql}\n`;
@@ -1228,8 +1343,8 @@ export async function getProcedureRawRows(
 
   try {
     const [out] = await pool.query(sql);
-    return { rows: out, sql, original: originalSql, file };
+    return { rows: out, sql, original: originalSql, file, displayFields };
   } catch {
-    return { rows: [], sql, original: originalSql, file };
+    return { rows: [], sql, original: originalSql, file, displayFields };
   }
 }

--- a/tests/db/procedureRawRows.test.js
+++ b/tests/db/procedureRawRows.test.js
@@ -20,14 +20,15 @@ function mockPool(createSql) {
   };
 }
 
-test('getProcedureRawRows expands alias and removes aggregates', async () => {
+test('getProcedureRawRows expands alias and removes aggregates', { concurrency: false }, async () => {
   const createSql = `CREATE PROCEDURE \`sp_test\`()
 BEGIN
-  SELECT c.name AS category, SUM(t.amount) AS total
+  SELECT c.name AS category, SUM(t.amount) AS total, SUM(t.count) AS cnt
   FROM trans t
   JOIN categories c ON c.id = t.category_id
   WHERE t.date BETWEEN start_date AND end_date
   GROUP BY c.name;
+  SELECT 'after';
 END`;
   const restore = mockPool(createSql);
   const { sql } = await db.getProcedureRawRows(
@@ -39,10 +40,88 @@ END`;
   );
   restore();
   assert.ok(sql.includes('t.amount AS total'));
-  assert.ok(sql.includes("c.name = 'Phones'"));
+  assert.ok(!/\bcnt\b/i.test(sql));
+  assert.ok(sql.includes("category = 'Phones'"));
   assert.ok(sql.includes("'2024-01-01'"));
   assert.ok(!/GROUP BY/i.test(sql));
   assert.ok(!/HAVING/i.test(sql));
   assert.ok(!/SUM\(/i.test(sql));
+  assert.ok(/^SELECT \* FROM \(/i.test(sql));
+  assert.ok(/after/i.test(sql));
   await fs.unlink(path.join(process.cwd(), 'config', 'sp_test_rows.sql')).catch(() => {});
 });
+
+test('getProcedureRawRows handles nested SUM expressions', { concurrency: false }, async () => {
+  const createSql = `CREATE PROCEDURE \`sp_case\`()
+BEGIN
+  SELECT t.id, t.name,
+         SUM(CASE WHEN t.type = 'a' THEN IFNULL(t.val,0) ELSE 0 END) AS a_val,
+         SUM(CASE WHEN t.type = 'b' THEN IFNULL(t.val,0) ELSE 0 END) AS b_val
+  FROM trans t;
+END`;
+  const restore = mockPool(createSql);
+  const { sql } = await db.getProcedureRawRows(
+    'sp_case',
+    {},
+    'b_val',
+    'id',
+    5,
+  );
+  restore();
+  assert.ok(
+    sql.includes("CASE WHEN t.type = 'b' THEN IFNULL(t.val,0) ELSE 0 END AS b_val"),
+  );
+  assert.ok(!/\ba_val\b/i.test(sql));
+  assert.ok(!/SUM\(/i.test(sql));
+  assert.ok(sql.includes("id = 5"));
+  await fs.unlink(path.join(process.cwd(), 'config', 'sp_case_rows.sql')).catch(() => {});
+});
+
+test(
+  'getProcedureRawRows appends visibleFields from all configs and returns displayFields',
+  { concurrency: false },
+  async () => {
+    const origRead = fs.readFile;
+    fs.readFile = async (p, enc) => {
+      if (p.endsWith(path.join('config', 'transactionForms.json'))) {
+        return JSON.stringify({
+          Foo: {
+            A: { mainFields: ['trans'], visibleFields: ['id', 'note'] },
+          },
+          Bar: {
+            B: { mainFields: ['trans'], visibleFields: ['date', 'note'] },
+          },
+        });
+      }
+      if (p.endsWith(path.join('config', 'tableDisplayFields.json'))) {
+        return JSON.stringify({
+          trans: { idField: 'id', displayFields: ['id', 'note', 'date'] },
+        });
+      }
+      return origRead(p, enc);
+    };
+    const createSql = `CREATE PROCEDURE \`sp_vis\`()
+BEGIN
+  SELECT tr.category, SUM(tr.amount) AS total
+  FROM (SELECT * FROM trans) tr
+  GROUP BY tr.category;
+END`;
+    const restore = mockPool(createSql);
+    const { sql, displayFields } = await db.getProcedureRawRows(
+      'sp_vis',
+      {},
+      'total',
+      'category',
+      'Phones',
+    );
+    restore();
+    fs.readFile = origRead;
+    assert.ok(sql.includes('tr.id'));
+    assert.ok(sql.includes('tr.note'));
+    assert.ok(sql.includes('tr.date'));
+    assert.deepEqual(displayFields, ['id', 'note', 'date']);
+    await fs
+      .unlink(path.join(process.cwd(), 'config', 'sp_vis_rows.sql'))
+      .catch(() => {});
+  },
+);


### PR DESCRIPTION
## Summary
- Remove all SUM fields except the clicked column during report drilldown
- Expand the selected aggregate's inner expression while handling nested cases
- Append unique visible fields from transaction configuration to drilldown queries
- Detect the primary table's alias and prefix appended fields accordingly
- Include table display-field settings so drilldown modals match table view style

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897394edf648331a1d4547fbec136e6