### PR TITLE
feat: add permissions actions

### DIFF
--- a/api-server/routes/pending_request.js
+++ b/api-server/routes/pending_request.js
@@ -4,7 +4,6 @@ import {
   createRequest,
   listRequests,
   respondRequest,
-  ALLOWED_TABLES,
   ALLOWED_REQUEST_TYPES,
 } from '../services/pendingRequest.js';
 import { getEmploymentSession } from '../../db/index.js';
@@ -22,10 +21,6 @@ router.post('/', requireAuth, async (req, res, next) => {
         .json({ message: 'table_name, record_id and request_type are required' });
     }
 
-    if (!ALLOWED_TABLES.has(table_name)) {
-      return res.status(400).json({ message: 'invalid table_name' });
-    }
-
     if (!ALLOWED_REQUEST_TYPES.has(request_type)) {
       return res.status(400).json({ message: 'invalid request_type' });
     }
@@ -38,6 +33,9 @@ router.post('/', requireAuth, async (req, res, next) => {
     });
     res.status(201).json(result);
   } catch (err) {
+    if (err.status === 400 && err.message === 'invalid table_name') {
+      return res.status(400).json({ message: 'invalid table_name' });
+    }
     next(err);
   }
 });

--- a/configs/permissionActions.json
+++ b/configs/permissionActions.json
@@ -1,4 +1,7 @@
 {
+  "permissions": [
+    { "key": "edit_delete_request", "name": "Edit/Delete Request" }
+  ],
   "forms": {
     "finance_transactions": {
       "name": "Finance Transactions",


### PR DESCRIPTION
## Summary
- support standalone permission keys including new `edit_delete_request`
- include permissions in permission API responses and batch populate
- render and save permission actions in User Level Actions page
- validate pending-request table names dynamically to support more tables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a465ccecb08331a9fb0fa6d7929c66