### PR TITLE
feat: read permissions from auth context

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -5,7 +5,6 @@ import UserMenu from "./UserMenu.jsx";
 import { useOutlet, useNavigate, useLocation } from "react-router-dom";
 import { AuthContext } from "../context/AuthContext.jsx";
 import { logout } from "../hooks/useAuth.jsx";
-import { useRolePermissions, refreshRolePermissions } from "../hooks/useRolePermissions.js";
 import { useCompanyModules } from "../hooks/useCompanyModules.js";
 import { useModules } from "../hooks/useModules.js";
 import { useTxnModules } from "../hooks/useTxnModules.js";
@@ -106,9 +105,6 @@ export default function ERPLayout() {
   }
 
   function handleHome() {
-    const userLevel = user?.user_level || company?.user_level;
-    const companyId = company?.company_id;
-    refreshRolePermissions(userLevel, companyId);
     navigate('/');
   }
 
@@ -188,9 +184,8 @@ function Header({ user, onLogout, onHome, isMobile, onToggleSidebar }) {
 
 /** Left sidebar with “menu groups” and “pinned items” **/
 function Sidebar({ onOpen, open, isMobile }) {
-  const { company } = useContext(AuthContext);
+  const { company, permissions: perms } = useContext(AuthContext);
   const location = useLocation();
-  const perms = useRolePermissions();
   const licensed = useCompanyModules(company?.company_id);
   const modules = useModules();
   const txnModuleKeys = useTxnModules();

--- a/src/erp.mgt.mn/components/HeaderMenu.jsx
+++ b/src/erp.mgt.mn/components/HeaderMenu.jsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import { useRolePermissions } from '../hooks/useRolePermissions.js';
+import React, { useContext } from 'react';
+import { AuthContext } from '../context/AuthContext.jsx';
 import { useModules } from '../hooks/useModules.js';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import useHeaderMappings from '../hooks/useHeaderMappings.js';
 
 export default function HeaderMenu({ onOpen }) {
-  const perms = useRolePermissions();
+  const { permissions: perms } = useContext(AuthContext);
   const modules = useModules();
   const generalConfig = useGeneralConfig();
   const items = modules.filter((r) => r.show_in_header);

--- a/src/erp.mgt.mn/components/LoginForm.jsx
+++ b/src/erp.mgt.mn/components/LoginForm.jsx
@@ -2,7 +2,6 @@
 import React, { useState, useContext } from 'react';
 import { login } from '../hooks/useAuth.jsx';
 import { AuthContext } from '../context/AuthContext.jsx';
-import { refreshRolePermissions } from '../hooks/useRolePermissions.js';
 import { refreshCompanyModules } from '../hooks/useCompanyModules.js';
 import { refreshModules } from '../hooks/useModules.js';
 import { refreshTxnModules } from '../hooks/useTxnModules.js';
@@ -17,7 +16,7 @@ export default function LoginForm() {
   const [isCompanyStep, setIsCompanyStep] = useState(false);
   const [companyId, setCompanyId] = useState('');
   const [error, setError] = useState(null);
-  const { setUser, setCompany } = useContext(AuthContext);
+  const { setUser, setCompany, setPermissions } = useContext(AuthContext);
   const navigate = useNavigate();
 
   async function handleSubmit(e) {
@@ -44,10 +43,7 @@ export default function LoginForm() {
       // The login response already returns the user profile
       setUser(loggedIn);
       setCompany(loggedIn.session || null);
-      refreshRolePermissions(
-        loggedIn.session?.user_level,
-        loggedIn.session?.company_id,
-      );
+      setPermissions(loggedIn.permissions || null);
       refreshCompanyModules(loggedIn.session?.company_id);
       refreshModules();
       refreshTxnModules();

--- a/src/erp.mgt.mn/context/AuthContext.jsx
+++ b/src/erp.mgt.mn/context/AuthContext.jsx
@@ -9,6 +9,8 @@ export const AuthContext = createContext({
   setUser: () => {},
   company: null,
   setCompany: () => {},
+  permissions: null,
+  setPermissions: () => {},
 });
 
 export default function AuthContextProvider({ children }) {
@@ -16,6 +18,7 @@ export default function AuthContextProvider({ children }) {
   // state from an unauthenticated user (`null`).
   const [user, setUser] = useState(undefined);
   const [company, setCompany] = useState(null);
+  const [permissions, setPermissions] = useState(null);
 
   // Persist selected company across reloads
   useEffect(() => {
@@ -55,12 +58,16 @@ export default function AuthContextProvider({ children }) {
           setUser(data);
           trackSetState('AuthContext.setCompany');
           setCompany(data.session || null);
+          trackSetState('AuthContext.setPermissions');
+          setPermissions(data.permissions || null);
         } else {
           // Not logged in or token expired
           trackSetState('AuthContext.setUser');
           setUser(null);
           trackSetState('AuthContext.setCompany');
           setCompany(null);
+          trackSetState('AuthContext.setPermissions');
+          setPermissions(null);
         }
       } catch (err) {
         console.error('Unable to fetch profile:', err);
@@ -68,6 +75,8 @@ export default function AuthContextProvider({ children }) {
         setUser(null);
         trackSetState('AuthContext.setCompany');
         setCompany(null);
+        trackSetState('AuthContext.setPermissions');
+        setPermissions(null);
       }
     }
 
@@ -80,12 +89,17 @@ export default function AuthContextProvider({ children }) {
       setUser(null);
       trackSetState('AuthContext.setCompany');
       setCompany(null);
+      trackSetState('AuthContext.setPermissions');
+      setPermissions(null);
     }
     window.addEventListener('auth:logout', handleLogout);
     return () => window.removeEventListener('auth:logout', handleLogout);
   }, []);
 
-  const value = useMemo(() => ({ user, setUser, company, setCompany }), [user, company]);
+  const value = useMemo(
+    () => ({ user, setUser, company, setCompany, permissions, setPermissions }),
+    [user, company, permissions],
+  );
 
   return (
     <AuthContext.Provider value={value}>

--- a/src/erp.mgt.mn/hooks/useRolePermissions.js
+++ b/src/erp.mgt.mn/hooks/useRolePermissions.js
@@ -1,72 +1,8 @@
-import { useContext, useEffect, useState } from 'react';
-import { debugLog } from '../utils/debug.js';
+import { useContext } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
 
-// Cache permissions by role so switching users does not refetch unnecessarily
-const cache = {};
-
-// Simple event emitter for permission refresh events
-const emitter = new EventTarget();
-
-export function refreshRolePermissions(userLevel, companyId) {
-  const key = `${userLevel}-${companyId || ''}`;
-  if (userLevel) delete cache[key];
-  emitter.dispatchEvent(new Event('refresh'));
-}
-
+// Simple helper to read permissions from AuthContext.
 export function useRolePermissions() {
-  const { user, company } = useContext(AuthContext);
-  const [perms, setPerms] = useState(null);
-
-  async function fetchPerms(roleId, companyId) {
-    try {
-      const params = [`roleId=${roleId}`];
-      if (companyId) params.push(`companyId=${companyId}`);
-      const res = await fetch(`/api/role_permissions?${params.join('&')}`, {
-        credentials: 'include',
-      });
-      const rows = res.ok ? await res.json() : [];
-      const map = {};
-      rows.forEach((r) => {
-        map[r.module_key] = !!r.allowed;
-      });
-      const key = `${roleId}-${companyId || ''}`;
-      cache[key] = map;
-      setPerms(map);
-    } catch (err) {
-      console.error('Failed to load permissions', err);
-      setPerms({});
-    }
-  }
-
-  useEffect(() => {
-    debugLog('useRolePermissions effect: load perms');
-    if (!user) {
-      setPerms(null);
-      return;
-    }
-    const roleId = company?.user_level || user?.user_level;
-    const companyId = company?.company_id;
-
-    const key = `${roleId}-${companyId || ''}`;
-
-    if (cache[key]) {
-      setPerms(cache[key]);
-    } else {
-      fetchPerms(roleId, companyId);
-    }
-  }, [user, company]);
-
-  // Listen for refresh events
-  useEffect(() => {
-    debugLog('useRolePermissions effect: refresh listener');
-    if (!user) return;
-    const roleId = company?.user_level || user?.user_level;
-    const companyId = company?.company_id;
-    const handler = () => fetchPerms(roleId, companyId);
-    emitter.addEventListener('refresh', handler);
-    return () => emitter.removeEventListener('refresh', handler);
-  }, [user, company]);
-
-  return perms;
+  const { permissions } = useContext(AuthContext);
+  return permissions;
 }

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -9,7 +9,6 @@ import { useSearchParams } from 'react-router-dom';
 import TableManager from '../components/TableManager.jsx';
 import ReportTable from '../components/ReportTable.jsx';
 import { AuthContext } from '../context/AuthContext.jsx';
-import { useRolePermissions } from '../hooks/useRolePermissions.js';
 import { useCompanyModules } from '../hooks/useCompanyModules.js';
 import { useTxnSession } from '../context/TxnSessionContext.jsx';
 import { useToast } from '../context/ToastContext.jsx';
@@ -51,9 +50,8 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
   const [procParams, setProcParams] = useState([]);
   const [reportResult, setReportResult] = useState(null);
   const [manualParams, setManualParams] = useState({});
-  const { company, user } = useContext(AuthContext);
+  const { company, user, permissions: perms } = useContext(AuthContext);
   const generalConfig = useGeneralConfig();
-  const perms = useRolePermissions();
   const licensed = useCompanyModules(company?.company_id);
   const tableRef = useRef(null);
   const prevModuleKey = useRef(moduleKey);

--- a/src/erp.mgt.mn/pages/FormsIndex.jsx
+++ b/src/erp.mgt.mn/pages/FormsIndex.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState, useContext } from 'react';
 import FinanceTransactionsPage from './FinanceTransactions.jsx';
 import { useModules } from '../hooks/useModules.js';
 import { AuthContext } from '../context/AuthContext.jsx';
-import { useRolePermissions } from '../hooks/useRolePermissions.js';
 import { useCompanyModules } from '../hooks/useCompanyModules.js';
 import { useTxnModules } from '../hooks/useTxnModules.js';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
@@ -11,8 +10,7 @@ import useHeaderMappings from '../hooks/useHeaderMappings.js';
 export default function FormsIndex() {
   const [transactions, setTransactions] = useState({});
   const modules = useModules();
-  const { company } = useContext(AuthContext);
-  const perms = useRolePermissions();
+  const { company, permissions: perms } = useContext(AuthContext);
   const licensed = useCompanyModules(company?.company_id);
   const txnModules = useTxnModules();
   const generalConfig = useGeneralConfig();

--- a/src/erp.mgt.mn/pages/RolePermissions.jsx
+++ b/src/erp.mgt.mn/pages/RolePermissions.jsx
@@ -1,6 +1,5 @@
 // src/erp.mgt.mn/pages/RolePermissions.jsx
 import React, { useEffect, useState, useContext } from "react";
-import { refreshRolePermissions } from "../hooks/useRolePermissions.js";
 import { AuthContext } from "../context/AuthContext.jsx";
 
 export default function RolePermissions() {
@@ -47,7 +46,6 @@ export default function RolePermissions() {
       return;
     }
     loadPerms(filterRoleId);
-    refreshRolePermissions(p.role_id, company?.company_id);
   }
 
   return (

--- a/src/erp.mgt.mn/pages/Settings.jsx
+++ b/src/erp.mgt.mn/pages/Settings.jsx
@@ -1,6 +1,6 @@
 // src/erp.mgt.mn/pages/Settings.jsx
-import React, { useEffect, useState } from 'react';
-import { useRolePermissions } from '../hooks/useRolePermissions.js';
+import React, { useEffect, useState, useContext } from 'react';
+import { AuthContext } from '../context/AuthContext.jsx';
 import { Outlet, Link } from 'react-router-dom';
 
 export default function SettingsPage() {
@@ -10,7 +10,7 @@ export default function SettingsPage() {
 }
 
 export function GeneralSettings() {
-  const perms = useRolePermissions();
+  const { permissions: perms } = useContext(AuthContext);
   if (!perms) {
     return <p>Уншиж байна…</p>;
   }


### PR DESCRIPTION
## Summary
- store permissions in AuthContext and provide setter
- remove role_permissions API hook; read permissions from context
- check context.permissions for sidebar, header menu, and other modules

## Testing
- `npm test` *(fails: moveImagesToDeleted archives images, getProcedureRawRows variations)*


------
https://chatgpt.com/codex/tasks/task_e_689dde76cab8833195b06d4494a32944