### PR TITLE
fix: enable row reordering and improve drilldown display

### DIFF
--- a/src/erp.mgt.mn/pages/ReportBuilder.jsx
+++ b/src/erp.mgt.mn/pages/ReportBuilder.jsx
@@ -470,7 +470,7 @@ function ReportBuilderInner() {
   function reorder(list, from, to) {
     const arr = [...list];
     const [moved] = arr.splice(from, 1);
-    arr.splice(to, 0, moved);
+    arr.splice(from < to ? to - 1 : to, 0, moved);
     return arr;
   }
 

--- a/src/erp.mgt.mn/utils/formatSqlValue.js
+++ b/src/erp.mgt.mn/utils/formatSqlValue.js
@@ -1,12 +1,20 @@
+import formatTimestamp from './formatTimestamp.js';
+
 export default function formatSqlValue(val, type = '') {
   const t = (type || '').toLowerCase();
+  if (t === 'date') {
+    const d = val instanceof Date ? val : new Date(val);
+    if (!Number.isNaN(d.getTime())) {
+      return `'${formatTimestamp(d).slice(0, 10)}'`;
+    }
+    return `'${String(val).slice(0, 10).replace(/'/g, "''")}'`;
+  }
   const stringTypes = [
     'char',
     'varchar',
     'text',
     'enum',
     'set',
-    'date',
     'datetime',
     'timestamp',
     'time',


### PR DESCRIPTION
## Summary
- Fix list reorder logic to correctly move rows in report builder
- Use original grouping field when left column shows `modal` and display initial value in drilldown results
- Format date fields to show only the `YYYY-MM-DD` portion and ensure DATE SQL parameters match

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b05eb87e48331b94e47c6e2e3ddd0