### PR TITLE
feat(api): allow activity logging without table param

### DIFF
--- a/api-server/controllers/companyModuleController.js
+++ b/api-server/controllers/companyModuleController.js
@@ -24,6 +24,8 @@ export async function updateLicense(req, res, next) {
       return res.sendStatus(403);
     }
     const { companyId, moduleKey, licensed } = req.body;
+    res.locals.logTable = 'company_module_licenses';
+    res.locals.logRecordId = `${companyId}-${moduleKey}`;
     await setCompanyModuleLicense(companyId, moduleKey, licensed);
     res.sendStatus(200);
   } catch (err) {

--- a/api-server/controllers/userCompanyController.js
+++ b/api-server/controllers/userCompanyController.js
@@ -36,6 +36,8 @@ export async function assignCompany(req, res, next) {
       return res.sendStatus(403);
     }
     const { empid, companyId, positionId, branchId } = req.body;
+    res.locals.logTable = 'user_companies';
+    res.locals.logRecordId = `${empid}-${companyId}`;
     await assignCompanyToUser(empid, companyId, positionId, branchId, req.user.empid);
     res.sendStatus(201);
   } catch (err) {
@@ -56,6 +58,8 @@ export async function updateAssignment(req, res, next) {
       return res.sendStatus(403);
     }
     const { empid, companyId, positionId, branchId } = req.body;
+    res.locals.logTable = 'user_companies';
+    res.locals.logRecordId = `${empid}-${companyId}`;
     await updateCompanyAssignment(empid, companyId, positionId, branchId);
     res.sendStatus(200);
   } catch (err) {
@@ -73,6 +77,8 @@ export async function removeAssignment(req, res, next) {
       return res.sendStatus(403);
     }
     const { empid, companyId } = req.body;
+    res.locals.logTable = 'user_companies';
+    res.locals.logRecordId = `${empid}-${companyId}`;
     await removeCompanyAssignment(empid, companyId);
     res.sendStatus(204);
   } catch (err) {

--- a/api-server/controllers/userController.js
+++ b/api-server/controllers/userController.js
@@ -32,11 +32,13 @@ export async function getUser(req, res, next) {
 
 export async function createUser(req, res, next) {
   try {
+    res.locals.logTable = 'users';
     const newUser = await dbCreateUser({
       empid: req.body.empid,
       password: req.body.password,
       created_by: req.user.empid
     });
+    res.locals.logRecordId = newUser.id;
     res.status(201).json(newUser);
   } catch (err) {
     next(err);
@@ -45,6 +47,8 @@ export async function createUser(req, res, next) {
 
 export async function updateUser(req, res, next) {
   try {
+    res.locals.logTable = 'users';
+    res.locals.logRecordId = req.params.id;
     const updated = await dbUpdateUser(req.params.id);
     res.json(updated);
   } catch (err) {
@@ -54,6 +58,8 @@ export async function updateUser(req, res, next) {
 
 export async function deleteUser(req, res, next) {
   try {
+    res.locals.logTable = 'users';
+    res.locals.logRecordId = req.params.id;
     await dbDeleteUser(req.params.id);
     res.sendStatus(204);
   } catch (err) {

--- a/api-server/middlewares/activityLogger.js
+++ b/api-server/middlewares/activityLogger.js
@@ -18,8 +18,12 @@ export function activityLogger(req, res, next) {
   res.on('finish', async () => {
     if (!user) return;
     const actionMap = { POST: 'create', PUT: 'update', DELETE: 'delete' };
-    const table = req.params?.table;
-    const recordId = res.locals.insertId || req.params?.id || req.body?.id;
+    const table = res.locals.logTable || req.params?.table;
+    const recordId =
+      res.locals.logRecordId ||
+      res.locals.insertId ||
+      req.params?.id ||
+      req.body?.id;
     if (!table || !recordId) return;
     try {
       await logUserAction({

--- a/tests/controllers/tableController.test.js
+++ b/tests/controllers/tableController.test.js
@@ -69,7 +69,7 @@ test('addRow defaults g_burtgel_id from g_id when missing', async () => {
     return [{}];
   });
   const req = { params: { table: 'SGereeJ' }, body: { g_id: 7 } };
-  const res = { status() { return this; }, json() {} };
+  const res = { locals: {}, status() { return this; }, json() {} };
   await controller.addRow(req, res, (e) => { if (e) throw e; });
   restore();
 });


### PR DESCRIPTION
## Summary
- allow routes without `:table` param to log activity via `res.locals`
- populate logging metadata in user, company license and assignment controllers
- test fixes for logging hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4477c95988331ab3d09efd0807c8c