### PR TITLE
Translate report headers and allow raw conditions

### DIFF
--- a/api-server/routes/procedures.js
+++ b/api-server/routes/procedures.js
@@ -49,7 +49,7 @@ router.post('/raw', requireAuth, async (req, res, next) => {
     const { name, params, column, groupField, groupValue, session } = req.body || {};
     if (!name || !column)
       return res.status(400).json({ message: 'name and column required' });
-    const { rows, sql, original, file } = await getProcedureRawRows(
+    const { rows, sql, original, file, displayFields } = await getProcedureRawRows(
       name,
       params || {},
       column,
@@ -57,7 +57,7 @@ router.post('/raw', requireAuth, async (req, res, next) => {
       groupValue,
       { ...(session || {}), empid: req.user?.empid },
     );
-    res.json({ rows, sql, original, file });
+    res.json({ rows, sql, original, file, displayFields });
   } catch (err) {
     next(err);
   }

--- a/api-server/routes/report_builder.js
+++ b/api-server/routes/report_builder.js
@@ -4,7 +4,7 @@ import fs from 'fs/promises';
 import { requireAuth } from '../middlewares/auth.js';
 import {
   listDatabaseTables,
-  listTableColumns,
+  listTableColumnsDetailed,
   saveStoredProcedure,
   saveView,
 } from '../../db/index.js';
@@ -28,7 +28,7 @@ router.get('/fields', requireAuth, async (req, res, next) => {
   try {
     const { table } = req.query;
     if (!table) return res.status(400).json({ message: 'table required' });
-    const fields = await listTableColumns(table);
+    const fields = await listTableColumnsDetailed(table);
     res.json({ fields });
   } catch (err) {
     next(err);

--- a/db/index.js
+++ b/db/index.js
@@ -566,6 +566,26 @@ export async function listTableColumns(tableName) {
   return rows.map((r) => r.COLUMN_NAME);
 }
 
+export async function listTableColumnsDetailed(tableName) {
+  const [rows] = await pool.query(
+    `SELECT COLUMN_NAME, COLUMN_TYPE
+       FROM information_schema.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = ?
+      ORDER BY ORDINAL_POSITION`,
+    [tableName],
+  );
+  return rows.map((r) => ({
+    name: r.COLUMN_NAME,
+    enumValues: /^enum\(/i.test(r.COLUMN_TYPE)
+      ? r.COLUMN_TYPE
+          .slice(5, -1)
+          .split(',')
+          .map((v) => v.trim().slice(1, -1))
+      : [],
+  }));
+}
+
 export async function saveStoredProcedure(sql) {
   const cleaned = sql
     .replace(/^DELIMITER \$\$/gm, '')
@@ -1130,34 +1150,79 @@ export async function getProcedureRawRows(
   function escapeRegExp(s) {
     return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
-  const selectMatches = [...body.matchAll(/SELECT[\s\S]*?(?=;|END|$)/gi)];
-  const colRegex = new RegExp(`\\b${escapeRegExp(column)}\\b`, 'i');
-  let sql = '';
-  for (const m of selectMatches) {
-    if (colRegex.test(m[0])) {
-      sql = m[0];
-      break;
-    }
-  }
-  if (!sql && selectMatches.length) {
-    sql = selectMatches[selectMatches.length - 1][0];
-  }
-  if (!sql) {
-    sql = createSql;
-  }
-
+  const firstSelectIdx = body.search(/SELECT/i);
+  let sql = firstSelectIdx === -1 ? createSql : body.slice(firstSelectIdx);
   const originalSql = sql;
+  let remainder = '';
+  let displayFields = [];
+  const firstSemi = sql.indexOf(';');
+  if (firstSemi !== -1) {
+    remainder = sql.slice(firstSemi);
+    sql = sql.slice(0, firstSemi);
+  }
 
   if (/^SELECT/i.test(sql)) {
-    const colRe = escapeRegExp(column);
-    const sumRegex = new RegExp(
-      `SUM\\(([^)]*)\\)\\s*(?:AS\\s+)?` + '`?' + colRe + '`?',
-      'i',
-    );
-    const sumMatch = sql.match(sumRegex);
-    if (sumMatch) {
-      sql = sql.replace(sumRegex, `${sumMatch[1]} AS ${column}`);
+    function filterAggregates(input, aliasToKeep) {
+      const upper = input.toUpperCase();
+      // find FROM at top level
+      let depth = 0;
+      let fromIdx = -1;
+      for (let i = 0; i < upper.length; i++) {
+        const ch = upper[i];
+        if (ch === '(') depth++;
+        else if (ch === ')') depth--;
+        else if (depth === 0 && upper.startsWith('FROM', i)) {
+          fromIdx = i;
+          break;
+        }
+      }
+      if (fromIdx === -1) return input;
+      const fieldsPart = input.slice(6, fromIdx);
+      const rest = input.slice(fromIdx);
+      const fields = [];
+      let buf = '';
+      depth = 0;
+      for (let i = 0; i < fieldsPart.length; i++) {
+        const ch = fieldsPart[i];
+        if (ch === '(') depth++;
+        else if (ch === ')') depth--;
+        if (ch === ',' && depth === 0) {
+          fields.push(buf.trim());
+          buf = '';
+        } else {
+          buf += ch;
+        }
+      }
+      if (buf.trim()) fields.push(buf.trim());
+      const kept = [];
+      for (let field of fields) {
+        const sumIdx = field.toUpperCase().indexOf('SUM(');
+        if (sumIdx === -1) {
+          kept.push(field);
+          continue;
+        }
+        const aliasMatch = field.match(/(?:AS\s+)?`?([a-zA-Z0-9_]+)`?\s*$/i);
+        const alias = aliasMatch ? aliasMatch[1] : null;
+        if (alias && alias.toLowerCase() === String(aliasToKeep).toLowerCase()) {
+          let start = sumIdx + 4;
+          let depth2 = 1;
+          let j = start;
+          while (j < field.length && depth2 > 0) {
+            const ch2 = field[j];
+            if (ch2 === '(') depth2++;
+            else if (ch2 === ')') depth2--;
+            j++;
+          }
+          const inner = field.slice(start, j - 1);
+          field = field.slice(0, sumIdx) + inner + field.slice(j);
+          kept.push(field.trim());
+        }
+      }
+      if (!kept.length) return input;
+      return 'SELECT ' + kept.join(', ') + ' ' + rest;
     }
+
+    sql = filterAggregates(sql, column);
 
     sql = sql.replace(/GROUP BY[\s\S]*?(HAVING|ORDER BY|$)/i, '$1');
     sql = sql.replace(/HAVING[\s\S]*?(ORDER BY|$)/i, '$1');
@@ -1188,36 +1253,111 @@ export async function getProcedureRawRows(
       }
     }
 
-    if (groupValue !== undefined) {
-      let condField = groupField;
-      const sel = sql.match(/SELECT\s+([\s\S]+?)\s+FROM/i);
-      if (sel) {
-        const firstField = sel[1].split(/,(?![^()]*\))/)[0]?.trim();
-        const m = firstField?.match(/^(.+?)\s+(?:AS\s+)?`?([a-z0-9_]+)`?$/i);
+    sql = sql.replace(/;\s*$/, '');
+
+    const fromIdx = (() => {
+      const upper = sql.toUpperCase();
+      let depth = 0;
+      for (let i = 0; i < upper.length; i++) {
+        const ch = upper[i];
+        if (ch === '(') depth++;
+        else if (ch === ')') depth--;
+        else if (depth === 0 && upper.startsWith('FROM', i)) return i;
+      }
+      return -1;
+    })();
+    if (fromIdx !== -1) {
+      const fieldsPart = sql.slice(6, fromIdx);
+      const rest = sql.slice(fromIdx);
+      const afterFrom = rest.slice(4).trimStart();
+      let table = '';
+      let alias = '';
+      if (afterFrom.startsWith('(')) {
+        let depth = 1;
+        let i = 1;
+        while (i < afterFrom.length && depth > 0) {
+          const ch = afterFrom[i];
+          if (ch === '(') depth++;
+          else if (ch === ')') depth--;
+          i++;
+        }
+        const sub = afterFrom.slice(1, i - 1);
+        const aliasMatch = afterFrom.slice(i).match(/^\s*([a-zA-Z0-9_]+)/);
+        alias = aliasMatch ? aliasMatch[1] : '';
+        const tableMatch = sub.match(/FROM\s+`?([a-zA-Z0-9_]+)`?/i);
+        table = tableMatch ? tableMatch[1] : '';
+      } else {
+        const m = afterFrom.match(/`?([a-zA-Z0-9_]+)`?(?:\s+(?:AS\s+)?([a-zA-Z0-9_]+))?/i);
         if (m) {
-          const expr = m[1].trim();
-          const alias = m[2];
-          if (!groupField || alias === groupField) condField = expr;
-        } else if (!groupField) {
-          condField = firstField;
+          table = m[1];
+          alias = m[2] || m[1];
         }
       }
-      if (condField) {
-        const rep =
-          typeof groupValue === 'number' ? String(groupValue) : `'${groupValue}'`;
-        const clause = `${condField} = ${rep}`;
-        if (/WHERE/i.test(sql)) {
-          sql = sql.replace(/WHERE/i, `WHERE ${clause} AND `);
-        } else {
-          sql += ` WHERE ${clause}`;
-        }
+      if (table) {
+        const prefix = alias ? `${alias}.` : '';
+        try {
+          const txt = await fs.readFile(
+            path.join(process.cwd(), 'config', 'transactionForms.json'),
+            'utf8',
+          );
+          const cfg = JSON.parse(txt);
+          const set = new Set();
+
+          function collect(obj) {
+            if (!obj || typeof obj !== 'object') return;
+            ['visibleFields', 'headerFields', 'mainFields', 'footerFields'].forEach(
+              (key) => {
+                if (Array.isArray(obj[key])) {
+                  for (const f of obj[key]) set.add(String(f));
+                }
+              },
+            );
+            for (const val of Object.values(obj)) {
+              if (val && typeof val === 'object' && !Array.isArray(val)) {
+                collect(val);
+              }
+            }
+          }
+
+          if (cfg[table]) {
+            collect(cfg[table]);
+          }
+          const add = [];
+          for (const f of set) {
+            if (!new RegExp(`\\b${escapeRegExp(f)}\\b`, 'i').test(fieldsPart)) {
+              add.push(prefix + f);
+            }
+          }
+          if (add.length) {
+            const fp = fieldsPart.trim();
+            const newFields = fp ? fp + ', ' + add.join(', ') : add.join(', ');
+            sql = 'SELECT ' + newFields + ' ' + rest;
+          }
+        } catch {}
+        try {
+          const dfTxt = await fs.readFile(
+            path.join(process.cwd(), 'config', 'tableDisplayFields.json'),
+            'utf8',
+          );
+          const dfCfg = JSON.parse(dfTxt);
+          if (dfCfg[table] && Array.isArray(dfCfg[table].displayFields)) {
+            displayFields = dfCfg[table].displayFields.map(String);
+          }
+        } catch {}
       }
     }
 
-    // Trim trailing statement terminators to avoid MySQL complaining when
-    // executing the reconstructed query.
+    if (groupValue !== undefined) {
+      const rep =
+        typeof groupValue === 'number' ? String(groupValue) : `'${groupValue}'`;
+      sql = `SELECT * FROM (${sql}) AS _raw WHERE ${groupField} = ${rep}`;
+    }
+
     sql = sql.replace(/;\s*$/, '');
   }
+
+  sql += remainder;
+  sql = sql.replace(/;\s*$/, '');
 
   const file = `${name.replace(/[^a-z0-9_]/gi, '_')}_rows.sql`;
   let content = `-- Original SQL for ${name}\n${originalSql}\n`;
@@ -1228,8 +1368,8 @@ export async function getProcedureRawRows(
 
   try {
     const [out] = await pool.query(sql);
-    return { rows: out, sql, original: originalSql, file };
+    return { rows: out, sql, original: originalSql, file, displayFields };
   } catch {
-    return { rows: [], sql, original: originalSql, file };
+    return { rows: [], sql, original: originalSql, file, displayFields };
   }
 }

--- a/src/erp.mgt.mn/pages/ReportBuilder.jsx
+++ b/src/erp.mgt.mn/pages/ReportBuilder.jsx
@@ -16,6 +16,7 @@ const CALC_OPERATORS = ['+', '-', '*', '/'];
 export default function ReportBuilder() {
   const [tables, setTables] = useState([]); // list of table names
   const [tableFields, setTableFields] = useState({}); // { tableName: [field, ...] }
+  const [fieldEnums, setFieldEnums] = useState({}); // { tableName: { field: [enum] } }
 
   const [procName, setProcName] = useState('');
   const [fromTable, setFromTable] = useState('');
@@ -27,6 +28,7 @@ export default function ReportBuilder() {
   const [params, setParams] = useState([]); // {name,type,source}
   const [conditions, setConditions] = useState([]); // {table,field,param,connector}
   const [fromFilters, setFromFilters] = useState([]); // {field,operator,valueType,param,value,connector}
+  const [unions, setUnions] = useState([]); // [table]
   const [selectSql, setSelectSql] = useState('');
   const [viewSql, setViewSql] = useState('');
   const [procSql, setProcSql] = useState('');
@@ -83,7 +85,13 @@ export default function ReportBuilder() {
         `/api/report_builder/fields?table=${encodeURIComponent(table)}`,
       );
       const data = await res.json();
-      setTableFields((prev) => ({ ...prev, [table]: data.fields || [] }));
+      const names = (data.fields || []).map((f) => f.name || f);
+      const enums = {};
+      (data.fields || []).forEach((f) => {
+        enums[f.name || f] = f.enumValues || [];
+      });
+      setTableFields((prev) => ({ ...prev, [table]: names }));
+      setFieldEnums((prev) => ({ ...prev, [table]: enums }));
     } catch (err) {
       console.error(err);
     }
@@ -99,6 +107,24 @@ export default function ReportBuilder() {
       })),
     );
   }, [fromTable]);
+
+  useEffect(() => {
+    const auto = fields
+      .filter((f) => f.aggregate === 'NONE' && f.table && f.field)
+      .map((f) => ({ table: f.table, field: f.field }));
+    setGroups((prev) => {
+      const map = new Map(prev.map((g) => [`${g.table}.${g.field}`, g]));
+      let changed = false;
+      auto.forEach((g) => {
+        const key = `${g.table}.${g.field}`;
+        if (!map.has(key)) {
+          map.set(key, g);
+          changed = true;
+        }
+      });
+      return changed ? Array.from(map.values()) : prev;
+    });
+  }, [fields]);
 
   const availableTables = [fromTable, ...joins.map((j) => j.table)].filter(Boolean);
 
@@ -451,6 +477,10 @@ export default function ReportBuilder() {
     ]);
   }
 
+  function addRawCondition() {
+    setConditions([...conditions, { raw: '', connector: 'AND' }]);
+  }
+
   function updateCondition(index, key, value) {
     const updated = conditions.map((c, i) => (i === index ? { ...c, [key]: value } : c));
     setConditions(updated);
@@ -485,6 +515,21 @@ export default function ReportBuilder() {
 
   function removeFromFilter(index) {
     setFromFilters(fromFilters.filter((_, i) => i !== index));
+  }
+
+  function addUnion() {
+    const remaining = tables.filter((t) => t !== fromTable);
+    const table = remaining[0] || tables[0];
+    if (!table) return;
+    setUnions([...unions, table]);
+  }
+
+  function updateUnion(index, value) {
+    setUnions(unions.map((u, i) => (i === index ? value : u)));
+  }
+
+  function removeUnion(index) {
+    setUnions(unions.filter((_, i) => i !== index));
   }
 
   function addJoinFilter(jIndex) {
@@ -606,6 +651,30 @@ export default function ReportBuilder() {
           return { expr, alias: f.alias || undefined };
         }
         if (f.aggregate && f.aggregate !== 'NONE' && f.source === 'field') {
+          if (f.aggregate === 'COUNT') {
+            if (f.conditions?.length) {
+              const cond = f.conditions
+                .filter((c) => c.field && (c.valueType === 'param' ? c.param : c.value))
+                .map((c, idx) => {
+                  if (!validTables.has(c.table)) {
+                    throw new Error(`Table ${c.table} is not joined`);
+                  }
+                  const connector = idx > 0 ? ` ${c.connector} ` : '';
+                  const right = c.valueType === 'param' ? `:${c.param}` : c.value;
+                  return (
+                    connector +
+                    `(${aliases[c.table]}.${c.field} ${c.operator} ${right})`
+                  );
+                })
+                .join('');
+              const expr = `SUM(CASE WHEN ${cond} THEN 1 ELSE 0 END)`;
+              if (f.alias) fieldExprMap[f.alias] = expr;
+              return { expr, alias: f.alias || undefined };
+            }
+            const expr = 'COUNT(*)';
+            if (f.alias) fieldExprMap[f.alias] = expr;
+            return { expr, alias: f.alias || undefined };
+          }
           if (f.conditions?.length) {
             const cond = f.conditions
               .filter((c) => c.field && (c.valueType === 'param' ? c.param : c.value))
@@ -614,8 +683,7 @@ export default function ReportBuilder() {
                   throw new Error(`Table ${c.table} is not joined`);
                 }
                 const connector = idx > 0 ? ` ${c.connector} ` : '';
-                const right =
-                  c.valueType === 'param' ? `:${c.param}` : c.value;
+                const right = c.valueType === 'param' ? `:${c.param}` : c.value;
                 return (
                   connector +
                   `(${aliases[c.table]}.${c.field} ${c.operator} ${right})`
@@ -640,8 +708,11 @@ export default function ReportBuilder() {
       : fromTable;
 
     const where = conditions
-      .filter((c) => c.table && c.field && c.param)
+      .filter((c) => c.raw || (c.table && c.field && c.param))
       .map((c) => {
+        if (c.raw) {
+          return { expr: c.raw, connector: c.connector };
+        }
         if (!validTables.has(c.table)) {
           throw new Error(`Table ${c.table} is not joined`);
         }
@@ -674,6 +745,8 @@ export default function ReportBuilder() {
         return { expr: `${left} ${h.operator} ${right}`, connector: h.connector };
       });
 
+    const unionTables = unions.filter((t) => t && t !== fromTable);
+
     const report = {
       from: { table: fromTableSql, alias: aliases[fromTable] },
       joins: joinDefs,
@@ -681,6 +754,7 @@ export default function ReportBuilder() {
       where,
       groupBy,
       having: havingDefs,
+      unions: unionTables,
     };
 
     return { report, params: params.map(({ name, type }) => ({ name, type })) };
@@ -788,6 +862,7 @@ export default function ReportBuilder() {
       params,
       conditions,
       fromFilters,
+      unions,
     };
     try {
       const name = procName || 'report';
@@ -866,6 +941,7 @@ export default function ReportBuilder() {
           })),
         );
         setGroups(data.groups || []);
+        setUnions(data.unions || []);
         setHaving(
           (data.having || []).map((h) => ({
             connector: h.connector || 'AND',
@@ -1010,6 +1086,19 @@ export default function ReportBuilder() {
                 {params.map((p) => (
                   <option key={p.name} value={p.name}>
                     {p.name}
+                  </option>
+                ))}
+              </select>
+            ) : fieldEnums[fromTable]?.[f.field]?.length ? (
+              <select
+                value={f.value}
+                onChange={(e) => updateFromFilter(i, 'value', e.target.value)}
+                style={{ marginLeft: '0.5rem' }}
+              >
+                <option value=""></option>
+                {fieldEnums[fromTable][f.field].map((v) => (
+                  <option key={v} value={v}>
+                    {v}
                   </option>
                 ))}
               </select>
@@ -1186,6 +1275,19 @@ export default function ReportBuilder() {
                       {params.map((p) => (
                         <option key={p.name} value={p.name}>
                           {p.name}
+                        </option>
+                      ))}
+                    </select>
+                  ) : fieldEnums[j.table]?.[f.field]?.length ? (
+                    <select
+                      value={f.value}
+                      onChange={(e) => updateJoinFilter(i, k, 'value', e.target.value)}
+                      style={{ marginLeft: '0.5rem' }}
+                    >
+                      <option value=""></option>
+                      {fieldEnums[j.table][f.field].map((v) => (
+                        <option key={v} value={v}>
+                          {v}
                         </option>
                       ))}
                     </select>
@@ -1461,6 +1563,21 @@ export default function ReportBuilder() {
                           </option>
                         ))}
                       </select>
+                    ) : fieldEnums[c.table]?.[c.field]?.length ? (
+                      <select
+                        value={c.value}
+                        onChange={(e) =>
+                          updateFieldCondition(i, k, 'value', e.target.value)
+                        }
+                        style={{ marginLeft: '0.5rem' }}
+                      >
+                        <option value=""></option>
+                        {fieldEnums[c.table][c.field].map((v) => (
+                          <option key={v} value={v}>
+                            {v}
+                          </option>
+                        ))}
+                      </select>
                     ) : (
                       <input
                         value={c.value}
@@ -1631,6 +1748,19 @@ export default function ReportBuilder() {
                   </option>
                 ))}
               </select>
+            ) : h.source === 'field' && fieldEnums[h.table]?.[h.field]?.length ? (
+              <select
+                value={h.value}
+                onChange={(e) => updateHaving(i, 'value', e.target.value)}
+                style={{ marginLeft: '0.5rem' }}
+              >
+                <option value=""></option>
+                {fieldEnums[h.table][h.field].map((v) => (
+                  <option key={v} value={v}>
+                    {v}
+                  </option>
+                ))}
+              </select>
             ) : (
               <input
                 value={h.value}
@@ -1647,6 +1777,25 @@ export default function ReportBuilder() {
           </div>
         ))}
         <button onClick={addHaving}>Add Having</button>
+      </section>
+
+      <section>
+        <h3>Union Tables</h3>
+        {unions.map((u, i) => (
+          <div key={i} style={{ marginBottom: '0.5rem' }}>
+            <select value={u} onChange={(e) => updateUnion(i, e.target.value)}>
+              {tables.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+            <button onClick={() => removeUnion(i)} style={{ marginLeft: '0.5rem' }}>
+              ✕
+            </button>
+          </div>
+        ))}
+        <button onClick={addUnion}>Add Union</button>
       </section>
 
       <section>
@@ -1710,48 +1859,69 @@ export default function ReportBuilder() {
                 <option value="OR">OR</option>
               </select>
             )}
-            <select
-              value={c.table}
-              onChange={(e) => updateCondition(i, 'table', e.target.value)}
-            >
-              {availableTables.map((t) => (
-                <option key={t} value={t}>
-                  {t}
-                </option>
-              ))}
-            </select>
-            <select
-              value={c.field}
-              onChange={(e) => updateCondition(i, 'field', e.target.value)}
-              style={{ marginLeft: '0.5rem' }}
-            >
-              {(tableFields[c.table] || []).map((f) => (
-                <option key={f} value={f}>
-                  {f}
-                </option>
-              ))}
-            </select>
-            <span> = </span>
-            <select
-              value={c.param}
-              onChange={(e) => updateCondition(i, 'param', e.target.value)}
-            >
-              {params.map((p) => (
-                <option key={p.name} value={p.name}>
-                  {p.name}
-                </option>
-              ))}
-            </select>
-            <button
-              onClick={() => removeCondition(i)}
-              style={{ marginLeft: '0.5rem' }}
-            >
-              ✕
-            </button>
+            {c.raw ? (
+              <>
+                <input
+                  value={c.raw}
+                  onChange={(e) => updateCondition(i, 'raw', e.target.value)}
+                  style={{ width: '60%' }}
+                />
+                <button
+                  onClick={() => removeCondition(i)}
+                  style={{ marginLeft: '0.5rem' }}
+                >
+                  ✕
+                </button>
+              </>
+            ) : (
+              <>
+                <select
+                  value={c.table}
+                  onChange={(e) => updateCondition(i, 'table', e.target.value)}
+                >
+                  {availableTables.map((t) => (
+                    <option key={t} value={t}>
+                      {t}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  value={c.field}
+                  onChange={(e) => updateCondition(i, 'field', e.target.value)}
+                  style={{ marginLeft: '0.5rem' }}
+                >
+                  {(tableFields[c.table] || []).map((f) => (
+                    <option key={f} value={f}>
+                      {f}
+                    </option>
+                  ))}
+                </select>
+                <span> = </span>
+                <select
+                  value={c.param}
+                  onChange={(e) => updateCondition(i, 'param', e.target.value)}
+                >
+                  {params.map((p) => (
+                    <option key={p.name} value={p.name}>
+                      {p.name}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  onClick={() => removeCondition(i)}
+                  style={{ marginLeft: '0.5rem' }}
+                >
+                  ✕
+                </button>
+              </>
+            )}
           </div>
         ))}
         <button onClick={addCondition} disabled={!params.length}>
           Add Condition
+        </button>
+        <button onClick={addRawCondition} style={{ marginLeft: '0.5rem' }}>
+          Add Raw Condition
         </button>
       </section>
 

--- a/src/erp.mgt.mn/utils/buildReportSql.js
+++ b/src/erp.mgt.mn/utils/buildReportSql.js
@@ -8,82 +8,103 @@
 export default function buildReportSql(definition = {}) {
   if (!definition.from) throw new Error('definition.from is required');
 
-  const parts = [];
+  function build(def) {
+    const parts = [];
 
-  // SELECT clause with alias expansion
-  const selectItems = (definition.select || []).filter((s) => s && s.expr);
-  const aliasMap = {};
+    // SELECT clause with alias expansion
+    const selectItems = (def.select || []).filter((s) => s && s.expr);
+    const aliasMap = {};
 
-  function expandExpr(expr) {
-    let result = expr;
-    let replaced = true;
-    while (replaced) {
-      replaced = false;
-      for (const [al, ex] of Object.entries(aliasMap)) {
-        const re = new RegExp(`\\b${al}\\b`, 'g');
-        if (re.test(result)) {
-          result = result.replace(re, `(${ex})`);
-          replaced = true;
+    function expandExpr(expr) {
+      let result = expr;
+      let replaced = true;
+      while (replaced) {
+        replaced = false;
+        for (const [al, ex] of Object.entries(aliasMap)) {
+          const re = new RegExp(`\\b${al}\\b`, 'g');
+          if (re.test(result)) {
+            result = result.replace(re, `(${ex})`);
+            replaced = true;
+          }
         }
       }
+      return result;
     }
-    return result;
+
+    const selectList =
+      selectItems
+        .map((sel) => {
+          const expr = expandExpr(sel.expr);
+          if (sel.alias) aliasMap[sel.alias] = expr;
+          return sel.alias ? `${expr} AS ${sel.alias}` : expr;
+        })
+        .join(',\n  ') || '*';
+    parts.push(`SELECT${selectList ? '\n  ' + selectList : ''}`);
+
+    // FROM clause
+    parts.push(
+      `FROM ${def.from.table}` + (def.from.alias ? ` ${def.from.alias}` : ''),
+    );
+
+    // JOIN clauses
+    (def.joins || []).forEach(({ table, alias, type = 'JOIN', on }) => {
+      if (!on) return;
+      parts.push(`${type} ${table}` + (alias ? ` ${alias}` : '') + ` ON ${on}`);
+    });
+
+    // WHERE clause
+    if (def.where?.length) {
+      const whereItems = def.where.filter((w) => w && w.expr);
+      if (whereItems.length) {
+        const whereClause = whereItems
+          .map((w, i) => {
+            const connector = i > 0 ? `${w.connector || 'AND'} ` : '';
+            return connector + w.expr;
+          })
+          .join('\n  ');
+        parts.push(`WHERE\n  ${whereClause}`);
+      }
+    }
+
+    // GROUP BY clause
+    const aggRe = /\b(SUM|COUNT|AVG|MIN|MAX)\s*\(/i;
+    const hasAgg = selectItems.some((s) => aggRe.test(s.expr));
+    const groupSet = new Set(def.groupBy || []);
+    if (hasAgg) {
+      selectItems.forEach((s) => {
+        if (!aggRe.test(s.expr)) {
+          const gb = s.alias || expandExpr(s.expr);
+          if (gb) groupSet.add(gb);
+        }
+      });
+    }
+    if (groupSet.size) {
+      parts.push(`GROUP BY ${Array.from(groupSet).join(', ')}`);
+    }
+
+    // HAVING clause
+    if (def.having?.length) {
+      const havingItems = def.having.filter((h) => h && h.expr);
+      if (havingItems.length) {
+        const havingClause = havingItems
+          .map((h, i) => {
+            const connector = i > 0 ? `${h.connector || 'AND'} ` : '';
+            return connector + h.expr;
+          })
+          .join('\n  ');
+        parts.push(`HAVING\n  ${havingClause}`);
+      }
+    }
+
+    return parts.join('\n');
   }
 
-  const selectList =
-    selectItems
-      .map((sel) => {
-        const expr = expandExpr(sel.expr);
-        if (sel.alias) aliasMap[sel.alias] = expr;
-        return sel.alias ? `${expr} AS ${sel.alias}` : expr;
-      })
-      .join(',\n  ') || '*';
-  parts.push(`SELECT${selectList ? '\n  ' + selectList : ''}`);
-
-  // FROM clause
-  parts.push(
-    `FROM ${definition.from.table}` +
-      (definition.from.alias ? ` ${definition.from.alias}` : '')
+  const main = build(definition);
+  const unions = definition.unions || [];
+  if (!unions.length) return main;
+  const rest = unions.map((t) =>
+    build({ ...definition, unions: [], from: { ...definition.from, table: t } }),
   );
-
-  // JOIN clauses
-  (definition.joins || []).forEach(({ table, alias, type = 'JOIN', on }) => {
-    if (!on) return;
-    parts.push(`${type} ${table}` + (alias ? ` ${alias}` : '') + ` ON ${on}`);
-  });
-
-  // WHERE clause
-  if (definition.where?.length) {
-    const whereItems = definition.where.filter((w) => w && w.expr);
-    if (whereItems.length) {
-      const whereClause = whereItems
-        .map((w, i) => {
-          const connector = i > 0 ? `${w.connector || 'AND'} ` : '';
-          return connector + w.expr;
-        })
-        .join('\n  ');
-      parts.push(`WHERE\n  ${whereClause}`);
-    }
-  }
-
-  // GROUP BY clause
-  if (definition.groupBy?.length) {
-    parts.push(`GROUP BY ${definition.groupBy.join(', ')}`);
-  }
-
-  // HAVING clause
-  if (definition.having?.length) {
-    const havingItems = definition.having.filter((h) => h && h.expr);
-    if (havingItems.length) {
-      const havingClause = havingItems
-        .map((h, i) => {
-          const connector = i > 0 ? `${h.connector || 'AND'} ` : '';
-          return connector + h.expr;
-        })
-        .join('\n  ');
-      parts.push(`HAVING\n  ${havingClause}`);
-    }
-  }
-
-  return parts.join('\n');
+  return [main, ...rest].join('\nUNION\n');
 }
+

--- a/tests/db/procedureRawRows.test.js
+++ b/tests/db/procedureRawRows.test.js
@@ -20,14 +20,15 @@ function mockPool(createSql) {
   };
 }
 
-test('getProcedureRawRows expands alias and removes aggregates', async () => {
+test('getProcedureRawRows expands alias and removes aggregates', { concurrency: false }, async () => {
   const createSql = `CREATE PROCEDURE \`sp_test\`()
 BEGIN
-  SELECT c.name AS category, SUM(t.amount) AS total
+  SELECT c.name AS category, SUM(t.amount) AS total, SUM(t.count) AS cnt
   FROM trans t
   JOIN categories c ON c.id = t.category_id
   WHERE t.date BETWEEN start_date AND end_date
   GROUP BY c.name;
+  SELECT 'after';
 END`;
   const restore = mockPool(createSql);
   const { sql } = await db.getProcedureRawRows(
@@ -39,10 +40,95 @@ END`;
   );
   restore();
   assert.ok(sql.includes('t.amount AS total'));
-  assert.ok(sql.includes("c.name = 'Phones'"));
+  assert.ok(!/\bcnt\b/i.test(sql));
+  assert.ok(sql.includes("category = 'Phones'"));
   assert.ok(sql.includes("'2024-01-01'"));
   assert.ok(!/GROUP BY/i.test(sql));
   assert.ok(!/HAVING/i.test(sql));
   assert.ok(!/SUM\(/i.test(sql));
+  assert.ok(/^SELECT \* FROM \(/i.test(sql));
+  assert.ok(/after/i.test(sql));
   await fs.unlink(path.join(process.cwd(), 'config', 'sp_test_rows.sql')).catch(() => {});
 });
+
+test('getProcedureRawRows handles nested SUM expressions', { concurrency: false }, async () => {
+  const createSql = `CREATE PROCEDURE \`sp_case\`()
+BEGIN
+  SELECT t.id, t.name,
+         SUM(CASE WHEN t.type = 'a' THEN IFNULL(t.val,0) ELSE 0 END) AS a_val,
+         SUM(CASE WHEN t.type = 'b' THEN IFNULL(t.val,0) ELSE 0 END) AS b_val
+  FROM trans t;
+END`;
+  const restore = mockPool(createSql);
+  const { sql } = await db.getProcedureRawRows(
+    'sp_case',
+    {},
+    'b_val',
+    'id',
+    5,
+  );
+  restore();
+  assert.ok(
+    sql.includes("CASE WHEN t.type = 'b' THEN IFNULL(t.val,0) ELSE 0 END AS b_val"),
+  );
+  assert.ok(!/\ba_val\b/i.test(sql));
+  assert.ok(!/SUM\(/i.test(sql));
+  assert.ok(sql.includes("id = 5"));
+  await fs.unlink(path.join(process.cwd(), 'config', 'sp_case_rows.sql')).catch(() => {});
+});
+
+test(
+  'getProcedureRawRows appends visibleFields from all configs and returns displayFields',
+  { concurrency: false },
+  async () => {
+    const origRead = fs.readFile;
+    fs.readFile = async (p, enc) => {
+      if (p.endsWith(path.join('config', 'transactionForms.json'))) {
+        return JSON.stringify({
+          trans: {
+            general: {
+              A: {
+                visibleFields: ['id'],
+                headerFields: ['hdr'],
+                mainFields: ['main'],
+                footerFields: ['ftr'],
+              },
+              subgroup: { B: { visibleFields: ['note'] } },
+            },
+          },
+        });
+      }
+      if (p.endsWith(path.join('config', 'tableDisplayFields.json'))) {
+        return JSON.stringify({
+          trans: { idField: 'id', displayFields: ['id', 'note', 'hdr', 'main', 'ftr'] },
+        });
+      }
+      return origRead(p, enc);
+    };
+    const createSql = `CREATE PROCEDURE \`sp_vis\`()
+BEGIN
+  SELECT tr.category, SUM(tr.amount) AS total
+  FROM (SELECT * FROM trans) tr
+  GROUP BY tr.category;
+END`;
+    const restore = mockPool(createSql);
+    const { sql, displayFields } = await db.getProcedureRawRows(
+      'sp_vis',
+      {},
+      'total',
+      'category',
+      'Phones',
+    );
+    restore();
+    fs.readFile = origRead;
+    assert.ok(sql.includes('tr.id'));
+    assert.ok(sql.includes('tr.note'));
+    assert.ok(sql.includes('tr.hdr'));
+    assert.ok(sql.includes('tr.main'));
+    assert.ok(sql.includes('tr.ftr'));
+    assert.deepEqual(displayFields, ['id', 'note', 'hdr', 'main', 'ftr']);
+    await fs
+      .unlink(path.join(process.cwd(), 'config', 'sp_vis_rows.sql'))
+      .catch(() => {});
+  },
+);

--- a/tests/utils/buildReportSql.test.js
+++ b/tests/utils/buildReportSql.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import buildReportSql from '../../src/erp.mgt.mn/utils/buildReportSql.js';
+
+test('buildReportSql adds non aggregated fields to group by', () => {
+  const sql = buildReportSql({
+    from: { table: 'sales', alias: 's' },
+    select: [
+      { expr: 's.category', alias: 'category' },
+      { expr: 'SUM(s.amount)', alias: 'total' },
+    ],
+  });
+  assert.ok(sql.includes('GROUP BY category'));
+  assert.ok(!sql.match(/GROUP BY.*GROUP BY/));
+});
+
+test('buildReportSql unions additional tables', () => {
+  const sql = buildReportSql({
+    from: { table: 'sales', alias: 's' },
+    select: [{ expr: 's.id' }],
+    unions: ['sales_archive'],
+  });
+  assert.ok(sql.includes('FROM sales s'));
+  assert.ok(sql.includes('UNION'));
+  assert.ok(sql.includes('FROM sales_archive s'));
+});


### PR DESCRIPTION
## Summary
- Display translated field names in report tables and drill-down modal
- Support UNION tables at end of report builder flow
- Permit raw SQL conditions and handle COUNT aggregates without hanging

## Testing
- `npm test`
- `node --test --test-concurrency=1`


------
https://chatgpt.com/codex/tasks/task_e_6897394edf648331a1d4547fbec136e6