### PR TITLE
Validate pending request inputs

### DIFF
--- a/api-server/routes/pending_request.js
+++ b/api-server/routes/pending_request.js
@@ -1,20 +1,15 @@
 import express from 'express';
 import { requireAuth } from '../middlewares/auth.js';
-import { createRequest, listRequests, respondRequest } from '../services/pendingRequest.js';
+import {
+  createRequest,
+  listRequests,
+  respondRequest,
+  ALLOWED_TABLES,
+  ALLOWED_REQUEST_TYPES,
+} from '../services/pendingRequest.js';
 import { getEmploymentSession } from '../../db/index.js';
 
 const router = express.Router();
-
-// Only allow pending requests for specific tables
-const ALLOWED_TABLES = new Set([
-  'users',
-  'user_companies',
-  'companies',
-  'transactions',
-  'transaction_forms',
-  'transaction_images',
-  'permissions',
-]);
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {
@@ -31,7 +26,7 @@ router.post('/', requireAuth, async (req, res, next) => {
       return res.status(400).json({ message: 'invalid table_name' });
     }
 
-    if (!['edit', 'delete'].includes(request_type)) {
+    if (!ALLOWED_REQUEST_TYPES.has(request_type)) {
       return res.status(400).json({ message: 'invalid request_type' });
     }
     const result = await createRequest({

--- a/api-server/services/pendingRequest.js
+++ b/api-server/services/pendingRequest.js
@@ -1,7 +1,24 @@
 import { pool, updateTableRow, deleteTableRow } from '../../db/index.js';
 import { logUserAction } from './userActivityLog.js';
 
+export const ALLOWED_REQUEST_TYPES = new Set(['edit', 'delete']);
+export const ALLOWED_TABLES = new Set([
+  'users',
+  'user_companies',
+  'companies',
+  'transactions',
+  'transaction_forms',
+  'transaction_images',
+  'permissions',
+]);
+
 export async function createRequest({ tableName, recordId, empId, requestType, proposedData }) {
+  if (!ALLOWED_TABLES.has(tableName)) {
+    throw new Error('Invalid table name');
+  }
+  if (!ALLOWED_REQUEST_TYPES.has(requestType)) {
+    throw new Error('Invalid request type');
+  }
   const [rows] = await pool.query(
     'SELECT employment_senior_empid FROM tbl_employment WHERE employment_emp_id = ? LIMIT 1',
     [empId]


### PR DESCRIPTION
## Summary
- centralize pending request validation constants
- enforce request type and table name checks before inserting requests

## Testing
- `npm test` *(fails: detectIncompleteImages finds and fixes files)*

------
https://chatgpt.com/codex/tasks/task_e_68a44febd83c83318e05551e7503a977