### PR TITLE
Use configurable prefixes for report procedures and views

### DIFF
--- a/api-server/routes/procedures.js
+++ b/api-server/routes/procedures.js
@@ -11,9 +11,8 @@ const router = express.Router();
 
 router.get('/', requireAuth, async (req, res, next) => {
   try {
-    const procedures = (await listStoredProcedures()).filter((p) =>
-      typeof p === 'string' && p.toLowerCase().includes('report'),
-    );
+    const { prefix = '' } = req.query;
+    const procedures = await listStoredProcedures(prefix);
     res.json({ procedures });
   } catch (err) {
     next(err);

--- a/api-server/routes/report_builder.js
+++ b/api-server/routes/report_builder.js
@@ -37,10 +37,11 @@ router.get('/fields', requireAuth, async (req, res, next) => {
   }
 });
 
-// List stored procedures containing "report"
+// List stored procedures
 router.get('/procedures', requireAuth, async (req, res, next) => {
   try {
-    const names = await listReportProcedures();
+    const { prefix = '' } = req.query;
+    const names = await listReportProcedures(prefix);
     res.json({ names });
   } catch (err) {
     next(err);
@@ -102,11 +103,17 @@ router.post('/procedure-files/:name', requireAuth, async (req, res, next) => {
 // List stored procedure files on host
 router.get('/procedure-files', requireAuth, async (req, res, next) => {
   try {
+    const { prefix = '' } = req.query;
     await fs.mkdir(PROC_DIR, { recursive: true });
     const files = await fs.readdir(PROC_DIR);
     const names = files
       .filter((f) => f.endsWith('.json'))
-      .map((f) => f.replace(/\.json$/, ''));
+      .map((f) => f.replace(/\.json$/, ''))
+      .filter(
+        (n) =>
+          typeof n === 'string' &&
+          (!prefix || n.toLowerCase().includes(prefix.toLowerCase())),
+      );
     res.json({ names });
   } catch (err) {
     next(err);
@@ -142,9 +149,17 @@ router.post('/configs/:name', requireAuth, async (req, res, next) => {
 // List saved report definitions
 router.get('/configs', requireAuth, async (req, res, next) => {
   try {
+    const { prefix = '' } = req.query;
     await fs.mkdir(CONFIG_DIR, { recursive: true });
     const files = await fs.readdir(CONFIG_DIR);
-    const names = files.filter((f) => f.endsWith('.json')).map((f) => f.replace(/\.json$/, ''));
+    const names = files
+      .filter((f) => f.endsWith('.json'))
+      .map((f) => f.replace(/\.json$/, ''))
+      .filter(
+        (n) =>
+          typeof n === 'string' &&
+          (!prefix || n.toLowerCase().includes(prefix.toLowerCase())),
+      );
     res.json({ names });
   } catch (err) {
     next(err);

--- a/api-server/routes/report_procedures.js
+++ b/api-server/routes/report_procedures.js
@@ -6,13 +6,16 @@ const router = express.Router();
 
 router.get('/', requireAuth, async (req, res, next) => {
   try {
-    const { branchId, departmentId } = req.query;
+    const { branchId, departmentId, prefix = '' } = req.query;
     const forms = await listTransactionNames({ branchId, departmentId });
     const set = new Set();
     Object.values(forms).forEach((info) => {
       if (Array.isArray(info.procedures)) {
         info.procedures.forEach((p) => {
-          if (typeof p === 'string' && p.toLowerCase().includes('report')) {
+          if (
+            typeof p === 'string' &&
+            (!prefix || p.toLowerCase().includes(prefix.toLowerCase()))
+          ) {
             set.add(p);
           }
         });

--- a/api-server/routes/views.js
+++ b/api-server/routes/views.js
@@ -6,7 +6,8 @@ const router = express.Router();
 
 router.get('/', requireAuth, async (req, res, next) => {
   try {
-    const views = await listDatabaseViews();
+    const { prefix = '' } = req.query;
+    const views = await listDatabaseViews(prefix);
     res.json(views);
   } catch (err) {
     next(err);

--- a/api-server/services/generalConfig.js
+++ b/api-server/services/generalConfig.js
@@ -31,8 +31,8 @@ const defaults = {
     showReportParams: false,
     procLabels: {},
     procFieldLabels: {},
-    reportProcSuffix: '',
-    reportViewSuffix: '',
+    reportProcPrefix: '',
+    reportViewPrefix: '',
   },
   images: {
     basePath: 'uploads',

--- a/config/generalConfig.json
+++ b/config/generalConfig.json
@@ -26,8 +26,8 @@
     "showReportParams": false,
     "procLabels": {},
     "procFieldLabels": {},
-    "reportProcSuffix": "",
-    "reportViewSuffix": "",
+    "reportProcPrefix": "",
+    "reportViewPrefix": "",
     "imageDir": "txn_images"
   },
   "images": {

--- a/src/erp.mgt.mn/hooks/useModules.js
+++ b/src/erp.mgt.mn/hooks/useModules.js
@@ -1,8 +1,9 @@
 import { useEffect, useState, useContext } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { debugLog } from '../utils/debug.js';
+import useGeneralConfig from '../hooks/useGeneralConfig.js';
 
-const cache = { data: null, branchId: undefined, departmentId: undefined };
+const cache = { data: null, branchId: undefined, departmentId: undefined, prefix: undefined };
 const emitter = new EventTarget();
 
 export function refreshModules() {
@@ -12,6 +13,7 @@ export function refreshModules() {
 
 export function useModules() {
   const { company } = useContext(AuthContext);
+  const generalConfig = useGeneralConfig();
   const [modules, setModules] = useState(cache.data || []);
 
   async function fetchModules() {
@@ -24,6 +26,8 @@ export function useModules() {
           params.set('branchId', company.branch_id);
         if (company?.department_id !== undefined)
           params.set('departmentId', company.department_id);
+        const prefix = generalConfig?.general?.reportProcPrefix || '';
+        if (prefix) params.set('prefix', prefix);
         const pres = await fetch(
           `/api/report_procedures${params.toString() ? `?${params.toString()}` : ''}`,
           { credentials: 'include' },
@@ -31,7 +35,12 @@ export function useModules() {
         if (pres.ok) {
           const data = await pres.json();
           const list = Array.isArray(data.procedures) ? data.procedures : [];
-          list.forEach((p) => {
+          const filtered = prefix
+            ? list.filter((p) =>
+                p.toLowerCase().includes(prefix.toLowerCase()),
+              )
+            : list;
+          filtered.forEach((p) => {
             const key = `proc_${p.toLowerCase().replace(/[^a-z0-9_]/g, '_')}`;
             rows.push({
               module_key: key,
@@ -48,6 +57,7 @@ export function useModules() {
       cache.data = rows;
       cache.branchId = company?.branch_id;
       cache.departmentId = company?.department_id;
+      cache.prefix = generalConfig?.general?.reportProcPrefix;
       setModules(rows);
     } catch (err) {
       console.error('Failed to load modules', err);
@@ -57,21 +67,23 @@ export function useModules() {
 
   useEffect(() => {
     debugLog('useModules effect: initial fetch');
+    const prefix = generalConfig?.general?.reportProcPrefix;
     if (
       !cache.data ||
       cache.branchId !== company?.branch_id ||
-      cache.departmentId !== company?.department_id
+      cache.departmentId !== company?.department_id ||
+      cache.prefix !== prefix
     ) {
       fetchModules();
     }
-  }, [company?.branch_id, company?.department_id]);
+  }, [company?.branch_id, company?.department_id, generalConfig?.general?.reportProcPrefix]);
 
   useEffect(() => {
     debugLog('useModules effect: refresh listener');
     const handler = () => fetchModules();
     emitter.addEventListener('refresh', handler);
     return () => emitter.removeEventListener('refresh', handler);
-  }, [company?.branch_id, company?.department_id]);
+  }, [company?.branch_id, company?.department_id, generalConfig?.general?.reportProcPrefix]);
 
   return modules;
 }

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -270,9 +270,19 @@ useEffect(() => {
     .then((cfg) => {
       if (canceled) return;
       if (cfg && cfg.moduleKey) {
-        if (!isEqual(cfg, prevConfigRef.current)) {
-          setConfig(cfg);
-          prevConfigRef.current = cfg;
+        const prefix = generalConfig?.general?.reportProcPrefix || '';
+        let nextCfg = cfg;
+        if (prefix && Array.isArray(cfg.procedures)) {
+          nextCfg = {
+            ...cfg,
+            procedures: cfg.procedures.filter((p) =>
+              p.toLowerCase().includes(prefix.toLowerCase()),
+            ),
+          };
+        }
+        if (!isEqual(nextCfg, prevConfigRef.current)) {
+          setConfig(nextCfg);
+          prevConfigRef.current = nextCfg;
         }
         setShowTable(true);
       } else {
@@ -291,7 +301,7 @@ useEffect(() => {
   return () => {
     canceled = true;
   };
-}, [table, name, addToast]);
+}, [table, name, addToast, generalConfig?.general?.reportProcPrefix]);
 
   useEffect(() => {
     if (!selectedProc) {

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -58,43 +58,63 @@ export default function FormsManagement() {
     procedures: [],
   });
 
-  useEffect(() => {
-    fetch('/api/tables', { credentials: 'include' })
-      .then((res) => (res.ok ? res.json() : []))
-      .then((data) => setTables(data))
-      .catch(() => setTables([]));
+    useEffect(() => {
+      const procPrefix = generalConfig?.general?.reportProcPrefix || '';
+      const viewPrefix = generalConfig?.general?.reportViewPrefix || '';
 
-    fetch('/api/views', { credentials: 'include' })
-      .then((res) => (res.ok ? res.json() : []))
-      .then((data) => setViews(data))
-      .catch(() => setViews([]));
+      fetch('/api/tables', { credentials: 'include' })
+        .then((res) => (res.ok ? res.json() : []))
+        .then((data) => setTables(data))
+        .catch(() => setTables([]));
 
-    fetch('/api/tables/code_branches?perPage=500', { credentials: 'include' })
-      .then((res) => (res.ok ? res.json() : { rows: [] }))
-      .then((data) => setBranches(data.rows || []))
-      .catch(() => setBranches([]));
-
-    fetch('/api/tables/code_department?perPage=500', { credentials: 'include' })
-      .then((res) => (res.ok ? res.json() : { rows: [] }))
-      .then((data) => setDepartments(data.rows || []))
-      .catch(() => setDepartments([]));
-
-    fetch('/api/tables/code_transaction?perPage=500', { credentials: 'include' })
-      .then((res) => (res.ok ? res.json() : { rows: [] }))
-      .then((data) => setTxnTypes(data.rows || []))
-      .catch(() => setTxnTypes([]));
-
-    fetch('/api/procedures', { credentials: 'include' })
-      .then((res) => (res.ok ? res.json() : { procedures: [] }))
-      .then((data) =>
-        setProcedureOptions(
-          (data.procedures || []).filter((p) =>
-            String(p).toLowerCase().includes('report'),
-          )
-        )
+      fetch(
+        `/api/views${viewPrefix ? `?prefix=${encodeURIComponent(viewPrefix)}` : ''}`,
+        { credentials: 'include' },
       )
-      .catch(() => setProcedureOptions([]));
-  }, []);
+        .then((res) => (res.ok ? res.json() : []))
+        .then((data) =>
+          setViews(
+            Array.isArray(data)
+              ? viewPrefix
+                ? data.filter((v) => String(v).includes(viewPrefix))
+                : data
+              : [],
+          ),
+        )
+        .catch(() => setViews([]));
+
+      fetch('/api/tables/code_branches?perPage=500', { credentials: 'include' })
+        .then((res) => (res.ok ? res.json() : { rows: [] }))
+        .then((data) => setBranches(data.rows || []))
+        .catch(() => setBranches([]));
+
+      fetch('/api/tables/code_department?perPage=500', { credentials: 'include' })
+        .then((res) => (res.ok ? res.json() : { rows: [] }))
+        .then((data) => setDepartments(data.rows || []))
+        .catch(() => setDepartments([]));
+
+      fetch('/api/tables/code_transaction?perPage=500', { credentials: 'include' })
+        .then((res) => (res.ok ? res.json() : { rows: [] }))
+        .then((data) => setTxnTypes(data.rows || []))
+        .catch(() => setTxnTypes([]));
+
+      fetch(
+        `/api/procedures${
+          procPrefix ? `?prefix=${encodeURIComponent(procPrefix)}` : ''
+        }`,
+        { credentials: 'include' },
+      )
+        .then((res) => (res.ok ? res.json() : { procedures: [] }))
+        .then((data) =>
+          setProcedureOptions(
+            (data.procedures || []).filter((p) => {
+              const low = String(p).toLowerCase();
+              return !procPrefix || low.includes(procPrefix.toLowerCase());
+            }),
+          ),
+        )
+        .catch(() => setProcedureOptions([]));
+    }, [generalConfig?.general?.reportProcPrefix, generalConfig?.general?.reportViewPrefix]);
 
   useEffect(() => {
     if (!table) return;

--- a/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
+++ b/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
@@ -209,29 +209,29 @@ export default function GeneralConfiguration() {
         <>
           <div style={{ marginBottom: '0.5rem' }}>
             <label>
-              Stored Procedure Suffix{' '}
+              Stored Procedure Prefix{' '}
               <input
-                name="reportProcSuffix"
+                name="reportProcPrefix"
                 type="text"
-                value={active.reportProcSuffix ?? ''}
+                value={active.reportProcPrefix ?? ''}
                 onChange={handleChange}
                 style={{ width: '8rem' }}
               />
             </label>
-            <div style={{ fontSize: '0.8rem' }}>Appended to report stored procedure names</div>
+            <div style={{ fontSize: '0.8rem' }}>Prepended to report stored procedure names</div>
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
             <label>
-              View Suffix{' '}
+              View Prefix{' '}
               <input
-                name="reportViewSuffix"
+                name="reportViewPrefix"
                 type="text"
-                value={active.reportViewSuffix ?? ''}
+                value={active.reportViewPrefix ?? ''}
                 onChange={handleChange}
                 style={{ width: '8rem' }}
               />
             </label>
-            <div style={{ fontSize: '0.8rem' }}>Appended to report view names</div>
+            <div style={{ fontSize: '0.8rem' }}>Prepended to report view names</div>
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
             <label>

--- a/src/erp.mgt.mn/pages/ReportBuilder.jsx
+++ b/src/erp.mgt.mn/pages/ReportBuilder.jsx
@@ -97,34 +97,43 @@ function ReportBuilderInner() {
       }
     }
     fetchTables();
+  }, []);
+
+  useEffect(() => {
+    const prefix = generalConfig?.general?.reportProcPrefix || '';
+    if (!generalConfig) return;
+    const query = prefix ? `?prefix=${encodeURIComponent(prefix)}` : '';
     async function fetchSaved() {
       try {
-        const res = await fetch('/api/report_builder/configs');
+        const res = await fetch(`/api/report_builder/configs${query}`);
         const data = await res.json();
-        setSavedReports(data.names || []);
-        setSelectedReport(data.names?.[0] || '');
+        const list = data.names || [];
+        setSavedReports(list);
+        setSelectedReport(list[0] || '');
       } catch (err) {
         console.error(err);
       }
       try {
-        const res = await fetch('/api/report_builder/procedure-files');
+        const res = await fetch(`/api/report_builder/procedure-files${query}`);
         const data = await res.json();
-        setProcFiles(data.names || []);
-        setSelectedProcFile(data.names?.[0] || '');
+        const list = data.names || [];
+        setProcFiles(list);
+        setSelectedProcFile(list[0] || '');
       } catch (err) {
         console.error(err);
       }
       try {
-        const res = await fetch('/api/report_builder/procedures');
+        const res = await fetch(`/api/report_builder/procedures${query}`);
         const data = await res.json();
-        setDbProcedures(data.names || []);
-        setSelectedDbProcedure(data.names?.[0] || '');
+        const list = data.names || [];
+        setDbProcedures(list);
+        setSelectedDbProcedure(list[0] || '');
       } catch (err) {
         console.error(err);
       }
     }
     fetchSaved();
-  }, []);
+  }, [generalConfig?.general?.reportProcPrefix]);
 
   // Ensure fields for a table are loaded
   async function ensureFields(table) {
@@ -320,12 +329,17 @@ function ReportBuilderInner() {
         if (value === 'alias') {
           next.baseAlias =
             fields.slice(0, index).find((pf) => pf.alias)?.alias || '';
+          next.table = '';
+          next.field = '';
+          next.aggregate = 'NONE';
+          next.calcParts = [];
         } else {
           const first = (tableFields[fromTable] || [])[0] || '';
           next.table = fromTable;
           next.field = first;
           if (!next.alias) next.alias = first;
           next.baseAlias = '';
+          next.calcParts = [];
           ensureFields(fromTable);
         }
       }
@@ -392,7 +406,7 @@ function ReportBuilderInner() {
     const parts = fields[fIndex].calcParts || [];
     const part = {
       source: 'alias',
-      alias: fields.slice(0, fIndex).find((pf) => pf.alias)?.alias || '',
+      alias: '',
       table: fromTable,
       field: (tableFields[fromTable] || [])[0] || '',
       operator: '+',
@@ -797,13 +811,21 @@ function ReportBuilderInner() {
       })
       .filter((j) => j.on);
 
-    const validTables = new Set([ft, ...joinDefs.map((j) => j.original)]);
+    // Track tables in a case-insensitive set so comparisons ignore letter case
+    const validTables = new Set(
+      [ft, ...joinDefs.map((j) => j.original)]
+        .filter(Boolean)
+        .map((t) => t.toLowerCase()),
+    );
 
     const fieldExprMap = {};
     const select = fs
       .filter((f) => (f.source === 'alias' ? f.baseAlias : f.field))
       .map((f) => {
-        if (f.source === 'field' && !validTables.has(f.table)) {
+        if (
+          f.source === 'field' &&
+          !validTables.has((f.table || '').toLowerCase())
+        ) {
           throw new Error(`Table ${f.table} is not joined`);
         }
         let base =
@@ -818,13 +840,17 @@ function ReportBuilderInner() {
                 ? p.alias
                 : `${aliases[p.table]}.${p.field}`;
             if (!seg) return;
-            if (p.source === 'field' && !validTables.has(p.table)) {
+            if (
+              p.source === 'field' &&
+              !validTables.has((p.table || '').toLowerCase())
+            ) {
               throw new Error(`Table ${p.table} is not joined`);
             }
             exprParts.push(`${p.operator} ${seg}`);
           });
           let expr = exprParts.join(' ');
           Object.entries(fieldExprMap).forEach(([al, ex]) => {
+            if (new RegExp(`\\b${al}\\b`).test(ex)) return;
             const re = new RegExp(`\\b${al}\\b`, 'g');
             expr = expr.replace(re, `(${ex})`);
           });
@@ -837,7 +863,7 @@ function ReportBuilderInner() {
               const cond = f.conditions
                 .filter((c) => c.field && (c.valueType === 'param' ? c.param : c.value))
                 .map((c, idx) => {
-                  if (!validTables.has(c.table)) {
+                  if (!validTables.has((c.table || '').toLowerCase())) {
                     throw new Error(`Table ${c.table} is not joined`);
                   }
                   const connector = idx > 0 ? ` ${c.connector} ` : '';
@@ -862,7 +888,7 @@ function ReportBuilderInner() {
             const cond = f.conditions
               .filter((c) => c.field && (c.valueType === 'param' ? c.param : c.value))
               .map((c, idx) => {
-                if (!validTables.has(c.table)) {
+                if (!validTables.has((c.table || '').toLowerCase())) {
                   throw new Error(`Table ${c.table} is not joined`);
                 }
                 const connector = idx > 0 ? ` ${c.connector} ` : '';
@@ -898,7 +924,7 @@ function ReportBuilderInner() {
         if (c.raw) {
           return { expr: c.raw, connector: c.connector, open: c.open, close: c.close };
         }
-        if (!validTables.has(c.table)) {
+        if (!validTables.has((c.table || '').toLowerCase())) {
           throw new Error(`Table ${c.table} is not joined`);
         }
         return {
@@ -912,7 +938,7 @@ function ReportBuilderInner() {
     const groupBy = gs
       .filter((g) => g.table && g.field)
       .map((g) => {
-        if (!validTables.has(g.table)) {
+        if (!validTables.has((g.table || '').toLowerCase())) {
           throw new Error(`Table ${g.table} is not joined`);
         }
         return `${aliases[g.table]}.${g.field}`;
@@ -925,7 +951,10 @@ function ReportBuilderInner() {
           h.source === 'alias'
             ? h.alias
             : `${h.aggregate}(${aliases[h.table]}.${h.field})`;
-        if (h.source === 'field' && !validTables.has(h.table)) {
+        if (
+          h.source === 'field' &&
+          !validTables.has((h.table || '').toLowerCase())
+        ) {
           throw new Error(`Table ${h.table} is not joined`);
         }
         const right = h.valueType === 'param' ? `:${h.param}` : h.value;
@@ -978,8 +1007,9 @@ function ReportBuilderInner() {
     try {
       const { report } = buildDefinition();
       const sql = buildReportSql(report);
-      const suffix = generalConfig?.general?.reportViewSuffix || '';
-      const viewName = `view_${procName || 'report'}${suffix}`;
+      const prefix = generalConfig?.general?.reportViewPrefix || '';
+      if (!procName) throw new Error('procedure name is required');
+      const viewName = `${prefix}${procName}`;
       const view = `CREATE OR REPLACE VIEW ${viewName} AS\n${sql};`;
       setViewSql(view);
       setError('');
@@ -993,12 +1023,12 @@ function ReportBuilderInner() {
     setProcSql('');
     try {
       const { report, params: p } = buildDefinition();
-      const suffix = generalConfig?.general?.reportProcSuffix || '';
+      const prefix = generalConfig?.general?.reportProcPrefix || '';
       const built = buildStoredProcedure({
-        name: procName || 'report',
+        name: procName,
         params: p,
         report,
-        suffix,
+        prefix,
       });
       setProcSql(built);
       setError('');
@@ -1012,17 +1042,32 @@ function ReportBuilderInner() {
     if (!procSql) return;
     if (!window.confirm('POST stored procedure to database?')) return;
     try {
-      const res = await fetch('/api/report_builder/procedures', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sql: procSql }),
-      });
+      const res = await fetch(
+        `/api/report_builder/procedures${
+          prefix ? `?prefix=${encodeURIComponent(prefix)}` : ''
+        }`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sql: procSql }),
+        },
+      );
       if (!res.ok) throw new Error('Save failed');
       try {
-        const listRes = await fetch('/api/report_builder/procedures');
+      const listRes = await fetch(
+        `/api/report_builder/procedures${
+          prefix ? `?prefix=${encodeURIComponent(prefix)}` : ''
+        }`,
+      );
         const data = await listRes.json();
-        setDbProcedures(data.names || []);
-        setSelectedDbProcedure(data.names?.[0] || '');
+        const prefix = generalConfig?.general?.reportProcPrefix || '';
+        const list = prefix
+          ? (data.names || []).filter((n) =>
+              n.toLowerCase().includes(prefix.toLowerCase()),
+            )
+          : data.names || [];
+        setDbProcedures(list);
+        setSelectedDbProcedure(list[0] || '');
       } catch (err) {
         console.error(err);
       }
@@ -1108,7 +1153,9 @@ function ReportBuilderInner() {
       unionQueries: legacyUnions,
     };
     try {
-      const name = procName || 'report';
+      const prefix = generalConfig?.general?.reportProcPrefix || '';
+      if (!procName) throw new Error('procedure name is required');
+      const name = `${prefix}${procName}`;
       const res = await fetch(
         `/api/report_builder/configs/${encodeURIComponent(name)}`,
         {
@@ -1118,9 +1165,12 @@ function ReportBuilderInner() {
         },
       );
       if (!res.ok) throw new Error('Save failed');
-      const listRes = await fetch('/api/report_builder/configs');
+      const listRes = await fetch(
+        `/api/report_builder/configs${prefix ? `?prefix=${encodeURIComponent(prefix)}` : ''}`,
+      );
       const listData = await listRes.json();
-      setSavedReports(listData.names || []);
+      const list = listData.names || [];
+      setSavedReports(list);
       setSelectedReport(name);
       window.dispatchEvent(
         new CustomEvent('toast', {
@@ -1237,7 +1287,9 @@ function ReportBuilderInner() {
 
   async function handleSaveProcFile() {
     if (!procSql) return;
-    const name = procName || 'report';
+    const prefix = generalConfig?.general?.reportProcPrefix || '';
+    if (!procName) return;
+    const name = `${prefix}${procName}`;
     try {
       const res = await fetch(
         `/api/report_builder/procedure-files/${encodeURIComponent(name)}`,
@@ -1248,9 +1300,12 @@ function ReportBuilderInner() {
         },
       );
       if (!res.ok) throw new Error('Save failed');
-      const listRes = await fetch('/api/report_builder/procedure-files');
+      const listRes = await fetch(
+        `/api/report_builder/procedure-files${prefix ? `?prefix=${encodeURIComponent(prefix)}` : ''}`,
+      );
       const listData = await listRes.json();
-      setProcFiles(listData.names || []);
+      const list = listData.names || [];
+      setProcFiles(list);
       setSelectedProcFile(name);
       window.dispatchEvent(
         new CustomEvent('toast', {
@@ -1280,7 +1335,33 @@ function ReportBuilderInner() {
   }
 
   function handleParseSql() {
-    setProcSql(procFileText);
+    const sql = procFileText || '';
+    setProcSql(sql);
+    const nameMatch = sql.match(/CREATE\s+PROCEDURE\s+`?([^`(]+)`?\s*\(/i);
+    if (nameMatch) {
+      const prefix = generalConfig?.general?.reportProcPrefix || '';
+      let name = nameMatch[1];
+      if (prefix && name.toLowerCase().startsWith(prefix.toLowerCase())) {
+        name = name.slice(prefix.length);
+      }
+      setProcName(name);
+    }
+    const paramsMatch = sql.match(/CREATE\s+PROCEDURE[\s\S]*?\(([^)]*)\)/i);
+    if (paramsMatch) {
+      const paramLines = paramsMatch[1]
+        .split(',')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      const parsed = paramLines
+        .map((line) => {
+          const m = line.match(/IN\s+([\w]+)\s+([\w()]+)/i);
+          return m ? { name: m[1], type: m[2] } : null;
+        })
+        .filter(Boolean);
+      setParams(parsed);
+    } else {
+      setParams([]);
+    }
   }
 
   if (loading) {
@@ -2395,7 +2476,7 @@ function ReportBuilderInner() {
         <label>
           Procedure Name:
           <div>
-            report_
+            {generalConfig?.general?.reportProcPrefix || ''}
             <input
               value={procName}
               onChange={(e) => setProcName(e.target.value)}

--- a/src/erp.mgt.mn/pages/Reports.jsx
+++ b/src/erp.mgt.mn/pages/Reports.jsx
@@ -28,26 +28,20 @@ export default function Reports() {
   }
 
   useEffect(() => {
-    const params = new URLSearchParams();
-    if (company?.branch_id !== undefined)
-      params.set('branchId', company.branch_id);
-    if (company?.department_id !== undefined)
-      params.set('departmentId', company.department_id);
-    fetch(`/api/transaction_forms?${params.toString()}`, { credentials: 'include' })
-      .then((res) => (res.ok ? res.json() : {}))
+    const prefix = generalConfig?.general?.reportProcPrefix || '';
+    fetch(
+      `/api/procedures${
+        prefix ? `?prefix=${encodeURIComponent(prefix)}` : ''
+      }`,
+      { credentials: 'include' },
+    )
+      .then((res) => (res.ok ? res.json() : { procedures: [] }))
       .then((data) => {
-        const set = new Set();
-        Object.values(data || {}).forEach((cfg) => {
-          if (Array.isArray(cfg.procedures)) {
-            cfg.procedures
-              .filter((p) => p.toLowerCase().includes('report'))
-              .forEach((p) => set.add(p));
-          }
-        });
-        setProcedures(Array.from(set).sort());
+        const list = Array.isArray(data.procedures) ? data.procedures : [];
+        setProcedures(list);
       })
       .catch(() => setProcedures([]));
-  }, [company?.branch_id, company?.department_id]);
+  }, [generalConfig?.general?.reportProcPrefix]);
 
   useEffect(() => {
     if (!selectedProc) {

--- a/src/erp.mgt.mn/utils/buildReportSql.js
+++ b/src/erp.mgt.mn/utils/buildReportSql.js
@@ -18,11 +18,14 @@ export default function buildReportSql(definition = {}) {
     function expandExpr(expr) {
       let result = expr;
       let replaced = true;
-      while (replaced) {
+      let guard = 0;
+      // Prevent infinite loops if aliases reference each other
+      while (replaced && guard < 50) {
         replaced = false;
+        guard++;
         for (const [al, ex] of Object.entries(aliasMap)) {
           const re = new RegExp(`\\b${al}\\b`, 'g');
-          if (re.test(result)) {
+          if (re.test(result) && !new RegExp(`\\b${al}\\b`).test(ex)) {
             result = result.replace(re, `(${ex})`);
             replaced = true;
           }

--- a/src/erp.mgt.mn/utils/buildStoredProcedure.js
+++ b/src/erp.mgt.mn/utils/buildStoredProcedure.js
@@ -3,18 +3,18 @@ import buildReportSql from './buildReportSql.js';
 /**
  * Build a stored procedure SQL string from a procedure definition.
  * @param {Object} definition
- * @param {string} definition.name - Procedure name without the "report_" prefix
+ * @param {string} definition.name - Procedure name excluding any configured prefix
  * @param {Array<{name:string,type:string}>} [definition.params]
  * @param {Object} definition.report - Report definition passed to buildReportSql
- * @param {string} [definition.suffix] - Optional suffix appended to the procedure name
+ * @param {string} [definition.prefix] - Optional prefix inserted at the start of the procedure name
  * @returns {string}
  */
 export default function buildStoredProcedure(definition = {}) {
-  const { name, params = [], report, suffix = '' } = definition;
+  const { name, params = [], report, prefix = '' } = definition;
   if (!name) throw new Error('procedure name is required');
   if (!report) throw new Error('report definition is required');
 
-  const procName = `report_${name}${suffix}`;
+  const procName = `${prefix}${name}`;
   const paramLines = params.map((p) => `IN ${p.name} ${p.type}`).join(',\n  ');
   let selectSql = buildReportSql(report);
   params.forEach((p) => {

--- a/tests/db/proceduresList.test.js
+++ b/tests/db/proceduresList.test.js
@@ -2,17 +2,17 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import * as db from '../../db/index.js';
 
-test('listReportProcedures returns routine names', async () => {
+test('listReportProcedures filters by prefix', async () => {
   const original = db.pool.query;
-  db.pool.query = async (sql) => {
+  db.pool.query = async (sql, params) => {
     if (/information_schema\.ROUTINES/i.test(sql)) {
-      return [[{ ROUTINE_NAME: 'report_a' }, { ROUTINE_NAME: 'report_b' }]];
+      return [[{ ROUTINE_NAME: 'bbb_proc' }]];
     }
     return [[]];
   };
-  const names = await db.listReportProcedures();
+  const names = await db.listReportProcedures('proc');
   db.pool.query = original;
-  assert.deepEqual(names, ['report_a', 'report_b']);
+  assert.deepEqual(names, ['bbb_proc']);
 });
 
 test('deleteProcedure drops routine', async () => {
@@ -22,7 +22,7 @@ test('deleteProcedure drops routine', async () => {
     calls.push(sql);
     return [];
   };
-  await db.deleteProcedure('report_a');
+  await db.deleteProcedure('proc_a');
   db.pool.query = original;
-  assert.ok(calls[0].includes('DROP PROCEDURE IF EXISTS `report_a`'));
+  assert.ok(calls[0].includes('DROP PROCEDURE IF EXISTS `proc_a`'));
 });

--- a/tests/utils/buildReportSql.test.js
+++ b/tests/utils/buildReportSql.test.js
@@ -42,3 +42,15 @@ test('buildReportSql allows parenthesized conditions', () => {
   });
   assert.ok(/\(t.branchid = :bid\s*OR t.alt_branch = :bid\)/.test(sql));
 });
+
+test('buildReportSql handles recursive aliases without hanging', () => {
+  const sql = buildReportSql({
+    from: { table: 'tbl', alias: 't' },
+    select: [
+      { expr: 'b', alias: 'a' },
+      { expr: 'a', alias: 'b' },
+      { expr: 'a', alias: 'c' },
+    ],
+  });
+  assert.ok(sql.includes('SELECT'));
+});

--- a/tests/utils/buildStoredProcedure.test.js
+++ b/tests/utils/buildStoredProcedure.test.js
@@ -5,12 +5,12 @@ import buildStoredProcedure from '../../src/erp.mgt.mn/utils/buildStoredProcedur
 // minimal report definition
 const report = { from: { table: 'tbl' } };
 
-test('buildStoredProcedure appends configured suffix', () => {
+test('buildStoredProcedure inserts configured prefix', () => {
   const sql = buildStoredProcedure({
     name: 'sales',
     report,
-    suffix: '_sp',
+    prefix: 'sp_',
   });
-  assert.ok(sql.includes('DROP PROCEDURE IF EXISTS report_sales_sp;'));
-  assert.ok(sql.includes('CREATE PROCEDURE report_sales_sp('));
+  assert.ok(sql.includes('DROP PROCEDURE IF EXISTS sp_sales;'));
+  assert.ok(sql.includes('CREATE PROCEDURE sp_sales('));
 });


### PR DESCRIPTION
## Summary
- Filter stored procedure configs, files, and database procedures by the configured prefix so Report Builder dropdowns populate correctly
- List report procedures by prefix on the Reports page and module loader, preventing empty menus and hardcoded names
- Restrict transaction configuration procedures to names containing the prefix, avoiding stray `report` entries when no prefix is set
- Filter report builder procedure files and configs on the server by prefix so stored procedure and config dropdowns are populated using the configured search text
- Populate stored procedure and config dropdowns in Report Builder using the same prefix-based logic as the delete procedure list
- Parse stored procedure SQL to populate procedure name and parameters in the Report Builder form
- Validate joined tables case-insensitively and guard SQL alias expansion to stop Create Procedure from hanging
- Clear stale field data when switching a Select field to use an alias and ignore self-referential alias mappings to prevent duplicate nested expressions in generated SQL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68988ee6d0288331ab528371cdafa888