### PR TITLE
fix: enable row reordering and improve drilldown display

### DIFF
--- a/src/erp.mgt.mn/components/ReportTable.jsx
+++ b/src/erp.mgt.mn/components/ReportTable.jsx
@@ -193,12 +193,18 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
       }),
     );
     const firstField = columns[0];
+    let groupField = firstField;
+    let groupValue = row[firstField];
+    if (String(groupValue).toLowerCase() === 'modal' && columns.length > 1) {
+      groupField = columns[1];
+      groupValue = row[groupField];
+    }
     const payload = {
       name: procedure,
       column: col,
       params,
-      groupField: firstField,
-      groupValue: row[firstField],
+      groupField,
+      groupValue,
       session: {
         empid: user?.empid,
         company_id: company?.company_id,
@@ -219,11 +225,15 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
         return data;
       })
       .then((data) => {
+        let outRows = data.rows || [];
+        if (String(row[firstField]).toLowerCase() === 'modal') {
+          outRows = outRows.map((r) => ({ ...r, [firstField]: groupValue }));
+        }
         setTxnInfo({
           loading: false,
           col,
           value,
-          data: data.rows || [],
+          data: outRows,
           sql: data.sql || '',
           displayFields: Array.isArray(data.displayFields)
             ? data.displayFields

--- a/src/erp.mgt.mn/pages/ReportBuilder.jsx
+++ b/src/erp.mgt.mn/pages/ReportBuilder.jsx
@@ -470,7 +470,7 @@ function ReportBuilderInner() {
   function reorder(list, from, to) {
     const arr = [...list];
     const [moved] = arr.splice(from, 1);
-    arr.splice(to, 0, moved);
+    arr.splice(from < to ? to - 1 : to, 0, moved);
     return arr;
   }
 


### PR DESCRIPTION
## Summary
- Fix list reorder logic to correctly move rows in report builder
- Use original grouping field when left column shows `modal` and display initial value in drilldown results

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b05eb87e48331b94e47c6e2e3ddd0