### PR TITLE
Log original data and add restoration API

### DIFF
--- a/api-server/controllers/activityLogController.js
+++ b/api-server/controllers/activityLogController.js
@@ -1,0 +1,59 @@
+import { pool, getPrimaryKeyColumns } from '../../db/index.js';
+import { logUserAction } from '../services/userActivityLog.js';
+
+export async function restoreLogEntry(req, res, next) {
+  try {
+    const { id } = req.params;
+    const [logs] = await pool.query(
+      'SELECT * FROM user_activity_log WHERE log_id = ? LIMIT 1',
+      [id],
+    );
+    const entry = logs[0];
+    if (!entry) return res.sendStatus(404);
+
+    const [rows] = await pool.query(
+      'SELECT employment_senior_empid FROM tbl_employment WHERE employment_emp_id = ? LIMIT 1',
+      [entry.emp_id],
+    );
+    const senior = rows[0]?.employment_senior_empid;
+    if (senior !== req.user.empid) return res.sendStatus(403);
+
+    const data = entry.details ? JSON.parse(entry.details) : null;
+    if (!data) return res.status(400).json({ message: 'No details to restore' });
+    const table = entry.table_name;
+    const pkCols = await getPrimaryKeyColumns(table);
+
+    if (entry.action === 'delete') {
+      const cols = Object.keys(data);
+      const placeholders = cols.map(() => '?').join(', ');
+      const sql = `INSERT INTO \`${table}\` (${cols
+        .map((c) => `\`${c}\``)
+        .join(', ')}) VALUES (${placeholders})`;
+      await pool.query(sql, cols.map((c) => data[c]));
+    } else if (entry.action === 'update') {
+      if (!pkCols.length)
+        return res.status(400).json({ message: 'No primary key for table' });
+      const setCols = Object.keys(data).filter((c) => !pkCols.includes(c));
+      const setSql = setCols.map((c) => `\`${c}\` = ?`).join(', ');
+      const whereSql = pkCols.map((c) => `\`${c}\` = ?`).join(' AND ');
+      await pool.query(
+        `UPDATE \`${table}\` SET ${setSql} WHERE ${whereSql}`,
+        [...setCols.map((c) => data[c]), ...pkCols.map((c) => data[c])],
+      );
+    } else {
+      return res.status(400).json({ message: 'Unsupported action' });
+    }
+
+    await logUserAction({
+      emp_id: req.user.empid,
+      table_name: table,
+      record_id: entry.record_id,
+      action: 'restore',
+      details: data,
+    });
+
+    res.sendStatus(200);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/api-server/middlewares/activityLogger.js
+++ b/api-server/middlewares/activityLogger.js
@@ -25,13 +25,16 @@ export function activityLogger(req, res, next) {
       res.locals.logRecordId ||
       res.locals.insertId;
     if (!table || !recordId) return;
+    const details =
+      res.locals.logDetails ||
+      (req.method === 'POST' ? req.body || null : null);
     try {
       await logUserAction({
         emp_id: user,
         table_name: table,
         record_id: recordId,
         action: actionMap[req.method],
-        details: req.body || null,
+        details,
       });
     } catch (err) {
       console.error('Failed to log user activity:', err);

--- a/api-server/routes/user_activity_log.js
+++ b/api-server/routes/user_activity_log.js
@@ -1,0 +1,9 @@
+import express from 'express';
+import { requireAuth } from '../middlewares/auth.js';
+import { restoreLogEntry } from '../controllers/activityLogController.js';
+
+const router = express.Router();
+
+router.post('/:id/restore', requireAuth, restoreLogEntry);
+
+export default router;

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -41,6 +41,7 @@ import { requireAuth } from "./middlewares/auth.js";
 import featureToggle from "./middlewares/featureToggle.js";
 import reportBuilderRoutes from "./routes/report_builder.js";
 import pendingRequestRoutes from "./routes/pending_request.js";
+import activityLogRoutes from "./routes/user_activity_log.js";
 
 // Polyfill for __dirname in ES modules
 const __filename = fileURLToPath(import.meta.url);
@@ -107,6 +108,7 @@ app.use("/api/tables", requireAuth, tableRoutes);
 app.use("/api/general_config", requireAuth, generalConfigRoutes);
 app.use("/api/permissions", permissionsRoutes);
 app.use("/api/pending_request", pendingRequestRoutes);
+app.use("/api/user_activity_log", activityLogRoutes);
 
 // Serve static React build and fallback to index.html
 // NOTE: adjust this path to where your SPA build actually lives.


### PR DESCRIPTION
## Summary
- Capture original row data before update or delete and log it for audit trails
- Add API endpoint to restore records using stored activity log data
- Register new restoration route on the server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a454ffad508331a11ea817d5f90d67