### PR TITLE
feat: add user level permissions helper

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -166,6 +166,55 @@ function mapEmploymentRow(row) {
   };
 }
 
+// Columns in code_userlevel and code_userlevel_settings that indicate the
+// permission flags. Keeping them in one place helps keep query building and
+// result mapping consistent across helpers.
+const USERLEVEL_FLAG_COLUMNS = [
+  "new_records",
+  "edit_delete_request",
+  "edit_records",
+  "delete_records",
+  "image_handler",
+  "audition",
+  "supervisor",
+  "companywide",
+  "branchwide",
+  "departmentwide",
+  "developer",
+  "system_settings",
+  "license_settings",
+  "ai",
+  "dashboard",
+  "ai_dashboard",
+];
+
+/**
+ * Fetch allowed actions for a given user level (uls_id) grouped by the flag
+ * columns. Returns an object where each flag maps to an array of module keys
+ * for which the flag is enabled.
+ */
+export async function getUserLevelPermissions(ulsId) {
+  if (!ulsId) return {};
+  const [rows] = await pool.query(
+    `SELECT module_key, ${USERLEVEL_FLAG_COLUMNS.join(", ")}
+       FROM code_userlevel_settings
+      WHERE uls_id = ?`,
+    [ulsId],
+  );
+
+  const grouped = {};
+  for (const flag of USERLEVEL_FLAG_COLUMNS) {
+    grouped[flag] = [];
+  }
+
+  for (const row of rows) {
+    for (const flag of USERLEVEL_FLAG_COLUMNS) {
+      if (row[flag]) grouped[flag].push(row.module_key);
+    }
+  }
+  return grouped;
+}
+
 /**
  * List all employment sessions for an employee
  */
@@ -219,12 +268,18 @@ export async function getEmploymentSessions(empid) {
      LEFT JOIN code_branches b ON e.employment_branch_id = b.id
      LEFT JOIN code_department d ON e.employment_department_id = d.${deptIdCol}
      LEFT JOIN tbl_employee emp ON e.employment_emp_id = emp.emp_id
-     LEFT JOIN code_userlevel ul ON e.employment_user_level = ul.userlever_id
+     LEFT JOIN code_userlevel ul ON e.employment_user_level = ul.userlevel_id
      WHERE e.employment_emp_id = ?
      ORDER BY e.id DESC`,
     [empid],
   );
-  return rows.map(mapEmploymentRow);
+  return Promise.all(
+    rows.map(async (r) => {
+      const session = mapEmploymentRow(r);
+      session.actions = await getUserLevelPermissions(session.user_level);
+      return session;
+    }),
+  );
 }
 
 /**
@@ -282,14 +337,16 @@ export async function getEmploymentSession(empid, companyId) {
        LEFT JOIN code_branches b ON e.employment_branch_id = b.id
        LEFT JOIN code_department d ON e.employment_department_id = d.${deptIdCol}
        LEFT JOIN tbl_employee emp ON e.employment_emp_id = emp.emp_id
-       LEFT JOIN code_userlevel ul ON e.employment_user_level = ul.userlever_id
+       LEFT JOIN code_userlevel ul ON e.employment_user_level = ul.userlevel_id
        WHERE e.employment_emp_id = ? AND e.employment_company_id = ?
        ORDER BY e.id DESC
        LIMIT 1`,
       [empid, companyId],
     );
     if (rows.length === 0) return null;
-    return mapEmploymentRow(rows[0]);
+    const session = mapEmploymentRow(rows[0]);
+    session.actions = await getUserLevelPermissions(session.user_level);
+    return session;
   }
   const sessions = await getEmploymentSessions(empid);
   return sessions[0] || null;


### PR DESCRIPTION
## Summary
- add helper to load allowed module actions for a user level
- include action lists when fetching employment sessions
- fix user level join column to match table schema

## Testing
- `npm test` *(fails: mysql.escape is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689dceb765bc8331a6c45bab4104cc4d