### PR TITLE
fix: enable row reordering and improve drilldown display

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -1225,7 +1225,11 @@ export async function getProcedureRawRows(
       if (buf.trim()) fields.push(buf.trim());
       const kept = [];
       for (let field of fields) {
-        const sumIdx = field.toUpperCase().indexOf('SUM(');
+        const upperField = field.toUpperCase();
+        if (upperField.includes('COUNT(')) {
+          continue;
+        }
+        const sumIdx = upperField.indexOf('SUM(');
         if (sumIdx === -1) {
           kept.push(field);
           continue;

--- a/src/erp.mgt.mn/components/ReportTable.jsx
+++ b/src/erp.mgt.mn/components/ReportTable.jsx
@@ -3,6 +3,7 @@ import { AuthContext } from '../context/AuthContext.jsx';
 import useGeneralConfig, { updateCache } from '../hooks/useGeneralConfig.js';
 import useHeaderMappings from '../hooks/useHeaderMappings.js';
 import Modal from './Modal.jsx';
+import formatTimestamp from '../utils/formatTimestamp.js';
 
 function ch(n) {
   return Math.round(n * 8);
@@ -29,6 +30,23 @@ function formatNumber(val) {
   if (val === null || val === undefined || val === '') return '';
   const num = Number(String(val).replace(',', '.'));
   return Number.isNaN(num) ? '' : numberFmt.format(num);
+}
+
+function formatCellValue(val) {
+  if (val === null || val === undefined) return '';
+  if (val instanceof Date) {
+    return formatTimestamp(val).slice(0, 10);
+  }
+  const str = String(val);
+  if (/^\d{4}-\d{2}-\d{2}/.test(str)) {
+    return str.slice(0, 10);
+  }
+  return val;
+}
+
+function isCountColumn(name) {
+  const f = String(name).toLowerCase();
+  return f === 'count' || f === 'count()' || f.startsWith('count(');
 }
 
 export default function ReportTable({ procedure = '', params = {}, rows = [] }) {
@@ -193,12 +211,34 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
       }),
     );
     const firstField = columns[0];
+    const displayValue = row[firstField];
+
+    let idx = 0;
+    let groupField = columns[idx];
+    let groupValue = row[groupField];
+
+    while (
+      idx < columns.length - 1 &&
+      (groupField.toLowerCase() === 'modal' ||
+        String(groupValue).toLowerCase() === 'modal' ||
+        isCountColumn(groupField) ||
+        Number.isNaN(Number(groupValue)))
+    ) {
+      idx += 1;
+      groupField = columns[idx];
+      groupValue = row[groupField];
+    }
+
+    const parsed = Number(groupValue);
+    if (!Number.isNaN(parsed)) {
+      groupValue = parsed;
+    }
     const payload = {
       name: procedure,
       column: col,
       params,
-      groupField: firstField,
-      groupValue: row[firstField],
+      groupField,
+      groupValue,
       session: {
         empid: user?.empid,
         company_id: company?.company_id,
@@ -219,11 +259,20 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
         return data;
       })
       .then((data) => {
+        let outRows = (data.rows || []).map((r) => {
+          const entries = Object.entries(r).filter(([k]) => !isCountColumn(k));
+          return Object.fromEntries(entries);
+        });
+        if (idx > 0 && !isCountColumn(firstField)) {
+          const replaceVal =
+            firstField.toLowerCase() === 'modal' ? groupValue : displayValue;
+          outRows = outRows.map((r) => ({ ...r, [firstField]: replaceVal }));
+        }
         setTxnInfo({
           loading: false,
           col,
           value,
-          data: data.rows || [],
+          data: outRows,
           sql: data.sql || '',
           displayFields: Array.isArray(data.displayFields)
             ? data.displayFields
@@ -467,7 +516,9 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
                       style={{ ...style, cursor: row[col] ? 'pointer' : 'default' }}
                       onClick={() => handleCellClick(col, row[col], row)}
                     >
-                      {numericColumns.includes(col) ? formatNumber(row[col]) : row[col]}
+                      {numericColumns.includes(col)
+                        ? formatNumber(row[col])
+                        : formatCellValue(row[col])}
                     </td>
                   );
                 })}
@@ -606,7 +657,9 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
                             textOverflow: 'ellipsis',
                           }}
                         >
-                          {typeof r[c] === 'number' ? formatNumber(r[c]) : r[c]}
+                          {typeof r[c] === 'number'
+                            ? formatNumber(r[c])
+                            : formatCellValue(r[c])}
                         </td>
                       ))}
                     </tr>

--- a/src/erp.mgt.mn/pages/ReportBuilder.jsx
+++ b/src/erp.mgt.mn/pages/ReportBuilder.jsx
@@ -470,7 +470,7 @@ function ReportBuilderInner() {
   function reorder(list, from, to) {
     const arr = [...list];
     const [moved] = arr.splice(from, 1);
-    arr.splice(to, 0, moved);
+    arr.splice(from < to ? to - 1 : to, 0, moved);
     return arr;
   }
 

--- a/src/erp.mgt.mn/utils/formatSqlValue.js
+++ b/src/erp.mgt.mn/utils/formatSqlValue.js
@@ -1,12 +1,20 @@
+import formatTimestamp from './formatTimestamp.js';
+
 export default function formatSqlValue(val, type = '') {
   const t = (type || '').toLowerCase();
+  if (t === 'date') {
+    const d = val instanceof Date ? val : new Date(val);
+    if (!Number.isNaN(d.getTime())) {
+      return `'${formatTimestamp(d).slice(0, 10)}'`;
+    }
+    return `'${String(val).slice(0, 10).replace(/'/g, "''")}'`;
+  }
   const stringTypes = [
     'char',
     'varchar',
     'text',
     'enum',
     'set',
-    'date',
     'datetime',
     'timestamp',
     'time',


### PR DESCRIPTION
## Summary
- Fix list reorder logic to correctly move rows in report builder
- Ignore any leading `modal` or `count()` helper columns during drill-down so SQL uses the row’s real identifier and modal results replace the placeholder with the resolved value
- Format date fields to show only the `YYYY-MM-DD` portion and ensure DATE SQL parameters match
- Drop `COUNT()` columns and non-clicked `SUM()` columns when transforming drill-down SQL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b05eb87e48331b94e47c6e2e3ddd0