### PR TITLE
fix: remove undefined unions from report builder

### DIFF
--- a/src/erp.mgt.mn/pages/ReportBuilder.jsx
+++ b/src/erp.mgt.mn/pages/ReportBuilder.jsx
@@ -800,7 +800,6 @@ function ReportBuilderInner() {
       where,
       groupBy,
       having: havingDefs,
-      unions: unionTables,
     };
   }
 
@@ -1124,25 +1123,6 @@ function ReportBuilderInner() {
             </option>
           ))}
         </select>
-      </section>
-
-      <section>
-        <h3>Union Tables</h3>
-        {unions.map((u, i) => (
-          <div key={i} style={{ marginBottom: '0.5rem' }}>
-            <select value={u} onChange={(e) => updateUnion(i, e.target.value)}>
-              {tables.map((t) => (
-                <option key={t} value={t}>
-                  {t}
-                </option>
-              ))}
-            </select>
-            <button onClick={() => removeUnion(i)} style={{ marginLeft: '0.5rem' }}>
-              ✕
-            </button>
-          </div>
-        ))}
-        <button onClick={addUnion}>Add Union</button>
       </section>
 
       <section>


### PR DESCRIPTION
## Summary
- remove leftover union table code causing runtime ReferenceError

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68986e9c3ec48331b8f80f443b5ec191