### PR TITLE
Refine transaction configuration UI and table handling

### DIFF
--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -4,6 +4,7 @@ import { refreshTxnModules } from '../hooks/useTxnModules.js';
 import { debugLog } from '../utils/debug.js';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import useHeaderMappings from '../hooks/useHeaderMappings.js';
+import Modal from '../components/Modal.jsx';
 
 export default function FormsManagement() {
   const [tables, setTables] = useState([]);
@@ -18,6 +19,10 @@ export default function FormsManagement() {
   const [columns, setColumns] = useState([]);
   const [views, setViews] = useState([]);
   const [procedureOptions, setProcedureOptions] = useState([]);
+  const [displayConfigs, setDisplayConfigs] = useState({});
+  const [displayLoaded, setDisplayLoaded] = useState(false);
+  const [tableDisplayCfg, setTableDisplayCfg] = useState(null);
+  const [showDisplayModal, setShowDisplayModal] = useState(false);
   const generalConfig = useGeneralConfig();
   const modules = useModules();
   const procMap = useHeaderMappings(procedureOptions);
@@ -65,8 +70,25 @@ export default function FormsManagement() {
 
       fetch('/api/tables', { credentials: 'include' })
         .then((res) => (res.ok ? res.json() : []))
-        .then((data) => setTables(data))
+        .then((data) =>
+          setTables(
+            Array.isArray(data)
+              ? data.filter((t) => String(t).startsWith('transaction_'))
+              : [],
+          ),
+        )
         .catch(() => setTables([]));
+
+      fetch('/api/display_fields', { credentials: 'include' })
+        .then((res) => (res.ok ? res.json() : {}))
+        .then((cfg) => {
+          setDisplayConfigs(cfg || {});
+          setDisplayLoaded(true);
+        })
+        .catch(() => {
+          setDisplayConfigs({});
+          setDisplayLoaded(true);
+        });
 
       fetch(
         `/api/views${viewPrefix ? `?prefix=${encodeURIComponent(viewPrefix)}` : ''}`,
@@ -116,6 +138,21 @@ export default function FormsManagement() {
         )
         .catch(() => setProcedureOptions([]));
     }, [generalConfig?.general?.reportProcPrefix, generalConfig?.general?.reportViewPrefix]);
+
+  useEffect(() => {
+    if (!table || !displayLoaded) {
+      setTableDisplayCfg(null);
+      return;
+    }
+    const cfg = displayConfigs[table];
+    if (cfg && Array.isArray(cfg.displayFields) && cfg.displayFields.length > 0) {
+      setTableDisplayCfg(cfg);
+      setShowDisplayModal(false);
+    } else {
+      setTableDisplayCfg(null);
+      setShowDisplayModal(true);
+    }
+  }, [table, displayConfigs, displayLoaded]);
 
   useEffect(() => {
     if (!table) return;
@@ -485,14 +522,29 @@ export default function FormsManagement() {
           ))}
         </select>
       </div>
-      {table && (
+      {tableDisplayCfg && (
+        <div style={{ marginBottom: '1rem' }}>
+          <div>
+            <strong>ID Field:</strong> {tableDisplayCfg.idField || '(none)'}
+          </div>
+          <div>
+            <strong>Display Fields:</strong>{' '}
+            {tableDisplayCfg.displayFields.join(', ')}
+          </div>
+        </div>
+      )}
+      {table && tableDisplayCfg && (
         <div>
-          <div style={{ marginBottom: '1rem' }}>
-            <select
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              style={{ marginRight: '0.5rem' }}
-            >
+          <div
+            style={{
+              marginBottom: '1rem',
+              display: 'flex',
+              flexDirection: 'column',
+              maxWidth: '20rem',
+              gap: '0.5rem',
+            }}
+          >
+            <select value={name} onChange={(e) => setName(e.target.value)}>
               <option value="">-- select transaction --</option>
               {names.map((n) => (
                 <option key={n} value={n}>
@@ -506,11 +558,7 @@ export default function FormsManagement() {
               value={name}
               onChange={(e) => setName(e.target.value)}
             />
-            <select
-              value={moduleKey}
-              onChange={(e) => setModuleKey(e.target.value)}
-              style={{ marginLeft: '0.5rem' }}
-            >
+            <select value={moduleKey} onChange={(e) => setModuleKey(e.target.value)}>
               <option value="">-- select module --</option>
               {modules.map((m) => (
                 <option key={m.module_key} value={m.module_key}>
@@ -525,7 +573,6 @@ export default function FormsManagement() {
                   e.target.value = '';
                 }
               }}
-              style={{ marginLeft: '0.5rem' }}
             >
               <option value="">Duplicate from existing</option>
               {Object.keys(dupConfigs).map((n) => (
@@ -534,31 +581,12 @@ export default function FormsManagement() {
                 </option>
               ))}
             </select>
-
-            {columns.length > 0 && (
-              <select
-                value={config.detectField}
-                onChange={(e) =>
-                  setConfig((c) => ({ ...c, detectField: e.target.value }))
-                }
-                style={{ marginLeft: '0.5rem' }}
-              >
-                <option value="">-- detection field --</option>
-                {columns.map((c) => (
-                  <option key={c} value={c}>
-                    {c}
-                  </option>
-                ))}
-              </select>
-            )}
-
             {columns.length > 0 && (
               <select
                 value={config.transactionTypeField}
                 onChange={(e) =>
                   setConfig((c) => ({ ...c, transactionTypeField: e.target.value }))
                 }
-                style={{ marginLeft: '0.5rem' }}
               >
                 <option value="">-- transaction type field --</option>
                 {columns.map((c) => (
@@ -568,7 +596,6 @@ export default function FormsManagement() {
                 ))}
               </select>
             )}
-
             {txnTypes.length > 0 && (
               <select
                 value={config.transactionTypeValue}
@@ -578,7 +605,6 @@ export default function FormsManagement() {
                   const found = txnTypes.find((t) => String(t.UITransType) === val);
                   if (found && found.UITransTypeName) setName(found.UITransTypeName);
                 }}
-                style={{ marginLeft: '0.5rem' }}
               >
                 <option value="">-- select type --</option>
                 {txnTypes.map((t) => (
@@ -588,33 +614,6 @@ export default function FormsManagement() {
                 ))}
               </select>
             )}
-
-            {procedureOptions.length > 0 && (
-              <>
-                <span style={{ marginLeft: '0.5rem' }}>Procedures</span>
-                <select
-                  multiple
-                  value={config.procedures}
-                  onChange={(e) =>
-                    setConfig((c) => ({
-                      ...c,
-                      procedures: Array.from(
-                        e.target.selectedOptions,
-                        (o) => o.value,
-                      ),
-                    }))
-                  }
-                  style={{ marginLeft: '0.5rem' }}
-                >
-                  {procedureOptions.map((p) => (
-                    <option key={p} value={p}>
-                      {p}
-                    </option>
-                  ))}
-                </select>
-              </>
-            )}
-
             <input
               type="text"
               placeholder="Image folder"
@@ -622,14 +621,8 @@ export default function FormsManagement() {
               onChange={(e) =>
                 setConfig((c) => ({ ...c, imageFolder: e.target.value }))
               }
-              style={{ marginLeft: '0.5rem' }}
             />
-            
-            {name && (
-              <button onClick={handleDelete} style={{ marginLeft: '0.5rem' }}>
-                Delete
-              </button>
-            )}
+            {name && <button onClick={handleDelete}>Delete</button>}
           </div>
           <div className="table-container overflow-x-auto" style={{ maxHeight: '70vh' }}>
           <table style={{ borderCollapse: 'collapse', width: '100%' }}>
@@ -859,14 +852,39 @@ export default function FormsManagement() {
                   }))
                 }
               >
-                {branches.map((b) => (
-                  <option key={b.id} value={b.id}>
-                    {b.code} - {b.name}
-                  </option>
-                ))}
+                {branches.map((b) => {
+                  const cfg = displayConfigs.code_branches;
+                  const idField = cfg?.idField || 'id';
+                  const labelParts = cfg?.displayFields
+                    ? cfg.displayFields.map((f) => b[f])
+                    : [b.code, b.name];
+                  const val = b[idField];
+                  return (
+                    <option key={val} value={val}>
+                      {labelParts.filter(Boolean).join(' - ')}
+                    </option>
+                  );
+                })}
               </select>
-              <button type="button" onClick={() => setConfig((c) => ({ ...c, allowedBranches: branches.map((b) => String(b.id)) }))}>All</button>
-              <button type="button" onClick={() => setConfig((c) => ({ ...c, allowedBranches: [] }))}>None</button>
+              <button
+                type="button"
+                onClick={() =>
+                  setConfig((c) => ({
+                    ...c,
+                    allowedBranches: branches.map((b) =>
+                      String(b[displayConfigs.code_branches?.idField || 'id']),
+                    ),
+                  }))
+                }
+              >
+                All
+              </button>
+              <button
+                type="button"
+                onClick={() => setConfig((c) => ({ ...c, allowedBranches: [] }))}
+              >
+                None
+              </button>
             </label>
             <label style={{ marginLeft: '1rem' }}>
               Allowed departments:{' '}
@@ -881,14 +899,39 @@ export default function FormsManagement() {
                   }))
                 }
               >
-                {departments.map((d) => (
-                  <option key={d.id} value={d.id}>
-                    {d.code} - {d.name}
-                  </option>
-                ))}
+                {departments.map((d) => {
+                  const cfg = displayConfigs.code_department;
+                  const idField = cfg?.idField || 'id';
+                  const labelParts = cfg?.displayFields
+                    ? cfg.displayFields.map((f) => d[f])
+                    : [d.code, d.name];
+                  const val = d[idField];
+                  return (
+                    <option key={val} value={val}>
+                      {labelParts.filter(Boolean).join(' - ')}
+                    </option>
+                  );
+                })}
               </select>
-              <button type="button" onClick={() => setConfig((c) => ({ ...c, allowedDepartments: departments.map((d) => String(d.id)) }))}>All</button>
-              <button type="button" onClick={() => setConfig((c) => ({ ...c, allowedDepartments: [] }))}>None</button>
+              <button
+                type="button"
+                onClick={() =>
+                  setConfig((c) => ({
+                    ...c,
+                    allowedDepartments: departments.map((d) =>
+                      String(d[displayConfigs.code_department?.idField || 'id']),
+                    ),
+                  }))
+                }
+              >
+                All
+              </button>
+              <button
+                type="button"
+                onClick={() => setConfig((c) => ({ ...c, allowedDepartments: [] }))}
+              >
+                None
+              </button>
             </label>
             {procedureOptions.length > 0 && (
               <label style={{ marginLeft: '1rem' }}>
@@ -921,6 +964,13 @@ export default function FormsManagement() {
           </div>
         </div>
       )}
+      <Modal
+        visible={showDisplayModal}
+        title="Display Fields Not Configured"
+        onClose={() => setShowDisplayModal(false)}
+      >
+        <p>No display field configuration found for this table.</p>
+      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Limit table selection to `transaction_`-prefixed tables and gate configuration on display field settings
- Simplify transaction configuration UI with vertical layout, remove duplicate controls, and respect `idField` for branch/department selections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f1649c56883318ba21b5ec04f6513