### PR TITLE
Refactor login to use employment session permissions

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -115,6 +115,88 @@ export async function getUserByEmpId(empid) {
 }
 
 /**
+ * Fetch employment session info and permission flags for an employee
+ */
+export async function getEmploymentSession(empid) {
+  const [rows] = await pool.query(
+    `SELECT
+        e.employment_company_id AS company_id,
+        c.name AS company_name,
+        e.employment_branch_id AS branch_id,
+        b.name AS branch_name,
+        e.employment_department_id AS department_id,
+        e.employment_position_id AS position_id,
+        e.employment_user_level AS user_level,
+        ul.new_records,
+        ul.edit_delete_request,
+        ul.edit_records,
+        ul.delete_records,
+        ul.image_handler,
+        ul.audition,
+        ul.supervisor,
+        ul.companywide,
+        ul.branchwide,
+        ul.departmentwide,
+        ul.developer,
+        ul.system_settings,
+        ul.license_settings,
+        ul.ai,
+        ul.dashboard,
+        ul.ai_dashboard
+     FROM tbl_employment e
+     LEFT JOIN companies c ON e.employment_company_id = c.id
+     LEFT JOIN code_branches b ON e.employment_branch_id = b.id
+     LEFT JOIN code_userlevel ul ON e.employment_user_level = ul.userlever_id
+     WHERE e.employment_emp_id = ?
+     ORDER BY e.id DESC
+     LIMIT 1`,
+    [empid],
+  );
+  if (rows.length === 0) return null;
+  const row = rows[0];
+  const {
+    new_records,
+    edit_delete_request,
+    edit_records,
+    delete_records,
+    image_handler,
+    audition,
+    supervisor,
+    companywide,
+    branchwide,
+    departmentwide,
+    developer,
+    system_settings,
+    license_settings,
+    ai,
+    dashboard,
+    ai_dashboard,
+    ...rest
+  } = row;
+  return {
+    ...rest,
+    permissions: {
+      new_records: !!new_records,
+      edit_delete_request: !!edit_delete_request,
+      edit_records: !!edit_records,
+      delete_records: !!delete_records,
+      image_handler: !!image_handler,
+      audition: !!audition,
+      supervisor: !!supervisor,
+      companywide: !!companywide,
+      branchwide: !!branchwide,
+      departmentwide: !!departmentwide,
+      developer: !!developer,
+      system_settings: !!system_settings,
+      license_settings: !!license_settings,
+      ai: !!ai,
+      dashboard: !!dashboard,
+      ai_dashboard: !!ai_dashboard,
+    },
+  };
+}
+
+/**
  * List all users
  */
 export async function listUsers() {

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -106,9 +106,9 @@ export default function ERPLayout() {
   }
 
   function handleHome() {
-    const roleId = user?.role_id || (user?.role === 'admin' ? 1 : 2);
-    const companyId = user?.company_id || company?.company_id;
-    refreshRolePermissions(roleId, companyId);
+    const userLevel = user?.user_level || company?.user_level;
+    const companyId = company?.company_id;
+    refreshRolePermissions(userLevel, companyId);
     navigate('/');
   }
 

--- a/src/erp.mgt.mn/context/AuthContext.jsx
+++ b/src/erp.mgt.mn/context/AuthContext.jsx
@@ -53,15 +53,21 @@ export default function AuthContextProvider({ children }) {
           const data = await res.json();
           trackSetState('AuthContext.setUser');
           setUser(data);
+          trackSetState('AuthContext.setCompany');
+          setCompany(data.session || null);
         } else {
           // Not logged in or token expired
           trackSetState('AuthContext.setUser');
           setUser(null);
+          trackSetState('AuthContext.setCompany');
+          setCompany(null);
         }
       } catch (err) {
         console.error('Unable to fetch profile:', err);
         trackSetState('AuthContext.setUser');
         setUser(null);
+        trackSetState('AuthContext.setCompany');
+        setCompany(null);
       }
     }
 

--- a/src/erp.mgt.mn/hooks/useRolePermissions.js
+++ b/src/erp.mgt.mn/hooks/useRolePermissions.js
@@ -8,9 +8,9 @@ const cache = {};
 // Simple event emitter for permission refresh events
 const emitter = new EventTarget();
 
-export function refreshRolePermissions(roleId, companyId) {
-  const key = `${roleId}-${companyId || ''}`;
-  if (roleId) delete cache[key];
+export function refreshRolePermissions(userLevel, companyId) {
+  const key = `${userLevel}-${companyId || ''}`;
+  if (userLevel) delete cache[key];
   emitter.dispatchEvent(new Event('refresh'));
 }
 
@@ -45,8 +45,7 @@ export function useRolePermissions() {
       setPerms(null);
       return;
     }
-    const roleId =
-      company?.role_id || user.role_id || (user.role === 'admin' ? 1 : 2);
+    const roleId = company?.user_level || user?.user_level;
     const companyId = company?.company_id;
 
     const key = `${roleId}-${companyId || ''}`;
@@ -62,8 +61,7 @@ export function useRolePermissions() {
   useEffect(() => {
     debugLog('useRolePermissions effect: refresh listener');
     if (!user) return;
-    const roleId =
-      company?.role_id || user.role_id || (user.role === 'admin' ? 1 : 2);
+    const roleId = company?.user_level || user?.user_level;
     const companyId = company?.company_id;
     const handler = () => fetchPerms(roleId, companyId);
     emitter.addEventListener('refresh', handler);


### PR DESCRIPTION
## Summary
- Authenticate users via `users` table and fetch employment session with permission flags
- Store session context in AuthContext and remove legacy `user_companies` lookup during login
- Drive role-based module permissions using `user_level` session data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b8200bb7c8331be544fcc847303ed