### PR TITLE
Normalize user level permission storage

### DIFF
--- a/db/migrations/2025-08-30_user_levels_permissions.sql
+++ b/db/migrations/2025-08-30_user_levels_permissions.sql
@@ -1,0 +1,71 @@
+-- Create normalized user level tables
+
+-- Rename existing code_userlevel table to user_levels
+RENAME TABLE code_userlevel TO user_levels;
+
+-- Create table to hold permissions per user level
+CREATE TABLE user_level_permissions (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_level_id INT NOT NULL,
+  permission VARCHAR(50) DEFAULT NULL,
+  action VARCHAR(20) DEFAULT NULL,
+  ul_module_key VARCHAR(50) DEFAULT NULL,
+  function_name VARCHAR(255) DEFAULT NULL,
+  FOREIGN KEY (user_level_id) REFERENCES user_levels(userlevel_id)
+);
+
+-- Move flag columns into user_level_permissions
+INSERT INTO user_level_permissions (user_level_id, permission)
+  SELECT userlevel_id, 'new_records' FROM user_levels WHERE new_records = 1;
+INSERT INTO user_level_permissions (user_level_id, permission)
+  SELECT userlevel_id, 'edit_delete_request' FROM user_levels WHERE edit_delete_request = 1;
+INSERT INTO user_level_permissions (user_level_id, permission)
+  SELECT userlevel_id, 'edit_records' FROM user_levels WHERE edit_records = 1;
+INSERT INTO user_level_permissions (user_level_id, permission)
+  SELECT userlevel_id, 'delete_records' FROM user_levels WHERE delete_records = 1;
+INSERT INTO user_level_permissions (user_level_id, permission)
+  SELECT userlevel_id, 'image_handler' FROM user_levels WHERE image_handler = 1;
+INSERT INTO user_level_permissions (user_level_id, permission)
+  SELECT userlevel_id, 'audition' FROM user_levels WHERE audition = 1;
+INSERT INTO user_level_permissions (user_level_id, permission)
+  SELECT userlevel_id, 'supervisor' FROM user_levels WHERE supervisor = 1;
+INSERT INTO user_level_permissions (user_level_id, permission)
+  SELECT userlevel_id, 'companywide' FROM user_levels WHERE companywide = 1;
+INSERT INTO user_level_permissions (user_level_id, permission)
+  SELECT userlevel_id, 'branchwide' FROM user_levels WHERE branchwide = 1;
+INSERT INTO user_level_permissions (user_level_id, permission)
+  SELECT userlevel_id, 'departmentwide' FROM user_levels WHERE departmentwide = 1;
+INSERT INTO user_level_permissions (user_level_id, permission)
+  SELECT userlevel_id, 'developer' FROM user_levels WHERE developer = 1;
+INSERT INTO user_level_permissions (user_level_id, permission)
+  SELECT userlevel_id, 'common_settings' FROM user_levels WHERE common_settings = 1;
+INSERT INTO user_level_permissions (user_level_id, permission)
+  SELECT userlevel_id, 'system_settings' FROM user_levels WHERE system_settings = 1;
+INSERT INTO user_level_permissions (user_level_id, permission)
+  SELECT userlevel_id, 'license_settings' FROM user_levels WHERE license_settings = 1;
+INSERT INTO user_level_permissions (user_level_id, permission)
+  SELECT userlevel_id, 'ai' FROM user_levels WHERE ai = 1;
+INSERT INTO user_level_permissions (user_level_id, permission)
+  SELECT userlevel_id, 'dashboard' FROM user_levels WHERE dashboard = 1;
+INSERT INTO user_level_permissions (user_level_id, permission)
+  SELECT userlevel_id, 'ai_dashboard' FROM user_levels WHERE ai_dashboard = 1;
+
+-- Remove deprecated boolean columns from user_levels
+ALTER TABLE user_levels
+  DROP COLUMN new_records,
+  DROP COLUMN edit_delete_request,
+  DROP COLUMN edit_records,
+  DROP COLUMN delete_records,
+  DROP COLUMN image_handler,
+  DROP COLUMN audition,
+  DROP COLUMN supervisor,
+  DROP COLUMN companywide,
+  DROP COLUMN branchwide,
+  DROP COLUMN departmentwide,
+  DROP COLUMN developer,
+  DROP COLUMN common_settings,
+  DROP COLUMN system_settings,
+  DROP COLUMN license_settings,
+  DROP COLUMN ai,
+  DROP COLUMN dashboard,
+  DROP COLUMN ai_dashboard;

--- a/db/scripts/migrate_user_level_permissions.sql
+++ b/db/scripts/migrate_user_level_permissions.sql
@@ -1,0 +1,26 @@
+-- Populate action entries in user_level_permissions based on existing settings
+INSERT INTO user_level_permissions (user_level_id, action, ul_module_key, function_name)
+SELECT DISTINCT p.user_level_id, s.action, s.ul_module_key, s.function_name
+FROM code_userlevel_settings s
+JOIN user_level_permissions p ON (
+  (s.new_records = 1 AND p.permission = 'new_records') OR
+  (s.edit_delete_request = 1 AND p.permission = 'edit_delete_request') OR
+  (s.edit_records = 1 AND p.permission = 'edit_records') OR
+  (s.delete_records = 1 AND p.permission = 'delete_records') OR
+  (s.image_handler = 1 AND p.permission = 'image_handler') OR
+  (s.audition = 1 AND p.permission = 'audition') OR
+  (s.supervisor = 1 AND p.permission = 'supervisor') OR
+  (s.companywide = 1 AND p.permission = 'companywide') OR
+  (s.branchwide = 1 AND p.permission = 'branchwide') OR
+  (s.departmentwide = 1 AND p.permission = 'departmentwide') OR
+  (s.developer = 1 AND p.permission = 'developer') OR
+  (s.common_settings = 1 AND p.permission = 'common_settings') OR
+  (s.system_settings = 1 AND p.permission = 'system_settings') OR
+  (s.license_settings = 1 AND p.permission = 'license_settings') OR
+  (s.ai = 1 AND p.permission = 'ai') OR
+  (s.dashboard = 1 AND p.permission = 'dashboard') OR
+  (s.ai_dashboard = 1 AND p.permission = 'ai_dashboard')
+);
+
+-- Remove legacy settings table
+DROP TABLE code_userlevel_settings;


### PR DESCRIPTION
## Summary
- Introduce `user_levels` and `user_level_permissions` tables with migration
- Migrate permission flags to rows and drop old boolean columns
- Update DB helpers to read permissions from `user_level_permissions`

## Testing
- `npm test` *(fails: deleteImage moves file to deleted_images)*

------
https://chatgpt.com/codex/tasks/task_e_689f525da37c8331bd77586f4455c0d7