### PR TITLE
Map user-level permissions and fix transaction form filtering

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -137,6 +137,8 @@ export async function findTableByProcedure(proc) {
 export async function listTransactionNames({ moduleKey, branchId, departmentId } = {}) {
   const cfg = await readConfig();
   const result = {};
+  const bId = branchId != null ? Number(branchId) : null;
+  const dId = departmentId != null ? Number(departmentId) : null;
   for (const [tbl, names] of Object.entries(cfg)) {
     for (const [name, info] of Object.entries(names)) {
       const parsed = parseEntry(info);
@@ -144,8 +146,8 @@ export async function listTransactionNames({ moduleKey, branchId, departmentId }
       const allowed = parsed.allowedBranches;
       const deptAllowed = parsed.allowedDepartments;
       if (moduleKey && moduleKey !== modKey) continue;
-      if (branchId && allowed.length > 0 && !allowed.includes(Number(branchId))) continue;
-      if (departmentId && deptAllowed.length > 0 && !deptAllowed.includes(Number(departmentId))) continue;
+      if (bId != null && allowed.length > 0 && !allowed.includes(bId)) continue;
+      if (dId != null && deptAllowed.length > 0 && !deptAllowed.includes(dId)) continue;
       result[name] = { table: tbl, ...parsed };
     }
   }

--- a/db/index.js
+++ b/db/index.js
@@ -320,24 +320,21 @@ export async function getUserLevelActions(userLevelId) {
     .join(' OR ');
   if (!conditions) return {};
   const [rows] = await pool.query(
-    `SELECT button, module_key, \`function\`, API FROM code_userlevel_settings WHERE ${conditions}`,
+    `SELECT action, ul_module_key, function_name FROM code_userlevel_settings WHERE ${conditions}`,
   );
-  const result = {};
-  for (const row of rows) {
-    if (row.button) {
-      (result.button ||= []).push(row.button);
-    }
-    if (row.module_key) {
-      (result.module_key ||= []).push(row.module_key);
-    }
-    if (row.function) {
-      (result.function ||= []).push(row.function);
-    }
-    if (row.API) {
-      (result.API ||= []).push(row.API);
+  const perms = {};
+  for (const { action, ul_module_key: mod, function_name: fn } of rows) {
+    if (action === 'module_key' && mod) {
+      perms[mod] = true;
+    } else if (action === 'button' && fn) {
+      (perms.buttons ||= {})[fn] = true;
+    } else if (action === 'function' && fn) {
+      (perms.functions ||= {})[fn] = true;
+    } else if (action === 'API' && fn) {
+      (perms.api ||= {})[fn] = true;
     }
   }
-  return result;
+  return perms;
 }
 
 /**

--- a/src/erp.mgt.mn/hooks/useModules.js
+++ b/src/erp.mgt.mn/hooks/useModules.js
@@ -22,10 +22,8 @@ export function useModules() {
       const rows = res.ok ? await res.json() : [];
       try {
         const params = new URLSearchParams();
-        if (branch !== undefined)
-          params.set('branchId', branch);
-        if (department !== undefined)
-          params.set('departmentId', department);
+        if (branch != null) params.set('branchId', branch);
+        if (department != null) params.set('departmentId', department);
         const prefix = generalConfig?.general?.reportProcPrefix || '';
         if (prefix) params.set('prefix', prefix);
         const pres = await fetch(

--- a/src/erp.mgt.mn/hooks/useTxnModules.js
+++ b/src/erp.mgt.mn/hooks/useTxnModules.js
@@ -17,10 +17,8 @@ export function useTxnModules() {
   async function fetchKeys() {
     try {
       const params = new URLSearchParams();
-      if (branch !== undefined)
-        params.set('branchId', branch);
-      if (department !== undefined)
-        params.set('departmentId', department);
+      if (branch != null) params.set('branchId', branch);
+      if (department != null) params.set('departmentId', department);
       const res = await fetch(
         `/api/transaction_forms${params.toString() ? `?${params.toString()}` : ''}`,
         { credentials: 'include' },

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -168,10 +168,8 @@ useEffect(() => {
     console.log('FinanceTransactions load forms effect');
     const params = new URLSearchParams();
     if (moduleKey) params.set('moduleKey', moduleKey);
-    if (branch !== undefined)
-      params.set('branchId', branch);
-    if (department !== undefined)
-      params.set('departmentId', department);
+    if (branch != null) params.set('branchId', branch);
+    if (department != null) params.set('departmentId', department);
     fetch(`/api/transaction_forms?${params.toString()}`, { credentials: 'include' })
       .then((res) => {
         if (!res.ok) {
@@ -192,13 +190,13 @@ useEffect(() => {
           if (mKey !== moduleKey) return;
           if (
             allowedB.length > 0 &&
-            branch !== undefined &&
+            branch != null &&
             !allowedB.includes(branch)
           )
             return;
           if (
             allowedD.length > 0 &&
-            department !== undefined &&
+            department != null &&
             !allowedD.includes(department)
           )
             return;

--- a/src/erp.mgt.mn/pages/FormsIndex.jsx
+++ b/src/erp.mgt.mn/pages/FormsIndex.jsx
@@ -40,10 +40,8 @@ export default function FormsIndex() {
 
   useEffect(() => {
     const params = new URLSearchParams();
-    if (branch !== undefined)
-      params.set('branchId', branch);
-    if (department !== undefined)
-      params.set('departmentId', department);
+    if (branch != null) params.set('branchId', branch);
+    if (department != null) params.set('departmentId', department);
     const url = `/api/transaction_forms${params.toString() ? `?${params.toString()}` : ''}`;
     fetch(url, { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : {}))
@@ -56,13 +54,13 @@ export default function FormsIndex() {
           if (!descendantKeys.includes(key)) return;
           if (
             allowedB.length > 0 &&
-            branch !== undefined &&
+            branch != null &&
             !allowedB.includes(branch)
           )
             return;
           if (
             allowedD.length > 0 &&
-            department !== undefined &&
+            department != null &&
             !allowedD.includes(department)
           )
             return;


### PR DESCRIPTION
## Summary
- Convert `getUserLevelActions` to return a boolean map keyed by module and nested maps for buttons/functions/APIs
- Expose allowed modules in session permissions so login immediately displays sidebar items
- Omit null branch/department IDs when requesting transaction forms and filter results with null-safe checks so allowed forms show correctly
- Normalize branch/department filters on the server to ignore null values

## Testing
- `npm test` *(fails: 5 failing tests, 93 passing, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_689ddcb645fc8331b3b84c654a620837