### PR TITLE
Refactor login to use employment session permissions

### DIFF
--- a/api-server/middlewares/auth.js
+++ b/api-server/middlewares/auth.js
@@ -18,16 +18,14 @@ export function requireAuth(req, res, next) {
   }
 
   function issueTokens(payload) {
-    const newAccess = jwtService.sign({
+    const base = {
       id: payload.id,
       empid: payload.empid,
       role: payload.role,
-    });
-    const newRefresh = jwtService.signRefresh({
-      id: payload.id,
-      empid: payload.empid,
-      role: payload.role,
-    });
+      companyId: payload.companyId,
+    };
+    const newAccess = jwtService.sign(base);
+    const newRefresh = jwtService.signRefresh(base);
     res.cookie(getCookieName(), newAccess, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
@@ -60,7 +58,7 @@ export function requireAuth(req, res, next) {
   try {
     // Verify the JWT
     const payload = jwtService.verify(token);
-    req.user = payload; // { id, empid, role, iat, exp }
+    req.user = payload; // { id, empid, role, companyId, iat, exp }
     return next();
   } catch (err) {
     if (err.name === 'TokenExpiredError' && rToken) {

--- a/config/tableDisplayFields.json
+++ b/config/tableDisplayFields.json
@@ -6,6 +6,12 @@
       "emp_lname"
     ]
   },
+  "code_department": {
+    "idField": "department_id",
+    "displayFields": [
+      "name"
+    ]
+  },
   "tbl_contracter": {
     "idField": "manuf_id",
     "displayFields": [

--- a/db/index.js
+++ b/db/index.js
@@ -38,6 +38,15 @@ import defaultModules from "./defaultModules.js";
 import { logDb } from "./debugLog.js";
 import fs from "fs/promises";
 import path from "path";
+import { getDisplayFields as getDisplayCfg } from "../api-server/services/displayFieldConfig.js";
+
+function buildDisplayExpr(alias, cfg, fallback) {
+  const fields = (cfg?.displayFields || []).map((f) => `${alias}.${f}`);
+  if (fields.length) {
+    return `TRIM(CONCAT_WS(' ', ${fields.join(', ')}))`;
+  }
+  return fallback;
+}
 
 const tableColumnsCache = new Map();
 
@@ -112,6 +121,176 @@ export async function getUserByEmpId(empid) {
   const user = rows[0];
   user.verifyPassword = async (plain) => bcrypt.compare(plain, user.password);
   return user;
+}
+
+function mapEmploymentRow(row) {
+  const {
+    new_records,
+    edit_delete_request,
+    edit_records,
+    delete_records,
+    image_handler,
+    audition,
+    supervisor,
+    companywide,
+    branchwide,
+    departmentwide,
+    developer,
+    system_settings,
+    license_settings,
+    ai,
+    dashboard,
+    ai_dashboard,
+    ...rest
+  } = row;
+  return {
+    ...rest,
+    permissions: {
+      new_records: !!new_records,
+      edit_delete_request: !!edit_delete_request,
+      edit_records: !!edit_records,
+      delete_records: !!delete_records,
+      image_handler: !!image_handler,
+      audition: !!audition,
+      supervisor: !!supervisor,
+      companywide: !!companywide,
+      branchwide: !!branchwide,
+      departmentwide: !!departmentwide,
+      developer: !!developer,
+      system_settings: !!system_settings,
+      license_settings: !!license_settings,
+      ai: !!ai,
+      dashboard: !!dashboard,
+      ai_dashboard: !!ai_dashboard,
+    },
+  };
+}
+
+/**
+ * List all employment sessions for an employee
+ */
+export async function getEmploymentSessions(empid) {
+  const [companyCfg, branchCfg, deptCfg, empCfg] = await Promise.all([
+    getDisplayCfg("companies"),
+    getDisplayCfg("code_branches"),
+    getDisplayCfg("code_department"),
+    getDisplayCfg("tbl_employee"),
+  ]);
+
+  const companyName = buildDisplayExpr("c", companyCfg, "c.name");
+  const branchName = buildDisplayExpr("b", branchCfg, "b.name");
+  const deptName = buildDisplayExpr("d", deptCfg, "d.name");
+  const empName = buildDisplayExpr(
+    "emp",
+    empCfg,
+    "CONCAT_WS(' ', emp.emp_fname, emp.emp_lname)",
+  );
+
+  const [rows] = await pool.query(
+    `SELECT
+        e.employment_company_id AS company_id,
+        ${companyName} AS company_name,
+        e.employment_branch_id AS branch_id,
+        ${branchName} AS branch_name,
+        e.employment_department_id AS department_id,
+        ${deptName} AS department_name,
+        e.employment_position_id AS position_id,
+        ${empName} AS employee_name,
+        e.employment_user_level AS user_level,
+        ul.new_records,
+        ul.edit_delete_request,
+        ul.edit_records,
+        ul.delete_records,
+        ul.image_handler,
+        ul.audition,
+        ul.supervisor,
+        ul.companywide,
+        ul.branchwide,
+        ul.departmentwide,
+        ul.developer,
+        ul.system_settings,
+        ul.license_settings,
+        ul.ai,
+        ul.dashboard,
+        ul.ai_dashboard
+     FROM tbl_employment e
+     LEFT JOIN companies c ON e.employment_company_id = c.id
+     LEFT JOIN code_branches b ON e.employment_branch_id = b.id
+     LEFT JOIN code_department d ON e.employment_department_id = d.id
+     LEFT JOIN tbl_employee emp ON e.employment_emp_id = emp.emp_id
+     LEFT JOIN code_userlevel ul ON e.employment_user_level = ul.userlever_id
+     WHERE e.employment_emp_id = ?
+     ORDER BY e.id DESC`,
+    [empid],
+  );
+  return rows.map(mapEmploymentRow);
+}
+
+/**
+ * Fetch employment session info and permission flags for an employee.
+ * Optionally filter by company ID.
+ */
+export async function getEmploymentSession(empid, companyId) {
+  if (companyId) {
+    const [companyCfg, branchCfg, deptCfg, empCfg] = await Promise.all([
+      getDisplayCfg("companies"),
+      getDisplayCfg("code_branches"),
+      getDisplayCfg("code_department"),
+      getDisplayCfg("tbl_employee"),
+    ]);
+
+    const companyName = buildDisplayExpr("c", companyCfg, "c.name");
+    const branchName = buildDisplayExpr("b", branchCfg, "b.name");
+    const deptName = buildDisplayExpr("d", deptCfg, "d.name");
+    const empName = buildDisplayExpr(
+      "emp",
+      empCfg,
+      "CONCAT_WS(' ', emp.emp_fname, emp.emp_lname)",
+    );
+
+    const [rows] = await pool.query(
+      `SELECT
+          e.employment_company_id AS company_id,
+          ${companyName} AS company_name,
+          e.employment_branch_id AS branch_id,
+          ${branchName} AS branch_name,
+          e.employment_department_id AS department_id,
+          ${deptName} AS department_name,
+          e.employment_position_id AS position_id,
+          ${empName} AS employee_name,
+          e.employment_user_level AS user_level,
+          ul.new_records,
+          ul.edit_delete_request,
+          ul.edit_records,
+          ul.delete_records,
+          ul.image_handler,
+          ul.audition,
+          ul.supervisor,
+          ul.companywide,
+          ul.branchwide,
+          ul.departmentwide,
+          ul.developer,
+          ul.system_settings,
+          ul.license_settings,
+          ul.ai,
+          ul.dashboard,
+          ul.ai_dashboard
+       FROM tbl_employment e
+       LEFT JOIN companies c ON e.employment_company_id = c.id
+       LEFT JOIN code_branches b ON e.employment_branch_id = b.id
+       LEFT JOIN code_department d ON e.employment_department_id = d.id
+       LEFT JOIN tbl_employee emp ON e.employment_emp_id = emp.emp_id
+       LEFT JOIN code_userlevel ul ON e.employment_user_level = ul.userlever_id
+       WHERE e.employment_emp_id = ? AND e.employment_company_id = ?
+       ORDER BY e.id DESC
+       LIMIT 1`,
+      [empid, companyId],
+    );
+    if (rows.length === 0) return null;
+    return mapEmploymentRow(rows[0]);
+  }
+  const sessions = await getEmploymentSessions(empid);
+  return sessions[0] || null;
 }
 
 /**

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -106,9 +106,9 @@ export default function ERPLayout() {
   }
 
   function handleHome() {
-    const roleId = user?.role_id || (user?.role === 'admin' ? 1 : 2);
-    const companyId = user?.company_id || company?.company_id;
-    refreshRolePermissions(roleId, companyId);
+    const userLevel = user?.user_level || company?.user_level;
+    const companyId = company?.company_id;
+    refreshRolePermissions(userLevel, companyId);
     navigate('/');
   }
 
@@ -178,6 +178,8 @@ function Header({ user, onLogout, onHome, isMobile, onToggleSidebar }) {
       {company && (
         <span style={styles.locationInfo}>
           {company.branch_name && `📍 ${company.branch_name} | `}
+          {company.department_name && `🏬 ${company.department_name} | `}
+          {company.employee_name && `👤 ${company.employee_name} | `}
           🏢 {company.company_name}
         </span>
       )}

--- a/src/erp.mgt.mn/components/LoginForm.jsx
+++ b/src/erp.mgt.mn/components/LoginForm.jsx
@@ -12,10 +12,12 @@ export default function LoginForm() {
   // login using employee ID only
   const [empid, setEmpid] = useState('');
   const [password, setPassword] = useState('');
+  const [storedCreds, setStoredCreds] = useState({ empid: '', password: '' });
+  const [companyOptions, setCompanyOptions] = useState([]);
+  const [isCompanyStep, setIsCompanyStep] = useState(false);
+  const [companyId, setCompanyId] = useState('');
   const [error, setError] = useState(null);
   const { setUser, setCompany } = useContext(AuthContext);
-  const [companyChoices, setCompanyChoices] = useState(null);
-  const [selectedCompany, setSelectedCompany] = useState('');
   const navigate = useNavigate();
 
   async function handleSubmit(e) {
@@ -24,84 +26,122 @@ export default function LoginForm() {
 
     try {
       // Send POST /api/auth/login with credentials: 'include'
-      const loggedIn = await login({ empid, password });
+      const payload = isCompanyStep
+        ? { ...storedCreds, companyId: Number(companyId) }
+        : { empid, password };
+      const loggedIn = await login(payload);
+
+      if (loggedIn.needsCompany) {
+        setStoredCreds({ empid, password });
+        setEmpid('');
+        setPassword('');
+        setCompanyOptions(loggedIn.sessions || []);
+        setCompanyId('');
+        setIsCompanyStep(true);
+        return;
+      }
 
       // The login response already returns the user profile
       setUser(loggedIn);
-
-      // Fetch company assignments
-      const res = await fetch(
-        `/api/user_companies?empid=${encodeURIComponent(loggedIn.empid)}`,
-        { credentials: 'include' },
+      setCompany(loggedIn.session || null);
+      refreshRolePermissions(
+        loggedIn.session?.user_level,
+        loggedIn.session?.company_id,
       );
-      const assignments = res.ok ? await res.json() : [];
-
-      if (assignments.length === 1) {
-        const choice = assignments[0];
-        setCompany(choice);
-        const roleId = choice.role_id || loggedIn.role_id || (loggedIn.role === 'admin' ? 1 : 2);
-        refreshRolePermissions(roleId, choice.company_id);
-        refreshCompanyModules(choice.company_id);
-        refreshModules();
-        refreshTxnModules();
-        navigate('/');
-      } else if (assignments.length > 1) {
-        setCompany(null);
-        setCompanyChoices(assignments);
-      } else {
-        refreshModules();
-        refreshTxnModules();
-        navigate('/');
-      }
+      refreshCompanyModules(loggedIn.session?.company_id);
+      refreshModules();
+      refreshTxnModules();
+      setStoredCreds({ empid: '', password: '' });
+      navigate('/');
     } catch (err) {
       console.error('Login failed:', err);
       setError(err.message || 'Login error');
     }
   }
 
-  if (companyChoices) {
+  if (isCompanyStep) {
     return (
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          const choice = companyChoices.find(
-            (c) => `${c.company_id}-${c.branch_id || ''}` === selectedCompany,
-          );
-          if (choice) {
-            setCompany(choice);
-            refreshRolePermissions(choice.role_id, choice.company_id);
-            refreshCompanyModules(choice.company_id);
-            refreshModules();
-            refreshTxnModules();
-            navigate('/');
-          }
-        }}
-        style={{ maxWidth: '320px' }}
-      >
+      <div style={{ maxWidth: '320px' }}>
+        <h1>Компани сонгох</h1>
+        <form onSubmit={handleSubmit}>
+          <div style={{ marginBottom: '0.75rem' }}>
+            <label htmlFor="company" style={{ display: 'block', marginBottom: '0.25rem' }}>
+              Компани
+            </label>
+            <select
+              id="company"
+              value={companyId}
+              onChange={(ev) => setCompanyId(ev.target.value)}
+              required
+              style={{ width: '100%', padding: '0.5rem', borderRadius: '3px', border: '1px solid #ccc' }}
+            >
+              <option value="">Компани сонгох</option>
+              {companyOptions.map((c) => (
+                <option key={c.company_id} value={c.company_id}>
+                  {c.company_name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {error && (
+            <p style={{ color: 'red', marginBottom: '0.75rem' }}>{error}</p>
+          )}
+
+          <button
+            type="submit"
+            style={{
+              backgroundColor: '#2563eb',
+              color: '#fff',
+              padding: '0.5rem 1rem',
+              border: '1px solid #2563eb',
+              borderRadius: '3px',
+              cursor: 'pointer',
+            }}
+          >
+            Сонгох
+          </button>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ maxWidth: '320px' }}>
+      <h1>Нэвтрэх</h1>
+      <form onSubmit={handleSubmit}>
         <div style={{ marginBottom: '0.75rem' }}>
-          <label htmlFor="company" style={{ display: 'block', marginBottom: '0.25rem' }}>
-            Компани сонгох
+          <label htmlFor="empid" style={{ display: 'block', marginBottom: '0.25rem' }}>
+            Ажилтны ID
           </label>
-          <select
-            id="company"
-            value={selectedCompany}
-            onChange={(e) => setSelectedCompany(e.target.value)}
+          <input
+            id="empid"
+            type="text"
+            value={empid}
+            onChange={(ev) => setEmpid(ev.target.value)}
             required
             style={{ width: '100%', padding: '0.5rem', borderRadius: '3px', border: '1px solid #ccc' }}
-          >
-            <option value="" disabled>
-              Сонгоно уу...
-            </option>
-            {companyChoices.map((c) => (
-              <option
-                key={c.company_id + '-' + (c.branch_id || '')}
-                value={`${c.company_id}-${c.branch_id || ''}`}
-              >
-                {c.branch_name ? `${c.branch_name} | ` : ''}{c.company_name}
-              </option>
-            ))}
-          </select>
+          />
         </div>
+
+        <div style={{ marginBottom: '0.75rem' }}>
+          <label htmlFor="password" style={{ display: 'block', marginBottom: '0.25rem' }}>
+            Нууц үг
+          </label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(ev) => setPassword(ev.target.value)}
+            required
+            style={{ width: '100%', padding: '0.5rem', borderRadius: '3px', border: '1px solid #ccc' }}
+          />
+        </div>
+
+        {error && (
+          <p style={{ color: 'red', marginBottom: '0.75rem' }}>{error}</p>
+        )}
+
         <button
           type="submit"
           style={{
@@ -113,62 +153,9 @@ export default function LoginForm() {
             cursor: 'pointer',
           }}
         >
-          Үргэлжлүүлэх
+          Нэвтрэх
         </button>
       </form>
-    );
-  }
-
-  return (
-    <form onSubmit={handleSubmit} style={{ maxWidth: '320px' }}>
-      <div style={{ marginBottom: '0.75rem' }}>
-        <label htmlFor="empid" style={{ display: 'block', marginBottom: '0.25rem' }}>
-          Ажилтны ID
-        </label>
-        <input
-          id="empid"
-          type="text"
-          value={empid}
-          onChange={(ev) => setEmpid(ev.target.value)}
-          required
-          style={{ width: '100%', padding: '0.5rem', borderRadius: '3px', border: '1px solid #ccc' }}
-        />
-      </div>
-
-      <div style={{ marginBottom: '0.75rem' }}>
-        <label
-          htmlFor="password"
-          style={{ display: 'block', marginBottom: '0.25rem' }}
-        >
-          Нууц үг
-        </label>
-        <input
-          id="password"
-          type="password"
-          value={password}
-          onChange={(ev) => setPassword(ev.target.value)}
-          required
-          style={{ width: '100%', padding: '0.5rem', borderRadius: '3px', border: '1px solid #ccc' }}
-        />
-      </div>
-
-      {error && (
-        <p style={{ color: 'red', marginBottom: '0.75rem' }}>{error}</p>
-      )}
-
-      <button
-        type="submit"
-        style={{
-          backgroundColor: '#2563eb',
-          color: '#fff',
-          padding: '0.5rem 1rem',
-          border: '1px solid #2563eb',
-          borderRadius: '3px',
-          cursor: 'pointer',
-        }}
-      >
-        Нэвтрэх
-      </button>
-    </form>
+    </div>
   );
 }

--- a/src/erp.mgt.mn/components/UserMenu.jsx
+++ b/src/erp.mgt.mn/components/UserMenu.jsx
@@ -1,9 +1,11 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext.jsx';
 
 export default function UserMenu({ user, onLogout }) {
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
+  const { company } = useContext(AuthContext);
 
   if (!user) return null;
 
@@ -24,7 +26,12 @@ export default function UserMenu({ user, onLogout }) {
   return (
     <div style={styles.wrapper}>
       <button style={styles.userBtn} onClick={toggle}>
-        {user.full_name ? `${user.full_name} (${user.empid})` : user.empid} ▾
+        {company?.employee_name
+          ? `${company.employee_name} (${user.empid})`
+          : user.empid}
+        {company?.company_name ? ` - ${company.company_name}` : ''}
+        {company?.branch_name ? ` - ${company.branch_name}` : ''}
+        {company?.department_name ? ` - ${company.department_name}` : ''} ▾
       </button>
       {open && (
         <div style={styles.menu}>

--- a/src/erp.mgt.mn/components/UserProfile.jsx
+++ b/src/erp.mgt.mn/components/UserProfile.jsx
@@ -2,6 +2,15 @@ import { useContext } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
 
 export default function UserProfile() {
-  const { user } = useContext(AuthContext);
-  return <div>Logged in as: {user.empid}</div>;
+  const { user, company } = useContext(AuthContext);
+  if (!user) return null;
+  return (
+    <div>
+      Logged in as: {company?.employee_name || user.empid}
+      {company?.employee_name && ` (${user.empid})`}
+      {company?.company_name && ` - ${company.company_name}`}
+      {company?.branch_name && ` - ${company.branch_name}`}
+      {company?.department_name && ` - ${company.department_name}`}
+    </div>
+  );
 }

--- a/src/erp.mgt.mn/context/AuthContext.jsx
+++ b/src/erp.mgt.mn/context/AuthContext.jsx
@@ -53,15 +53,21 @@ export default function AuthContextProvider({ children }) {
           const data = await res.json();
           trackSetState('AuthContext.setUser');
           setUser(data);
+          trackSetState('AuthContext.setCompany');
+          setCompany(data.session || null);
         } else {
           // Not logged in or token expired
           trackSetState('AuthContext.setUser');
           setUser(null);
+          trackSetState('AuthContext.setCompany');
+          setCompany(null);
         }
       } catch (err) {
         console.error('Unable to fetch profile:', err);
         trackSetState('AuthContext.setUser');
         setUser(null);
+        trackSetState('AuthContext.setCompany');
+        setCompany(null);
       }
     }
 

--- a/src/erp.mgt.mn/hooks/useAuth.jsx
+++ b/src/erp.mgt.mn/hooks/useAuth.jsx
@@ -7,17 +7,19 @@ import { API_BASE } from '../utils/apiBase.js';
 
 /**
  * Performs a login request and sets an HttpOnly cookie on success.
- * @param {{empid: string, password: string}} credentials - empid refers to the employee login ID
- * @returns {Promise<{id: number, empid: string, role: string}>}
+ * If multiple companies are configured for the user, the response will
+ * include a `needsCompany` flag with available sessions.
+ * @param {{empid: string, password: string, companyId?: number}} credentials
+ * @returns {Promise<any>}
 */
-export async function login({ empid, password }) {
+export async function login({ empid, password, companyId }) {
   let res;
   try {
     res = await fetch(`${API_BASE}/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-    credentials: 'include', // Ensures cookie is stored
-    body: JSON.stringify({ empid, password }),
+      credentials: 'include', // Ensures cookie is stored
+      body: JSON.stringify({ empid, password, companyId }),
     });
   } catch (err) {
     // Network errors (e.g. server unreachable)
@@ -25,17 +27,15 @@ export async function login({ empid, password }) {
   }
 
   if (!res.ok) {
-    let message = 'Login failed';
     const contentType = res.headers.get('content-type') || '';
+    let message = 'Login failed';
     if (contentType.includes('application/json')) {
       const data = await res.json().catch(() => ({}));
       if (data && data.message) message = data.message;
     } else if (res.status === 503) {
       message = 'Service unavailable';
     } else {
-      // Consume text to avoid unhandled promise rejections
-      const text = await res.text().catch(() => '');
-      if (text) message = text;
+      message = res.statusText || message;
     }
     throw new Error(message);
   }

--- a/src/erp.mgt.mn/hooks/useRolePermissions.js
+++ b/src/erp.mgt.mn/hooks/useRolePermissions.js
@@ -8,9 +8,9 @@ const cache = {};
 // Simple event emitter for permission refresh events
 const emitter = new EventTarget();
 
-export function refreshRolePermissions(roleId, companyId) {
-  const key = `${roleId}-${companyId || ''}`;
-  if (roleId) delete cache[key];
+export function refreshRolePermissions(userLevel, companyId) {
+  const key = `${userLevel}-${companyId || ''}`;
+  if (userLevel) delete cache[key];
   emitter.dispatchEvent(new Event('refresh'));
 }
 
@@ -45,8 +45,7 @@ export function useRolePermissions() {
       setPerms(null);
       return;
     }
-    const roleId =
-      company?.role_id || user.role_id || (user.role === 'admin' ? 1 : 2);
+    const roleId = company?.user_level || user?.user_level;
     const companyId = company?.company_id;
 
     const key = `${roleId}-${companyId || ''}`;
@@ -62,8 +61,7 @@ export function useRolePermissions() {
   useEffect(() => {
     debugLog('useRolePermissions effect: refresh listener');
     if (!user) return;
-    const roleId =
-      company?.role_id || user.role_id || (user.role === 'admin' ? 1 : 2);
+    const roleId = company?.user_level || user?.user_level;
     const companyId = company?.company_id;
     const handler = () => fetchPerms(roleId, companyId);
     emitter.addEventListener('refresh', handler);

--- a/src/erp.mgt.mn/pages/Login.jsx
+++ b/src/erp.mgt.mn/pages/Login.jsx
@@ -5,7 +5,6 @@ import LoginForm from '../components/LoginForm.jsx';
 export default function LoginPage() {
   return (
     <div style={{ padding: '2rem' }}>
-      <h1>Нэвтрэх</h1>
       <LoginForm />
     </div>
   );


### PR DESCRIPTION
## Summary
- Authenticate users via `users` table and fetch employment session with permission flags
- Store session context in AuthContext and remove legacy `user_companies` lookup during login
- Drive role-based module permissions using `user_level` session data
- Prompt users with multiple employments to choose a company on a dedicated screen, clearing credential fields
- Show friendly login error messages instead of raw HTML when the server returns non-JSON responses
- Separate login into credential and company-selection steps using explicit state
- Return employee and department names with session data and display them in account info
- Build company, branch, department, and employee display names using tableDisplayFields configuration and surface them in the header and user menu

## Testing
- `npm test -- --test-concurrency=1`


------
https://chatgpt.com/codex/tasks/task_e_689b8200bb7c8331be544fcc847303ed