### PR TITLE
feat: add transaction detection column

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -75,6 +75,8 @@ function parseEntry(raw = {}) {
       typeof raw.transactionTypeValue === 'string'
         ? raw.transactionTypeValue
         : '',
+    detectField:
+      typeof raw.detectField === 'string' ? raw.detectField : '',
     moduleKey: typeof raw.moduleKey === 'string' ? raw.moduleKey : '',
     allowedBranches: Array.isArray(raw.allowedBranches)
       ? raw.allowedBranches.map((v) => Number(v)).filter((v) => !Number.isNaN(v))
@@ -184,6 +186,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     viewSource = {},
     transactionTypeField = '',
     transactionTypeValue = '',
+    detectField = '',
     procedures = [],
   } = config || {};
   const uid = arrify(userIdFields.length ? userIdFields : userIdField ? [userIdField] : []);
@@ -226,6 +229,7 @@ export async function setFormConfig(table, name, config, options = {}) {
     viewSource: viewSource && typeof viewSource === 'object' ? viewSource : {},
     transactionTypeField: transactionTypeField || '',
     transactionTypeValue: transactionTypeValue || '',
+    detectField: detectField || '',
     moduleKey: parentModuleKey,
     moduleLabel: moduleLabel || undefined,
     allowedBranches: ab,

--- a/docs/transaction-form-config.md
+++ b/docs/transaction-form-config.md
@@ -42,6 +42,7 @@ speed up loading when the images are viewed.
   row so you can verify the view integration.
 - **transactionTypeField** – column used to store the transaction type code
 - **transactionTypeValue** – default transaction type code value
+- **detectField** – column where automated detection results are stored
 - **moduleKey** – module slug used to group the form under a module. If omitted,
   the transaction will not be associated with any module and is hidden from the
   Forms list.

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -53,6 +53,7 @@ export default function FormsManagement() {
     viewSource: {},
     transactionTypeField: '',
     transactionTypeValue: '',
+    detectField: '',
     allowedBranches: [],
     allowedDepartments: [],
     procedures: [],
@@ -161,6 +162,7 @@ export default function FormsManagement() {
             viewSource: filtered[name].viewSource || {},
             transactionTypeField: filtered[name].transactionTypeField || '',
             transactionTypeValue: filtered[name].transactionTypeValue || '',
+            detectField: filtered[name].detectField || '',
             allowedBranches: (filtered[name].allowedBranches || []).map(String),
             allowedDepartments: (filtered[name].allowedDepartments || []).map(String),
             procedures: filtered[name].procedures || [],
@@ -193,6 +195,7 @@ export default function FormsManagement() {
             viewSource: {},
             transactionTypeField: '',
             transactionTypeValue: '',
+            detectField: '',
             allowedBranches: [],
             allowedDepartments: [],
             procedures: [],
@@ -228,6 +231,7 @@ export default function FormsManagement() {
           viewSource: {},
           transactionTypeField: '',
           transactionTypeValue: '',
+          detectField: '',
           allowedBranches: [],
           allowedDepartments: [],
           procedures: [],
@@ -268,6 +272,7 @@ export default function FormsManagement() {
           viewSource: cfg.viewSource || {},
           transactionTypeField: cfg.transactionTypeField || '',
           transactionTypeValue: cfg.transactionTypeValue || '',
+          detectField: cfg.detectField || '',
           allowedBranches: (cfg.allowedBranches || []).map(String),
           allowedDepartments: (cfg.allowedDepartments || []).map(String),
           procedures: cfg.procedures || [],
@@ -300,6 +305,7 @@ export default function FormsManagement() {
           viewSource: {},
           transactionTypeField: '',
           transactionTypeValue: '',
+          detectField: '',
           allowedBranches: [],
           allowedDepartments: [],
           procedures: [],
@@ -424,6 +430,7 @@ export default function FormsManagement() {
       viewSource: {},
       transactionTypeField: '',
       transactionTypeValue: '',
+      detectField: '',
       allowedBranches: [],
       allowedDepartments: [],
       procedures: [],
@@ -458,6 +465,7 @@ export default function FormsManagement() {
       viewSource: cfg.viewSource || {},
       transactionTypeField: cfg.transactionTypeField || '',
       transactionTypeValue: cfg.transactionTypeValue || '',
+      detectField: cfg.detectField || '',
       allowedBranches: (cfg.allowedBranches || []).map(String),
       allowedDepartments: (cfg.allowedDepartments || []).map(String),
       procedures: cfg.procedures || [],
@@ -526,6 +534,23 @@ export default function FormsManagement() {
                 </option>
               ))}
             </select>
+
+            {columns.length > 0 && (
+              <select
+                value={config.detectField}
+                onChange={(e) =>
+                  setConfig((c) => ({ ...c, detectField: e.target.value }))
+                }
+                style={{ marginLeft: '0.5rem' }}
+              >
+                <option value="">-- detection field --</option>
+                {columns.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+            )}
 
             {columns.length > 0 && (
               <select

--- a/tests/db/transactionFormConfig.test.js
+++ b/tests/db/transactionFormConfig.test.js
@@ -110,6 +110,15 @@ await test('setFormConfig stores additional field lists', async () => {
   await restore();
 });
 
+await test('setFormConfig stores detectField', async () => {
+  const { orig, restore } = await withTempFile();
+  await fs.writeFile(filePath, '{}');
+  await setFormConfig('tbl', 'DetectCfg', { detectField: 'd_field' });
+  const data = JSON.parse(await fs.readFile(filePath, 'utf8'));
+  assert.equal(data.tbl.DetectCfg.detectField, 'd_field');
+  await restore();
+});
+
 await test('deleteFormConfig removes entry when unused', async () => {
   const { orig, restore } = await withTempFile();
   await fs.writeFile(


### PR DESCRIPTION
## Summary
- add `detectField` support to transaction form config service
- expose detection field selection in form management UI
- document and test transaction detection column

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c61fc437c833187ceac2cd0b74af8