### PR TITLE
fix: enable row reordering and improve drilldown display

### DIFF
--- a/src/erp.mgt.mn/components/ReportTable.jsx
+++ b/src/erp.mgt.mn/components/ReportTable.jsx
@@ -3,6 +3,7 @@ import { AuthContext } from '../context/AuthContext.jsx';
 import useGeneralConfig, { updateCache } from '../hooks/useGeneralConfig.js';
 import useHeaderMappings from '../hooks/useHeaderMappings.js';
 import Modal from './Modal.jsx';
+import formatTimestamp from '../utils/formatTimestamp.js';
 
 function ch(n) {
   return Math.round(n * 8);
@@ -29,6 +30,18 @@ function formatNumber(val) {
   if (val === null || val === undefined || val === '') return '';
   const num = Number(String(val).replace(',', '.'));
   return Number.isNaN(num) ? '' : numberFmt.format(num);
+}
+
+function formatCellValue(val) {
+  if (val === null || val === undefined) return '';
+  if (val instanceof Date) {
+    return formatTimestamp(val).slice(0, 10);
+  }
+  const str = String(val);
+  if (/^\d{4}-\d{2}-\d{2}/.test(str)) {
+    return str.slice(0, 10);
+  }
+  return val;
 }
 
 export default function ReportTable({ procedure = '', params = {}, rows = [] }) {
@@ -193,12 +206,43 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
       }),
     );
     const firstField = columns[0];
+    const displayValue = row[firstField];
+    let groupField = firstField;
+    let groupValue = displayValue;
+
+    const firstFieldIsModal = firstField.toLowerCase() === 'modal';
+    const firstValueIsModal = String(displayValue).toLowerCase() === 'modal';
+    const secondField = columns[1];
+    const secondFieldIsModal =
+      !firstFieldIsModal && secondField && secondField.toLowerCase() === 'modal';
+
+    if (firstFieldIsModal && secondField) {
+      groupField = secondField;
+      groupValue = row[secondField];
+    } else if (firstValueIsModal && secondField) {
+      groupValue = row[secondField];
+    }
+
+    if (
+      columns.length > 2 &&
+      (String(groupValue).toLowerCase() === 'modal' || isNaN(Number(groupValue)))
+    ) {
+      const alt = row[columns[2]];
+      if (alt !== undefined) {
+        groupValue = alt;
+      }
+    }
+
+    const parsed = Number(groupValue);
+    if (!Number.isNaN(parsed)) {
+      groupValue = parsed;
+    }
     const payload = {
       name: procedure,
       column: col,
       params,
-      groupField: firstField,
-      groupValue: row[firstField],
+      groupField,
+      groupValue,
       session: {
         empid: user?.empid,
         company_id: company?.company_id,
@@ -219,11 +263,17 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
         return data;
       })
       .then((data) => {
+        let outRows = data.rows || [];
+        if (firstFieldIsModal || firstValueIsModal) {
+          outRows = outRows.map((r) => ({ ...r, [firstField]: groupValue }));
+        } else if (secondFieldIsModal) {
+          outRows = outRows.map((r) => ({ ...r, [firstField]: displayValue }));
+        }
         setTxnInfo({
           loading: false,
           col,
           value,
-          data: data.rows || [],
+          data: outRows,
           sql: data.sql || '',
           displayFields: Array.isArray(data.displayFields)
             ? data.displayFields
@@ -467,7 +517,9 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
                       style={{ ...style, cursor: row[col] ? 'pointer' : 'default' }}
                       onClick={() => handleCellClick(col, row[col], row)}
                     >
-                      {numericColumns.includes(col) ? formatNumber(row[col]) : row[col]}
+                      {numericColumns.includes(col)
+                        ? formatNumber(row[col])
+                        : formatCellValue(row[col])}
                     </td>
                   );
                 })}
@@ -606,7 +658,9 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
                             textOverflow: 'ellipsis',
                           }}
                         >
-                          {typeof r[c] === 'number' ? formatNumber(r[c]) : r[c]}
+                          {typeof r[c] === 'number'
+                            ? formatNumber(r[c])
+                            : formatCellValue(r[c])}
                         </td>
                       ))}
                     </tr>

--- a/src/erp.mgt.mn/pages/ReportBuilder.jsx
+++ b/src/erp.mgt.mn/pages/ReportBuilder.jsx
@@ -470,7 +470,7 @@ function ReportBuilderInner() {
   function reorder(list, from, to) {
     const arr = [...list];
     const [moved] = arr.splice(from, 1);
-    arr.splice(to, 0, moved);
+    arr.splice(from < to ? to - 1 : to, 0, moved);
     return arr;
   }
 

--- a/src/erp.mgt.mn/utils/formatSqlValue.js
+++ b/src/erp.mgt.mn/utils/formatSqlValue.js
@@ -1,12 +1,20 @@
+import formatTimestamp from './formatTimestamp.js';
+
 export default function formatSqlValue(val, type = '') {
   const t = (type || '').toLowerCase();
+  if (t === 'date') {
+    const d = val instanceof Date ? val : new Date(val);
+    if (!Number.isNaN(d.getTime())) {
+      return `'${formatTimestamp(d).slice(0, 10)}'`;
+    }
+    return `'${String(val).slice(0, 10).replace(/'/g, "''")}'`;
+  }
   const stringTypes = [
     'char',
     'varchar',
     'text',
     'enum',
     'set',
-    'date',
     'datetime',
     'timestamp',
     'time',


### PR DESCRIPTION
## Summary
- Fix list reorder logic to correctly move rows in report builder
- When the first column shows a modal placeholder, drill‑down SQL now uses the row's original identifier from the adjacent column and normalizes numeric values
- Format date fields to show only the `YYYY-MM-DD` portion and ensure DATE SQL parameters match
- Drill-down queries now pull the first column's original identifier when a `modal` helper column is present, while modal results keep the displayed label

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b05eb87e48331b94e47c6e2e3ddd0