### PR TITLE
Refactor login to new authentication session scheme

### DIFF
--- a/src/erp.mgt.mn/components/LoginForm.jsx
+++ b/src/erp.mgt.mn/components/LoginForm.jsx
@@ -2,7 +2,6 @@
 import React, { useState, useContext } from 'react';
 import { login } from '../hooks/useAuth.jsx';
 import { AuthContext } from '../context/AuthContext.jsx';
-import { refreshRolePermissions } from '../hooks/useRolePermissions.js';
 import { refreshCompanyModules } from '../hooks/useCompanyModules.js';
 import { refreshModules } from '../hooks/useModules.js';
 import { refreshTxnModules } from '../hooks/useTxnModules.js';
@@ -13,9 +12,10 @@ export default function LoginForm() {
   const [empid, setEmpid] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState(null);
-  const { setUser, setCompany } = useContext(AuthContext);
-  const [companyChoices, setCompanyChoices] = useState(null);
-  const [selectedCompany, setSelectedCompany] = useState('');
+  const { setUser, setSession, setUserLevel, setPermissions } =
+    useContext(AuthContext);
+  const [sessionChoices, setSessionChoices] = useState(null);
+  const [selectedSession, setSelectedSession] = useState('');
   const navigate = useNavigate();
 
   async function handleSubmit(e) {
@@ -26,29 +26,39 @@ export default function LoginForm() {
       // Send POST /api/auth/login with credentials: 'include'
       const loggedIn = await login({ empid, password });
 
-      // The login response already returns the user profile
-      setUser(loggedIn);
+      // The login response includes user profile and session info
+      setUser(loggedIn.user);
 
-      // Fetch company assignments
-      const res = await fetch(
-        `/api/user_companies?empid=${encodeURIComponent(loggedIn.empid)}`,
-        { credentials: 'include' },
-      );
-      const assignments = res.ok ? await res.json() : [];
+      const sessions = Array.isArray(loggedIn.sessions)
+        ? loggedIn.sessions
+        : loggedIn.session
+        ? [
+            {
+              session: loggedIn.session,
+              user_level: loggedIn.user_level,
+              permissions: loggedIn.permissions,
+            },
+          ]
+        : [];
 
-      if (assignments.length === 1) {
-        const choice = assignments[0];
-        setCompany(choice);
-        const roleId = choice.role_id || loggedIn.role_id || (loggedIn.role === 'admin' ? 1 : 2);
-        refreshRolePermissions(roleId, choice.company_id);
-        refreshCompanyModules(choice.company_id);
+      if (sessions.length === 1) {
+        const choice = sessions[0];
+        setSession(choice.session);
+        setUserLevel(choice.user_level ?? null);
+        setPermissions(choice.permissions ?? null);
+        if (choice.session?.company_id)
+          refreshCompanyModules(choice.session.company_id);
         refreshModules();
         refreshTxnModules();
         navigate('/');
-      } else if (assignments.length > 1) {
-        setCompany(null);
-        setCompanyChoices(assignments);
+      } else if (sessions.length > 1) {
+        setSession(null);
+        setSessionChoices(sessions);
       } else {
+        // No active employment session; proceed without session info
+        setSession(null);
+        setUserLevel(loggedIn.user_level ?? null);
+        setPermissions(loggedIn.permissions ?? null);
         refreshModules();
         refreshTxnModules();
         navigate('/');
@@ -59,18 +69,18 @@ export default function LoginForm() {
     }
   }
 
-  if (companyChoices) {
+  if (sessionChoices) {
     return (
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          const choice = companyChoices.find(
-            (c) => `${c.company_id}-${c.branch_id || ''}` === selectedCompany,
-          );
+          const choice = sessionChoices.find((_, idx) => `${idx}` === selectedSession);
           if (choice) {
-            setCompany(choice);
-            refreshRolePermissions(choice.role_id, choice.company_id);
-            refreshCompanyModules(choice.company_id);
+            setSession(choice.session);
+            setUserLevel(choice.user_level ?? null);
+            setPermissions(choice.permissions ?? null);
+            if (choice.session?.company_id)
+              refreshCompanyModules(choice.session.company_id);
             refreshModules();
             refreshTxnModules();
             navigate('/');
@@ -79,25 +89,23 @@ export default function LoginForm() {
         style={{ maxWidth: '320px' }}
       >
         <div style={{ marginBottom: '0.75rem' }}>
-          <label htmlFor="company" style={{ display: 'block', marginBottom: '0.25rem' }}>
+          <label htmlFor="session" style={{ display: 'block', marginBottom: '0.25rem' }}>
             Компани сонгох
           </label>
           <select
-            id="company"
-            value={selectedCompany}
-            onChange={(e) => setSelectedCompany(e.target.value)}
+            id="session"
+            value={selectedSession}
+            onChange={(e) => setSelectedSession(e.target.value)}
             required
             style={{ width: '100%', padding: '0.5rem', borderRadius: '3px', border: '1px solid #ccc' }}
           >
             <option value="" disabled>
               Сонгоно уу...
             </option>
-            {companyChoices.map((c) => (
-              <option
-                key={c.company_id + '-' + (c.branch_id || '')}
-                value={`${c.company_id}-${c.branch_id || ''}`}
-              >
-                {c.branch_name ? `${c.branch_name} | ` : ''}{c.company_name}
+            {sessionChoices.map((c, idx) => (
+              <option key={idx} value={idx}>
+                {c.session?.branch_name ? `${c.session.branch_name} | ` : ''}
+                {c.session?.company_name || c.session?.company_id}
               </option>
             ))}
           </select>

--- a/src/erp.mgt.mn/context/AuthContext.jsx
+++ b/src/erp.mgt.mn/context/AuthContext.jsx
@@ -7,6 +7,13 @@ import { API_BASE } from '../utils/apiBase.js';
 export const AuthContext = createContext({
   user: null,
   setUser: () => {},
+  session: null,
+  setSession: () => {},
+  userLevel: null,
+  setUserLevel: () => {},
+  permissions: null,
+  setPermissions: () => {},
+  // Backwards compatibility for older hooks expecting `company`
   company: null,
   setCompany: () => {},
 });
@@ -15,16 +22,18 @@ export default function AuthContextProvider({ children }) {
   // `user` starts as `undefined` so we can distinguish the initial loading
   // state from an unauthenticated user (`null`).
   const [user, setUser] = useState(undefined);
-  const [company, setCompany] = useState(null);
+  const [session, setSession] = useState(null);
+  const [userLevel, setUserLevel] = useState(null);
+  const [permissions, setPermissions] = useState(null);
 
-  // Persist selected company across reloads
+  // Persist selected session across reloads
   useEffect(() => {
-    debugLog('AuthContext: load stored company');
-    const stored = localStorage.getItem('erp_selected_company');
+    debugLog('AuthContext: load stored session');
+    const stored = localStorage.getItem('erp_session');
     if (stored) {
       try {
-        trackSetState('AuthContext.setCompany');
-        setCompany(JSON.parse(stored));
+        trackSetState('AuthContext.setSession');
+        setSession(JSON.parse(stored));
       } catch {
         // ignore parse errors
       }
@@ -32,13 +41,13 @@ export default function AuthContextProvider({ children }) {
   }, []);
 
   useEffect(() => {
-    debugLog('AuthContext: persist company');
-    if (company) {
-      localStorage.setItem('erp_selected_company', JSON.stringify(company));
+    debugLog('AuthContext: persist session');
+    if (session) {
+      localStorage.setItem('erp_session', JSON.stringify(session));
     } else {
-      localStorage.removeItem('erp_selected_company');
+      localStorage.removeItem('erp_session');
     }
-  }, [company]);
+  }, [session]);
 
   // On mount, attempt to load the current profile (if a cookie is present)
   useEffect(() => {
@@ -52,16 +61,34 @@ export default function AuthContextProvider({ children }) {
         if (res.ok) {
           const data = await res.json();
           trackSetState('AuthContext.setUser');
-          setUser(data);
+          setUser(data.user || data);
+          trackSetState('AuthContext.setSession');
+          setSession(data.session || null);
+          trackSetState('AuthContext.setUserLevel');
+          setUserLevel(data.user_level ?? null);
+          trackSetState('AuthContext.setPermissions');
+          setPermissions(data.permissions ?? null);
         } else {
           // Not logged in or token expired
           trackSetState('AuthContext.setUser');
           setUser(null);
+          trackSetState('AuthContext.setSession');
+          setSession(null);
+          trackSetState('AuthContext.setUserLevel');
+          setUserLevel(null);
+          trackSetState('AuthContext.setPermissions');
+          setPermissions(null);
         }
       } catch (err) {
         console.error('Unable to fetch profile:', err);
         trackSetState('AuthContext.setUser');
         setUser(null);
+        trackSetState('AuthContext.setSession');
+        setSession(null);
+        trackSetState('AuthContext.setUserLevel');
+        setUserLevel(null);
+        trackSetState('AuthContext.setPermissions');
+        setPermissions(null);
       }
     }
 
@@ -72,14 +99,32 @@ export default function AuthContextProvider({ children }) {
     function handleLogout() {
       trackSetState('AuthContext.setUser');
       setUser(null);
-      trackSetState('AuthContext.setCompany');
-      setCompany(null);
+      trackSetState('AuthContext.setSession');
+      setSession(null);
+      trackSetState('AuthContext.setUserLevel');
+      setUserLevel(null);
+      trackSetState('AuthContext.setPermissions');
+      setPermissions(null);
     }
     window.addEventListener('auth:logout', handleLogout);
     return () => window.removeEventListener('auth:logout', handleLogout);
   }, []);
 
-  const value = useMemo(() => ({ user, setUser, company, setCompany }), [user, company]);
+  const value = useMemo(
+    () => ({
+      user,
+      setUser,
+      session,
+      setSession,
+      userLevel,
+      setUserLevel,
+      permissions,
+      setPermissions,
+      company: session,
+      setCompany: setSession,
+    }),
+    [user, session, userLevel, permissions],
+  );
 
   return (
     <AuthContext.Provider value={value}>

--- a/src/erp.mgt.mn/hooks/useAuth.jsx
+++ b/src/erp.mgt.mn/hooks/useAuth.jsx
@@ -1,14 +1,20 @@
 // src/erp.mgt.mn/hooks/useAuth.jsx
-import { useContext } from 'react';
-import { AuthContext } from '../context/AuthContext.jsx';
 import { API_BASE } from '../utils/apiBase.js';
 
 // src/erp.mgt.mn/hooks/useAuth.jsx
 
 /**
  * Performs a login request and sets an HttpOnly cookie on success.
- * @param {{empid: string, password: string}} credentials - empid refers to the employee login ID
- * @returns {Promise<{id: number, empid: string, role: string}>}
+ * The backend returns the authenticated user profile along with the
+ * selected employment session and permission flags.
+ * @param {{empid: string, password: string}} credentials - employee login ID and password
+ * @returns {Promise<{
+ *   user: object,
+ *   session?: object,
+ *   sessions?: Array<object>,
+ *   user_level?: number,
+ *   permissions?: object
+ * }>}
 */
 export async function login({ empid, password }) {
   let res;
@@ -16,8 +22,8 @@ export async function login({ empid, password }) {
     res = await fetch(`${API_BASE}/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-    credentials: 'include', // Ensures cookie is stored
-    body: JSON.stringify({ empid, password }),
+      credentials: 'include', // Ensures cookie is stored
+      body: JSON.stringify({ empid, password }),
     });
   } catch (err) {
     // Network errors (e.g. server unreachable)
@@ -55,8 +61,9 @@ export async function logout() {
 
 /**
  * Fetches current user profile if authenticated.
- * @returns {Promise<{id: number, empid: string, role: string}>}
-*/
+ * The structure mirrors the login response and typically contains
+ * the user object, the active session and the permission flags.
+ */
 export async function fetchProfile() {
   const res = await fetch(`${API_BASE}/auth/me`, { credentials: 'include' });
   if (!res.ok) throw new Error('Not authenticated');


### PR DESCRIPTION
## Summary
- adapt client login flow to new authentication API that returns user profile, session and permission flags
- extend auth context to store session, user level and permissions and persist session
- remove legacy user_companies lookup and support multi-session selection in login form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b7bf5b8808331a9bc3f389de84bf2