### PR TITLE
Translate report headers and allow raw conditions

### DIFF
--- a/api-server/routes/procedures.js
+++ b/api-server/routes/procedures.js
@@ -49,7 +49,7 @@ router.post('/raw', requireAuth, async (req, res, next) => {
     const { name, params, column, groupField, groupValue, session } = req.body || {};
     if (!name || !column)
       return res.status(400).json({ message: 'name and column required' });
-    const { rows, sql, original, file } = await getProcedureRawRows(
+    const { rows, sql, original, file, displayFields } = await getProcedureRawRows(
       name,
       params || {},
       column,
@@ -57,7 +57,7 @@ router.post('/raw', requireAuth, async (req, res, next) => {
       groupValue,
       { ...(session || {}), empid: req.user?.empid },
     );
-    res.json({ rows, sql, original, file });
+    res.json({ rows, sql, original, file, displayFields });
   } catch (err) {
     next(err);
   }

--- a/db/index.js
+++ b/db/index.js
@@ -566,6 +566,26 @@ export async function listTableColumns(tableName) {
   return rows.map((r) => r.COLUMN_NAME);
 }
 
+export async function listTableColumnsDetailed(tableName) {
+  const [rows] = await pool.query(
+    `SELECT COLUMN_NAME, COLUMN_TYPE
+       FROM information_schema.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = ?
+      ORDER BY ORDINAL_POSITION`,
+    [tableName],
+  );
+  return rows.map((r) => ({
+    name: r.COLUMN_NAME,
+    enumValues: /^enum\(/i.test(r.COLUMN_TYPE)
+      ? r.COLUMN_TYPE
+          .slice(5, -1)
+          .split(',')
+          .map((v) => v.trim().slice(1, -1))
+      : [],
+  }));
+}
+
 export async function saveStoredProcedure(sql) {
   const cleaned = sql
     .replace(/^DELIMITER \$\$/gm, '')
@@ -583,6 +603,23 @@ export async function saveStoredProcedure(sql) {
 
 export async function saveView(sql) {
   await pool.query(sql);
+}
+
+export async function listReportProcedures() {
+  const [rows] = await pool.query(
+    `SELECT ROUTINE_NAME
+       FROM information_schema.ROUTINES
+      WHERE ROUTINE_TYPE = 'PROCEDURE'
+        AND ROUTINE_SCHEMA = DATABASE()
+        AND ROUTINE_NAME LIKE '%report%'
+      ORDER BY ROUTINE_NAME`,
+  );
+  return rows.map((r) => r.ROUTINE_NAME);
+}
+
+export async function deleteProcedure(name) {
+  if (!name) return;
+  await pool.query(`DROP PROCEDURE IF EXISTS \`${name}\``);
 }
 
 export async function getTableColumnLabels(tableName) {
@@ -1130,34 +1167,79 @@ export async function getProcedureRawRows(
   function escapeRegExp(s) {
     return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
-  const selectMatches = [...body.matchAll(/SELECT[\s\S]*?(?=;|END|$)/gi)];
-  const colRegex = new RegExp(`\\b${escapeRegExp(column)}\\b`, 'i');
-  let sql = '';
-  for (const m of selectMatches) {
-    if (colRegex.test(m[0])) {
-      sql = m[0];
-      break;
-    }
-  }
-  if (!sql && selectMatches.length) {
-    sql = selectMatches[selectMatches.length - 1][0];
-  }
-  if (!sql) {
-    sql = createSql;
-  }
-
+  const firstSelectIdx = body.search(/SELECT/i);
+  let sql = firstSelectIdx === -1 ? createSql : body.slice(firstSelectIdx);
   const originalSql = sql;
+  let remainder = '';
+  let displayFields = [];
+  const firstSemi = sql.indexOf(';');
+  if (firstSemi !== -1) {
+    remainder = sql.slice(firstSemi);
+    sql = sql.slice(0, firstSemi);
+  }
 
   if (/^SELECT/i.test(sql)) {
-    const colRe = escapeRegExp(column);
-    const sumRegex = new RegExp(
-      `SUM\\(([^)]*)\\)\\s*(?:AS\\s+)?` + '`?' + colRe + '`?',
-      'i',
-    );
-    const sumMatch = sql.match(sumRegex);
-    if (sumMatch) {
-      sql = sql.replace(sumRegex, `${sumMatch[1]} AS ${column}`);
+    function filterAggregates(input, aliasToKeep) {
+      const upper = input.toUpperCase();
+      // find FROM at top level
+      let depth = 0;
+      let fromIdx = -1;
+      for (let i = 0; i < upper.length; i++) {
+        const ch = upper[i];
+        if (ch === '(') depth++;
+        else if (ch === ')') depth--;
+        else if (depth === 0 && upper.startsWith('FROM', i)) {
+          fromIdx = i;
+          break;
+        }
+      }
+      if (fromIdx === -1) return input;
+      const fieldsPart = input.slice(6, fromIdx);
+      const rest = input.slice(fromIdx);
+      const fields = [];
+      let buf = '';
+      depth = 0;
+      for (let i = 0; i < fieldsPart.length; i++) {
+        const ch = fieldsPart[i];
+        if (ch === '(') depth++;
+        else if (ch === ')') depth--;
+        if (ch === ',' && depth === 0) {
+          fields.push(buf.trim());
+          buf = '';
+        } else {
+          buf += ch;
+        }
+      }
+      if (buf.trim()) fields.push(buf.trim());
+      const kept = [];
+      for (let field of fields) {
+        const sumIdx = field.toUpperCase().indexOf('SUM(');
+        if (sumIdx === -1) {
+          kept.push(field);
+          continue;
+        }
+        const aliasMatch = field.match(/(?:AS\s+)?`?([a-zA-Z0-9_]+)`?\s*$/i);
+        const alias = aliasMatch ? aliasMatch[1] : null;
+        if (alias && alias.toLowerCase() === String(aliasToKeep).toLowerCase()) {
+          let start = sumIdx + 4;
+          let depth2 = 1;
+          let j = start;
+          while (j < field.length && depth2 > 0) {
+            const ch2 = field[j];
+            if (ch2 === '(') depth2++;
+            else if (ch2 === ')') depth2--;
+            j++;
+          }
+          const inner = field.slice(start, j - 1);
+          field = field.slice(0, sumIdx) + inner + field.slice(j);
+          kept.push(field.trim());
+        }
+      }
+      if (!kept.length) return input;
+      return 'SELECT ' + kept.join(', ') + ' ' + rest;
     }
+
+    sql = filterAggregates(sql, column);
 
     sql = sql.replace(/GROUP BY[\s\S]*?(HAVING|ORDER BY|$)/i, '$1');
     sql = sql.replace(/HAVING[\s\S]*?(ORDER BY|$)/i, '$1');
@@ -1188,36 +1270,111 @@ export async function getProcedureRawRows(
       }
     }
 
-    if (groupValue !== undefined) {
-      let condField = groupField;
-      const sel = sql.match(/SELECT\s+([\s\S]+?)\s+FROM/i);
-      if (sel) {
-        const firstField = sel[1].split(/,(?![^()]*\))/)[0]?.trim();
-        const m = firstField?.match(/^(.+?)\s+(?:AS\s+)?`?([a-z0-9_]+)`?$/i);
+    sql = sql.replace(/;\s*$/, '');
+
+    const fromIdx = (() => {
+      const upper = sql.toUpperCase();
+      let depth = 0;
+      for (let i = 0; i < upper.length; i++) {
+        const ch = upper[i];
+        if (ch === '(') depth++;
+        else if (ch === ')') depth--;
+        else if (depth === 0 && upper.startsWith('FROM', i)) return i;
+      }
+      return -1;
+    })();
+    if (fromIdx !== -1) {
+      const fieldsPart = sql.slice(6, fromIdx);
+      const rest = sql.slice(fromIdx);
+      const afterFrom = rest.slice(4).trimStart();
+      let table = '';
+      let alias = '';
+      if (afterFrom.startsWith('(')) {
+        let depth = 1;
+        let i = 1;
+        while (i < afterFrom.length && depth > 0) {
+          const ch = afterFrom[i];
+          if (ch === '(') depth++;
+          else if (ch === ')') depth--;
+          i++;
+        }
+        const sub = afterFrom.slice(1, i - 1);
+        const aliasMatch = afterFrom.slice(i).match(/^\s*([a-zA-Z0-9_]+)/);
+        alias = aliasMatch ? aliasMatch[1] : '';
+        const tableMatch = sub.match(/FROM\s+`?([a-zA-Z0-9_]+)`?/i);
+        table = tableMatch ? tableMatch[1] : '';
+      } else {
+        const m = afterFrom.match(/`?([a-zA-Z0-9_]+)`?(?:\s+(?:AS\s+)?([a-zA-Z0-9_]+))?/i);
         if (m) {
-          const expr = m[1].trim();
-          const alias = m[2];
-          if (!groupField || alias === groupField) condField = expr;
-        } else if (!groupField) {
-          condField = firstField;
+          table = m[1];
+          alias = m[2] || m[1];
         }
       }
-      if (condField) {
-        const rep =
-          typeof groupValue === 'number' ? String(groupValue) : `'${groupValue}'`;
-        const clause = `${condField} = ${rep}`;
-        if (/WHERE/i.test(sql)) {
-          sql = sql.replace(/WHERE/i, `WHERE ${clause} AND `);
-        } else {
-          sql += ` WHERE ${clause}`;
-        }
+      if (table) {
+        const prefix = alias ? `${alias}.` : '';
+        try {
+          const txt = await fs.readFile(
+            path.join(process.cwd(), 'config', 'transactionForms.json'),
+            'utf8',
+          );
+          const cfg = JSON.parse(txt);
+          const set = new Set();
+
+          function collect(obj) {
+            if (!obj || typeof obj !== 'object') return;
+            ['visibleFields', 'headerFields', 'mainFields', 'footerFields'].forEach(
+              (key) => {
+                if (Array.isArray(obj[key])) {
+                  for (const f of obj[key]) set.add(String(f));
+                }
+              },
+            );
+            for (const val of Object.values(obj)) {
+              if (val && typeof val === 'object' && !Array.isArray(val)) {
+                collect(val);
+              }
+            }
+          }
+
+          if (cfg[table]) {
+            collect(cfg[table]);
+          }
+          const add = [];
+          for (const f of set) {
+            if (!new RegExp(`\\b${escapeRegExp(f)}\\b`, 'i').test(fieldsPart)) {
+              add.push(prefix + f);
+            }
+          }
+          if (add.length) {
+            const fp = fieldsPart.trim();
+            const newFields = fp ? fp + ', ' + add.join(', ') : add.join(', ');
+            sql = 'SELECT ' + newFields + ' ' + rest;
+          }
+        } catch {}
+        try {
+          const dfTxt = await fs.readFile(
+            path.join(process.cwd(), 'config', 'tableDisplayFields.json'),
+            'utf8',
+          );
+          const dfCfg = JSON.parse(dfTxt);
+          if (dfCfg[table] && Array.isArray(dfCfg[table].displayFields)) {
+            displayFields = dfCfg[table].displayFields.map(String);
+          }
+        } catch {}
       }
     }
 
-    // Trim trailing statement terminators to avoid MySQL complaining when
-    // executing the reconstructed query.
+    if (groupValue !== undefined) {
+      const rep =
+        typeof groupValue === 'number' ? String(groupValue) : `'${groupValue}'`;
+      sql = `SELECT * FROM (${sql}) AS _raw WHERE ${groupField} = ${rep}`;
+    }
+
     sql = sql.replace(/;\s*$/, '');
   }
+
+  sql += remainder;
+  sql = sql.replace(/;\s*$/, '');
 
   const file = `${name.replace(/[^a-z0-9_]/gi, '_')}_rows.sql`;
   let content = `-- Original SQL for ${name}\n${originalSql}\n`;
@@ -1228,8 +1385,8 @@ export async function getProcedureRawRows(
 
   try {
     const [out] = await pool.query(sql);
-    return { rows: out, sql, original: originalSql, file };
+    return { rows: out, sql, original: originalSql, file, displayFields };
   } catch {
-    return { rows: [], sql, original: originalSql, file };
+    return { rows: [], sql, original: originalSql, file, displayFields };
   }
 }

--- a/docs/report-builder.md
+++ b/docs/report-builder.md
@@ -1,0 +1,9 @@
+# Report Builder
+
+The Report Builder now guards its initial data fetch and wraps all rendering
+inside an error boundary. When the table list fails to load, the page shows a
+clear message instead of a blank screen. Any runtime errors triggered by button
+presses are caught and displayed, preventing the window from going blank.
+
+When extending the builder, throw descriptive errors rather than letting
+failures fall through silently so the boundary can surface them to the user.

--- a/src/erp.mgt.mn/components/ErrorBoundary.jsx
+++ b/src/erp.mgt.mn/components/ErrorBoundary.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, info) {
+    console.error(error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      const message = this.state.error?.message || 'Something went wrong';
+      return <div style={{ color: 'red' }}>{message}</div>;
+    }
+    return this.props.children;
+  }
+}

--- a/src/erp.mgt.mn/pages/ReportBuilder.jsx
+++ b/src/erp.mgt.mn/pages/ReportBuilder.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import buildStoredProcedure from '../utils/buildStoredProcedure.js';
 import buildReportSql from '../utils/buildReportSql.js';
+import ErrorBoundary from '../components/ErrorBoundary.jsx';
 
 const SESSION_PARAMS = [
   { name: 'session_branch_id', type: 'INT' },
@@ -13,28 +14,34 @@ const AGGREGATES = ['NONE', 'SUM', 'COUNT', 'MAX', 'MIN'];
 const OPERATORS = ['=', '>', '<', '>=', '<=', '<>'];
 const CALC_OPERATORS = ['+', '-', '*', '/'];
 
-export default function ReportBuilder() {
+function ReportBuilderInner() {
   const [tables, setTables] = useState([]); // list of table names
   const [tableFields, setTableFields] = useState({}); // { tableName: [field, ...] }
+  const [fieldEnums, setFieldEnums] = useState({}); // { tableName: { field: [enum] } }
 
   const [procName, setProcName] = useState('');
   const [fromTable, setFromTable] = useState('');
-  const [joins, setJoins] = useState([]); // {table, alias, type, targetTable, conditions:[{fromField,toField,connector}], filters:[]}
+  const [joins, setJoins] = useState([]); // {table, alias, type, targetTable, conditions:[{fromField,toField,connector,open,close}], filters:[]}
   const [fields, setFields] = useState([]); // {source:'field'|'alias', table, field, baseAlias, alias, aggregate, conditions:[], calcParts:[{source,table,field,alias,operator}]}
   const [dragIndex, setDragIndex] = useState(null);
   const [groups, setGroups] = useState([]); // {table, field}
   const [having, setHaving] = useState([]); // {source:'field'|'alias', aggregate, table, field, alias, operator, valueType, value, param, connector}
   const [params, setParams] = useState([]); // {name,type,source}
   const [conditions, setConditions] = useState([]); // {table,field,param,connector}
-  const [fromFilters, setFromFilters] = useState([]); // {field,operator,valueType,param,value,connector}
+  const [fromFilters, setFromFilters] = useState([]); // {field,operator,valueType,param,value,connector,open,close}
+  const [unionQueries, setUnionQueries] = useState([]); // array of prior query states
   const [selectSql, setSelectSql] = useState('');
   const [viewSql, setViewSql] = useState('');
   const [procSql, setProcSql] = useState('');
   const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
   const [savedReports, setSavedReports] = useState([]);
   const [selectedReport, setSelectedReport] = useState('');
   const [procFiles, setProcFiles] = useState([]);
   const [selectedProcFile, setSelectedProcFile] = useState('');
+  const [dbProcedures, setDbProcedures] = useState([]);
+  const [selectedDbProcedure, setSelectedDbProcedure] = useState('');
   const [procFileText, setProcFileText] = useState('');
 
   const [customParamName, setCustomParamName] = useState('');
@@ -45,12 +52,16 @@ export default function ReportBuilder() {
     async function fetchTables() {
       try {
         const res = await fetch('/api/report_builder/tables');
-        const data = await res.json();
+        if (!res.ok) throw new Error('Failed to load tables');
+        const data = await res.json().catch(() => ({}));
         setTables(data.tables || []);
         const first = data.tables?.[0];
         if (first) setFromTable(first);
       } catch (err) {
         console.error(err);
+        setLoadError('Failed to load tables');
+      } finally {
+        setLoading(false);
       }
     }
     fetchTables();
@@ -71,6 +82,14 @@ export default function ReportBuilder() {
       } catch (err) {
         console.error(err);
       }
+      try {
+        const res = await fetch('/api/report_builder/procedures');
+        const data = await res.json();
+        setDbProcedures(data.names || []);
+        setSelectedDbProcedure(data.names?.[0] || '');
+      } catch (err) {
+        console.error(err);
+      }
     }
     fetchSaved();
   }, []);
@@ -83,7 +102,13 @@ export default function ReportBuilder() {
         `/api/report_builder/fields?table=${encodeURIComponent(table)}`,
       );
       const data = await res.json();
-      setTableFields((prev) => ({ ...prev, [table]: data.fields || [] }));
+      const names = (data.fields || []).map((f) => f.name || f);
+      const enums = {};
+      (data.fields || []).forEach((f) => {
+        enums[f.name || f] = f.enumValues || [];
+      });
+      setTableFields((prev) => ({ ...prev, [table]: names }));
+      setFieldEnums((prev) => ({ ...prev, [table]: enums }));
     } catch (err) {
       console.error(err);
     }
@@ -99,6 +124,24 @@ export default function ReportBuilder() {
       })),
     );
   }, [fromTable]);
+
+  useEffect(() => {
+    const auto = fields
+      .filter((f) => f.aggregate === 'NONE' && f.table && f.field)
+      .map((f) => ({ table: f.table, field: f.field }));
+    setGroups((prev) => {
+      const map = new Map(prev.map((g) => [`${g.table}.${g.field}`, g]));
+      let changed = false;
+      auto.forEach((g) => {
+        const key = `${g.table}.${g.field}`;
+        if (!map.has(key)) {
+          map.set(key, g);
+          changed = true;
+        }
+      });
+      return changed ? Array.from(map.values()) : prev;
+    });
+  }, [fields]);
 
   const availableTables = [fromTable, ...joins.map((j) => j.table)].filter(Boolean);
 
@@ -167,6 +210,8 @@ export default function ReportBuilder() {
       fromField: (tableFields[j.targetTable] || [])[0] || '',
       toField: (tableFields[j.table] || [])[0] || '',
       connector: 'AND',
+      open: 0,
+      close: 0,
     };
     const updated = joins.map((jn, i) =>
       i === jIndex ? { ...jn, conditions: [...jn.conditions, newCond] } : jn,
@@ -377,6 +422,8 @@ export default function ReportBuilder() {
         param: params[0]?.name || '',
         value: '',
         connector: 'AND',
+        open: 0,
+        close: 0,
       },
     ]);
   }
@@ -447,7 +494,16 @@ export default function ReportBuilder() {
         field: (tableFields[table] || [])[0] || '',
         param: params[0].name,
         connector: 'AND',
+        open: 0,
+        close: 0,
       },
+    ]);
+  }
+
+  function addRawCondition() {
+    setConditions([
+      ...conditions,
+      { raw: '', connector: 'AND', open: 0, close: 0 },
     ]);
   }
 
@@ -472,6 +528,8 @@ export default function ReportBuilder() {
         value: '',
         param: params[0]?.name || '',
         connector: 'AND',
+        open: 0,
+        close: 0,
       },
     ]);
   }
@@ -487,6 +545,25 @@ export default function ReportBuilder() {
     setFromFilters(fromFilters.filter((_, i) => i !== index));
   }
 
+  function addUnionQuery() {
+    const snapshot = {
+      fromTable,
+      joins,
+      fields,
+      groups,
+      having,
+      conditions,
+      fromFilters,
+    };
+    setUnionQueries([...unionQueries, snapshot]);
+    setJoins([]);
+    setFields([]);
+    setGroups([]);
+    setHaving([]);
+    setConditions([]);
+    setFromFilters([]);
+  }
+
   function addJoinFilter(jIndex) {
     const join = joins[jIndex];
     ensureFields(join.table);
@@ -497,6 +574,8 @@ export default function ReportBuilder() {
       value: '',
       param: params[0]?.name || '',
       connector: 'AND',
+      open: 0,
+      close: 0,
     };
     const updated = joins.map((j, i) =>
       i === jIndex ? { ...j, filters: [...(j.filters || []), newFilter] } : j,
@@ -524,38 +603,45 @@ export default function ReportBuilder() {
     setJoins(updated);
   }
 
-  function buildAliases() {
-    const map = {};
-    if (fromTable) map[fromTable] = 't0';
-    joins.forEach((j, i) => {
-      map[j.table] = j.alias || `t${i + 1}`;
-    });
-    return map;
-  }
-
-  function buildDefinition() {
-    const aliases = buildAliases();
+  function buildFromState(st) {
+    const { fromTable: ft, joins: js, fields: fs, groups: gs, having: hv, conditions: cs, fromFilters: ff } = st;
+    const aliases = {};
+    if (ft) aliases[ft] = 't0';
+    const usedAliases = new Set(Object.values(aliases));
+    let nextAlias = 1;
 
     function buildTableFilterSql(filters) {
-      return filters
+      return (filters || [])
         .filter((f) => f.field && (f.valueType === 'param' ? f.param : f.value))
         .map((f, idx) => {
           const right = f.valueType === 'param' ? `:${f.param}` : f.value;
           const connector = idx > 0 ? ` ${f.connector} ` : '';
-          return `${connector}(${f.field} ${f.operator} ${right})`;
+          const open = '('.repeat(f.open || 0);
+          const close = ')'.repeat(f.close || 0);
+          return `${connector}${open}${f.field} ${f.operator} ${right}${close}`;
         })
         .join('');
     }
 
-    const joinDefs = joins
+    const joinDefs = (js || [])
       .map((j) => {
+        let alias = j.alias || `t${nextAlias++}`;
+        while (usedAliases.has(alias)) {
+          alias = `t${nextAlias++}`;
+        }
+        usedAliases.add(alias);
+        if (!aliases[j.table]) aliases[j.table] = alias;
         const conds = j.conditions.filter((c) => c.fromField && c.toField);
         const onInner = conds
-          .map(
-            (c, idx) =>
-              (idx > 0 ? ` ${c.connector} ` : '') +
-              `${aliases[j.targetTable]}.${c.fromField} = ${aliases[j.table]}.${c.toField}`,
-          )
+          .map((c, idx) => {
+            const connector = idx > 0 ? ` ${c.connector} ` : '';
+            const open = '('.repeat(c.open || 0);
+            const close = ')'.repeat(c.close || 0);
+            return (
+              connector +
+              `${open}${aliases[j.targetTable]}.${c.fromField} = ${alias}.${c.toField}${close}`
+            );
+          })
           .join('');
         const on = conds.length > 1 ? `(${onInner})` : onInner;
         const tablePart = j.filters?.length
@@ -563,7 +649,7 @@ export default function ReportBuilder() {
           : j.table;
         return {
           table: tablePart,
-          alias: aliases[j.table],
+          alias,
           type: j.type,
           on,
           original: j.table,
@@ -571,10 +657,10 @@ export default function ReportBuilder() {
       })
       .filter((j) => j.on);
 
-    const validTables = new Set([fromTable, ...joinDefs.map((j) => j.original)]);
+    const validTables = new Set([ft, ...joinDefs.map((j) => j.original)]);
 
     const fieldExprMap = {};
-    const select = fields
+    const select = fs
       .filter((f) => (f.source === 'alias' ? f.baseAlias : f.field))
       .map((f) => {
         if (f.source === 'field' && !validTables.has(f.table)) {
@@ -606,6 +692,30 @@ export default function ReportBuilder() {
           return { expr, alias: f.alias || undefined };
         }
         if (f.aggregate && f.aggregate !== 'NONE' && f.source === 'field') {
+          if (f.aggregate === 'COUNT') {
+            if (f.conditions?.length) {
+              const cond = f.conditions
+                .filter((c) => c.field && (c.valueType === 'param' ? c.param : c.value))
+                .map((c, idx) => {
+                  if (!validTables.has(c.table)) {
+                    throw new Error(`Table ${c.table} is not joined`);
+                  }
+                  const connector = idx > 0 ? ` ${c.connector} ` : '';
+                  const right = c.valueType === 'param' ? `:${c.param}` : c.value;
+                  return (
+                    connector +
+                    `(${aliases[c.table]}.${c.field} ${c.operator} ${right})`
+                  );
+                })
+                .join('');
+              const expr = `SUM(CASE WHEN ${cond} THEN 1 ELSE 0 END)`;
+              if (f.alias) fieldExprMap[f.alias] = expr;
+              return { expr, alias: f.alias || undefined };
+            }
+            const expr = 'COUNT(*)';
+            if (f.alias) fieldExprMap[f.alias] = expr;
+            return { expr, alias: f.alias || undefined };
+          }
           if (f.conditions?.length) {
             const cond = f.conditions
               .filter((c) => c.field && (c.valueType === 'param' ? c.param : c.value))
@@ -614,8 +724,7 @@ export default function ReportBuilder() {
                   throw new Error(`Table ${c.table} is not joined`);
                 }
                 const connector = idx > 0 ? ` ${c.connector} ` : '';
-                const right =
-                  c.valueType === 'param' ? `:${c.param}` : c.value;
+                const right = c.valueType === 'param' ? `:${c.param}` : c.value;
                 return (
                   connector +
                   `(${aliases[c.table]}.${c.field} ${c.operator} ${right})`
@@ -635,23 +744,28 @@ export default function ReportBuilder() {
         return { expr, alias: f.alias || undefined };
       });
 
-    const fromTableSql = fromFilters.length
-      ? `(SELECT * FROM ${fromTable} WHERE ${buildTableFilterSql(fromFilters)})`
-      : fromTable;
+    const fromTableSql = ff.length
+      ? `(SELECT * FROM ${ft} WHERE ${buildTableFilterSql(ff)})`
+      : ft;
 
-    const where = conditions
-      .filter((c) => c.table && c.field && c.param)
+    const where = cs
+      .filter((c) => c.raw || (c.table && c.field && c.param))
       .map((c) => {
+        if (c.raw) {
+          return { expr: c.raw, connector: c.connector, open: c.open, close: c.close };
+        }
         if (!validTables.has(c.table)) {
           throw new Error(`Table ${c.table} is not joined`);
         }
         return {
           expr: `${aliases[c.table]}.${c.field} = :${c.param}`,
           connector: c.connector,
+          open: c.open,
+          close: c.close,
         };
       });
 
-    const groupBy = groups
+    const groupBy = gs
       .filter((g) => g.table && g.field)
       .map((g) => {
         if (!validTables.has(g.table)) {
@@ -660,7 +774,7 @@ export default function ReportBuilder() {
         return `${aliases[g.table]}.${g.field}`;
       });
 
-    const havingDefs = having
+    const havingDefs = hv
       .filter((h) => (h.source === 'alias' ? h.alias : h.table && h.field))
       .map((h) => {
         const left =
@@ -671,19 +785,34 @@ export default function ReportBuilder() {
           throw new Error(`Table ${h.table} is not joined`);
         }
         const right = h.valueType === 'param' ? `:${h.param}` : h.value;
-        return { expr: `${left} ${h.operator} ${right}`, connector: h.connector };
+        return {
+          expr: `${left} ${h.operator} ${right}`,
+          connector: h.connector,
+          open: h.open,
+          close: h.close,
+        };
       });
 
-    const report = {
-      from: { table: fromTableSql, alias: aliases[fromTable] },
+    return {
+      from: { table: fromTableSql, alias: aliases[ft] },
       joins: joinDefs,
       select,
       where,
       groupBy,
       having: havingDefs,
     };
+  }
 
-    return { report, params: params.map(({ name, type }) => ({ name, type })) };
+  function buildDefinition(includeCurrent = true) {
+    const states = includeCurrent
+      ? [...unionQueries, { fromTable, joins, fields, groups, having, conditions, fromFilters }]
+      : [...unionQueries];
+    const reports = states.map((s) => buildFromState(s));
+    const [first, ...rest] = reports;
+    return {
+      report: { ...first, unions: rest },
+      params: params.map(({ name, type }) => ({ name, type })),
+    };
   }
 
   function handleGenerateSql() {
@@ -739,6 +868,14 @@ export default function ReportBuilder() {
         body: JSON.stringify({ sql: procSql }),
       });
       if (!res.ok) throw new Error('Save failed');
+      try {
+        const listRes = await fetch('/api/report_builder/procedures');
+        const data = await listRes.json();
+        setDbProcedures(data.names || []);
+        setSelectedDbProcedure(data.names?.[0] || '');
+      } catch (err) {
+        console.error(err);
+      }
       window.dispatchEvent(
         new CustomEvent('toast', {
           detail: { message: 'Stored procedure saved', type: 'success' },
@@ -748,6 +885,31 @@ export default function ReportBuilder() {
       window.dispatchEvent(
         new CustomEvent('toast', {
           detail: { message: err.message || 'Save failed', type: 'error' },
+        }),
+      );
+    }
+  }
+
+  async function handleDeleteProcedure() {
+    if (!selectedDbProcedure) return;
+    if (!window.confirm(`Delete procedure ${selectedDbProcedure}?`)) return;
+    try {
+      const res = await fetch(
+        `/api/report_builder/procedures/${encodeURIComponent(selectedDbProcedure)}`,
+        { method: 'DELETE' },
+      );
+      if (!res.ok) throw new Error('Delete failed');
+      setDbProcedures(dbProcedures.filter((n) => n !== selectedDbProcedure));
+      setSelectedDbProcedure('');
+      window.dispatchEvent(
+        new CustomEvent('toast', {
+          detail: { message: 'Procedure deleted', type: 'success' },
+        }),
+      );
+    } catch (err) {
+      window.dispatchEvent(
+        new CustomEvent('toast', {
+          detail: { message: err.message || 'Delete failed', type: 'error' },
         }),
       );
     }
@@ -788,6 +950,7 @@ export default function ReportBuilder() {
       params,
       conditions,
       fromFilters,
+      unionQueries,
     };
     try {
       const name = procName || 'report';
@@ -866,6 +1029,7 @@ export default function ReportBuilder() {
           })),
         );
         setGroups(data.groups || []);
+        setUnionQueries(data.unionQueries || []);
         setHaving(
           (data.having || []).map((h) => ({
             connector: h.connector || 'AND',
@@ -939,8 +1103,11 @@ export default function ReportBuilder() {
     setProcSql(procFileText);
   }
 
-  if (!tables.length) {
+  if (loading) {
     return <div>Loading...</div>;
+  }
+  if (!tables.length) {
+    return <div>{loadError || 'No tables found'}</div>;
   }
 
   return (
@@ -972,6 +1139,12 @@ export default function ReportBuilder() {
                 <option value="OR">OR</option>
               </select>
             )}
+            <input
+              type="number"
+              value={f.open || 0}
+              onChange={(e) => updateFromFilter(i, 'open', Number(e.target.value))}
+              style={{ width: '3rem', marginRight: '0.25rem' }}
+            />
             <select
               value={f.field}
               onChange={(e) => updateFromFilter(i, 'field', e.target.value)}
@@ -1013,6 +1186,19 @@ export default function ReportBuilder() {
                   </option>
                 ))}
               </select>
+            ) : fieldEnums[fromTable]?.[f.field]?.length ? (
+              <select
+                value={f.value}
+                onChange={(e) => updateFromFilter(i, 'value', e.target.value)}
+                style={{ marginLeft: '0.5rem' }}
+              >
+                <option value=""></option>
+                {fieldEnums[fromTable][f.field].map((v) => (
+                  <option key={v} value={v}>
+                    {v}
+                  </option>
+                ))}
+              </select>
             ) : (
               <input
                 value={f.value}
@@ -1020,6 +1206,12 @@ export default function ReportBuilder() {
                 style={{ marginLeft: '0.5rem' }}
               />
             )}
+            <input
+              type="number"
+              value={f.close || 0}
+              onChange={(e) => updateFromFilter(i, 'close', Number(e.target.value))}
+              style={{ width: '3rem', marginLeft: '0.25rem' }}
+            />
             <button
               onClick={() => removeFromFilter(i)}
               style={{ marginLeft: '0.5rem' }}
@@ -1094,6 +1286,14 @@ export default function ReportBuilder() {
                       <option value="OR">OR</option>
                     </select>
                   )}
+                  <input
+                    type="number"
+                    value={c.open || 0}
+                    onChange={(e) =>
+                      updateJoinCondition(i, k, 'open', Number(e.target.value))
+                    }
+                    style={{ width: '3rem', marginRight: '0.25rem' }}
+                  />
                   <select
                     value={c.fromField}
                     onChange={(e) =>
@@ -1119,6 +1319,14 @@ export default function ReportBuilder() {
                       </option>
                     ))}
                   </select>
+                  <input
+                    type="number"
+                    value={c.close || 0}
+                    onChange={(e) =>
+                      updateJoinCondition(i, k, 'close', Number(e.target.value))
+                    }
+                    style={{ width: '3rem', marginLeft: '0.25rem' }}
+                  />
                   <button
                     onClick={() => removeJoinCondition(i, k)}
                     style={{ marginLeft: '0.5rem' }}
@@ -1148,6 +1356,14 @@ export default function ReportBuilder() {
                       <option value="OR">OR</option>
                     </select>
                   )}
+                  <input
+                    type="number"
+                    value={f.open || 0}
+                    onChange={(e) =>
+                      updateJoinFilter(i, k, 'open', Number(e.target.value))
+                    }
+                    style={{ width: '3rem', marginRight: '0.25rem' }}
+                  />
                   <select
                     value={f.field}
                     onChange={(e) => updateJoinFilter(i, k, 'field', e.target.value)}
@@ -1189,6 +1405,19 @@ export default function ReportBuilder() {
                         </option>
                       ))}
                     </select>
+                  ) : fieldEnums[j.table]?.[f.field]?.length ? (
+                    <select
+                      value={f.value}
+                      onChange={(e) => updateJoinFilter(i, k, 'value', e.target.value)}
+                      style={{ marginLeft: '0.5rem' }}
+                    >
+                      <option value=""></option>
+                      {fieldEnums[j.table][f.field].map((v) => (
+                        <option key={v} value={v}>
+                          {v}
+                        </option>
+                      ))}
+                    </select>
                   ) : (
                     <input
                       value={f.value}
@@ -1196,6 +1425,14 @@ export default function ReportBuilder() {
                       style={{ marginLeft: '0.5rem' }}
                     />
                   )}
+                  <input
+                    type="number"
+                    value={f.close || 0}
+                    onChange={(e) =>
+                      updateJoinFilter(i, k, 'close', Number(e.target.value))
+                    }
+                    style={{ width: '3rem', marginLeft: '0.25rem' }}
+                  />
                   <button
                     onClick={() => removeJoinFilter(i, k)}
                     style={{ marginLeft: '0.5rem' }}
@@ -1461,6 +1698,21 @@ export default function ReportBuilder() {
                           </option>
                         ))}
                       </select>
+                    ) : fieldEnums[c.table]?.[c.field]?.length ? (
+                      <select
+                        value={c.value}
+                        onChange={(e) =>
+                          updateFieldCondition(i, k, 'value', e.target.value)
+                        }
+                        style={{ marginLeft: '0.5rem' }}
+                      >
+                        <option value=""></option>
+                        {fieldEnums[c.table][c.field].map((v) => (
+                          <option key={v} value={v}>
+                            {v}
+                          </option>
+                        ))}
+                      </select>
                     ) : (
                       <input
                         value={c.value}
@@ -1542,6 +1794,12 @@ export default function ReportBuilder() {
                 <option value="OR">OR</option>
               </select>
             )}
+            <input
+              type="number"
+              value={h.open || 0}
+              onChange={(e) => updateHaving(i, 'open', Number(e.target.value))}
+              style={{ width: '3rem', marginRight: '0.25rem' }}
+            />
             <select
               value={h.source}
               onChange={(e) => updateHaving(i, 'source', e.target.value)}
@@ -1631,6 +1889,19 @@ export default function ReportBuilder() {
                   </option>
                 ))}
               </select>
+            ) : h.source === 'field' && fieldEnums[h.table]?.[h.field]?.length ? (
+              <select
+                value={h.value}
+                onChange={(e) => updateHaving(i, 'value', e.target.value)}
+                style={{ marginLeft: '0.5rem' }}
+              >
+                <option value=""></option>
+                {fieldEnums[h.table][h.field].map((v) => (
+                  <option key={v} value={v}>
+                    {v}
+                  </option>
+                ))}
+              </select>
             ) : (
               <input
                 value={h.value}
@@ -1638,6 +1909,12 @@ export default function ReportBuilder() {
                 style={{ marginLeft: '0.5rem' }}
               />
             )}
+            <input
+              type="number"
+              value={h.close || 0}
+              onChange={(e) => updateHaving(i, 'close', Number(e.target.value))}
+              style={{ width: '3rem', marginLeft: '0.25rem' }}
+            />
             <button
               onClick={() => removeHaving(i)}
               style={{ marginLeft: '0.5rem' }}
@@ -1647,6 +1924,14 @@ export default function ReportBuilder() {
           </div>
         ))}
         <button onClick={addHaving}>Add Having</button>
+      </section>
+
+      <section>
+        <h3>Union Queries</h3>
+        <div style={{ marginBottom: '0.5rem' }}>
+          Added: {unionQueries.length}
+        </div>
+        <button onClick={addUnionQuery}>Add UNION</button>
       </section>
 
       <section>
@@ -1710,48 +1995,101 @@ export default function ReportBuilder() {
                 <option value="OR">OR</option>
               </select>
             )}
-            <select
-              value={c.table}
-              onChange={(e) => updateCondition(i, 'table', e.target.value)}
-            >
-              {availableTables.map((t) => (
-                <option key={t} value={t}>
-                  {t}
-                </option>
-              ))}
-            </select>
-            <select
-              value={c.field}
-              onChange={(e) => updateCondition(i, 'field', e.target.value)}
-              style={{ marginLeft: '0.5rem' }}
-            >
-              {(tableFields[c.table] || []).map((f) => (
-                <option key={f} value={f}>
-                  {f}
-                </option>
-              ))}
-            </select>
-            <span> = </span>
-            <select
-              value={c.param}
-              onChange={(e) => updateCondition(i, 'param', e.target.value)}
-            >
-              {params.map((p) => (
-                <option key={p.name} value={p.name}>
-                  {p.name}
-                </option>
-              ))}
-            </select>
-            <button
-              onClick={() => removeCondition(i)}
-              style={{ marginLeft: '0.5rem' }}
-            >
-              ✕
-            </button>
+            {c.raw ? (
+              <>
+                <input
+                  type="number"
+                  value={c.open || 0}
+                  onChange={(e) =>
+                    updateCondition(i, 'open', Number(e.target.value))
+                  }
+                  style={{ width: '3rem', marginRight: '0.25rem' }}
+                />
+                <input
+                  value={c.raw}
+                  onChange={(e) => updateCondition(i, 'raw', e.target.value)}
+                  style={{ width: '50%' }}
+                />
+                <input
+                  type="number"
+                  value={c.close || 0}
+                  onChange={(e) =>
+                    updateCondition(i, 'close', Number(e.target.value))
+                  }
+                  style={{ width: '3rem', marginLeft: '0.25rem' }}
+                />
+                <button
+                  onClick={() => removeCondition(i)}
+                  style={{ marginLeft: '0.5rem' }}
+                >
+                  ✕
+                </button>
+              </>
+            ) : (
+              <>
+                <input
+                  type="number"
+                  value={c.open || 0}
+                  onChange={(e) =>
+                    updateCondition(i, 'open', Number(e.target.value))
+                  }
+                  style={{ width: '3rem', marginRight: '0.25rem' }}
+                />
+                <select
+                  value={c.table}
+                  onChange={(e) => updateCondition(i, 'table', e.target.value)}
+                >
+                  {availableTables.map((t) => (
+                    <option key={t} value={t}>
+                      {t}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  value={c.field}
+                  onChange={(e) => updateCondition(i, 'field', e.target.value)}
+                  style={{ marginLeft: '0.5rem' }}
+                >
+                  {(tableFields[c.table] || []).map((f) => (
+                    <option key={f} value={f}>
+                      {f}
+                    </option>
+                  ))}
+                </select>
+                <span> = </span>
+                <select
+                  value={c.param}
+                  onChange={(e) => updateCondition(i, 'param', e.target.value)}
+                >
+                  {params.map((p) => (
+                    <option key={p.name} value={p.name}>
+                      {p.name}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  type="number"
+                  value={c.close || 0}
+                  onChange={(e) =>
+                    updateCondition(i, 'close', Number(e.target.value))
+                  }
+                  style={{ width: '3rem', marginLeft: '0.25rem' }}
+                />
+                <button
+                  onClick={() => removeCondition(i)}
+                  style={{ marginLeft: '0.5rem' }}
+                >
+                  ✕
+                </button>
+              </>
+            )}
           </div>
         ))}
         <button onClick={addCondition} disabled={!params.length}>
           Add Condition
+        </button>
+        <button onClick={addRawCondition} style={{ marginLeft: '0.5rem' }}>
+          Add Raw Condition
         </button>
       </section>
 
@@ -1807,6 +2145,20 @@ export default function ReportBuilder() {
         <button onClick={handleLoadProcFile} style={{ marginLeft: '0.5rem' }}>
           Load from Host
         </button>
+        <select
+          value={selectedDbProcedure}
+          onChange={(e) => setSelectedDbProcedure(e.target.value)}
+          style={{ marginLeft: '0.5rem' }}
+        >
+          {dbProcedures.map((n) => (
+            <option key={n} value={n}>
+              {n}
+            </option>
+          ))}
+        </select>
+        <button onClick={handleDeleteProcedure} style={{ marginLeft: '0.5rem' }}>
+          Delete Procedure
+        </button>
       </section>
 
       {procFileText && (
@@ -1857,3 +2209,11 @@ export default function ReportBuilder() {
   );
 }
 
+
+export default function ReportBuilder(props) {
+  return (
+    <ErrorBoundary>
+      <ReportBuilderInner {...props} />
+    </ErrorBoundary>
+  );
+}

--- a/src/erp.mgt.mn/utils/buildReportSql.js
+++ b/src/erp.mgt.mn/utils/buildReportSql.js
@@ -8,82 +8,105 @@
 export default function buildReportSql(definition = {}) {
   if (!definition.from) throw new Error('definition.from is required');
 
-  const parts = [];
+  function build(def) {
+    const parts = [];
 
-  // SELECT clause with alias expansion
-  const selectItems = (definition.select || []).filter((s) => s && s.expr);
-  const aliasMap = {};
+    // SELECT clause with alias expansion
+    const selectItems = (def.select || []).filter((s) => s && s.expr);
+    const aliasMap = {};
 
-  function expandExpr(expr) {
-    let result = expr;
-    let replaced = true;
-    while (replaced) {
-      replaced = false;
-      for (const [al, ex] of Object.entries(aliasMap)) {
-        const re = new RegExp(`\\b${al}\\b`, 'g');
-        if (re.test(result)) {
-          result = result.replace(re, `(${ex})`);
-          replaced = true;
+    function expandExpr(expr) {
+      let result = expr;
+      let replaced = true;
+      while (replaced) {
+        replaced = false;
+        for (const [al, ex] of Object.entries(aliasMap)) {
+          const re = new RegExp(`\\b${al}\\b`, 'g');
+          if (re.test(result)) {
+            result = result.replace(re, `(${ex})`);
+            replaced = true;
+          }
         }
       }
+      return result;
     }
-    return result;
-  }
 
-  const selectList =
-    selectItems
-      .map((sel) => {
-        const expr = expandExpr(sel.expr);
-        if (sel.alias) aliasMap[sel.alias] = expr;
-        return sel.alias ? `${expr} AS ${sel.alias}` : expr;
-      })
-      .join(',\n  ') || '*';
-  parts.push(`SELECT${selectList ? '\n  ' + selectList : ''}`);
-
-  // FROM clause
-  parts.push(
-    `FROM ${definition.from.table}` +
-      (definition.from.alias ? ` ${definition.from.alias}` : '')
-  );
-
-  // JOIN clauses
-  (definition.joins || []).forEach(({ table, alias, type = 'JOIN', on }) => {
-    if (!on) return;
-    parts.push(`${type} ${table}` + (alias ? ` ${alias}` : '') + ` ON ${on}`);
-  });
-
-  // WHERE clause
-  if (definition.where?.length) {
-    const whereItems = definition.where.filter((w) => w && w.expr);
-    if (whereItems.length) {
-      const whereClause = whereItems
-        .map((w, i) => {
-          const connector = i > 0 ? `${w.connector || 'AND'} ` : '';
-          return connector + w.expr;
+    const selectList =
+      selectItems
+        .map((sel) => {
+          const expr = expandExpr(sel.expr);
+          if (sel.alias) aliasMap[sel.alias] = expr;
+          return sel.alias ? `${expr} AS ${sel.alias}` : expr;
         })
-        .join('\n  ');
-      parts.push(`WHERE\n  ${whereClause}`);
+        .join(',\n  ') || '*';
+    parts.push(`SELECT${selectList ? '\n  ' + selectList : ''}`);
+
+    // FROM clause
+    parts.push(
+      `FROM ${def.from.table}` + (def.from.alias ? ` ${def.from.alias}` : ''),
+    );
+
+    // JOIN clauses
+    (def.joins || []).forEach(({ table, alias, type = 'JOIN', on }) => {
+      if (!on) return;
+      parts.push(`${type} ${table}` + (alias ? ` ${alias}` : '') + ` ON ${on}`);
+    });
+
+    // WHERE clause
+    if (def.where?.length) {
+      const whereItems = def.where.filter((w) => w && w.expr);
+      if (whereItems.length) {
+        const whereClause = whereItems
+          .map((w, i) => {
+            const connector = i > 0 ? `${w.connector || 'AND'} ` : '';
+            const open = '('.repeat(w.open || 0);
+            const close = ')'.repeat(w.close || 0);
+            return connector + open + w.expr + close;
+          })
+          .join('\n  ');
+        parts.push(`WHERE\n  ${whereClause}`);
+      }
     }
-  }
 
-  // GROUP BY clause
-  if (definition.groupBy?.length) {
-    parts.push(`GROUP BY ${definition.groupBy.join(', ')}`);
-  }
-
-  // HAVING clause
-  if (definition.having?.length) {
-    const havingItems = definition.having.filter((h) => h && h.expr);
-    if (havingItems.length) {
-      const havingClause = havingItems
-        .map((h, i) => {
-          const connector = i > 0 ? `${h.connector || 'AND'} ` : '';
-          return connector + h.expr;
-        })
-        .join('\n  ');
-      parts.push(`HAVING\n  ${havingClause}`);
+    // GROUP BY clause
+    const aggRe = /\b(SUM|COUNT|AVG|MIN|MAX)\s*\(/i;
+    const hasAgg = selectItems.some((s) => aggRe.test(s.expr));
+    const groupSet = new Set(def.groupBy || []);
+    if (hasAgg) {
+      selectItems.forEach((s) => {
+        if (!aggRe.test(s.expr)) {
+          const gb = s.alias || expandExpr(s.expr);
+          if (gb) groupSet.add(gb);
+        }
+      });
     }
+    if (groupSet.size) {
+      parts.push(`GROUP BY ${Array.from(groupSet).join(', ')}`);
+    }
+
+    // HAVING clause
+    if (def.having?.length) {
+      const havingItems = def.having.filter((h) => h && h.expr);
+      if (havingItems.length) {
+        const havingClause = havingItems
+          .map((h, i) => {
+            const connector = i > 0 ? `${h.connector || 'AND'} ` : '';
+            const open = '('.repeat(h.open || 0);
+            const close = ')'.repeat(h.close || 0);
+            return connector + open + h.expr + close;
+          })
+          .join('\n  ');
+        parts.push(`HAVING\n  ${havingClause}`);
+      }
+    }
+
+    return parts.join('\n');
   }
 
-  return parts.join('\n');
+  const main = build(definition);
+  const unions = definition.unions || [];
+  if (!unions.length) return main;
+  const rest = unions.map((u) => build(u));
+  return [main, ...rest].map((q) => `(${q})`).join('\nUNION\n');
 }
+

--- a/tests/db/procedureRawRows.test.js
+++ b/tests/db/procedureRawRows.test.js
@@ -20,14 +20,15 @@ function mockPool(createSql) {
   };
 }
 
-test('getProcedureRawRows expands alias and removes aggregates', async () => {
+test('getProcedureRawRows expands alias and removes aggregates', { concurrency: false }, async () => {
   const createSql = `CREATE PROCEDURE \`sp_test\`()
 BEGIN
-  SELECT c.name AS category, SUM(t.amount) AS total
+  SELECT c.name AS category, SUM(t.amount) AS total, SUM(t.count) AS cnt
   FROM trans t
   JOIN categories c ON c.id = t.category_id
   WHERE t.date BETWEEN start_date AND end_date
   GROUP BY c.name;
+  SELECT 'after';
 END`;
   const restore = mockPool(createSql);
   const { sql } = await db.getProcedureRawRows(
@@ -39,10 +40,95 @@ END`;
   );
   restore();
   assert.ok(sql.includes('t.amount AS total'));
-  assert.ok(sql.includes("c.name = 'Phones'"));
+  assert.ok(!/\bcnt\b/i.test(sql));
+  assert.ok(sql.includes("category = 'Phones'"));
   assert.ok(sql.includes("'2024-01-01'"));
   assert.ok(!/GROUP BY/i.test(sql));
   assert.ok(!/HAVING/i.test(sql));
   assert.ok(!/SUM\(/i.test(sql));
+  assert.ok(/^SELECT \* FROM \(/i.test(sql));
+  assert.ok(/after/i.test(sql));
   await fs.unlink(path.join(process.cwd(), 'config', 'sp_test_rows.sql')).catch(() => {});
 });
+
+test('getProcedureRawRows handles nested SUM expressions', { concurrency: false }, async () => {
+  const createSql = `CREATE PROCEDURE \`sp_case\`()
+BEGIN
+  SELECT t.id, t.name,
+         SUM(CASE WHEN t.type = 'a' THEN IFNULL(t.val,0) ELSE 0 END) AS a_val,
+         SUM(CASE WHEN t.type = 'b' THEN IFNULL(t.val,0) ELSE 0 END) AS b_val
+  FROM trans t;
+END`;
+  const restore = mockPool(createSql);
+  const { sql } = await db.getProcedureRawRows(
+    'sp_case',
+    {},
+    'b_val',
+    'id',
+    5,
+  );
+  restore();
+  assert.ok(
+    sql.includes("CASE WHEN t.type = 'b' THEN IFNULL(t.val,0) ELSE 0 END AS b_val"),
+  );
+  assert.ok(!/\ba_val\b/i.test(sql));
+  assert.ok(!/SUM\(/i.test(sql));
+  assert.ok(sql.includes("id = 5"));
+  await fs.unlink(path.join(process.cwd(), 'config', 'sp_case_rows.sql')).catch(() => {});
+});
+
+test(
+  'getProcedureRawRows appends visibleFields from all configs and returns displayFields',
+  { concurrency: false },
+  async () => {
+    const origRead = fs.readFile;
+    fs.readFile = async (p, enc) => {
+      if (p.endsWith(path.join('config', 'transactionForms.json'))) {
+        return JSON.stringify({
+          trans: {
+            general: {
+              A: {
+                visibleFields: ['id'],
+                headerFields: ['hdr'],
+                mainFields: ['main'],
+                footerFields: ['ftr'],
+              },
+              subgroup: { B: { visibleFields: ['note'] } },
+            },
+          },
+        });
+      }
+      if (p.endsWith(path.join('config', 'tableDisplayFields.json'))) {
+        return JSON.stringify({
+          trans: { idField: 'id', displayFields: ['id', 'note', 'hdr', 'main', 'ftr'] },
+        });
+      }
+      return origRead(p, enc);
+    };
+    const createSql = `CREATE PROCEDURE \`sp_vis\`()
+BEGIN
+  SELECT tr.category, SUM(tr.amount) AS total
+  FROM (SELECT * FROM trans) tr
+  GROUP BY tr.category;
+END`;
+    const restore = mockPool(createSql);
+    const { sql, displayFields } = await db.getProcedureRawRows(
+      'sp_vis',
+      {},
+      'total',
+      'category',
+      'Phones',
+    );
+    restore();
+    fs.readFile = origRead;
+    assert.ok(sql.includes('tr.id'));
+    assert.ok(sql.includes('tr.note'));
+    assert.ok(sql.includes('tr.hdr'));
+    assert.ok(sql.includes('tr.main'));
+    assert.ok(sql.includes('tr.ftr'));
+    assert.deepEqual(displayFields, ['id', 'note', 'hdr', 'main', 'ftr']);
+    await fs
+      .unlink(path.join(process.cwd(), 'config', 'sp_vis_rows.sql'))
+      .catch(() => {});
+  },
+);

--- a/tests/db/proceduresList.test.js
+++ b/tests/db/proceduresList.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as db from '../../db/index.js';
+
+test('listReportProcedures returns routine names', async () => {
+  const original = db.pool.query;
+  db.pool.query = async (sql) => {
+    if (/information_schema\.ROUTINES/i.test(sql)) {
+      return [[{ ROUTINE_NAME: 'report_a' }, { ROUTINE_NAME: 'report_b' }]];
+    }
+    return [[]];
+  };
+  const names = await db.listReportProcedures();
+  db.pool.query = original;
+  assert.deepEqual(names, ['report_a', 'report_b']);
+});
+
+test('deleteProcedure drops routine', async () => {
+  const calls = [];
+  const original = db.pool.query;
+  db.pool.query = async (sql) => {
+    calls.push(sql);
+    return [];
+  };
+  await db.deleteProcedure('report_a');
+  db.pool.query = original;
+  assert.ok(calls[0].includes('DROP PROCEDURE IF EXISTS `report_a`'));
+});

--- a/tests/utils/buildReportSql.test.js
+++ b/tests/utils/buildReportSql.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import buildReportSql from '../../src/erp.mgt.mn/utils/buildReportSql.js';
+
+test('buildReportSql adds non aggregated fields to group by', () => {
+  const sql = buildReportSql({
+    from: { table: 'sales', alias: 's' },
+    select: [
+      { expr: 's.category', alias: 'category' },
+      { expr: 'SUM(s.amount)', alias: 'total' },
+    ],
+  });
+  assert.ok(sql.includes('GROUP BY category'));
+  assert.ok(!sql.match(/GROUP BY.*GROUP BY/));
+});
+
+test('buildReportSql unions additional queries', () => {
+  const sql = buildReportSql({
+    from: { table: 'sales', alias: 's' },
+    select: [{ expr: 's.id' }],
+    unions: [
+      {
+        from: { table: 'sales_archive', alias: 'sa' },
+        select: [{ expr: 'sa.id' }],
+      },
+    ],
+  });
+  assert.ok(sql.includes('FROM sales s'));
+  assert.ok(sql.includes('UNION'));
+  assert.ok(sql.includes('FROM sales_archive sa'));
+});
+
+test('buildReportSql allows parenthesized conditions', () => {
+  const sql = buildReportSql({
+    from: { table: 'tbl', alias: 't' },
+    select: [{ expr: 't.id' }],
+    where: [
+      { expr: 't.branchid = :bid', open: 1 },
+      { expr: 't.alt_branch = :bid', connector: 'OR', close: 1 },
+    ],
+  });
+  assert.ok(/\(t.branchid = :bid\s*OR t.alt_branch = :bid\)/.test(sql));
+});


### PR DESCRIPTION
## Summary
- Prevent duplicate table aliases in saved procedures by generating unique join aliases and supporting parenthesized join conditions
- Surface database report procedures in the builder with a dropdown and allow deleting selected procedures
- Avoid a blank Report Builder page by surfacing table-load failures
- Wrap Report Builder in an error boundary to show friendly errors instead of a blank screen and document the new behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897394edf648331a1d4547fbec136e6