### PR TITLE
Add user-level action permissions UI and endpoints

### DIFF
--- a/api-server/app.js
+++ b/api-server/app.js
@@ -22,6 +22,7 @@ import displayFieldRoutes from "./routes/display_fields.js";
 import codingTableConfigRoutes from "./routes/coding_table_configs.js";
 import generatedSqlRoutes from "./routes/generated_sql.js";
 import generalConfigRoutes from "./routes/general_config.js";
+import permissionsRoutes from "./routes/permissions.js";
 import { getGeneralConfig } from "./services/generalConfig.js";
 
 // Polyfill for __dirname in ES modules
@@ -82,6 +83,7 @@ app.use("/api/display_fields", displayFieldRoutes);
 app.use("/api/coding_table_configs", codingTableConfigRoutes);
 app.use("/api/generated_sql", generatedSqlRoutes);
 app.use("/api/general_config", generalConfigRoutes);
+app.use("/api/permissions", permissionsRoutes);
 
 // Serve static React build and fallback to index.html
 // NOTE: adjust this path to where your SPA build actually lives.

--- a/api-server/controllers/permissionsController.js
+++ b/api-server/controllers/permissionsController.js
@@ -1,0 +1,35 @@
+import {
+  listActionGroups,
+  getUserLevelActions,
+  setUserLevelActions,
+} from '../../db/index.js';
+
+export async function listGroups(req, res, next) {
+  try {
+    const groups = await listActionGroups();
+    res.json(groups);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getActions(req, res, next) {
+  try {
+    const id = req.params.userLevelId;
+    const actions = await getUserLevelActions(id);
+    res.json(actions);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function updateActions(req, res, next) {
+  try {
+    const id = req.params.userLevelId;
+    const { modules, buttons, functions, api } = req.body;
+    await setUserLevelActions(id, { modules, buttons, functions, api });
+    res.sendStatus(200);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/api-server/routes/permissions.js
+++ b/api-server/routes/permissions.js
@@ -1,0 +1,11 @@
+import express from 'express';
+import { requireAuth } from '../middlewares/auth.js';
+import { listGroups, getActions, updateActions } from '../controllers/permissionsController.js';
+
+const router = express.Router();
+
+router.get('/actions', requireAuth, listGroups);
+router.get('/actions/:userLevelId', requireAuth, getActions);
+router.put('/actions/:userLevelId', requireAuth, updateActions);
+
+export default router;

--- a/src/erp.mgt.mn/pages/UserLevelActions.jsx
+++ b/src/erp.mgt.mn/pages/UserLevelActions.jsx
@@ -1,0 +1,100 @@
+import React, { useState, useEffect } from "react";
+
+export default function UserLevelActions() {
+  const [groups, setGroups] = useState({ modules: [], buttons: [], functions: [], api: [] });
+  const [selected, setSelected] = useState({ modules: [], buttons: [], functions: [], api: [] });
+  const [userLevelId, setUserLevelId] = useState("");
+
+  useEffect(() => {
+    fetch("/api/permissions/actions", { credentials: "include" })
+      .then((res) => res.json())
+      .then(setGroups)
+      .catch((err) => console.error("Failed to load action groups", err));
+  }, []);
+
+  function loadCurrent() {
+    if (!userLevelId) return;
+    fetch(`/api/permissions/actions/${userLevelId}`, { credentials: "include" })
+      .then((res) => res.json())
+      .then((data) => {
+        setSelected({
+          modules: Object.keys(data).filter(
+            (k) => !["buttons", "functions", "api"].includes(k)
+          ),
+          buttons: Object.keys(data.buttons || {}),
+          functions: Object.keys(data.functions || {}),
+          api: Object.keys(data.api || {}),
+        });
+      })
+      .catch((err) => console.error("Failed to load current actions", err));
+  }
+
+  function handleSelect(type, options) {
+    setSelected((prev) => ({ ...prev, [type]: options }));
+  }
+
+  async function handleSave() {
+    if (!userLevelId) return;
+    const res = await fetch(`/api/permissions/actions/${userLevelId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(selected),
+    });
+    if (!res.ok) alert("Failed to save actions");
+  }
+
+  function renderSelect(type, items) {
+    return (
+      <select
+        multiple
+        value={selected[type]}
+        onChange={(e) =>
+          handleSelect(type, Array.from(e.target.selectedOptions).map((o) => o.value))
+        }
+        style={{ minWidth: "200px", minHeight: "120px" }}
+      >
+        {items.map((it) => (
+          <option key={it} value={it}>
+            {it}
+          </option>
+        ))}
+      </select>
+    );
+  }
+
+  return (
+    <div>
+      <h2>User Level Actions</h2>
+      <input
+        type="text"
+        placeholder="User Level ID"
+        value={userLevelId}
+        onChange={(e) => setUserLevelId(e.target.value)}
+        style={{ marginRight: "0.5rem" }}
+      />
+      <button onClick={loadCurrent} style={{ marginRight: "0.5rem" }}>
+        Load
+      </button>
+      <button onClick={handleSave}>Save</button>
+      <div style={{ display: "flex", gap: "1rem", marginTop: "1rem" }}>
+        <div>
+          <h3>Modules</h3>
+          {renderSelect("modules", groups.modules)}
+        </div>
+        <div>
+          <h3>Buttons</h3>
+          {renderSelect("buttons", groups.buttons)}
+        </div>
+        <div>
+          <h3>Functions</h3>
+          {renderSelect("functions", groups.functions)}
+        </div>
+        <div>
+          <h3>APIs</h3>
+          {renderSelect("api", groups.api)}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- expose action groups from `code_userlevel_settings` and helper to update `user_level_permissions`
- add permissions controller and routes for listing and saving user-level actions
- create React page with multi-select lists to manage module, button, function and API actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f547af2e083319168b9fd102e4df1