### PR TITLE
Ensure user level permissions exist for new modules

### DIFF
--- a/api-server/controllers/moduleController.js
+++ b/api-server/controllers/moduleController.js
@@ -4,6 +4,7 @@ import {
   populateDefaultModules,
   populateRoleModulePermissions,
   populateCompanyModuleLicenses,
+  populateUserLevelModulePermissions,
   getEmploymentSession,
 } from "../../db/index.js";
 import { logActivity } from "../utils/activityLog.js";
@@ -67,6 +68,7 @@ export async function populatePermissions(req, res, next) {
     await populateDefaultModules();
     await populateCompanyModuleLicenses();
     await populateRoleModulePermissions();
+    await populateUserLevelModulePermissions();
     res.sendStatus(204);
   } catch (err) {
     next(err);

--- a/db/scripts/populate_user_level_module_permissions.sql
+++ b/db/scripts/populate_user_level_module_permissions.sql
@@ -1,0 +1,11 @@
+-- Backfill module_key permissions for all user levels
+INSERT INTO user_level_permissions (user_level_id, action, ul_module_key)
+SELECT ul.userlevel_id, 'module_key', m.module_key
+  FROM user_levels ul
+  CROSS JOIN modules m
+  WHERE NOT EXISTS (
+    SELECT 1 FROM user_level_permissions up
+     WHERE up.user_level_id = ul.userlevel_id
+       AND up.action = 'module_key'
+       AND up.ul_module_key = m.module_key
+  );


### PR DESCRIPTION
## Summary
- Automatically seed `user_level_permissions` when modules are inserted or updated
- Provide backfill utility to create missing module permission rows for all user levels
- Populate user-level permissions as part of the permissions deployment routine

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f55da97408331a19babc5b3fac709