### PR TITLE
Add foreign key constraint for notifications

### DIFF
--- a/db/migrations/2025-10-16_notifications_fk.sql
+++ b/db/migrations/2025-10-16_notifications_fk.sql
@@ -1,0 +1,12 @@
+-- Ensure notifications related_id references pending_request
+
+-- Clean up notifications with missing pending_request
+DELETE n FROM notifications n
+LEFT JOIN pending_request p ON n.related_id = p.request_id
+WHERE p.request_id IS NULL;
+
+-- Add foreign key constraint linking notifications to pending_request
+ALTER TABLE notifications
+  ADD KEY idx_notifications_request (related_id),
+  ADD CONSTRAINT fk_notifications_request FOREIGN KEY (related_id)
+    REFERENCES pending_request(request_id);


### PR DESCRIPTION
## Summary
- clean orphaned notifications before adding constraint
- enforce notifications.related_id referencing pending_request.request_id

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a45665fcbc8331806f540f7dd3ec88