### PR TITLE
Expose employment identifiers and persist in auth context

### DIFF
--- a/api-server/controllers/authController.js
+++ b/api-server/controllers/authController.js
@@ -37,12 +37,18 @@ export async function login(req, res, next) {
     }
 
     const permissions = await getUserLevelActions(session.user_level);
+    const {
+      company_id: company,
+      branch_id: branch,
+      department_id: department,
+      position_id: position,
+    } = session || {};
 
     const payload = {
       id: user.id,
       empid: user.empid,
       role: user.role,
-      companyId: session.company_id,
+      companyId: company,
     };
     const token = jwtService.sign(payload);
     const refreshToken = jwtService.signRefresh(payload);
@@ -65,6 +71,10 @@ export async function login(req, res, next) {
       role: user.role,
       full_name: session?.employee_name,
       user_level: session?.user_level,
+      company,
+      branch,
+      department,
+      position,
       session,
       permissions,
     });
@@ -89,12 +99,22 @@ export async function getProfile(req, res) {
   const permissions = session?.user_level
     ? await getUserLevelActions(session.user_level)
     : {};
+  const {
+    company_id: company,
+    branch_id: branch,
+    department_id: department,
+    position_id: position,
+  } = session || {};
   res.json({
     id: req.user.id,
     empid: req.user.empid,
     role: req.user.role,
     full_name: session?.employee_name,
     user_level: session?.user_level,
+    company,
+    branch,
+    department,
+    position,
     session,
     permissions,
   });
@@ -127,11 +147,17 @@ export async function refresh(req, res) {
     const permissions = session?.user_level
       ? await getUserLevelActions(session.user_level)
       : {};
+    const {
+      company_id: company,
+      branch_id: branch,
+      department_id: department,
+      position_id: position,
+    } = session || {};
     const newPayload = {
       id: user.id,
       empid: user.empid,
       role: user.role,
-      companyId: payload.companyId,
+      companyId: company,
     };
     const newAccess = jwtService.sign(newPayload);
     const newRefresh = jwtService.signRefresh(newPayload);
@@ -153,6 +179,10 @@ export async function refresh(req, res) {
       role: user.role,
       full_name: session?.employee_name,
       user_level: session?.user_level,
+      company,
+      branch,
+      department,
+      position,
       session,
       permissions,
     });

--- a/db/index.js
+++ b/db/index.js
@@ -125,6 +125,10 @@ export async function getUserByEmpId(empid) {
 
 function mapEmploymentRow(row) {
   const {
+    company_id,
+    branch_id,
+    department_id,
+    position_id,
     new_records,
     edit_delete_request,
     edit_records,
@@ -145,6 +149,10 @@ function mapEmploymentRow(row) {
     ...rest
   } = row;
   return {
+    company_id,
+    branch_id,
+    department_id,
+    position_id,
     ...rest,
     permissions: {
       new_records: !!new_records,

--- a/src/erp.mgt.mn/components/AppLayout.jsx
+++ b/src/erp.mgt.mn/components/AppLayout.jsx
@@ -4,7 +4,7 @@ import { AuthContext } from '../context/AuthContext.jsx';
 import { logout } from '../hooks/useAuth.jsx';
 
 export default function AppLayout({ children, title }) {
-  const { user, company } = useContext(AuthContext);
+  const { user, session } = useContext(AuthContext);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -50,10 +50,10 @@ export default function AppLayout({ children, title }) {
         <header className="sticky top-0 z-10 bg-white shadow-md flex items-center justify-between px-4 py-2">
           <h1 className="text-lg font-semibold">{title || 'ERP'}</h1>
           <div className="flex items-center space-x-3 text-sm">
-            {company && (
+            {session && (
               <span>
-                {company.branch_name && `${company.branch_name} | `}
-                {company.company_name}
+                {session.branch_name && `${session.branch_name} | `}
+                {session.company_name}
               </span>
             )}
             {user && (

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -23,7 +23,7 @@ import useHeaderMappings from "../hooks/useHeaderMappings.js";
  *  - Main content area (faux window container)
  */
 export default function ERPLayout() {
-  const { user, setUser, company } = useContext(AuthContext);
+  const { user, setUser } = useContext(AuthContext);
   const generalConfig = useGeneralConfig();
   const renderCount = useRef(0);
   useEffect(() => {
@@ -138,7 +138,7 @@ export default function ERPLayout() {
 
 /** Top header bar **/
 function Header({ user, onLogout, onHome, isMobile, onToggleSidebar }) {
-  const { company } = useContext(AuthContext);
+  const { session } = useContext(AuthContext);
   function handleOpen(id) {
     console.log("open module", id);
   }
@@ -168,11 +168,11 @@ function Header({ user, onLogout, onHome, isMobile, onToggleSidebar }) {
         <button style={styles.iconBtn}>❔ Тусламж</button>
       </nav>
       <HeaderMenu onOpen={handleOpen} />
-      {company && (
+      {session && (
         <span style={styles.locationInfo}>
-          {company.branch_name && `📍 ${company.branch_name} | `}
-          {company.department_name && `🏬 ${company.department_name} | `}
-          🏢 {company.company_name}
+          {session.branch_name && `📍 ${session.branch_name} | `}
+          {session.department_name && `🏬 ${session.department_name} | `}
+          🏢 {session.company_name}
         </span>
       )}
       <div style={styles.userSection}>
@@ -186,7 +186,7 @@ function Header({ user, onLogout, onHome, isMobile, onToggleSidebar }) {
 function Sidebar({ onOpen, open, isMobile }) {
   const { company, permissions: perms } = useContext(AuthContext);
   const location = useLocation();
-  const licensed = useCompanyModules(company?.company_id);
+  const licensed = useCompanyModules(company);
   const modules = useModules();
   const txnModuleKeys = useTxnModules();
   const generalConfig = useGeneralConfig();

--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -56,7 +56,9 @@ export default forwardRef(function InlineTransactionTable({
   viewColumns = {},
   procTriggers = {},
   user = {},
-  company = {},
+  company,
+  branch,
+  department,
   scope = 'forms',
   labelFontSize,
   boxWidth,
@@ -94,19 +96,19 @@ export default forwardRef(function InlineTransactionTable({
         if (row[f] === undefined || row[f] === '') row[f] = user.empid;
       });
     }
-    if (company?.branch_id !== undefined) {
+    if (branch !== undefined) {
       branchIdSet.forEach((f) => {
-        if (row[f] === undefined || row[f] === '') row[f] = company.branch_id;
+        if (row[f] === undefined || row[f] === '') row[f] = branch;
       });
     }
-    if (company?.department_id !== undefined) {
+    if (department !== undefined) {
       departmentIdSet.forEach((f) => {
-        if (row[f] === undefined || row[f] === '') row[f] = company.department_id;
+        if (row[f] === undefined || row[f] === '') row[f] = department;
       });
     }
-    if (company?.company_id !== undefined) {
+    if (company !== undefined) {
       companyIdSet.forEach((f) => {
-        if (row[f] === undefined || row[f] === '') row[f] = company.company_id;
+        if (row[f] === undefined || row[f] === '') row[f] = company;
       });
     }
     const now = formatTimestamp(new Date()).slice(0, 10);
@@ -405,8 +407,8 @@ export default forwardRef(function InlineTransactionTable({
       };
       const getParam = (p) => {
         if (p === '$current') return getVal(tCol);
-        if (p === '$branchId') return company?.branch_id;
-        if (p === '$companyId') return company?.company_id;
+        if (p === '$branchId') return branch;
+        if (p === '$companyId') return company;
         if (p === '$employeeId') return user?.empid;
         if (p === '$date') return formatTimestamp(new Date()).slice(0, 10);
         return getVal(p);

--- a/src/erp.mgt.mn/components/LoginForm.jsx
+++ b/src/erp.mgt.mn/components/LoginForm.jsx
@@ -16,7 +16,15 @@ export default function LoginForm() {
   const [isCompanyStep, setIsCompanyStep] = useState(false);
   const [companyId, setCompanyId] = useState('');
   const [error, setError] = useState(null);
-  const { setUser, setCompany, setPermissions } = useContext(AuthContext);
+  const {
+    setUser,
+    setSession,
+    setCompany,
+    setBranch,
+    setDepartment,
+    setPosition,
+    setPermissions,
+  } = useContext(AuthContext);
   const navigate = useNavigate();
 
   async function handleSubmit(e) {
@@ -42,9 +50,13 @@ export default function LoginForm() {
 
       // The login response already returns the user profile
       setUser(loggedIn);
-      setCompany(loggedIn.session || null);
+      setSession(loggedIn.session || null);
+      setCompany(loggedIn.company ?? loggedIn.session?.company_id ?? null);
+      setBranch(loggedIn.branch ?? loggedIn.session?.branch_id ?? null);
+      setDepartment(loggedIn.department ?? loggedIn.session?.department_id ?? null);
+      setPosition(loggedIn.position ?? loggedIn.session?.position_id ?? null);
       setPermissions(loggedIn.permissions || null);
-      refreshCompanyModules(loggedIn.session?.company_id);
+      refreshCompanyModules(loggedIn.company);
       refreshModules();
       refreshTxnModules();
       setStoredCreds({ empid: '', password: '' });

--- a/src/erp.mgt.mn/components/ReportTable.jsx
+++ b/src/erp.mgt.mn/components/ReportTable.jsx
@@ -65,7 +65,7 @@ function isCountColumn(name) {
 }
 
 export default function ReportTable({ procedure = '', params = {}, rows = [] }) {
-  const { user, company } = useContext(AuthContext);
+  const { user, company, branch, department } = useContext(AuthContext);
   const generalConfig = useGeneralConfig();
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
@@ -339,9 +339,9 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
       extraConditions,
       session: {
         empid: user?.empid,
-        company_id: company?.company_id,
-        branch_id: company?.branch_id,
-        department_id: company?.department_id,
+        company_id: company,
+        branch_id: branch,
+        department_id: department,
       },
     };
     setTxnInfo({ loading: true, col, value, data: [], sql: '', displayFields: [] });

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -98,7 +98,7 @@ const RowFormModal = function RowFormModal({
     () => new Set(disabledFields.map((f) => f.toLowerCase())),
     [disabledFields],
   );
-  const { user, company } = useContext(AuthContext);
+  const { user, company, branch, department } = useContext(AuthContext);
   const [formVals, setFormVals] = useState(() => {
     const init = {};
     const now = new Date();
@@ -120,12 +120,12 @@ const RowFormModal = function RowFormModal({
       }
       if (missing && !val) {
         if (userIdSet.has(c) && user?.empid) val = user.empid;
-        else if (branchIdSet.has(c) && company?.branch_id !== undefined)
-          val = company.branch_id;
-        else if (departmentIdSet.has(c) && company?.department_id !== undefined)
-          val = company.department_id;
-        else if (companyIdSet.has(c) && company?.company_id !== undefined)
-          val = company.company_id;
+        else if (branchIdSet.has(c) && branch !== undefined)
+          val = branch;
+        else if (departmentIdSet.has(c) && department !== undefined)
+          val = department;
+        else if (companyIdSet.has(c) && company !== undefined)
+          val = company;
       }
       init[c] = val;
     });
@@ -262,12 +262,12 @@ const RowFormModal = function RowFormModal({
       }
       if (missing && !v) {
         if (userIdSet.has(c) && user?.empid) v = user.empid;
-        else if (branchIdSet.has(c) && company?.branch_id !== undefined)
-          v = company.branch_id;
-        else if (departmentIdSet.has(c) && company?.department_id !== undefined)
-          v = company.department_id;
-        else if (companyIdSet.has(c) && company?.company_id !== undefined)
-          v = company.company_id;
+        else if (branchIdSet.has(c) && branch !== undefined)
+          v = branch;
+        else if (departmentIdSet.has(c) && department !== undefined)
+          v = department;
+        else if (companyIdSet.has(c) && company !== undefined)
+          v = company;
       }
       vals[c] = v;
     });
@@ -276,7 +276,7 @@ const RowFormModal = function RowFormModal({
     if (!same) setFormVals(vals);
     inputRefs.current = {};
     setErrors({});
-  }, [row, visible, user, company]);
+  }, [row, visible, user, company, branch, department]);
 
   function resizeInputs() {
     Object.values({ ...inputRefs.current, ...readonlyRefs.current }).forEach((el) => {
@@ -510,8 +510,8 @@ const RowFormModal = function RowFormModal({
       };
       const getParam = (p) => {
         if (p === '$current') return getVal(tCol);
-        if (p === '$branchId') return company?.branch_id;
-        if (p === '$companyId') return company?.company_id;
+        if (p === '$branchId') return branch;
+        if (p === '$companyId') return company;
         if (p === '$employeeId') return user?.empid;
         if (p === '$date') return formatTimestamp(new Date()).slice(0, 10);
         return getVal(p);
@@ -1004,6 +1004,8 @@ const RowFormModal = function RowFormModal({
               procTriggers={procTriggers}
               user={user}
               company={company}
+              branch={branch}
+              department={department}
               columnCaseMap={columnCaseMap}
               tableName={table}
               imagenameFields={imagenameField}

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -163,7 +163,7 @@ const TableManager = forwardRef(function TableManager({
   const [customEndDate, setCustomEndDate] = useState('');
   const [typeFilter, setTypeFilter] = useState('');
   const [typeOptions, setTypeOptions] = useState([]);
-  const { user, company } = useContext(AuthContext);
+  const { user, company, branch, department } = useContext(AuthContext);
   const generalConfig = useGeneralConfig();
   const { addToast } = useToast();
 
@@ -356,14 +356,14 @@ const TableManager = forwardRef(function TableManager({
     } else {
       setTypeFilter('');
     }
-    if (company?.branch_id !== undefined && branchIdFields.length > 0) {
+    if (branch !== undefined && branchIdFields.length > 0) {
       branchIdFields.forEach((f) => {
-        if (validCols.has(f)) newFilters[f] = company.branch_id;
+        if (validCols.has(f)) newFilters[f] = branch;
       });
     }
-    if (company?.department_id !== undefined && departmentIdFields.length > 0) {
+    if (department !== undefined && departmentIdFields.length > 0) {
       departmentIdFields.forEach((f) => {
-        if (validCols.has(f)) newFilters[f] = company.department_id;
+        if (validCols.has(f)) newFilters[f] = department;
       });
     }
     if (user?.empid !== undefined && userIdFields.length > 0) {
@@ -732,9 +732,9 @@ const TableManager = forwardRef(function TableManager({
     all.forEach((c) => {
       let v = (formConfig?.defaultValues || {})[c] || '';
       if (userIdFields.includes(c) && user?.empid) v = user.empid;
-      if (branchIdFields.includes(c) && company?.branch_id !== undefined) v = company.branch_id;
-      if (departmentIdFields.includes(c) && company?.department_id !== undefined) v = company.department_id;
-      if (companyIdFields.includes(c) && company?.company_id !== undefined) v = company.company_id;
+      if (branchIdFields.includes(c) && branch !== undefined) v = branch;
+      if (departmentIdFields.includes(c) && department !== undefined) v = department;
+      if (companyIdFields.includes(c) && company !== undefined) v = company;
       vals[c] = v;
       defaults[c] = v;
       if (!v && formConfig?.dateField?.includes(c)) {
@@ -959,16 +959,16 @@ const TableManager = forwardRef(function TableManager({
         if (columns.has(f)) merged[f] = user?.empid;
       });
       branchIdFields.forEach((f) => {
-        if (columns.has(f) && company?.branch_id !== undefined)
-          merged[f] = company.branch_id;
+        if (columns.has(f) && branch !== undefined)
+          merged[f] = branch;
       });
       departmentIdFields.forEach((f) => {
-        if (columns.has(f) && company?.department_id !== undefined)
-          merged[f] = company.department_id;
+        if (columns.has(f) && department !== undefined)
+          merged[f] = department;
       });
       companyIdFields.forEach((f) => {
-        if (columns.has(f) && company?.company_id !== undefined)
-          merged[f] = company.company_id;
+        if (columns.has(f) && company !== undefined)
+          merged[f] = company;
       });
     }
 
@@ -1588,10 +1588,10 @@ const TableManager = forwardRef(function TableManager({
           )}
         </div>
       )}
-      {branchIdFields.length > 0 && company?.branch_id !== undefined && (
+      {branchIdFields.length > 0 && branch !== undefined && (
         <div style={{ backgroundColor: '#ddffee', padding: '0.25rem', textAlign: 'left' }}>
           Branch:{' '}
-          <span style={{ marginRight: '0.5rem' }}>{company.branch_id}</span>
+          <span style={{ marginRight: '0.5rem' }}>{branch}</span>
           {user?.role === 'admin' && (
             <button
               onClick={() =>
@@ -1603,10 +1603,10 @@ const TableManager = forwardRef(function TableManager({
           )}
         </div>
       )}
-      {departmentIdFields.length > 0 && company?.department_id !== undefined && (
+      {departmentIdFields.length > 0 && department !== undefined && (
         <div style={{ backgroundColor: '#eefcff', padding: '0.25rem', textAlign: 'left' }}>
           Department:{' '}
-          <span style={{ marginRight: '0.5rem' }}>{company.department_id}</span>
+          <span style={{ marginRight: '0.5rem' }}>{department}</span>
           {user?.role === 'admin' && (
             <button onClick={() => departmentIdFields.forEach((f) => handleFilterChange(f, ''))}>
               Clear Department Filter

--- a/src/erp.mgt.mn/components/UserMenu.jsx
+++ b/src/erp.mgt.mn/components/UserMenu.jsx
@@ -5,7 +5,7 @@ import { AuthContext } from '../context/AuthContext.jsx';
 export default function UserMenu({ user, onLogout }) {
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
-  const { company } = useContext(AuthContext);
+  const { session } = useContext(AuthContext);
 
   if (!user) return null;
 
@@ -26,7 +26,7 @@ export default function UserMenu({ user, onLogout }) {
   return (
     <div style={styles.wrapper}>
       <button style={styles.userBtn} onClick={toggle}>
-        {company?.employee_name || user.empid} ▾
+        {session?.employee_name || user.empid} ▾
       </button>
       {open && (
         <div style={styles.menu}>

--- a/src/erp.mgt.mn/components/UserProfile.jsx
+++ b/src/erp.mgt.mn/components/UserProfile.jsx
@@ -2,15 +2,15 @@ import { useContext } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
 
 export default function UserProfile() {
-  const { user, company } = useContext(AuthContext);
+  const { user, session } = useContext(AuthContext);
   if (!user) return null;
   return (
     <div>
-      Logged in as: {company?.employee_name || user.empid}
-      {company?.employee_name && ` (${user.empid})`}
-      {company?.company_name && ` - ${company.company_name}`}
-      {company?.branch_name && ` - ${company.branch_name}`}
-      {company?.department_name && ` - ${company.department_name}`}
+      Logged in as: {session?.employee_name || user.empid}
+      {session?.employee_name && ` (${user.empid})`}
+      {session?.company_name && ` - ${session.company_name}`}
+      {session?.branch_name && ` - ${session.branch_name}`}
+      {session?.department_name && ` - ${session.department_name}`}
     </div>
   );
 }

--- a/src/erp.mgt.mn/hooks/useModules.js
+++ b/src/erp.mgt.mn/hooks/useModules.js
@@ -12,7 +12,7 @@ export function refreshModules() {
 }
 
 export function useModules() {
-  const { company } = useContext(AuthContext);
+  const { branch, department } = useContext(AuthContext);
   const generalConfig = useGeneralConfig();
   const [modules, setModules] = useState(cache.data || []);
 
@@ -22,10 +22,10 @@ export function useModules() {
       const rows = res.ok ? await res.json() : [];
       try {
         const params = new URLSearchParams();
-        if (company?.branch_id !== undefined)
-          params.set('branchId', company.branch_id);
-        if (company?.department_id !== undefined)
-          params.set('departmentId', company.department_id);
+        if (branch !== undefined)
+          params.set('branchId', branch);
+        if (department !== undefined)
+          params.set('departmentId', department);
         const prefix = generalConfig?.general?.reportProcPrefix || '';
         if (prefix) params.set('prefix', prefix);
         const pres = await fetch(
@@ -55,8 +55,8 @@ export function useModules() {
         console.error('Failed to load procedures', e);
       }
       cache.data = rows;
-      cache.branchId = company?.branch_id;
-      cache.departmentId = company?.department_id;
+      cache.branchId = branch;
+      cache.departmentId = department;
       cache.prefix = generalConfig?.general?.reportProcPrefix;
       setModules(rows);
     } catch (err) {
@@ -70,20 +70,20 @@ export function useModules() {
     const prefix = generalConfig?.general?.reportProcPrefix;
     if (
       !cache.data ||
-      cache.branchId !== company?.branch_id ||
-      cache.departmentId !== company?.department_id ||
+      cache.branchId !== branch ||
+      cache.departmentId !== department ||
       cache.prefix !== prefix
     ) {
       fetchModules();
     }
-  }, [company?.branch_id, company?.department_id, generalConfig?.general?.reportProcPrefix]);
+  }, [branch, department, generalConfig?.general?.reportProcPrefix]);
 
   useEffect(() => {
     debugLog('useModules effect: refresh listener');
     const handler = () => fetchModules();
     emitter.addEventListener('refresh', handler);
     return () => emitter.removeEventListener('refresh', handler);
-  }, [company?.branch_id, company?.department_id, generalConfig?.general?.reportProcPrefix]);
+  }, [branch, department, generalConfig?.general?.reportProcPrefix]);
 
   return modules;
 }

--- a/src/erp.mgt.mn/hooks/useTxnModules.js
+++ b/src/erp.mgt.mn/hooks/useTxnModules.js
@@ -11,16 +11,16 @@ export function refreshTxnModules() {
 }
 
 export function useTxnModules() {
-  const { company } = useContext(AuthContext);
+  const { branch, department } = useContext(AuthContext);
   const [keys, setKeys] = useState(cache.keys || new Set());
 
   async function fetchKeys() {
     try {
       const params = new URLSearchParams();
-      if (company?.branch_id !== undefined)
-        params.set('branchId', company.branch_id);
-      if (company?.department_id !== undefined)
-        params.set('departmentId', company.department_id);
+      if (branch !== undefined)
+        params.set('branchId', branch);
+      if (department !== undefined)
+        params.set('departmentId', department);
       const res = await fetch(
         `/api/transaction_forms${params.toString() ? `?${params.toString()}` : ''}`,
         { credentials: 'include' },
@@ -31,8 +31,8 @@ export function useTxnModules() {
         if (info && info.moduleKey) set.add(info.moduleKey);
       });
       cache.keys = set;
-      cache.branchId = company?.branch_id;
-      cache.departmentId = company?.department_id;
+      cache.branchId = branch;
+      cache.departmentId = department;
       setKeys(new Set(set));
     } catch (err) {
       console.error('Failed to load transaction modules', err);
@@ -44,19 +44,19 @@ export function useTxnModules() {
     debugLog('useTxnModules effect: initial fetch');
     if (
       !cache.keys ||
-      cache.branchId !== company?.branch_id ||
-      cache.departmentId !== company?.department_id
+      cache.branchId !== branch ||
+      cache.departmentId !== department
     ) {
       fetchKeys();
     }
-  }, [company?.branch_id, company?.department_id]);
+  }, [branch, department]);
 
   useEffect(() => {
     debugLog('useTxnModules effect: refresh listener');
     const handler = () => fetchKeys();
     emitter.addEventListener('refresh', handler);
     return () => emitter.removeEventListener('refresh', handler);
-  }, [company?.branch_id, company?.department_id]);
+  }, [branch, department]);
 
   return keys;
 }

--- a/src/erp.mgt.mn/pages/BlueLinkPage.jsx
+++ b/src/erp.mgt.mn/pages/BlueLinkPage.jsx
@@ -15,7 +15,7 @@ const initialLayout = {
 };
 
 export default function BlueLinkPage() {
-  const { user, company } = useContext(AuthContext);
+  const { user, session } = useContext(AuthContext);
 
   useEffect(() => {
     if (window.erpDebug) console.warn('Mounted: BlueLinkPage');
@@ -34,7 +34,7 @@ export default function BlueLinkPage() {
       <h2 style={{ marginTop: 0 }}>Blue Link демо</h2>
       <p>
         Welcome, {user?.full_name || user?.username}
-        {company && ` (${company.company_name})`}
+        {session && ` (${session.company_name})`}
       </p>
       <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap', marginBottom: '1rem' }}>
         <div style={cardStyle}>

--- a/src/erp.mgt.mn/pages/CompanyLicenses.jsx
+++ b/src/erp.mgt.mn/pages/CompanyLicenses.jsx
@@ -8,7 +8,7 @@ export default function CompanyLicenses() {
   const { company } = useContext(AuthContext);
 
   useEffect(() => {
-    loadLicenses(company?.company_id || '');
+    loadLicenses(company || '');
   }, [company]);
 
   function loadLicenses(companyId) {

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -50,9 +50,9 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
   const [procParams, setProcParams] = useState([]);
   const [reportResult, setReportResult] = useState(null);
   const [manualParams, setManualParams] = useState({});
-  const { company, user, permissions: perms } = useContext(AuthContext);
+  const { company, branch, department, user, permissions: perms } = useContext(AuthContext);
   const generalConfig = useGeneralConfig();
-  const licensed = useCompanyModules(company?.company_id);
+  const licensed = useCompanyModules(company);
   const tableRef = useRef(null);
   const prevModuleKey = useRef(moduleKey);
   const { addToast } = useToast();
@@ -168,10 +168,10 @@ useEffect(() => {
     console.log('FinanceTransactions load forms effect');
     const params = new URLSearchParams();
     if (moduleKey) params.set('moduleKey', moduleKey);
-    if (company?.branch_id !== undefined)
-      params.set('branchId', company.branch_id);
-    if (company?.department_id !== undefined)
-      params.set('departmentId', company.department_id);
+    if (branch !== undefined)
+      params.set('branchId', branch);
+    if (department !== undefined)
+      params.set('departmentId', department);
     fetch(`/api/transaction_forms?${params.toString()}`, { credentials: 'include' })
       .then((res) => {
         if (!res.ok) {
@@ -192,14 +192,14 @@ useEffect(() => {
           if (mKey !== moduleKey) return;
           if (
             allowedB.length > 0 &&
-            company?.branch_id !== undefined &&
-            !allowedB.includes(company.branch_id)
+            branch !== undefined &&
+            !allowedB.includes(branch)
           )
             return;
           if (
             allowedD.length > 0 &&
-            company?.department_id !== undefined &&
-            !allowedD.includes(company.department_id)
+            department !== undefined &&
+            !allowedD.includes(department)
           )
             return;
           if (perms && !perms[mKey]) return;
@@ -216,7 +216,7 @@ useEffect(() => {
         addToast('Failed to load transaction forms', 'error');
         setConfigs({});
       });
-  }, [moduleKey, company, perms, licensed]);
+  }, [moduleKey, company, branch, department, perms, licensed]);
 
   useEffect(() => {
     console.log('FinanceTransactions table sync effect');
@@ -335,12 +335,12 @@ useEffect(() => {
       const name = p.toLowerCase();
       if (name.includes('start') || name.includes('from')) return startDate || null;
       if (name.includes('end') || name.includes('to')) return endDate || null;
-      if (name.includes('branch')) return company?.branch_id ?? null;
-      if (name.includes('company')) return company?.company_id ?? null;
+      if (name.includes('branch')) return branch ?? null;
+      if (name.includes('company')) return company ?? null;
       if (name.includes('user') || name.includes('emp')) return user?.empid ?? null;
       return null;
     });
-  }, [procParams, startDate, endDate, company, user]);
+  }, [procParams, startDate, endDate, company, branch, user]);
 
   const finalParams = useMemo(() => {
     return procParams.map((p, i) => {

--- a/src/erp.mgt.mn/pages/FormsIndex.jsx
+++ b/src/erp.mgt.mn/pages/FormsIndex.jsx
@@ -10,8 +10,8 @@ import useHeaderMappings from '../hooks/useHeaderMappings.js';
 export default function FormsIndex() {
   const [transactions, setTransactions] = useState({});
   const modules = useModules();
-  const { company, permissions: perms } = useContext(AuthContext);
-  const licensed = useCompanyModules(company?.company_id);
+  const { company, branch, department, permissions: perms } = useContext(AuthContext);
+  const licensed = useCompanyModules(company);
   const txnModules = useTxnModules();
   const generalConfig = useGeneralConfig();
 
@@ -40,10 +40,10 @@ export default function FormsIndex() {
 
   useEffect(() => {
     const params = new URLSearchParams();
-    if (company?.branch_id !== undefined)
-      params.set('branchId', company.branch_id);
-    if (company?.department_id !== undefined)
-      params.set('departmentId', company.department_id);
+    if (branch !== undefined)
+      params.set('branchId', branch);
+    if (department !== undefined)
+      params.set('departmentId', department);
     const url = `/api/transaction_forms${params.toString() ? `?${params.toString()}` : ''}`;
     fetch(url, { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : {}))
@@ -56,14 +56,14 @@ export default function FormsIndex() {
           if (!descendantKeys.includes(key)) return;
           if (
             allowedB.length > 0 &&
-            company?.branch_id !== undefined &&
-            !allowedB.includes(company.branch_id)
+            branch !== undefined &&
+            !allowedB.includes(branch)
           )
             return;
           if (
             allowedD.length > 0 &&
-            company?.department_id !== undefined &&
-            !allowedD.includes(company.department_id)
+            department !== undefined &&
+            !allowedD.includes(department)
           )
             return;
           if (perms && !perms[key]) return;

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -117,7 +117,7 @@ async function putRow(addToast, table, id, row) {
 
 export default function PosTransactionsPage() {
   const { addToast } = useToast();
-  const { user, company } = useContext(AuthContext);
+  const { user, company, branch } = useContext(AuthContext);
   const generalConfig = useGeneralConfig();
   const [configs, setConfigs] = useState({});
   const [name, setName] = useState('');
@@ -493,14 +493,14 @@ export default function PosTransactionsPage() {
           if (next[tbl][f] === undefined) next[tbl][f] = user.empid;
         });
       }
-      if (fc.branchIdFields && company?.branch_id !== undefined) {
+      if (fc.branchIdFields && branch !== undefined) {
         fc.branchIdFields.forEach((f) => {
-          if (next[tbl][f] === undefined) next[tbl][f] = company.branch_id;
+          if (next[tbl][f] === undefined) next[tbl][f] = branch;
         });
       }
-      if (fc.companyIdFields && company?.company_id !== undefined) {
+      if (fc.companyIdFields && company !== undefined) {
         fc.companyIdFields.forEach((f) => {
-          if (next[tbl][f] === undefined) next[tbl][f] = company.company_id;
+          if (next[tbl][f] === undefined) next[tbl][f] = company;
         });
       }
       if (fc.transactionTypeField && fc.transactionTypeValue) {
@@ -550,14 +550,14 @@ export default function PosTransactionsPage() {
             if (updated[f] === undefined) updated[f] = user.empid;
           });
         }
-        if (fc.branchIdFields && company?.branch_id !== undefined) {
+        if (fc.branchIdFields && branch !== undefined) {
           fc.branchIdFields.forEach((f) => {
-            if (updated[f] === undefined) updated[f] = company.branch_id;
+            if (updated[f] === undefined) updated[f] = branch;
           });
         }
-        if (fc.companyIdFields && company?.company_id !== undefined) {
+        if (fc.companyIdFields && company !== undefined) {
           fc.companyIdFields.forEach((f) => {
-            if (updated[f] === undefined) updated[f] = company.company_id;
+            if (updated[f] === undefined) updated[f] = company;
           });
         }
         if (fc.transactionTypeField && fc.transactionTypeValue) {
@@ -580,8 +580,8 @@ export default function PosTransactionsPage() {
 
     const session = {
       employeeId: user?.empid,
-      companyId: company?.company_id,
-      branchId: company?.branch_id,
+      companyId: company,
+      branchId: branch,
       date: formatTimestamp(new Date()),
     };
     try {
@@ -709,8 +709,8 @@ export default function PosTransactionsPage() {
     const postData = { masterId: masterIdRef.current, single, multi };
     const session = {
       employeeId: user?.empid,
-      companyId: company?.company_id,
-      branchId: company?.branch_id,
+      companyId: company,
+      branchId: branch,
       date: formatTimestamp(new Date()),
     };
     try {
@@ -1018,7 +1018,7 @@ export default function PosTransactionsPage() {
                     viewDisplays={viewDisplaysMap[t.table] || {}}
                     viewColumns={viewColumnsMap[t.table] || {}}
                     user={user}
-                    company={company}
+                    
                     columnCaseMap={(columnMeta[t.table] || []).reduce((m,c)=>{m[c.name.toLowerCase()] = c.name;return m;}, {})}
                     onChange={(changes) => handleChange(t.table, changes)}
                     onRowsChange={(rows) => handleRowsChange(t.table, rows)}

--- a/src/erp.mgt.mn/pages/Reports.jsx
+++ b/src/erp.mgt.mn/pages/Reports.jsx
@@ -8,7 +8,7 @@ import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import useHeaderMappings from '../hooks/useHeaderMappings.js';
 
 export default function Reports() {
-  const { company, user } = useContext(AuthContext);
+  const { company, branch, user } = useContext(AuthContext);
   const { addToast } = useToast();
   const generalConfig = useGeneralConfig();
   const [procedures, setProcedures] = useState([]);
@@ -67,12 +67,12 @@ export default function Reports() {
       const name = p.toLowerCase();
       if (name.includes('start') || name.includes('from')) return startDate || null;
       if (name.includes('end') || name.includes('to')) return endDate || null;
-      if (name.includes('branch')) return company?.branch_id ?? null;
-      if (name.includes('company')) return company?.company_id ?? null;
+      if (name.includes('branch')) return branch ?? null;
+      if (name.includes('company')) return company ?? null;
       if (name.includes('user') || name.includes('emp')) return user?.empid ?? null;
       return null;
     });
-  }, [procParams, startDate, endDate, company, user]);
+  }, [procParams, startDate, endDate, company, branch, user]);
 
   const finalParams = useMemo(() => {
     return procParams.map((p, i) => {

--- a/src/erp.mgt.mn/pages/RolePermissions.jsx
+++ b/src/erp.mgt.mn/pages/RolePermissions.jsx
@@ -10,7 +10,7 @@ export default function RolePermissions() {
   function loadPerms(roleId) {
     const params = [];
     if (roleId) params.push(`roleId=${encodeURIComponent(roleId)}`);
-    if (company) params.push(`companyId=${encodeURIComponent(company.company_id)}`);
+    if (company) params.push(`companyId=${encodeURIComponent(company)}`);
     const url = params.length ? `/api/role_permissions?${params.join("&")}` : "/api/role_permissions";
     fetch(url, { credentials: "include" })
       .then((res) => {
@@ -35,7 +35,7 @@ export default function RolePermissions() {
       headers: { "Content-Type": "application/json" },
       credentials: "include",
       body: JSON.stringify({
-        companyId: company?.company_id,
+        companyId: company,
         roleId: p.role_id,
         moduleKey: p.module_key,
         allowed: p.allowed ? 0 : 1,

--- a/src/erp.mgt.mn/pages/UserCompanies.jsx
+++ b/src/erp.mgt.mn/pages/UserCompanies.jsx
@@ -20,7 +20,7 @@ export default function UserCompanies() {
   function loadAssignments(empid) {
     const params = [];
     if (empid) params.push(`empid=${encodeURIComponent(empid)}`);
-    if (company) params.push(`companyId=${encodeURIComponent(company.company_id)}`);
+    if (company) params.push(`companyId=${encodeURIComponent(company)}`);
     const url = params.length ? `/api/user_companies?${params.join('&')}` : '/api/user_companies';
     fetch(url, { credentials: 'include' })
       .then(res => {

--- a/src/erp.mgt.mn/pages/Users.jsx
+++ b/src/erp.mgt.mn/pages/Users.jsx
@@ -13,7 +13,7 @@ export default function Users() {
   }, []);
 
   function loadUsers() {
-    const params = company ? `?companyId=${encodeURIComponent(company.company_id)}` : '';
+    const params = company ? `?companyId=${encodeURIComponent(company)}` : '';
     fetch(`/api/users${params}`, { credentials: 'include' })
       .then((res) => {
         if (!res.ok) throw new Error('Failed to fetch users');


### PR DESCRIPTION
## Summary
- include company, branch, department and position IDs in employment session mapping
- expose these identifiers from auth endpoints and store them in AuthContext
- adapt frontend components to consume new AuthContext fields

## Testing
- `npm test` *(fails: deleteImageMovesFile moves file to deleted_images)*

------
https://chatgpt.com/codex/tasks/task_e_689de2f2360c833193dd5f9d1a0853cc