### PR TITLE
Fix user level column typo in migrations

### DIFF
--- a/db/migrations/2025-08-16_rename_userlevel_column.sql
+++ b/db/migrations/2025-08-16_rename_userlevel_column.sql
@@ -1,0 +1,3 @@
+-- Rename user level column typo
+ALTER TABLE code_userlevel
+  RENAME COLUMN userlever_id TO userlevel_id;


### PR DESCRIPTION
## Summary
- rename mistaken `userlever_id` column to `userlevel_id`

## Testing
- `npm test` *(fails: 6 failed, 92 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689de14f6e7c8331a1838851375fc7fb