### PR TITLE
Add user actions debug endpoint

### DIFF
--- a/api-server/app.js
+++ b/api-server/app.js
@@ -14,6 +14,7 @@ import companyRoutes from "./routes/companies.js";
 import settingsRoutes from "./routes/settings.js";
 import userCompanyRoutes from "./routes/user_companies.js";
 import rolePermissionRoutes from "./routes/role_permissions.js";
+import userActionRoutes from "./routes/user_actions.js";
 import moduleRoutes from "./routes/modules.js";
 import openaiRoutes from "./routes/openai.js";
 import headerMappingRoutes from "./routes/header_mappings.js";
@@ -68,6 +69,7 @@ app.get("/api/csrf-token", (req, res) => {
 
 // API routes
 app.use("/api/auth", authRoutes);
+app.use("/api/auth", userActionRoutes);
 app.use("/api/users", userRoutes);
 app.use("/api/companies", companyRoutes);
 app.use("/api/settings", settingsRoutes);

--- a/api-server/controllers/rolePermissionController.js
+++ b/api-server/controllers/rolePermissionController.js
@@ -1,6 +1,8 @@
 import {
   listRoleModulePermissions,
-  setRoleModulePermission
+  setRoleModulePermission,
+  getEmploymentSession,
+  getUserLevelActions,
 } from '../../db/index.js';
 
 export async function listPermissions(req, res, next) {
@@ -22,6 +24,21 @@ export async function updatePermission(req, res, next) {
     const { companyId, roleId, moduleKey, allowed } = req.body;
     await setRoleModulePermission(companyId, roleId, moduleKey, allowed);
     res.sendStatus(200);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getUserActions(req, res, next) {
+  try {
+    const session = await getEmploymentSession(
+      req.user.empid,
+      req.user.companyId,
+    );
+    const permissions = session?.user_level
+      ? await getUserLevelActions(session.user_level)
+      : {};
+    res.json(permissions);
   } catch (err) {
     next(err);
   }

--- a/api-server/routes/user_actions.js
+++ b/api-server/routes/user_actions.js
@@ -1,0 +1,9 @@
+import express from 'express';
+import { requireAuth } from '../middlewares/auth.js';
+import { getUserActions } from '../controllers/rolePermissionController.js';
+
+const router = express.Router();
+
+router.get('/user_actions', requireAuth, getUserActions);
+
+export default router;


### PR DESCRIPTION
## Summary
- add controller to fetch authenticated user's action permissions
- expose secured `/auth/user_actions` route
- wire new route into app for debugging/admin tools

## Testing
- `npm test` *(fails: tests 99, pass 93, fail 5)*

------
https://chatgpt.com/codex/tasks/task_e_689de024bad08331ad300269c27834b8