### PR TITLE
Exclude transaction modules from permission population

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -659,12 +659,13 @@ export async function populateUserLevelModulePermissions() {
      SELECT ul.userlevel_id, 'module_key', m.module_key
        FROM user_levels ul
        CROSS JOIN modules m
-       WHERE NOT EXISTS (
-         SELECT 1 FROM user_level_permissions up
-          WHERE up.userlevel_id = ul.userlevel_id
-            AND up.action = 'module_key'
-            AND up.action_key = m.module_key
-       )`,
+       WHERE m.module_key NOT LIKE 'transactions\\_%'
+         AND NOT EXISTS (
+           SELECT 1 FROM user_level_permissions up
+            WHERE up.userlevel_id = ul.userlevel_id
+              AND up.action = 'module_key'
+              AND up.action_key = m.module_key
+         )`,
   );
 }
 

--- a/db/scripts/populate_user_level_module_permissions.sql
+++ b/db/scripts/populate_user_level_module_permissions.sql
@@ -3,9 +3,10 @@ INSERT INTO user_level_permissions (userlevel_id, action, action_key)
 SELECT ul.userlevel_id, 'module_key', m.module_key
   FROM user_levels ul
   CROSS JOIN modules m
-  WHERE NOT EXISTS (
-    SELECT 1 FROM user_level_permissions up
-     WHERE up.userlevel_id = ul.userlevel_id
-       AND up.action = 'module_key'
-       AND up.action_key = m.module_key
-  );
+  WHERE m.module_key NOT LIKE 'transactions\_%'
+    AND NOT EXISTS (
+      SELECT 1 FROM user_level_permissions up
+       WHERE up.userlevel_id = ul.userlevel_id
+         AND up.action = 'module_key'
+         AND up.action_key = m.module_key
+    );


### PR DESCRIPTION
## Summary
- Skip `transactions_*` modules when backfilling `user_level_permissions`
- SQL script updated to avoid duplicates for dynamic modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a180c2f1648331a22d6695fea65ecc