### PR TITLE
Include user info in refresh token and rotate on refresh

### DIFF
--- a/api-server/controllers/authController.js
+++ b/api-server/controllers/authController.js
@@ -16,7 +16,11 @@ export async function login(req, res, next) {
       role: user.role,
     });
 
-    const refreshToken = jwtService.signRefresh({ id: user.id });
+    const refreshToken = jwtService.signRefresh({
+      id: user.id,
+      empid: user.empid,
+      role: user.role,
+    });
 
     res.cookie(getCookieName(), token, {
       httpOnly: true,
@@ -87,11 +91,22 @@ export async function refresh(req, res) {
       empid: user.empid,
       role: user.role,
     });
+    const newRefresh = jwtService.signRefresh({
+      id: user.id,
+      empid: user.empid,
+      role: user.role,
+    });
     res.cookie(getCookieName(), newAccess, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
       maxAge: jwtService.getExpiryMillis(),
+    });
+    res.cookie(getRefreshCookieName(), newRefresh, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: jwtService.getRefreshExpiryMillis(),
     });
     res.json({
       id: user.id,

--- a/api-server/middlewares/auth.js
+++ b/api-server/middlewares/auth.js
@@ -5,41 +5,9 @@ import { getCookieName, getRefreshCookieName } from '../utils/cookieNames.js';
 export function requireAuth(req, res, next) {
   // Read from req.cookies (not req.signedCookies) because we didn't sign it
   const token = req.cookies?.[getCookieName()];
-  if (!token) {
-    return res.status(401).json({ message: 'Authentication required' });
-  }
+  const rToken = req.cookies?.[getRefreshCookieName()];
 
-  try {
-    // Verify the JWT
-    const payload = jwtService.verify(token);
-    req.user = payload; // { id, empid, role, iat, exp }
-    next();
-  } catch (err) {
-    let refreshed = false;
-    if (err.name === 'TokenExpiredError') {
-      const rToken = req.cookies?.[getRefreshCookieName()];
-      if (rToken) {
-        try {
-          const rPayload = jwtService.verifyRefresh(rToken);
-          const newAccess = jwtService.sign({
-            id: rPayload.id,
-            empid: rPayload.empid,
-            role: rPayload.role,
-          });
-          res.cookie(getCookieName(), newAccess, {
-            httpOnly: true,
-            secure: process.env.NODE_ENV === 'production',
-            sameSite: 'lax',
-            maxAge: jwtService.getExpiryMillis(),
-          });
-          req.user = jwtService.verify(newAccess);
-          refreshed = true;
-        } catch {}
-      }
-    }
-    if (refreshed) return next();
-
-    console.error('JWT verification failed:', err);
+  function clearCookies() {
     const opts = {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
@@ -47,6 +15,66 @@ export function requireAuth(req, res, next) {
     };
     res.clearCookie(getCookieName(), opts);
     res.clearCookie(getRefreshCookieName(), opts);
+  }
+
+  function issueTokens(payload) {
+    const newAccess = jwtService.sign({
+      id: payload.id,
+      empid: payload.empid,
+      role: payload.role,
+    });
+    const newRefresh = jwtService.signRefresh({
+      id: payload.id,
+      empid: payload.empid,
+      role: payload.role,
+    });
+    res.cookie(getCookieName(), newAccess, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: jwtService.getExpiryMillis(),
+    });
+    res.cookie(getRefreshCookieName(), newRefresh, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: jwtService.getRefreshExpiryMillis(),
+    });
+    req.user = jwtService.verify(newAccess);
+  }
+
+  if (!token) {
+    if (rToken) {
+      try {
+        const payload = jwtService.verifyRefresh(rToken);
+        issueTokens(payload);
+        return next();
+      } catch {
+        clearCookies();
+      }
+    }
+    clearCookies();
+    return res.status(401).json({ message: 'Authentication required' });
+  }
+
+  try {
+    // Verify the JWT
+    const payload = jwtService.verify(token);
+    req.user = payload; // { id, empid, role, iat, exp }
+    return next();
+  } catch (err) {
+    if (err.name === 'TokenExpiredError' && rToken) {
+      try {
+        const payload = jwtService.verifyRefresh(rToken);
+        issueTokens(payload);
+        return next();
+      } catch {
+        clearCookies();
+      }
+    }
+
+    console.error('JWT verification failed:', err);
+    clearCookies();
     return res.status(401).json({ message: 'Invalid or expired token' });
   }
 }

--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -38,14 +38,37 @@ import { useTxnModules } from './hooks/useTxnModules.js';
 import useGeneralConfig from './hooks/useGeneralConfig.js';
 
 export default function App() {
+  useEffect(() => {
+    debugLog('Component mounted: App');
+  }, []);
+
+  return (
+    <ToastProvider>
+      <AuthContextProvider>
+        <TxnSessionProvider>
+          <LoadingProvider>
+            <TabProvider>
+              <HashRouter>
+                <Routes>
+                  <Route path="/login" element={<LoginPage />} />
+                  <Route element={<RequireAuth />}>
+                    <Route path="/*" element={<AuthedApp />} />
+                  </Route>
+                </Routes>
+              </HashRouter>
+            </TabProvider>
+          </LoadingProvider>
+        </TxnSessionProvider>
+      </AuthContextProvider>
+    </ToastProvider>
+  );
+}
+
+function AuthedApp() {
   const modules = useModules();
   const txnModules = useTxnModules();
   const generalConfig = useGeneralConfig();
   const headerMap = useHeaderMappings(modules.map((m) => m.module_key));
-
-  useEffect(() => {
-    debugLog('Component mounted: App');
-  }, []);
 
   const moduleMap = {};
   modules.forEach((m) => {
@@ -143,32 +166,17 @@ export default function App() {
     .map((m) => moduleMap[m.module_key]);
 
   return (
-    <ToastProvider>
-      <AuthContextProvider>
-        <TxnSessionProvider>
-          <LoadingProvider>
-            <TabProvider>
-              <HashRouter>
-                <Routes>
-                  <Route path="/login" element={<LoginPage />} />
-                  <Route element={<RequireAuth />}>
-                    <Route path="/" element={<ERPLayout />}>{roots.map(renderRoute)}</Route>
-                    <Route
-                      path="inventory-demo"
-                      element={
-                        <AppLayout title="Inventory">
-                          <InventoryPage />
-                        </AppLayout>
-                      }
-                    />
-                  </Route>
-                </Routes>
-              </HashRouter>
-            </TabProvider>
-          </LoadingProvider>
-        </TxnSessionProvider>
-      </AuthContextProvider>
-    </ToastProvider>
+    <Routes>
+      <Route path="/" element={<ERPLayout />}>{roots.map(renderRoute)}</Route>
+      <Route
+        path="inventory-demo"
+        element={
+          <AppLayout title="Inventory">
+            <InventoryPage />
+          </AppLayout>
+        }
+      />
+    </Routes>
   );
 }
 

--- a/src/erp.mgt.mn/components/RequireAuth.jsx
+++ b/src/erp.mgt.mn/components/RequireAuth.jsx
@@ -4,5 +4,8 @@ import { Navigate, Outlet } from 'react-router-dom';
 
 export default function RequireAuth() {
   const { user } = useContext(AuthContext);
+  // While the profile is being loaded (`user` is undefined), render nothing to
+  // avoid redirecting to the login page during a hard refresh.
+  if (user === undefined) return null;
   return user ? <Outlet /> : <Navigate to="/login" replace />;
 }

--- a/src/erp.mgt.mn/utils/csrfFetch.js
+++ b/src/erp.mgt.mn/utils/csrfFetch.js
@@ -56,6 +56,13 @@ window.fetch = async (url, options = {}, _retry) => {
         return window.fetch(url, options, true);
       }
     }
+    if (!url.toString().includes('/auth/login')) {
+      window.dispatchEvent(new CustomEvent('auth:logout'));
+      if (!window.location.hash.startsWith('#/login')) {
+        window.location.hash = '#/login';
+      }
+    }
+    return res;
   }
   if (!res.ok) {
     let errorMsg = res.statusText;


### PR DESCRIPTION
## Summary
- ensure refresh tokens carry id, empid and role
- rotate refresh token alongside access token during automatic and manual refresh
- refresh session when access token cookie has expired
- clear auth cookies when refresh token is missing or invalid so inactive sessions log out
- redirect to login and clear auth state on 401 responses, avoiding repeated toast errors
- defer module loading until after authentication to prevent unauthorized API calls on the login page
- wait for profile lookup before redirecting so a hard refresh doesn't send the user to the login page

## Testing
- `npm test`
- `node --test tests/api/deleteImageMovesFile.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6897037a74cc83319682d356b549780f