### PR TITLE
Add common_settings flag to user level permissions

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -136,6 +136,7 @@ function mapEmploymentRow(row) {
     branchwide,
     departmentwide,
     developer,
+    common_settings,
     system_settings,
     license_settings,
     ai,
@@ -157,6 +158,7 @@ function mapEmploymentRow(row) {
       branchwide: !!branchwide,
       departmentwide: !!departmentwide,
       developer: !!developer,
+      common_settings: !!common_settings,
       system_settings: !!system_settings,
       license_settings: !!license_settings,
       ai: !!ai,
@@ -209,6 +211,7 @@ export async function getEmploymentSessions(empid) {
         ul.branchwide,
         ul.departmentwide,
         ul.developer,
+        ul.common_settings,
         ul.system_settings,
         ul.license_settings,
         ul.ai,
@@ -272,6 +275,7 @@ export async function getEmploymentSession(empid, companyId) {
           ul.branchwide,
           ul.departmentwide,
           ul.developer,
+          ul.common_settings,
           ul.system_settings,
           ul.license_settings,
           ul.ai,
@@ -297,7 +301,7 @@ export async function getEmploymentSession(empid, companyId) {
 
 export async function getUserLevelActions(userLevelId) {
   const [flagsRows] = await pool.query(
-    `SELECT new_records, edit_delete_request, edit_records, delete_records, image_handler, audition, supervisor, companywide, branchwide, departmentwide, developer, system_settings, license_settings, ai, dashboard, ai_dashboard FROM code_userlevel WHERE userlevel_id = ?`,
+    `SELECT new_records, edit_delete_request, edit_records, delete_records, image_handler, audition, supervisor, companywide, branchwide, departmentwide, developer, common_settings, system_settings, license_settings, ai, dashboard, ai_dashboard FROM code_userlevel WHERE userlevel_id = ?`,
     [userLevelId],
   );
   if (!flagsRows.length) return {};

--- a/db/migrations/2025-08-02_code_userlevel_common_settings.sql
+++ b/db/migrations/2025-08-02_code_userlevel_common_settings.sql
@@ -1,0 +1,3 @@
+-- Add common_settings flag to code_userlevel
+ALTER TABLE code_userlevel
+  ADD COLUMN common_settings TINYINT(1) NOT NULL DEFAULT 0 AFTER developer;

--- a/db/schema_v4.sql
+++ b/db/schema_v4.sql
@@ -332,3 +332,7 @@ CREATE TABLE role_module_permissions (
   FOREIGN KEY (role_id)   REFERENCES user_roles(id),
   FOREIGN KEY (module_key) REFERENCES modules(module_key)
 );
+
+-- Add common_settings flag
+ALTER TABLE code_userlevel
+  ADD COLUMN common_settings TINYINT(1) NOT NULL DEFAULT 0 AFTER developer;

--- a/db/scripts/populate_userlevel_common_settings.sql
+++ b/db/scripts/populate_userlevel_common_settings.sql
@@ -1,0 +1,3 @@
+-- Initialize common_settings using existing system_settings values
+UPDATE code_userlevel
+SET common_settings = system_settings;


### PR DESCRIPTION
## Summary
- add `common_settings` column to `code_userlevel` with migration and schema update
- seed `common_settings` from existing `system_settings` values
- include `common_settings` in permission queries and user level actions

## Testing
- `npm test` *(fails: 6 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689de16df78c833192b936b3bcd1aebe