### PR TITLE
Map user-level permissions and allow dynamic transaction forms

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -137,6 +137,8 @@ export async function findTableByProcedure(proc) {
 export async function listTransactionNames({ moduleKey, branchId, departmentId } = {}) {
   const cfg = await readConfig();
   const result = {};
+  const bId = branchId != null ? Number(branchId) : null;
+  const dId = departmentId != null ? Number(departmentId) : null;
   for (const [tbl, names] of Object.entries(cfg)) {
     for (const [name, info] of Object.entries(names)) {
       const parsed = parseEntry(info);
@@ -144,8 +146,8 @@ export async function listTransactionNames({ moduleKey, branchId, departmentId }
       const allowed = parsed.allowedBranches;
       const deptAllowed = parsed.allowedDepartments;
       if (moduleKey && moduleKey !== modKey) continue;
-      if (branchId && allowed.length > 0 && !allowed.includes(Number(branchId))) continue;
-      if (departmentId && deptAllowed.length > 0 && !deptAllowed.includes(Number(departmentId))) continue;
+      if (bId != null && allowed.length > 0 && !allowed.includes(bId)) continue;
+      if (dId != null && deptAllowed.length > 0 && !deptAllowed.includes(dId)) continue;
       result[name] = { table: tbl, ...parsed };
     }
   }

--- a/db/index.js
+++ b/db/index.js
@@ -320,24 +320,21 @@ export async function getUserLevelActions(userLevelId) {
     .join(' OR ');
   if (!conditions) return {};
   const [rows] = await pool.query(
-    `SELECT button, module_key, \`function\`, API FROM code_userlevel_settings WHERE ${conditions}`,
+    `SELECT action, ul_module_key, function_name FROM code_userlevel_settings WHERE ${conditions}`,
   );
-  const result = {};
-  for (const row of rows) {
-    if (row.button) {
-      (result.button ||= []).push(row.button);
-    }
-    if (row.module_key) {
-      (result.module_key ||= []).push(row.module_key);
-    }
-    if (row.function) {
-      (result.function ||= []).push(row.function);
-    }
-    if (row.API) {
-      (result.API ||= []).push(row.API);
+  const perms = {};
+  for (const { action, ul_module_key: mod, function_name: fn } of rows) {
+    if (action === 'module_key' && mod) {
+      perms[mod] = true;
+    } else if (action === 'button' && fn) {
+      (perms.buttons ||= {})[fn] = true;
+    } else if (action === 'function' && fn) {
+      (perms.functions ||= {})[fn] = true;
+    } else if (action === 'API' && fn) {
+      (perms.api ||= {})[fn] = true;
     }
   }
-  return result;
+  return perms;
 }
 
 /**

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -214,14 +214,11 @@ function Sidebar({ onOpen, open, isMobile }) {
 
   const map = {};
   modules.forEach((m) => {
-    if (
-      !perms[m.module_key] ||
-      !licensed[m.module_key] ||
-      !m.show_in_sidebar
-    )
-      return;
-    if (isFormsDescendant(m) && txnModuleKeys && !txnModuleKeys.has(m.module_key))
-      return;
+    const formsDesc = isFormsDescendant(m);
+    const isTxn = formsDesc && txnModuleKeys && txnModuleKeys.has(m.module_key);
+    if (formsDesc && !isTxn) return;
+    if (!m.show_in_sidebar) return;
+    if (!isTxn && (!perms[m.module_key] || !licensed[m.module_key])) return;
     const label =
       generalConfig.general?.procLabels?.[m.module_key] ||
       headerMap[m.module_key] ||

--- a/src/erp.mgt.mn/components/HeaderMenu.jsx
+++ b/src/erp.mgt.mn/components/HeaderMenu.jsx
@@ -1,12 +1,14 @@
 import React, { useContext } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { useModules } from '../hooks/useModules.js';
+import { useTxnModules } from '../hooks/useTxnModules.js';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import useHeaderMappings from '../hooks/useHeaderMappings.js';
 
 export default function HeaderMenu({ onOpen }) {
   const { permissions: perms } = useContext(AuthContext);
   const modules = useModules();
+  const txnModuleKeys = useTxnModules();
   const generalConfig = useGeneralConfig();
   const items = modules.filter((r) => r.show_in_header);
   const headerMap = useHeaderMappings(items.map((m) => m.module_key));
@@ -15,20 +17,21 @@ export default function HeaderMenu({ onOpen }) {
 
   return (
     <nav style={styles.menu}>
-      {items.map(
-        (m) =>
-          perms[m.module_key] && (
-            <button
-              key={m.module_key}
-              style={styles.btn}
-              onClick={() => onOpen(m.module_key)}
-            >
-              {generalConfig.general?.procLabels?.[m.module_key] ||
-                headerMap[m.module_key] ||
-                m.label}
-            </button>
-          ),
-      )}
+      {items.map((m) => {
+        const isTxn = txnModuleKeys && txnModuleKeys.has(m.module_key);
+        if (!isTxn && (!perms || !perms[m.module_key])) return null;
+        return (
+          <button
+            key={m.module_key}
+            style={styles.btn}
+            onClick={() => onOpen(m.module_key)}
+          >
+            {generalConfig.general?.procLabels?.[m.module_key] ||
+              headerMap[m.module_key] ||
+              m.label}
+          </button>
+        );
+      })}
     </nav>
   );
 }

--- a/src/erp.mgt.mn/hooks/useModules.js
+++ b/src/erp.mgt.mn/hooks/useModules.js
@@ -22,10 +22,8 @@ export function useModules() {
       const rows = res.ok ? await res.json() : [];
       try {
         const params = new URLSearchParams();
-        if (branch !== undefined)
-          params.set('branchId', branch);
-        if (department !== undefined)
-          params.set('departmentId', department);
+        if (branch != null) params.set('branchId', branch);
+        if (department != null) params.set('departmentId', department);
         const prefix = generalConfig?.general?.reportProcPrefix || '';
         if (prefix) params.set('prefix', prefix);
         const pres = await fetch(

--- a/src/erp.mgt.mn/hooks/useTxnModules.js
+++ b/src/erp.mgt.mn/hooks/useTxnModules.js
@@ -17,10 +17,8 @@ export function useTxnModules() {
   async function fetchKeys() {
     try {
       const params = new URLSearchParams();
-      if (branch !== undefined)
-        params.set('branchId', branch);
-      if (department !== undefined)
-        params.set('departmentId', department);
+      if (branch != null) params.set('branchId', branch);
+      if (department != null) params.set('departmentId', department);
       const res = await fetch(
         `/api/transaction_forms${params.toString() ? `?${params.toString()}` : ''}`,
         { credentials: 'include' },

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -168,10 +168,8 @@ useEffect(() => {
     console.log('FinanceTransactions load forms effect');
     const params = new URLSearchParams();
     if (moduleKey) params.set('moduleKey', moduleKey);
-    if (branch !== undefined)
-      params.set('branchId', branch);
-    if (department !== undefined)
-      params.set('departmentId', department);
+    if (branch != null) params.set('branchId', branch);
+    if (department != null) params.set('departmentId', department);
     fetch(`/api/transaction_forms?${params.toString()}`, { credentials: 'include' })
       .then((res) => {
         if (!res.ok) {
@@ -192,18 +190,28 @@ useEffect(() => {
           if (mKey !== moduleKey) return;
           if (
             allowedB.length > 0 &&
-            branch !== undefined &&
+            branch != null &&
             !allowedB.includes(branch)
           )
             return;
           if (
             allowedD.length > 0 &&
-            department !== undefined &&
+            department != null &&
             !allowedD.includes(department)
           )
             return;
-          if (perms && !perms[mKey]) return;
-          if (licensed && !licensed[mKey]) return;
+          if (
+            perms &&
+            Object.prototype.hasOwnProperty.call(perms, mKey) &&
+            !perms[mKey]
+          )
+            return;
+          if (
+            licensed &&
+            Object.prototype.hasOwnProperty.call(licensed, mKey) &&
+            !licensed[mKey]
+          )
+            return;
           filtered[n] = info;
         });
         setConfigs(filtered);
@@ -438,7 +446,15 @@ useEffect(() => {
   }
 
   if (!perms || !licensed) return <p>Ачааллаж байна...</p>;
-  if (!perms[moduleKey] || !licensed[moduleKey]) return <p>Нэвтрэх эрхгүй.</p>;
+  if (
+    (perms &&
+      Object.prototype.hasOwnProperty.call(perms, moduleKey) &&
+      !perms[moduleKey]) ||
+    (licensed &&
+      Object.prototype.hasOwnProperty.call(licensed, moduleKey) &&
+      !licensed[moduleKey])
+  )
+    return <p>Нэвтрэх эрхгүй.</p>;
 
   const caption = 'Гүйлгээ сонгоно уу';
 

--- a/src/erp.mgt.mn/pages/FormsIndex.jsx
+++ b/src/erp.mgt.mn/pages/FormsIndex.jsx
@@ -40,10 +40,8 @@ export default function FormsIndex() {
 
   useEffect(() => {
     const params = new URLSearchParams();
-    if (branch !== undefined)
-      params.set('branchId', branch);
-    if (department !== undefined)
-      params.set('departmentId', department);
+    if (branch != null) params.set('branchId', branch);
+    if (department != null) params.set('departmentId', department);
     const url = `/api/transaction_forms${params.toString() ? `?${params.toString()}` : ''}`;
     fetch(url, { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : {}))
@@ -56,18 +54,28 @@ export default function FormsIndex() {
           if (!descendantKeys.includes(key)) return;
           if (
             allowedB.length > 0 &&
-            branch !== undefined &&
+            branch != null &&
             !allowedB.includes(branch)
           )
             return;
           if (
             allowedD.length > 0 &&
-            department !== undefined &&
+            department != null &&
             !allowedD.includes(department)
           )
             return;
-          if (perms && !perms[key]) return;
-          if (licensed && !licensed[key]) return;
+          if (
+            perms &&
+            Object.prototype.hasOwnProperty.call(perms, key) &&
+            !perms[key]
+          )
+            return;
+          if (
+            licensed &&
+            Object.prototype.hasOwnProperty.call(licensed, key) &&
+            !licensed[key]
+          )
+            return;
           if (!grouped[key]) grouped[key] = [];
           grouped[key].push(name);
         });


### PR DESCRIPTION
## Summary
- Skip permission and license checks unless settings explicitly deny a form
- Let FinanceTransactions load modules not listed in user-level settings
- Render dynamic transaction modules in sidebar and header without configured permissions

## Testing
- `npm test` *(fails: 5 failing tests, 93 passing, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_689ddcb645fc8331b3b84c654a620837