### PR TITLE
Filter dynamic transaction tables by session fields

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -357,6 +357,11 @@ const TableManager = forwardRef(function TableManager({
     } else {
       setTypeFilter('');
     }
+    if (company !== undefined && companyIdFields.length > 0) {
+      companyIdFields.forEach((f) => {
+        if (validCols.has(f)) newFilters[f] = company;
+      });
+    }
     if (branch !== undefined && branchIdFields.length > 0) {
       branchIdFields.forEach((f) => {
         if (validCols.has(f)) newFilters[f] = branch;
@@ -375,7 +380,7 @@ const TableManager = forwardRef(function TableManager({
     if (Object.keys(newFilters).length > 0) {
       setFilters((f) => ({ ...f, ...newFilters }));
     }
-  }, [formConfig, validCols, user, company]);
+  }, [formConfig, validCols, user, company, branch, department]);
 
   useEffect(() => {
     if (!formConfig?.transactionTypeField) {
@@ -1587,12 +1592,27 @@ const TableManager = forwardRef(function TableManager({
                 </option>
               ))}
             </select>
-          ) : (
-            <span style={{ marginRight: '0.5rem' }}>{typeFilter || 'All'}</span>
-          )}
+            ) : (
+              <span style={{ marginRight: '0.5rem' }}>{typeFilter || 'All'}</span>
+            )}
           {typeFilter && buttonPerms['Clear Transaction Type Filter'] && (
             <button onClick={() => setTypeFilter('')}>
               Clear Transaction Type Filter
+            </button>
+          )}
+        </div>
+      )}
+      {companyIdFields.length > 0 && company !== undefined && (
+        <div style={{ backgroundColor: '#ffddff', padding: '0.25rem', textAlign: 'left' }}>
+          Company:{' '}
+          <span style={{ marginRight: '0.5rem' }}>{company}</span>
+          {buttonPerms['Clear Company Filter'] && (
+            <button
+              onClick={() =>
+                companyIdFields.forEach((f) => handleFilterChange(f, ''))
+              }
+            >
+              Clear Company Filter
             </button>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Filter transaction tables using company, branch, department, user and date values from the selected configuration
- Expose current company filter in UI with option to clear

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a430689d2c8331a79d51c6defbaf41