### PR TITLE
feat: add permissions actions

### DIFF
--- a/configs/permissionActions.json
+++ b/configs/permissionActions.json
@@ -1,4 +1,7 @@
 {
+  "permissions": [
+    { "key": "edit_delete_request", "name": "Edit/Delete Request" }
+  ],
   "forms": {
     "finance_transactions": {
       "name": "Finance Transactions",


### PR DESCRIPTION
## Summary
- support standalone permission keys including new `edit_delete_request`
- include permissions in permission API responses and batch populate
- render and save permission actions in User Level Actions page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a465ccecb08331a9fb0fa6d7929c66