### PR TITLE
refactor login flow for new permissions

### DIFF
--- a/api-server/controllers/authController.js
+++ b/api-server/controllers/authController.js
@@ -4,6 +4,7 @@ import {
   updateUserPassword,
   getEmploymentSession,
   getEmploymentSessions,
+  getPermissionsForUserLevel,
 } from '../../db/index.js';
 import { hash } from '../services/passwordService.js';
 import * as jwtService from '../services/jwtService.js';
@@ -44,6 +45,14 @@ export async function login(req, res, next) {
     const token = jwtService.sign(payload);
     const refreshToken = jwtService.signRefresh(payload);
 
+    const permissions = await getPermissionsForUserLevel(session.user_level);
+    const userProfile = {
+      id: user.id,
+      empid: user.empid,
+      role: user.role,
+      full_name: session?.employee_name,
+    };
+
     res.cookie(getCookieName(), token, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
@@ -56,14 +65,7 @@ export async function login(req, res, next) {
       sameSite: 'lax',
       maxAge: jwtService.getRefreshExpiryMillis(),
     });
-    res.json({
-      id: user.id,
-      empid: user.empid,
-      role: user.role,
-      full_name: session?.employee_name,
-      user_level: session?.user_level,
-      session,
-    });
+    res.json({ user: userProfile, session, permissions });
   } catch (err) {
     next(err);
   }
@@ -81,15 +83,18 @@ export async function logout(req, res) {
 }
 
 export async function getProfile(req, res) {
-  const session = await getEmploymentSession(req.user.empid, req.user.companyId);
-  res.json({
+  const session = await getEmploymentSession(
+    req.user.empid,
+    req.user.companyId,
+  );
+  const permissions = await getPermissionsForUserLevel(session?.user_level);
+  const userProfile = {
     id: req.user.id,
     empid: req.user.empid,
     role: req.user.role,
     full_name: session?.employee_name,
-    user_level: session?.user_level,
-    session,
-  });
+  };
+  res.json({ user: userProfile, session, permissions });
 }
 
 export async function changePassword(req, res, next) {
@@ -124,6 +129,13 @@ export async function refresh(req, res) {
     };
     const newAccess = jwtService.sign(newPayload);
     const newRefresh = jwtService.signRefresh(newPayload);
+    const permissions = await getPermissionsForUserLevel(session?.user_level);
+    const userProfile = {
+      id: user.id,
+      empid: user.empid,
+      role: user.role,
+      full_name: session?.employee_name,
+    };
     res.cookie(getCookieName(), newAccess, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
@@ -136,14 +148,7 @@ export async function refresh(req, res) {
       sameSite: 'lax',
       maxAge: jwtService.getRefreshExpiryMillis(),
     });
-    res.json({
-      id: user.id,
-      empid: user.empid,
-      role: user.role,
-      full_name: session?.employee_name,
-      user_level: session?.user_level,
-      session,
-    });
+    res.json({ user: userProfile, session, permissions });
   } catch (err) {
     const opts = {
       httpOnly: true,

--- a/db/index.js
+++ b/db/index.js
@@ -124,46 +124,77 @@ export async function getUserByEmpId(empid) {
 }
 
 function mapEmploymentRow(row) {
-  const {
-    new_records,
-    edit_delete_request,
-    edit_records,
-    delete_records,
-    image_handler,
-    audition,
-    supervisor,
-    companywide,
-    branchwide,
-    departmentwide,
-    developer,
-    system_settings,
-    license_settings,
-    ai,
-    dashboard,
-    ai_dashboard,
-    ...rest
-  } = row;
-  return {
-    ...rest,
-    permissions: {
-      new_records: !!new_records,
-      edit_delete_request: !!edit_delete_request,
-      edit_records: !!edit_records,
-      delete_records: !!delete_records,
-      image_handler: !!image_handler,
-      audition: !!audition,
-      supervisor: !!supervisor,
-      companywide: !!companywide,
-      branchwide: !!branchwide,
-      departmentwide: !!departmentwide,
-      developer: !!developer,
-      system_settings: !!system_settings,
-      license_settings: !!license_settings,
-      ai: !!ai,
-      dashboard: !!dashboard,
-      ai_dashboard: !!ai_dashboard,
-    },
+  const { ...rest } = row;
+  return { ...rest };
+}
+
+export async function getPermissionsForUserLevel(userLevel) {
+  if (!userLevel) {
+    return { actions: {} };
+  }
+
+  const [baseRows] = await pool.query(
+    `SELECT developer, system_settings, license_settings, ai, dashboard, ai_dashboard
+       FROM code_userlevel
+      WHERE userlever_id = ?
+      LIMIT 1`,
+    [userLevel],
+  );
+  const base = baseRows[0] || {};
+  const baseFlags = {
+    developer: base.developer ? 1 : 0,
+    system_settings: base.system_settings ? 1 : 0,
+    license_settings: base.license_settings ? 1 : 0,
+    ai: base.ai ? 1 : 0,
+    dashboard: base.dashboard ? 1 : 0,
+    ai_dashboard: base.ai_dashboard ? 1 : 0,
   };
+
+  const [rows] = await pool.query(
+    `SELECT action, ul_module_key, function_name,
+            new_records, edit_delete_request, edit_records, delete_records,
+            image_handler, audition, supervisor, companywide, branchwide,
+            departmentwide, developer, system_settings, license_settings,
+            ai, dashboard, ai_dashboard
+       FROM code_userlevel_settings
+      WHERE uls_id = ?`,
+    [userLevel],
+  );
+
+  const actions = {};
+  for (const r of rows) {
+    const perms = {};
+    const fields = [
+      'new_records',
+      'edit_delete_request',
+      'edit_records',
+      'delete_records',
+      'image_handler',
+      'audition',
+      'supervisor',
+      'companywide',
+      'branchwide',
+      'departmentwide',
+      'developer',
+      'system_settings',
+      'license_settings',
+      'ai',
+      'dashboard',
+      'ai_dashboard',
+    ];
+    for (const f of fields) {
+      if (r[f]) perms[f] = 1;
+    }
+    if (Object.keys(perms).length === 0) continue;
+
+    let key = r.ul_module_key || r.function_name;
+    if (!key) continue;
+    const group = r.action;
+    actions[group] = actions[group] || {};
+    actions[group][key] = { ...perms };
+  }
+
+  return { ...baseFlags, actions };
 }
 
 /**
@@ -197,29 +228,12 @@ export async function getEmploymentSessions(empid) {
         ${deptName} AS department_name,
         e.employment_position_id AS position_id,
         ${empName} AS employee_name,
-        e.employment_user_level AS user_level,
-        ul.new_records,
-        ul.edit_delete_request,
-        ul.edit_records,
-        ul.delete_records,
-        ul.image_handler,
-        ul.audition,
-        ul.supervisor,
-        ul.companywide,
-        ul.branchwide,
-        ul.departmentwide,
-        ul.developer,
-        ul.system_settings,
-        ul.license_settings,
-        ul.ai,
-        ul.dashboard,
-        ul.ai_dashboard
+        e.employment_user_level AS user_level
      FROM tbl_employment e
      LEFT JOIN companies c ON e.employment_company_id = c.id
      LEFT JOIN code_branches b ON e.employment_branch_id = b.id
      LEFT JOIN code_department d ON e.employment_department_id = d.${deptIdCol}
      LEFT JOIN tbl_employee emp ON e.employment_emp_id = emp.emp_id
-     LEFT JOIN code_userlevel ul ON e.employment_user_level = ul.userlever_id
      WHERE e.employment_emp_id = ?
      ORDER BY e.id DESC`,
     [empid],
@@ -260,29 +274,12 @@ export async function getEmploymentSession(empid, companyId) {
           ${deptName} AS department_name,
           e.employment_position_id AS position_id,
           ${empName} AS employee_name,
-          e.employment_user_level AS user_level,
-          ul.new_records,
-          ul.edit_delete_request,
-          ul.edit_records,
-          ul.delete_records,
-          ul.image_handler,
-          ul.audition,
-          ul.supervisor,
-          ul.companywide,
-          ul.branchwide,
-          ul.departmentwide,
-          ul.developer,
-          ul.system_settings,
-          ul.license_settings,
-          ul.ai,
-          ul.dashboard,
-          ul.ai_dashboard
+          e.employment_user_level AS user_level
        FROM tbl_employment e
        LEFT JOIN companies c ON e.employment_company_id = c.id
        LEFT JOIN code_branches b ON e.employment_branch_id = b.id
        LEFT JOIN code_department d ON e.employment_department_id = d.${deptIdCol}
        LEFT JOIN tbl_employee emp ON e.employment_emp_id = emp.emp_id
-       LEFT JOIN code_userlevel ul ON e.employment_user_level = ul.userlever_id
        WHERE e.employment_emp_id = ? AND e.employment_company_id = ?
        ORDER BY e.id DESC
        LIMIT 1`,

--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -181,9 +181,11 @@ function AuthedApp() {
 }
 
 function RequireAdminPage({ children }) {
-  const { user } = useContext(AuthContext);
+  const { user, permissions } = useContext(AuthContext);
   if (!user) {
     return <Navigate to="/login" replace />;
   }
-  return user.role === 'admin' ? children : <Navigate to="/" replace />;
+  return permissions?.developer || permissions?.system_settings
+    ? children
+    : <Navigate to="/" replace />;
 }

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -5,7 +5,7 @@ import UserMenu from "./UserMenu.jsx";
 import { useOutlet, useNavigate, useLocation } from "react-router-dom";
 import { AuthContext } from "../context/AuthContext.jsx";
 import { logout } from "../hooks/useAuth.jsx";
-import { useRolePermissions, refreshRolePermissions } from "../hooks/useRolePermissions.js";
+import { useRolePermissions } from "../hooks/useRolePermissions.js";
 import { useCompanyModules } from "../hooks/useCompanyModules.js";
 import { useModules } from "../hooks/useModules.js";
 import { useTxnModules } from "../hooks/useTxnModules.js";
@@ -24,7 +24,7 @@ import useHeaderMappings from "../hooks/useHeaderMappings.js";
  *  - Main content area (faux window container)
  */
 export default function ERPLayout() {
-  const { user, setUser, company } = useContext(AuthContext);
+  const { user, setUser, company, setCompany, setPermissions } = useContext(AuthContext);
   const generalConfig = useGeneralConfig();
   const renderCount = useRef(0);
   useEffect(() => {
@@ -102,13 +102,12 @@ export default function ERPLayout() {
   async function handleLogout() {
     await logout();
     setUser(null);
+    setCompany(null);
+    setPermissions(null);
     navigate("/login");
   }
 
   function handleHome() {
-    const userLevel = user?.user_level || company?.user_level;
-    const companyId = company?.company_id;
-    refreshRolePermissions(userLevel, companyId);
     navigate('/');
   }
 

--- a/src/erp.mgt.mn/components/Layout.jsx
+++ b/src/erp.mgt.mn/components/Layout.jsx
@@ -11,7 +11,7 @@ import { logout } from '../hooks/useAuth.jsx';
  *  - Main content area (faux window container)
  */
 export default function ERPLayout() {
-  const { user, setUser } = useContext(AuthContext);
+  const { user, setUser, setCompany, setPermissions } = useContext(AuthContext);
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -34,6 +34,8 @@ export default function ERPLayout() {
   async function handleLogout() {
     await logout();
     setUser(null);
+    setCompany(null);
+    setPermissions(null);
     navigate('/login');
   }
 
@@ -83,7 +85,7 @@ function Header({ user, onLogout }) {
 
 /** Left sidebar with “menu groups” and “pinned items” **/
 function Sidebar() {
-  const { user } = useContext(AuthContext);
+  const { user, permissions } = useContext(AuthContext);
 
   // You can expand/collapse these groups if you like; this is a static example
   return (
@@ -108,7 +110,7 @@ function Sidebar() {
         <NavLink to="/settings" className="menu-item" style={styles.menuItem} end>
           General
         </NavLink>
-        {user?.role === 'admin' && (
+        {(permissions?.developer || permissions?.system_settings) && (
           <>
             <NavLink to="/settings/users" className="menu-item" style={styles.menuItem}>
               Users

--- a/src/erp.mgt.mn/components/LoginForm.jsx
+++ b/src/erp.mgt.mn/components/LoginForm.jsx
@@ -2,7 +2,6 @@
 import React, { useState, useContext } from 'react';
 import { login } from '../hooks/useAuth.jsx';
 import { AuthContext } from '../context/AuthContext.jsx';
-import { refreshRolePermissions } from '../hooks/useRolePermissions.js';
 import { refreshCompanyModules } from '../hooks/useCompanyModules.js';
 import { refreshModules } from '../hooks/useModules.js';
 import { refreshTxnModules } from '../hooks/useTxnModules.js';
@@ -17,7 +16,7 @@ export default function LoginForm() {
   const [isCompanyStep, setIsCompanyStep] = useState(false);
   const [companyId, setCompanyId] = useState('');
   const [error, setError] = useState(null);
-  const { setUser, setCompany } = useContext(AuthContext);
+  const { setUser, setCompany, setPermissions } = useContext(AuthContext);
   const navigate = useNavigate();
 
   async function handleSubmit(e) {
@@ -41,13 +40,9 @@ export default function LoginForm() {
         return;
       }
 
-      // The login response already returns the user profile
-      setUser(loggedIn);
+      setUser(loggedIn.user);
       setCompany(loggedIn.session || null);
-      refreshRolePermissions(
-        loggedIn.session?.user_level,
-        loggedIn.session?.company_id,
-      );
+      setPermissions(loggedIn.permissions || null);
       refreshCompanyModules(loggedIn.session?.company_id);
       refreshModules();
       refreshTxnModules();

--- a/src/erp.mgt.mn/components/LogoutButton.jsx
+++ b/src/erp.mgt.mn/components/LogoutButton.jsx
@@ -4,7 +4,7 @@ import { useAuth } from '../hooks/useAuth.jsx';    // <-- import the hook, not `
 import { AuthContext } from '../context/AuthContext.jsx';
 
 export default function LogoutButton() {
-  const { user, setUser } = useContext(AuthContext);
+  const { user, setUser, setCompany, setPermissions } = useContext(AuthContext);
 
   // Destructure `logout` from the hook:
   const { logout } = useAuth();
@@ -13,6 +13,8 @@ export default function LogoutButton() {
     try {
       await logout();
       setUser(null);
+      setCompany(null);
+      setPermissions(null);
     } catch (err) {
       console.error('Logout failed:', err);
     }

--- a/src/erp.mgt.mn/components/ReportTable.jsx
+++ b/src/erp.mgt.mn/components/ReportTable.jsx
@@ -65,7 +65,7 @@ function isCountColumn(name) {
 }
 
 export default function ReportTable({ procedure = '', params = {}, rows = [] }) {
-  const { user, company } = useContext(AuthContext);
+  const { user, company, permissions } = useContext(AuthContext);
   const generalConfig = useGeneralConfig();
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
@@ -508,14 +508,15 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
       <div>
         <h4>
           {procLabel}
-          {user?.role === 'admin' && generalConfig.general?.editLabelsEnabled && (
-            <button
-              onClick={handleEditProcLabel}
-              style={{ marginLeft: '0.5rem' }}
-            >
-              Edit label
-            </button>
-          )}
+          {(permissions?.developer || permissions?.system_settings) &&
+            generalConfig.general?.editLabelsEnabled && (
+              <button
+                onClick={handleEditProcLabel}
+                style={{ marginLeft: '0.5rem' }}
+              >
+                Edit label
+              </button>
+            )}
         </h4>
         {paramText && <div style={{ marginTop: '0.25rem' }}>{paramText}</div>}
         <p>No data</p>
@@ -527,11 +528,15 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
     <div style={{ marginTop: '1rem' }}>
       <h4>
         {procLabel}
-        {user?.role === 'admin' && generalConfig.general?.editLabelsEnabled && (
-          <button onClick={handleEditProcLabel} style={{ marginLeft: '0.5rem' }}>
-            Edit label
-          </button>
-        )}
+        {(permissions?.developer || permissions?.system_settings) &&
+          generalConfig.general?.editLabelsEnabled && (
+            <button
+              onClick={handleEditProcLabel}
+              style={{ marginLeft: '0.5rem' }}
+            >
+              Edit label
+            </button>
+          )}
       </h4>
       {paramText && <div style={{ marginTop: '0.25rem' }}>{paramText}</div>}
       <div style={{ marginBottom: '0.5rem', display: 'flex', alignItems: 'center' }}>
@@ -789,21 +794,22 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
           )}
         </Modal>
       )}
-      {user?.role === 'admin' && generalConfig.general?.editLabelsEnabled && (
-        <button
-          onClick={() => {
-            const map = {};
-            columns.forEach((c) => {
-              map[c] = fieldLabels[c] || '';
-            });
-            setLabelEdits(map);
-            setEditLabels(true);
-          }}
-          style={{ marginTop: '0.5rem' }}
-        >
-          Edit Field Labels
-        </button>
-      )}
+      {(permissions?.developer || permissions?.system_settings) &&
+        generalConfig.general?.editLabelsEnabled && (
+          <button
+            onClick={() => {
+              const map = {};
+              columns.forEach((c) => {
+                map[c] = fieldLabels[c] || '';
+              });
+              setLabelEdits(map);
+              setEditLabels(true);
+            }}
+            style={{ marginTop: '0.5rem' }}
+          >
+            Edit Field Labels
+          </button>
+        )}
       {editLabels && (
         <div
           style={{

--- a/src/erp.mgt.mn/components/RequireAdmin.jsx
+++ b/src/erp.mgt.mn/components/RequireAdmin.jsx
@@ -3,9 +3,11 @@ import { AuthContext } from '../context/AuthContext.jsx';
 import { Navigate, Outlet } from 'react-router-dom';
 
 export default function RequireAdmin() {
-  const { user } = useContext(AuthContext);
+  const { user, permissions } = useContext(AuthContext);
   if (!user) {
     return <Navigate to="/login" replace />;
   }
-  return user.role === 'admin' ? <Outlet /> : <Navigate to="/" replace />;
+  return permissions?.developer || permissions?.system_settings
+    ? <Outlet />
+    : <Navigate to="/" replace />;
 }

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -163,7 +163,7 @@ const TableManager = forwardRef(function TableManager({
   const [customEndDate, setCustomEndDate] = useState('');
   const [typeFilter, setTypeFilter] = useState('');
   const [typeOptions, setTypeOptions] = useState([]);
-  const { user, company } = useContext(AuthContext);
+  const { user, company, permissions } = useContext(AuthContext);
   const generalConfig = useGeneralConfig();
   const { addToast } = useToast();
 
@@ -1592,7 +1592,7 @@ const TableManager = forwardRef(function TableManager({
         <div style={{ backgroundColor: '#ddffee', padding: '0.25rem', textAlign: 'left' }}>
           Branch:{' '}
           <span style={{ marginRight: '0.5rem' }}>{company.branch_id}</span>
-          {user?.role === 'admin' && (
+          {(permissions?.developer || permissions?.system_settings) && (
             <button
               onClick={() =>
                 branchIdFields.forEach((f) => handleFilterChange(f, ''))
@@ -1607,7 +1607,7 @@ const TableManager = forwardRef(function TableManager({
         <div style={{ backgroundColor: '#eefcff', padding: '0.25rem', textAlign: 'left' }}>
           Department:{' '}
           <span style={{ marginRight: '0.5rem' }}>{company.department_id}</span>
-          {user?.role === 'admin' && (
+          {(permissions?.developer || permissions?.system_settings) && (
             <button onClick={() => departmentIdFields.forEach((f) => handleFilterChange(f, ''))}>
               Clear Department Filter
             </button>
@@ -1618,7 +1618,7 @@ const TableManager = forwardRef(function TableManager({
         <div style={{ backgroundColor: '#ffeecc', padding: '0.25rem', textAlign: 'left' }}>
           User:{' '}
           <span style={{ marginRight: '0.5rem' }}>{user.empid}</span>
-          {user?.role === 'admin' && (
+          {(permissions?.developer || permissions?.system_settings) && (
             <button
               onClick={() =>
                 userIdFields.forEach((f) => handleFilterChange(f, ''))
@@ -2188,7 +2188,8 @@ const TableManager = forwardRef(function TableManager({
           </li>
         </ul>
       )}
-      {user?.role === 'admin' && generalConfig.general?.editLabelsEnabled && (
+      {(permissions?.developer || permissions?.system_settings) &&
+        generalConfig.general?.editLabelsEnabled && (
         <button onClick={() => {
           const map = {};
           columnMeta.forEach((c) => { map[c.name] = c.label || ''; });

--- a/src/erp.mgt.mn/hooks/useRolePermissions.js
+++ b/src/erp.mgt.mn/hooks/useRolePermissions.js
@@ -1,72 +1,9 @@
-import { useContext, useEffect, useState } from 'react';
-import { debugLog } from '../utils/debug.js';
+import { useContext } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
 
-// Cache permissions by role so switching users does not refetch unnecessarily
-const cache = {};
-
-// Simple event emitter for permission refresh events
-const emitter = new EventTarget();
-
-export function refreshRolePermissions(userLevel, companyId) {
-  const key = `${userLevel}-${companyId || ''}`;
-  if (userLevel) delete cache[key];
-  emitter.dispatchEvent(new Event('refresh'));
-}
+export function refreshRolePermissions() {}
 
 export function useRolePermissions() {
-  const { user, company } = useContext(AuthContext);
-  const [perms, setPerms] = useState(null);
-
-  async function fetchPerms(roleId, companyId) {
-    try {
-      const params = [`roleId=${roleId}`];
-      if (companyId) params.push(`companyId=${companyId}`);
-      const res = await fetch(`/api/role_permissions?${params.join('&')}`, {
-        credentials: 'include',
-      });
-      const rows = res.ok ? await res.json() : [];
-      const map = {};
-      rows.forEach((r) => {
-        map[r.module_key] = !!r.allowed;
-      });
-      const key = `${roleId}-${companyId || ''}`;
-      cache[key] = map;
-      setPerms(map);
-    } catch (err) {
-      console.error('Failed to load permissions', err);
-      setPerms({});
-    }
-  }
-
-  useEffect(() => {
-    debugLog('useRolePermissions effect: load perms');
-    if (!user) {
-      setPerms(null);
-      return;
-    }
-    const roleId = company?.user_level || user?.user_level;
-    const companyId = company?.company_id;
-
-    const key = `${roleId}-${companyId || ''}`;
-
-    if (cache[key]) {
-      setPerms(cache[key]);
-    } else {
-      fetchPerms(roleId, companyId);
-    }
-  }, [user, company]);
-
-  // Listen for refresh events
-  useEffect(() => {
-    debugLog('useRolePermissions effect: refresh listener');
-    if (!user) return;
-    const roleId = company?.user_level || user?.user_level;
-    const companyId = company?.company_id;
-    const handler = () => fetchPerms(roleId, companyId);
-    emitter.addEventListener('refresh', handler);
-    return () => emitter.removeEventListener('refresh', handler);
-  }, [user, company]);
-
-  return perms;
+  const { permissions } = useContext(AuthContext);
+  return permissions?.actions?.module_key || {};
 }


### PR DESCRIPTION
## Summary
- build permission objects from code_userlevel and code_userlevel_settings
- return unified user, session, and permissions in auth endpoints
- front-end now stores session context and permission flags
- fix login failure by removing nonexistent `api_name` column from permission query

## Testing
- `npm test` *(fails: deleteImage moves file to deleted_images; getProcedureRawRows appends visibleFields from all configs and returns displayFields; getProcedureRawRows applies extraConditions from primary table only; getProcedureRawRows accepts prefixed field names; getProcedureRawRows formats date conditions; getProcedureRawRows formats time conditions)*

------
https://chatgpt.com/codex/tasks/task_e_689dbe42ae888331a421b582cd063a74