### PR TITLE
Map user-level permissions and allow dynamic transaction forms

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -137,6 +137,8 @@ export async function findTableByProcedure(proc) {
 export async function listTransactionNames({ moduleKey, branchId, departmentId } = {}) {
   const cfg = await readConfig();
   const result = {};
+  const bId = branchId ? Number(branchId) : null;
+  const dId = departmentId ? Number(departmentId) : null;
   for (const [tbl, names] of Object.entries(cfg)) {
     for (const [name, info] of Object.entries(names)) {
       const parsed = parseEntry(info);
@@ -144,8 +146,8 @@ export async function listTransactionNames({ moduleKey, branchId, departmentId }
       const allowed = parsed.allowedBranches;
       const deptAllowed = parsed.allowedDepartments;
       if (moduleKey && moduleKey !== modKey) continue;
-      if (branchId && allowed.length > 0 && !allowed.includes(Number(branchId))) continue;
-      if (departmentId && deptAllowed.length > 0 && !deptAllowed.includes(Number(departmentId))) continue;
+      if (bId != null && allowed.length > 0 && !allowed.includes(bId)) continue;
+      if (dId != null && deptAllowed.length > 0 && !deptAllowed.includes(dId)) continue;
       result[name] = { table: tbl, ...parsed };
     }
   }

--- a/db/index.js
+++ b/db/index.js
@@ -320,24 +320,21 @@ export async function getUserLevelActions(userLevelId) {
     .join(' OR ');
   if (!conditions) return {};
   const [rows] = await pool.query(
-    `SELECT button, module_key, \`function\`, API FROM code_userlevel_settings WHERE ${conditions}`,
+    `SELECT action, ul_module_key, function_name FROM code_userlevel_settings WHERE ${conditions}`,
   );
-  const result = {};
-  for (const row of rows) {
-    if (row.button) {
-      (result.button ||= []).push(row.button);
-    }
-    if (row.module_key) {
-      (result.module_key ||= []).push(row.module_key);
-    }
-    if (row.function) {
-      (result.function ||= []).push(row.function);
-    }
-    if (row.API) {
-      (result.API ||= []).push(row.API);
+  const perms = {};
+  for (const { action, ul_module_key: mod, function_name: fn } of rows) {
+    if (action === 'module_key' && mod) {
+      perms[mod] = true;
+    } else if (action === 'button' && fn) {
+      (perms.buttons ||= {})[fn] = true;
+    } else if (action === 'function' && fn) {
+      (perms.functions ||= {})[fn] = true;
+    } else if (action === 'API' && fn) {
+      (perms.api ||= {})[fn] = true;
     }
   }
-  return result;
+  return perms;
 }
 
 /**

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -214,14 +214,12 @@ function Sidebar({ onOpen, open, isMobile }) {
 
   const map = {};
   modules.forEach((m) => {
-    if (
-      !perms[m.module_key] ||
-      !licensed[m.module_key] ||
-      !m.show_in_sidebar
-    )
-      return;
-    if (isFormsDescendant(m) && txnModuleKeys && !txnModuleKeys.has(m.module_key))
-      return;
+    const formsDesc = isFormsDescendant(m);
+    const isTxn = formsDesc && txnModuleKeys && txnModuleKeys.has(m.module_key);
+    if (formsDesc && !isTxn) return;
+    if (!m.show_in_sidebar) return;
+    if (!licensed[m.module_key]) return;
+    if (!isTxn && !perms[m.module_key]) return;
     const label =
       generalConfig.general?.procLabels?.[m.module_key] ||
       headerMap[m.module_key] ||

--- a/src/erp.mgt.mn/components/HeaderMenu.jsx
+++ b/src/erp.mgt.mn/components/HeaderMenu.jsx
@@ -1,34 +1,40 @@
 import React, { useContext } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { useModules } from '../hooks/useModules.js';
+import { useTxnModules } from '../hooks/useTxnModules.js';
+import { useCompanyModules } from '../hooks/useCompanyModules.js';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import useHeaderMappings from '../hooks/useHeaderMappings.js';
 
 export default function HeaderMenu({ onOpen }) {
-  const { permissions: perms } = useContext(AuthContext);
+  const { company, permissions: perms } = useContext(AuthContext);
   const modules = useModules();
+  const txnModuleKeys = useTxnModules();
+  const licensed = useCompanyModules(company);
   const generalConfig = useGeneralConfig();
   const items = modules.filter((r) => r.show_in_header);
   const headerMap = useHeaderMappings(items.map((m) => m.module_key));
 
-  if (!perms) return null;
+  if (!perms || !licensed) return null;
 
   return (
     <nav style={styles.menu}>
-      {items.map(
-        (m) =>
-          perms[m.module_key] && (
-            <button
-              key={m.module_key}
-              style={styles.btn}
-              onClick={() => onOpen(m.module_key)}
-            >
-              {generalConfig.general?.procLabels?.[m.module_key] ||
-                headerMap[m.module_key] ||
-                m.label}
-            </button>
-          ),
-      )}
+      {items.map((m) => {
+        const isTxn = txnModuleKeys && txnModuleKeys.has(m.module_key);
+        if (!licensed[m.module_key]) return null;
+        if (!isTxn && !perms[m.module_key]) return null;
+        return (
+          <button
+            key={m.module_key}
+            style={styles.btn}
+            onClick={() => onOpen(m.module_key)}
+          >
+            {generalConfig.general?.procLabels?.[m.module_key] ||
+              headerMap[m.module_key] ||
+              m.label}
+          </button>
+        );
+      })}
     </nav>
   );
 }

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -102,6 +102,7 @@ const TableManager = forwardRef(function TableManager({
   initialPerPage = 10,
   addLabel = 'Мөр нэмэх',
   showTable = true,
+  buttonPerms = {},
 }, ref) {
   const mounted = useRef(false);
   const renderCount = useRef(0);
@@ -772,7 +773,9 @@ const TableManager = forwardRef(function TableManager({
     setShowForm(true);
   }
 
-  useImperativeHandle(ref, () => ({ openAdd }));
+  useImperativeHandle(ref, () => ({
+    openAdd: buttonPerms['New transaction'] ? openAdd : () => {},
+  }));
 
   async function openDetail(row) {
     setDetailRow(row);
@@ -1443,9 +1446,11 @@ const TableManager = forwardRef(function TableManager({
           textAlign: 'left',
         }}
       >
-        <button onClick={openAdd} style={{ marginRight: '0.5rem' }}>
-          {addLabel}
-        </button>
+        {buttonPerms['New transaction'] && (
+          <button onClick={openAdd} style={{ marginRight: '0.5rem' }}>
+            {addLabel}
+          </button>
+        )}
         <button onClick={selectCurrentPage} style={{ marginRight: '0.5rem' }}>
           Select All
         </button>
@@ -1455,7 +1460,7 @@ const TableManager = forwardRef(function TableManager({
         <button onClick={refreshRows} style={{ marginRight: '0.5rem' }}>
           Refresh Table
         </button>
-        {selectedRows.size > 0 && (
+        {selectedRows.size > 0 && buttonPerms['Delete transaction'] && (
           <button onClick={handleDeleteSelected}>Delete Selected</button>
         )}
       </div>
@@ -1899,20 +1904,24 @@ const TableManager = forwardRef(function TableManager({
                       >
                         ➕ Add Img
                       </button>
-                      <button
-                        onClick={() => openEdit(r)}
-                        disabled={rid === undefined}
-                        style={actionBtnStyle}
-                      >
-                        🖉 Edit
-                      </button>
-                      <button
-                        onClick={() => handleDelete(r)}
-                        disabled={rid === undefined}
-                        style={deleteBtnStyle}
-                      >
-                        ❌ Delete
-                      </button>
+                      {buttonPerms['Edit transaction'] && (
+                        <button
+                          onClick={() => openEdit(r)}
+                          disabled={rid === undefined}
+                          style={actionBtnStyle}
+                        >
+                          🖉 Edit
+                        </button>
+                      )}
+                      {buttonPerms['Delete transaction'] && (
+                        <button
+                          onClick={() => handleDelete(r)}
+                          disabled={rid === undefined}
+                          style={deleteBtnStyle}
+                        >
+                          ❌ Delete
+                        </button>
+                      )}
                     </>
                   );
                 })()}
@@ -2248,7 +2257,8 @@ function propsEqual(prev, next) {
     prev.refreshId === next.refreshId &&
     prev.formConfig === next.formConfig &&
     prev.allConfigs === next.allConfigs &&
-    prev.showTable === next.showTable
+    prev.showTable === next.showTable &&
+    prev.buttonPerms === next.buttonPerms
   );
 }
 

--- a/src/erp.mgt.mn/hooks/useModules.js
+++ b/src/erp.mgt.mn/hooks/useModules.js
@@ -22,10 +22,8 @@ export function useModules() {
       const rows = res.ok ? await res.json() : [];
       try {
         const params = new URLSearchParams();
-        if (branch !== undefined)
-          params.set('branchId', branch);
-        if (department !== undefined)
-          params.set('departmentId', department);
+        if (branch) params.set('branchId', branch);
+        if (department) params.set('departmentId', department);
         const prefix = generalConfig?.general?.reportProcPrefix || '';
         if (prefix) params.set('prefix', prefix);
         const pres = await fetch(

--- a/src/erp.mgt.mn/hooks/useTxnModules.js
+++ b/src/erp.mgt.mn/hooks/useTxnModules.js
@@ -17,10 +17,8 @@ export function useTxnModules() {
   async function fetchKeys() {
     try {
       const params = new URLSearchParams();
-      if (branch !== undefined)
-        params.set('branchId', branch);
-      if (department !== undefined)
-        params.set('departmentId', department);
+      if (branch) params.set('branchId', branch);
+      if (department) params.set('departmentId', department);
       const res = await fetch(
         `/api/transaction_forms${params.toString() ? `?${params.toString()}` : ''}`,
         { credentials: 'include' },

--- a/src/erp.mgt.mn/pages/FormsIndex.jsx
+++ b/src/erp.mgt.mn/pages/FormsIndex.jsx
@@ -40,10 +40,8 @@ export default function FormsIndex() {
 
   useEffect(() => {
     const params = new URLSearchParams();
-    if (branch !== undefined)
-      params.set('branchId', branch);
-    if (department !== undefined)
-      params.set('departmentId', department);
+    if (branch) params.set('branchId', branch);
+    if (department) params.set('departmentId', department);
     const url = `/api/transaction_forms${params.toString() ? `?${params.toString()}` : ''}`;
     fetch(url, { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : {}))
@@ -54,20 +52,22 @@ export default function FormsIndex() {
           const allowedD = info.allowedDepartments || [];
           const key = info.moduleKey || 'forms';
           if (!descendantKeys.includes(key)) return;
+          if (allowedB.length > 0 && branch && !allowedB.includes(branch))
+            return;
+          if (allowedD.length > 0 && department && !allowedD.includes(department))
+            return;
           if (
-            allowedB.length > 0 &&
-            branch !== undefined &&
-            !allowedB.includes(branch)
+            perms &&
+            Object.prototype.hasOwnProperty.call(perms, key) &&
+            !perms[key]
           )
             return;
           if (
-            allowedD.length > 0 &&
-            department !== undefined &&
-            !allowedD.includes(department)
+            licensed &&
+            Object.prototype.hasOwnProperty.call(licensed, key) &&
+            !licensed[key]
           )
             return;
-          if (perms && !perms[key]) return;
-          if (licensed && !licensed[key]) return;
           if (!grouped[key]) grouped[key] = [];
           grouped[key].push(name);
         });


### PR DESCRIPTION
## Summary
- Require licensed modules for sidebar and header entries while still showing dynamic transaction forms based on transaction configuration
- Pass detailed button permissions to FinanceTransactions and TableManager so Add/Edit/Delete controls appear only when allowed

## Testing
- `npm test` *(fails: detectIncompleteImages handles files without sp_primary_code; moveImagesToDeleted archives images; getProcedureRawRows appends visibleFields from all configs and returns displayFields; getProcedureRawRows applies extraConditions from primary table only; getProcedureRawRows accepts prefixed field names; getProcedureRawRows formats date conditions; getProcedureRawRows formats time conditions)*

------
https://chatgpt.com/codex/tasks/task_e_689ddcb645fc8331b3b84c654a620837