### PR TITLE
feat: add action permissions admin page

### DIFF
--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -15,6 +15,7 @@ import ReportsPage from './pages/Reports.jsx';
 import UsersPage from './pages/Users.jsx';
 import UserCompaniesPage from './pages/UserCompanies.jsx';
 import RolePermissionsPage from './pages/RolePermissions.jsx';
+import ActionPermissionsPage from './pages/ActionPermissions.jsx';
 import CompanyLicensesPage from './pages/CompanyLicenses.jsx';
 import TablesManagementPage from './pages/TablesManagement.jsx';
 import CodingTablesPage from './pages/CodingTables.jsx';
@@ -92,6 +93,7 @@ function AuthedApp() {
     users: <UsersPage />,
     user_companies: <UserCompaniesPage />,
     role_permissions: <RolePermissionsPage />,
+    action_permissions: <ActionPermissionsPage />,
     modules: <ModulesPage />,
     company_licenses: <CompanyLicensesPage />,
     tables_management: <TablesManagementPage />,
@@ -124,6 +126,7 @@ function AuthedApp() {
     'users',
     'user_companies',
     'role_permissions',
+    'action_permissions',
     'modules',
     'company_licenses',
     'tables_management',

--- a/src/erp.mgt.mn/pages/ActionPermissions.jsx
+++ b/src/erp.mgt.mn/pages/ActionPermissions.jsx
@@ -1,0 +1,160 @@
+// src/erp.mgt.mn/pages/ActionPermissions.jsx
+import React, { useEffect, useState } from "react";
+
+export default function ActionPermissions() {
+  const [groups, setGroups] = useState({
+    modules: [],
+    buttons: [],
+    functions: [],
+    api: [],
+  });
+  const [selected, setSelected] = useState({
+    modules: [],
+    buttons: [],
+    functions: [],
+    api: [],
+  });
+  const [original, setOriginal] = useState({
+    modules: [],
+    buttons: [],
+    functions: [],
+    api: [],
+  });
+  const [userLevelId, setUserLevelId] = useState("");
+
+  useEffect(() => {
+    fetch("/api/permissions/actions", { credentials: "include" })
+      .then((res) => res.json())
+      .then(setGroups)
+      .catch((err) => console.error("Failed to load action groups", err));
+  }, []);
+
+  function loadCurrent() {
+    if (!userLevelId) return;
+    fetch(`/api/permissions/actions/${userLevelId}`, { credentials: "include" })
+      .then((res) => res.json())
+      .then((data) => {
+        const sel = {
+          modules: Object.keys(data).filter(
+            (k) => !["buttons", "functions", "api"].includes(k),
+          ),
+          buttons: Object.keys(data.buttons || {}),
+          functions: Object.keys(data.functions || {}),
+          api: Object.keys(data.api || {}),
+        };
+        setSelected(sel);
+        setOriginal(sel);
+      })
+      .catch((err) => console.error("Failed to load current actions", err));
+  }
+
+  function handleSelect(type, options) {
+    setSelected((prev) => ({ ...prev, [type]: options }));
+  }
+
+  function mapType(type) {
+    if (type === "modules") return "module_key";
+    if (type === "buttons") return "button";
+    if (type === "functions") return "function";
+    return "API";
+  }
+
+  async function handleSave() {
+    if (!userLevelId) return;
+    const types = ["modules", "buttons", "functions", "api"];
+    try {
+      for (const t of types) {
+        const added = selected[t].filter((x) => !original[t].includes(x));
+        const removed = original[t].filter((x) => !selected[t].includes(x));
+        for (const key of added) {
+          const res = await fetch("/api/permissions", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            credentials: "include",
+            body: JSON.stringify({
+              userLevelId,
+              actionType: mapType(t),
+              actionKey: key,
+            }),
+          });
+          if (!res.ok) throw new Error("Failed to add permission");
+        }
+        for (const key of removed) {
+          const res = await fetch("/api/permissions", {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            credentials: "include",
+            body: JSON.stringify({
+              userLevelId,
+              actionType: mapType(t),
+              actionKey: key,
+            }),
+          });
+          if (!res.ok) throw new Error("Failed to remove permission");
+        }
+      }
+      setOriginal(selected);
+    } catch (err) {
+      console.error(err);
+      alert("Failed to save permissions");
+    }
+  }
+
+  function renderSelect(type, items) {
+    return (
+      <select
+        multiple
+        value={selected[type]}
+        onChange={(e) =>
+          handleSelect(
+            type,
+            Array.from(e.target.selectedOptions).map((o) => o.value),
+          )
+        }
+        style={{ minWidth: "200px", minHeight: "120px" }}
+      >
+        {items.map((it) => (
+          <option key={it} value={it}>
+            {it}
+          </option>
+        ))}
+      </select>
+    );
+  }
+
+  return (
+    <div>
+      <h2>Action Permissions</h2>
+      <input
+        type="text"
+        placeholder="User Level ID"
+        value={userLevelId}
+        onChange={(e) => setUserLevelId(e.target.value)}
+        style={{ marginRight: "0.5rem" }}
+      />
+      <button onClick={loadCurrent} style={{ marginRight: "0.5rem" }}>
+        Load
+      </button>
+      <button onClick={handleSave}>Save</button>
+      <div style={{ display: "flex", gap: "1rem", marginTop: "1rem" }}>
+        <div>
+          <h3>Modules</h3>
+          {renderSelect("modules", groups.modules)}
+        </div>
+        <div>
+          <h3>Buttons</h3>
+          {renderSelect("buttons", groups.buttons)}
+        </div>
+        <div>
+          <h3>Functions</h3>
+          {renderSelect("functions", groups.functions)}
+        </div>
+        <div>
+          <h3>APIs</h3>
+          {renderSelect("api", groups.api)}
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add ActionPermissions page to manage user level permissions by action group
- wire ActionPermissions into app routing and admin-only sections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1991d79cc8331ac7d85423ab52d94