### PR TITLE
feat: add activity logging and pending request workflow

### DIFF
--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -104,6 +104,7 @@ export async function addRow(req, res, next) {
       row.g_burtgel_id = row.g_id ?? 0;
     }
     const result = await insertTableRow(req.params.table, row);
+    res.locals.insertId = result?.id;
     res.status(201).json(result);
   } catch (err) {
     if (/Can't update table .* in stored function\/trigger/i.test(err.message)) {

--- a/api-server/middlewares/activityLogger.js
+++ b/api-server/middlewares/activityLogger.js
@@ -1,0 +1,38 @@
+import * as jwtService from '../services/jwtService.js';
+import { getCookieName } from '../utils/cookieNames.js';
+import { logUserAction } from '../services/userActivityLog.js';
+
+export function activityLogger(req, res, next) {
+  if (!['POST', 'PUT', 'DELETE'].includes(req.method)) return next();
+
+  let user = null;
+  if (req.user) {
+    user = req.user.empid || req.user.id;
+  } else if (req.cookies?.[getCookieName()]) {
+    try {
+      const payload = jwtService.verify(req.cookies[getCookieName()]);
+      user = payload.empid || payload.id;
+    } catch {}
+  }
+
+  res.on('finish', async () => {
+    if (!user) return;
+    const actionMap = { POST: 'create', PUT: 'update', DELETE: 'delete' };
+    const table = req.params?.table;
+    const recordId = res.locals.insertId || req.params?.id || req.body?.id;
+    if (!table || !recordId) return;
+    try {
+      await logUserAction({
+        emp_id: user,
+        table_name: table,
+        record_id: recordId,
+        action: actionMap[req.method],
+        details: req.body || null,
+      });
+    } catch (err) {
+      console.error('Failed to log user activity:', err);
+    }
+  });
+
+  next();
+}

--- a/api-server/routes/pending_request.js
+++ b/api-server/routes/pending_request.js
@@ -1,0 +1,57 @@
+import express from 'express';
+import { requireAuth } from '../middlewares/auth.js';
+import { createRequest, listRequests, respondRequest } from '../services/pendingRequest.js';
+import { getEmploymentSession } from '../../db/index.js';
+
+const router = express.Router();
+
+router.post('/', requireAuth, async (req, res, next) => {
+  try {
+    const session = await getEmploymentSession(req.user.empid, req.user.companyId);
+    if (!session?.permissions?.edit_delete_request) return res.sendStatus(403);
+    const { table_name, record_id, request_type, proposed_data } = req.body;
+    if (!table_name || !record_id || !request_type) {
+      return res.status(400).json({ message: 'table_name, record_id and request_type are required' });
+    }
+    const result = await createRequest({
+      tableName: table_name,
+      recordId: record_id,
+      empId: req.user.empid,
+      requestType: request_type,
+      proposedData: proposed_data,
+    });
+    res.status(201).json(result);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/', requireAuth, async (req, res, next) => {
+  try {
+    const { status, senior_empid } = req.query;
+    if (!status || !senior_empid) {
+      return res.status(400).json({ message: 'status and senior_empid are required' });
+    }
+    if (req.user.empid !== senior_empid) return res.sendStatus(403);
+    const requests = await listRequests(status, senior_empid);
+    res.json(requests);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.put('/:id/respond', requireAuth, async (req, res, next) => {
+  try {
+    const { status, response_notes } = req.body;
+    if (!['accepted', 'declined'].includes(status)) {
+      return res.status(400).json({ message: 'invalid status' });
+    }
+    await respondRequest(req.params.id, req.user.empid, status, response_notes);
+    res.sendStatus(204);
+  } catch (err) {
+    if (err.message === 'Forbidden') return res.sendStatus(403);
+    next(err);
+  }
+});
+
+export default router;

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -7,6 +7,7 @@ import cookieParser from "cookie-parser";
 import { testConnection } from "../db/index.js";
 import { errorHandler } from "./middlewares/errorHandler.js";
 import { logger } from "./middlewares/logging.js";
+import { activityLogger } from "./middlewares/activityLogger.js";
 import authRoutes from "./routes/auth.js";
 import userRoutes from "./routes/users.js";
 import companyRoutes from "./routes/companies.js";
@@ -39,6 +40,7 @@ import permissionsRoutes from "./routes/permissions.js";
 import { requireAuth } from "./middlewares/auth.js";
 import featureToggle from "./middlewares/featureToggle.js";
 import reportBuilderRoutes from "./routes/report_builder.js";
+import pendingRequestRoutes from "./routes/pending_request.js";
 
 // Polyfill for __dirname in ES modules
 const __filename = fileURLToPath(import.meta.url);
@@ -50,6 +52,7 @@ app.use(express.json({ limit: '100mb' }));
 app.use(express.urlencoded({ extended: true, limit: '100mb' }));
 app.use(cookieParser());
 app.use(logger);
+app.use(activityLogger);
 
 // Serve uploaded images statically
 const imgCfg = await getGeneralConfig();
@@ -103,6 +106,7 @@ app.use("/api/transaction_images", transactionImageRoutes);
 app.use("/api/tables", requireAuth, tableRoutes);
 app.use("/api/general_config", requireAuth, generalConfigRoutes);
 app.use("/api/permissions", permissionsRoutes);
+app.use("/api/pending_request", pendingRequestRoutes);
 
 // Serve static React build and fallback to index.html
 // NOTE: adjust this path to where your SPA build actually lives.

--- a/api-server/services/pendingRequest.js
+++ b/api-server/services/pendingRequest.js
@@ -1,0 +1,107 @@
+import { pool, updateTableRow, deleteTableRow } from '../../db/index.js';
+import { logUserAction } from './userActivityLog.js';
+
+export async function createRequest({ tableName, recordId, empId, requestType, proposedData }) {
+  const [rows] = await pool.query(
+    'SELECT employment_senior_empid FROM tbl_employment WHERE employment_emp_id = ? LIMIT 1',
+    [empId]
+  );
+  const senior = rows[0]?.employment_senior_empid || null;
+  const [result] = await pool.query(
+    `INSERT INTO pending_request (table_name, record_id, emp_id, senior_empid, request_type, proposed_data)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [tableName, recordId, empId, senior, requestType, proposedData ? JSON.stringify(proposedData) : null]
+  );
+  const requestId = result.insertId;
+  await logUserAction({
+    emp_id: empId,
+    table_name: tableName,
+    record_id: recordId,
+    action: requestType === 'edit' ? 'request_edit' : 'request_delete',
+    details: proposedData || null,
+    request_id: requestId,
+  });
+  if (senior) {
+    await pool.query(
+      `INSERT INTO notifications (recipient_empid, type, related_id, message)
+       VALUES (?, 'request', ?, ?)`,
+      [senior, requestId, `Pending ${requestType} request for ${tableName}#${recordId}`]
+    );
+  }
+  return { request_id: requestId, senior_empid: senior };
+}
+
+export async function listRequests(status, seniorEmpid) {
+  const [rows] = await pool.query(
+    `SELECT * FROM pending_request WHERE status = ? AND senior_empid = ?`,
+    [status, seniorEmpid]
+  );
+  return rows;
+}
+
+export async function respondRequest(id, responseEmpid, status, notes) {
+  const [rows] = await pool.query(
+    'SELECT * FROM pending_request WHERE request_id = ?',
+    [id]
+  );
+  const req = rows[0];
+  if (!req) throw new Error('Request not found');
+  if (req.senior_empid !== responseEmpid) throw new Error('Forbidden');
+
+  if (status === 'accepted') {
+    if (req.request_type === 'edit' && req.proposed_data) {
+      const data = typeof req.proposed_data === 'string' ? JSON.parse(req.proposed_data) : req.proposed_data;
+      await updateTableRow(req.table_name, req.record_id, data);
+      await logUserAction({
+        emp_id: responseEmpid,
+        table_name: req.table_name,
+        record_id: req.record_id,
+        action: 'update',
+        details: data,
+        request_id: id,
+      });
+    } else if (req.request_type === 'delete') {
+      await deleteTableRow(req.table_name, req.record_id);
+      await logUserAction({
+        emp_id: responseEmpid,
+        table_name: req.table_name,
+        record_id: req.record_id,
+        action: 'delete',
+        request_id: id,
+      });
+    }
+    await pool.query(
+      `UPDATE pending_request SET status = 'accepted', responded_at = NOW(), response_empid = ?, response_notes = ? WHERE request_id = ?`,
+      [responseEmpid, notes || null, id]
+    );
+    await logUserAction({
+      emp_id: responseEmpid,
+      table_name: req.table_name,
+      record_id: req.record_id,
+      action: 'approve',
+      request_id: id,
+    });
+    await pool.query(
+      `INSERT INTO notifications (recipient_empid, type, related_id, message)
+       VALUES (?, 'response', ?, ?)`,
+      [req.emp_id, id, 'Request approved']
+    );
+  } else {
+    await pool.query(
+      `UPDATE pending_request SET status = 'declined', responded_at = NOW(), response_empid = ?, response_notes = ? WHERE request_id = ?`,
+      [responseEmpid, notes || null, id]
+    );
+    await logUserAction({
+      emp_id: responseEmpid,
+      table_name: req.table_name,
+      record_id: req.record_id,
+      action: 'decline',
+      request_id: id,
+    });
+    await pool.query(
+      `INSERT INTO notifications (recipient_empid, type, related_id, message)
+       VALUES (?, 'response', ?, ?)`,
+      [req.emp_id, id, 'Request declined']
+    );
+  }
+}

--- a/api-server/services/userActivityLog.js
+++ b/api-server/services/userActivityLog.js
@@ -1,0 +1,9 @@
+import { pool } from '../../db/index.js';
+
+export async function logUserAction({ emp_id, table_name, record_id, action, details = null, request_id = null }) {
+  await pool.query(
+    `INSERT INTO user_activity_log (emp_id, table_name, record_id, action, details, request_id)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [emp_id, table_name, record_id, action, details ? JSON.stringify(details) : null, request_id]
+  );
+}

--- a/db/migrations/2025-10-15_user_activity_pending_notifications.sql
+++ b/db/migrations/2025-10-15_user_activity_pending_notifications.sql
@@ -1,0 +1,51 @@
+-- Add tables for user activity log and pending edit/delete workflow
+
+-- 1. Activity log for all data‑modifying operations
+CREATE TABLE IF NOT EXISTS user_activity_log (
+  log_id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+  emp_id          VARCHAR(10) NOT NULL,
+  table_name      VARCHAR(100) NOT NULL,
+  record_id       BIGINT NOT NULL,
+  action          ENUM('create','update','delete','request_edit','request_delete','approve','decline') NOT NULL,
+  details         JSON NULL,
+  request_id      BIGINT NULL,
+  timestamp       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  KEY idx_user_activity_emp (emp_id),
+  KEY idx_user_activity_request (request_id)
+);
+
+-- 2. Pending edit/delete requests awaiting approval
+CREATE TABLE IF NOT EXISTS pending_request (
+  request_id      BIGINT AUTO_INCREMENT PRIMARY KEY,
+  table_name      VARCHAR(100) NOT NULL,
+  record_id       BIGINT NOT NULL,
+  emp_id          VARCHAR(10) NOT NULL,
+  senior_empid    VARCHAR(10) NOT NULL,
+  request_type    ENUM('edit','delete') NOT NULL,
+  proposed_data   JSON NULL,
+  status          ENUM('pending','accepted','declined') NOT NULL DEFAULT 'pending',
+  created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  responded_at    TIMESTAMP NULL,
+  response_empid  VARCHAR(10) NULL,
+  response_notes  TEXT NULL,
+  KEY idx_pending_status_senior (status, senior_empid),
+  KEY idx_pending_emp (emp_id),
+  CONSTRAINT fk_pending_emp FOREIGN KEY (emp_id) REFERENCES tbl_employment(employment_emp_id),
+  CONSTRAINT fk_pending_senior FOREIGN KEY (senior_empid) REFERENCES tbl_employment(employment_emp_id)
+);
+
+-- 3. Notifications table for dashboard alerts
+CREATE TABLE IF NOT EXISTS notifications (
+  notification_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  recipient_empid VARCHAR(10) NOT NULL,
+  type            ENUM('request','response') NOT NULL,
+  related_id      BIGINT NOT NULL,
+  message         TEXT NOT NULL,
+  is_read         BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  KEY idx_notifications_recipient (recipient_empid)
+);
+
+-- Foreign key from activity log to pending requests
+ALTER TABLE user_activity_log
+  ADD CONSTRAINT fk_activity_request FOREIGN KEY (request_id) REFERENCES pending_request(request_id);


### PR DESCRIPTION
## Summary
- add `user_activity_log`, `pending_request`, and `notifications` tables
- log POST/PUT/DELETE requests to `user_activity_log`
- implement API endpoints for creating and responding to edit/delete requests

## Testing
- `npm test` *(fails: 2 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a4415ab9e0833192aa717d7b88ee05