### PR TITLE
Use transactions for pending requests

### DIFF
--- a/api-server/services/pendingRequest.js
+++ b/api-server/services/pendingRequest.js
@@ -28,39 +28,52 @@ export async function createRequest({ tableName, recordId, empId, requestType, p
   if (!ALLOWED_REQUEST_TYPES.has(requestType)) {
     throw new Error('Invalid request type');
   }
-  const [rows] = await pool.query(
-    'SELECT employment_senior_empid FROM tbl_employment WHERE employment_emp_id = ? LIMIT 1',
-    [empId]
-  );
-  const senior = rows[0]?.employment_senior_empid || null;
-  const [result] = await pool.query(
-    `INSERT INTO pending_request (table_name, record_id, emp_id, senior_empid, request_type, proposed_data)
-     VALUES (?, ?, ?, ?, ?, ?)`,
-    [tableName, recordId, empId, senior, requestType, proposedData ? JSON.stringify(proposedData) : null]
-  );
-  const requestId = result.insertId;
-  await logUserAction({
-    emp_id: empId,
-    table_name: tableName,
-    record_id: recordId,
-    action: requestType === 'edit' ? 'request_edit' : 'request_delete',
-    details: proposedData || null,
-    request_id: requestId,
-  });
-  if (senior) {
-    await pool.query(
-      `INSERT INTO notifications (recipient_empid, type, related_id, message)
-       VALUES (?, 'request', ?, ?)`,
-      [senior, requestId, `Pending ${requestType} request for ${tableName}#${recordId}`]
+  const conn = await pool.getConnection();
+  try {
+    await conn.query('BEGIN');
+    const [rows] = await conn.query(
+      'SELECT employment_senior_empid FROM tbl_employment WHERE employment_emp_id = ? LIMIT 1',
+      [empId],
     );
+    const senior = rows[0]?.employment_senior_empid || null;
+    const [result] = await conn.query(
+      `INSERT INTO pending_request (table_name, record_id, emp_id, senior_empid, request_type, proposed_data)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [tableName, recordId, empId, senior, requestType, proposedData ? JSON.stringify(proposedData) : null],
+    );
+    const requestId = result.insertId;
+    await logUserAction(
+      {
+        emp_id: empId,
+        table_name: tableName,
+        record_id: recordId,
+        action: requestType === 'edit' ? 'request_edit' : 'request_delete',
+        details: proposedData || null,
+        request_id: requestId,
+      },
+      conn,
+    );
+    if (senior) {
+      await conn.query(
+        `INSERT INTO notifications (recipient_empid, type, related_id, message)
+         VALUES (?, 'request', ?, ?)`,
+        [senior, requestId, `Pending ${requestType} request for ${tableName}#${recordId}`],
+      );
+    }
+    await conn.query('COMMIT');
+    return { request_id: requestId, senior_empid: senior };
+  } catch (err) {
+    await conn.query('ROLLBACK');
+    throw err;
+  } finally {
+    conn.release();
   }
-  return { request_id: requestId, senior_empid: senior };
 }
 
 export async function listRequests(status, seniorEmpid) {
   const [rows] = await pool.query(
     `SELECT * FROM pending_request WHERE status = ? AND senior_empid = ?`,
-    [status, seniorEmpid]
+    [status, seniorEmpid],
   );
   return rows.map((row) => ({
     ...row,
@@ -69,68 +82,90 @@ export async function listRequests(status, seniorEmpid) {
 }
 
 export async function respondRequest(id, responseEmpid, status, notes) {
-  const [rows] = await pool.query(
-    'SELECT * FROM pending_request WHERE request_id = ?',
-    [id]
-  );
-  const req = rows[0];
-  if (!req) throw new Error('Request not found');
-  if (req.senior_empid !== responseEmpid) throw new Error('Forbidden');
+  const conn = await pool.getConnection();
+  try {
+    await conn.query('BEGIN');
+    const [rows] = await conn.query(
+      'SELECT * FROM pending_request WHERE request_id = ?',
+      [id],
+    );
+    const req = rows[0];
+    if (!req) throw new Error('Request not found');
+    if (req.senior_empid !== responseEmpid) throw new Error('Forbidden');
 
-  if (status === 'accepted') {
-    const data = parseProposedData(req.proposed_data);
-    if (req.request_type === 'edit' && data) {
-      await updateTableRow(req.table_name, req.record_id, data);
-      await logUserAction({
-        emp_id: responseEmpid,
-        table_name: req.table_name,
-        record_id: req.record_id,
-        action: 'update',
-        details: data,
-        request_id: id,
-      });
-    } else if (req.request_type === 'delete') {
-      await deleteTableRow(req.table_name, req.record_id);
-      await logUserAction({
-        emp_id: responseEmpid,
-        table_name: req.table_name,
-        record_id: req.record_id,
-        action: 'delete',
-        request_id: id,
-      });
+    if (status === 'accepted') {
+      const data = parseProposedData(req.proposed_data);
+      if (req.request_type === 'edit' && data) {
+        await updateTableRow(req.table_name, req.record_id, data, conn);
+        await logUserAction(
+          {
+            emp_id: responseEmpid,
+            table_name: req.table_name,
+            record_id: req.record_id,
+            action: 'update',
+            details: data,
+            request_id: id,
+          },
+          conn,
+        );
+      } else if (req.request_type === 'delete') {
+        await deleteTableRow(req.table_name, req.record_id, conn);
+        await logUserAction(
+          {
+            emp_id: responseEmpid,
+            table_name: req.table_name,
+            record_id: req.record_id,
+            action: 'delete',
+            request_id: id,
+          },
+          conn,
+        );
+      }
+      await conn.query(
+        `UPDATE pending_request SET status = 'accepted', responded_at = NOW(), response_empid = ?, response_notes = ? WHERE request_id = ?`,
+        [responseEmpid, notes || null, id],
+      );
+      await logUserAction(
+        {
+          emp_id: responseEmpid,
+          table_name: req.table_name,
+          record_id: req.record_id,
+          action: 'approve',
+          request_id: id,
+        },
+        conn,
+      );
+      await conn.query(
+        `INSERT INTO notifications (recipient_empid, type, related_id, message)
+         VALUES (?, 'response', ?, ?)`,
+        [req.emp_id, id, 'Request approved'],
+      );
+    } else {
+      await conn.query(
+        `UPDATE pending_request SET status = 'declined', responded_at = NOW(), response_empid = ?, response_notes = ? WHERE request_id = ?`,
+        [responseEmpid, notes || null, id],
+      );
+      await logUserAction(
+        {
+          emp_id: responseEmpid,
+          table_name: req.table_name,
+          record_id: req.record_id,
+          action: 'decline',
+          request_id: id,
+        },
+        conn,
+      );
+      await conn.query(
+        `INSERT INTO notifications (recipient_empid, type, related_id, message)
+         VALUES (?, 'response', ?, ?)`,
+        [req.emp_id, id, 'Request declined'],
+      );
     }
-    await pool.query(
-      `UPDATE pending_request SET status = 'accepted', responded_at = NOW(), response_empid = ?, response_notes = ? WHERE request_id = ?`,
-      [responseEmpid, notes || null, id]
-    );
-    await logUserAction({
-      emp_id: responseEmpid,
-      table_name: req.table_name,
-      record_id: req.record_id,
-      action: 'approve',
-      request_id: id,
-    });
-    await pool.query(
-      `INSERT INTO notifications (recipient_empid, type, related_id, message)
-       VALUES (?, 'response', ?, ?)`,
-      [req.emp_id, id, 'Request approved']
-    );
-  } else {
-    await pool.query(
-      `UPDATE pending_request SET status = 'declined', responded_at = NOW(), response_empid = ?, response_notes = ? WHERE request_id = ?`,
-      [responseEmpid, notes || null, id]
-    );
-    await logUserAction({
-      emp_id: responseEmpid,
-      table_name: req.table_name,
-      record_id: req.record_id,
-      action: 'decline',
-      request_id: id,
-    });
-    await pool.query(
-      `INSERT INTO notifications (recipient_empid, type, related_id, message)
-       VALUES (?, 'response', ?, ?)`,
-      [req.emp_id, id, 'Request declined']
-    );
+    await conn.query('COMMIT');
+  } catch (err) {
+    await conn.query('ROLLBACK');
+    throw err;
+  } finally {
+    conn.release();
   }
 }

--- a/api-server/services/userActivityLog.js
+++ b/api-server/services/userActivityLog.js
@@ -1,7 +1,10 @@
 import { pool } from '../../db/index.js';
 
-export async function logUserAction({ emp_id, table_name, record_id, action, details = null, request_id = null }) {
-  await pool.query(
+export async function logUserAction(
+  { emp_id, table_name, record_id, action, details = null, request_id = null },
+  conn = pool,
+) {
+  await conn.query(
     `INSERT INTO user_activity_log (emp_id, table_name, record_id, action, details, request_id)
      VALUES (?, ?, ?, ?, ?, ?)`,
     [emp_id, table_name, record_id, action, details ? JSON.stringify(details) : null, request_id]

--- a/db/index.js
+++ b/db/index.js
@@ -1057,7 +1057,7 @@ export async function listTableRows(
 /**
  * Update a table row by id
  */
-export async function updateTableRow(tableName, id, updates) {
+export async function updateTableRow(tableName, id, updates, conn = pool) {
   const columns = await getTableColumnsSafe(tableName);
   const keys = Object.keys(updates);
   await ensureValidColumns(tableName, columns, keys);
@@ -1067,7 +1067,7 @@ export async function updateTableRow(tableName, id, updates) {
 
   if (tableName === 'company_module_licenses') {
     const [companyId, moduleKey] = String(id).split('-');
-    await pool.query(
+    await conn.query(
       `UPDATE company_module_licenses SET ${setClause} WHERE company_id = ? AND module_key = ?`,
       [...values, companyId, moduleKey],
     );
@@ -1076,7 +1076,7 @@ export async function updateTableRow(tableName, id, updates) {
 
   if (tableName === 'user_companies') {
     const [empId, companyId] = String(id).split('-');
-    await pool.query(
+    await conn.query(
       `UPDATE user_companies SET ${setClause} WHERE empid = ? AND company_id = ?`,
       [...values, empId, companyId],
     );
@@ -1094,7 +1094,7 @@ export async function updateTableRow(tableName, id, updates) {
   if (pkCols.length === 1) {
     const col = pkCols[0];
     const where = col === 'id' ? 'id = ?' : `\`${col}\` = ?`;
-    await pool.query(
+    await conn.query(
       `UPDATE ?? SET ${setClause} WHERE ${where}`,
       [tableName, ...values, id],
     );
@@ -1103,7 +1103,7 @@ export async function updateTableRow(tableName, id, updates) {
 
   const parts = String(id).split('-');
   const where = pkCols.map((c) => `\`${c}\` = ?`).join(' AND ');
-  await pool.query(
+  await conn.query(
     `UPDATE ?? SET ${setClause} WHERE ${where}`,
     [tableName, ...values, ...parts],
   );


### PR DESCRIPTION
## Summary
- wrap pending request creation and responses in explicit DB transactions
- allow logging helper to use a provided connection
- update row update helper to accept a connection for transactional use

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a451c9d3a48331b00aea2e60be487c