### PR TITLE
feat(api): log activity for non-generic routes

### DIFF
--- a/api-server/controllers/companyModuleController.js
+++ b/api-server/controllers/companyModuleController.js
@@ -24,8 +24,6 @@ export async function updateLicense(req, res, next) {
       return res.sendStatus(403);
     }
     const { companyId, moduleKey, licensed } = req.body;
-    res.locals.logTable = 'company_module_licenses';
-    res.locals.logRecordId = `${companyId}-${moduleKey}`;
     await setCompanyModuleLicense(companyId, moduleKey, licensed);
     res.sendStatus(200);
   } catch (err) {

--- a/api-server/controllers/userCompanyController.js
+++ b/api-server/controllers/userCompanyController.js
@@ -6,7 +6,6 @@ import {
   listAllUserCompanies,
   getEmploymentSession,
 } from '../../db/index.js';
-import { requireAuth } from '../middlewares/auth.js';
 
 export async function listAssignments(req, res, next) {
   try {
@@ -36,8 +35,6 @@ export async function assignCompany(req, res, next) {
       return res.sendStatus(403);
     }
     const { empid, companyId, positionId, branchId } = req.body;
-    res.locals.logTable = 'user_companies';
-    res.locals.logRecordId = `${empid}-${companyId}`;
     await assignCompanyToUser(empid, companyId, positionId, branchId, req.user.empid);
     res.sendStatus(201);
   } catch (err) {
@@ -58,8 +55,6 @@ export async function updateAssignment(req, res, next) {
       return res.sendStatus(403);
     }
     const { empid, companyId, positionId, branchId } = req.body;
-    res.locals.logTable = 'user_companies';
-    res.locals.logRecordId = `${empid}-${companyId}`;
     await updateCompanyAssignment(empid, companyId, positionId, branchId);
     res.sendStatus(200);
   } catch (err) {
@@ -77,8 +72,6 @@ export async function removeAssignment(req, res, next) {
       return res.sendStatus(403);
     }
     const { empid, companyId } = req.body;
-    res.locals.logTable = 'user_companies';
-    res.locals.logRecordId = `${empid}-${companyId}`;
     await removeCompanyAssignment(empid, companyId);
     res.sendStatus(204);
   } catch (err) {

--- a/api-server/controllers/userController.js
+++ b/api-server/controllers/userController.js
@@ -6,7 +6,6 @@ import {
   updateUser as dbUpdateUser,
   deleteUserById as dbDeleteUser
 } from '../../db/index.js';
-import { requireAuth } from '../middlewares/auth.js';
 
 export async function listUsers(req, res, next) {
   try {
@@ -32,7 +31,6 @@ export async function getUser(req, res, next) {
 
 export async function createUser(req, res, next) {
   try {
-    res.locals.logTable = 'users';
     const newUser = await dbCreateUser({
       empid: req.body.empid,
       password: req.body.password,
@@ -47,8 +45,6 @@ export async function createUser(req, res, next) {
 
 export async function updateUser(req, res, next) {
   try {
-    res.locals.logTable = 'users';
-    res.locals.logRecordId = req.params.id;
     const updated = await dbUpdateUser(req.params.id);
     res.json(updated);
   } catch (err) {
@@ -58,8 +54,6 @@ export async function updateUser(req, res, next) {
 
 export async function deleteUser(req, res, next) {
   try {
-    res.locals.logTable = 'users';
-    res.locals.logRecordId = req.params.id;
     await dbDeleteUser(req.params.id);
     res.sendStatus(204);
   } catch (err) {

--- a/api-server/middlewares/activityLogger.js
+++ b/api-server/middlewares/activityLogger.js
@@ -18,12 +18,12 @@ export function activityLogger(req, res, next) {
   res.on('finish', async () => {
     if (!user) return;
     const actionMap = { POST: 'create', PUT: 'update', DELETE: 'delete' };
-    const table = res.locals.logTable || req.params?.table;
+    const table = req.params?.table || res.locals.logTable;
     const recordId =
-      res.locals.logRecordId ||
-      res.locals.insertId ||
       req.params?.id ||
-      req.body?.id;
+      req.body?.id ||
+      res.locals.logRecordId ||
+      res.locals.insertId;
     if (!table || !recordId) return;
     try {
       await logUserAction({

--- a/api-server/routes/company_modules.js
+++ b/api-server/routes/company_modules.js
@@ -4,5 +4,17 @@ import { requireAuth } from '../middlewares/auth.js';
 
 const router = express.Router();
 router.get('/', requireAuth, listLicenses);
-router.put('/', requireAuth, updateLicense);
+router.put(
+  '/',
+  requireAuth,
+  (req, res, next) => {
+    res.locals.logTable = 'company_module_licenses';
+    const { companyId, moduleKey } = req.body || {};
+    if (companyId && moduleKey) {
+      res.locals.logRecordId = `${companyId}-${moduleKey}`;
+    }
+    next();
+  },
+  updateLicense,
+);
 export default router;

--- a/api-server/routes/user_companies.js
+++ b/api-server/routes/user_companies.js
@@ -9,7 +9,43 @@ import { requireAuth } from '../middlewares/auth.js';
 
 const router = express.Router();
 router.get('/', requireAuth, listAssignments);
-router.post('/', requireAuth, assignCompany);
-router.delete('/', requireAuth, removeAssignment);
-router.put('/', requireAuth, updateAssignment);
+router.post(
+  '/',
+  requireAuth,
+  (req, res, next) => {
+    res.locals.logTable = 'user_companies';
+    const { empid, companyId } = req.body || {};
+    if (empid && companyId) {
+      res.locals.logRecordId = `${empid}-${companyId}`;
+    }
+    next();
+  },
+  assignCompany,
+);
+router.delete(
+  '/',
+  requireAuth,
+  (req, res, next) => {
+    res.locals.logTable = 'user_companies';
+    const { empid, companyId } = req.body || {};
+    if (empid && companyId) {
+      res.locals.logRecordId = `${empid}-${companyId}`;
+    }
+    next();
+  },
+  removeAssignment,
+);
+router.put(
+  '/',
+  requireAuth,
+  (req, res, next) => {
+    res.locals.logTable = 'user_companies';
+    const { empid, companyId } = req.body || {};
+    if (empid && companyId) {
+      res.locals.logRecordId = `${empid}-${companyId}`;
+    }
+    next();
+  },
+  updateAssignment,
+);
 export default router;

--- a/api-server/routes/users.js
+++ b/api-server/routes/users.js
@@ -9,7 +9,33 @@ import { requireAuth } from '../middlewares/auth.js';
 
 const router = express.Router();
 router.get('/', requireAuth, listUsers);
-router.post('/', requireAuth, createUser);
-router.put('/:id', requireAuth, updateUser);
-router.delete('/:id', requireAuth, deleteUser);
+router.post(
+  '/',
+  requireAuth,
+  (req, res, next) => {
+    res.locals.logTable = 'users';
+    next();
+  },
+  createUser,
+);
+router.put(
+  '/:id',
+  requireAuth,
+  (req, res, next) => {
+    res.locals.logTable = 'users';
+    res.locals.logRecordId = req.params.id;
+    next();
+  },
+  updateUser,
+);
+router.delete(
+  '/:id',
+  requireAuth,
+  (req, res, next) => {
+    res.locals.logTable = 'users';
+    res.locals.logRecordId = req.params.id;
+    next();
+  },
+  deleteUser,
+);
 export default router;


### PR DESCRIPTION
## Summary
- allow activity logger to read table and record id from `res.locals` when route params are absent
- populate logging context in users, company modules, and user company routes prior to database writes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a44c74d9f8833185badececbd909a6