### PR TITLE
Expose pending request widget on dashboards

### DIFF
--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -38,6 +38,7 @@ import FinanceTransactionsPage from './pages/FinanceTransactions.jsx';
 import { useModules } from './hooks/useModules.js';
 import { useTxnModules } from './hooks/useTxnModules.js';
 import useGeneralConfig from './hooks/useGeneralConfig.js';
+import TabbedWindows from './components/TabbedWindows.jsx';
 
 export default function App() {
   useEffect(() => {
@@ -107,6 +108,7 @@ function AuthedApp() {
     general_configuration: <GeneralConfigurationPage />,
     image_management: <ImageManagementPage />,
     change_password: <ChangePasswordPage />,
+    sales: <TabbedWindows />,
   };
 
   modules.forEach((m) => {

--- a/src/erp.mgt.mn/components/PendingRequestWidget.jsx
+++ b/src/erp.mgt.mn/components/PendingRequestWidget.jsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState, useContext } from 'react';
+import { AuthContext } from '../context/AuthContext.jsx';
+
+export default function PendingRequestWidget() {
+  const { user } = useContext(AuthContext);
+  const [requests, setRequests] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  async function load() {
+    if (!user?.empid) return;
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `/api/pending_request?status=pending&senior_empid=${encodeURIComponent(
+          user.empid,
+        )}`,
+        { credentials: 'include' },
+      );
+      if (res.ok) {
+        const data = await res.json();
+        setRequests(Array.isArray(data) ? data : []);
+      } else {
+        setRequests([]);
+      }
+    } catch {
+      setRequests([]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, [user?.empid]);
+
+  async function respond(id, status) {
+    try {
+      const res = await fetch(`/api/pending_request/${id}/respond`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ status }),
+      });
+      if (res.ok) {
+        setRequests((r) => r.filter((req) => req.request_id !== id));
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  if (!user?.empid) return null;
+  return (
+    <div>
+      <h3>Pending Requests</h3>
+      {loading ? (
+        <p>Loading...</p>
+      ) : requests.length === 0 ? (
+        <p>No pending requests</p>
+      ) : (
+        <ul>
+          {requests.map((r) => (
+            <li key={r.request_id} style={{ marginBottom: '0.5rem' }}>
+              <div>
+                {r.request_type} {r.table_name} #{r.record_id}
+              </div>
+              <button
+                onClick={() => respond(r.request_id, 'accepted')}
+                style={{ marginRight: '0.25rem' }}
+              >
+                Accept
+              </button>
+              <button onClick={() => respond(r.request_id, 'declined')}>
+                Decline
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/erp.mgt.mn/pages/BlueLinkPage.jsx
+++ b/src/erp.mgt.mn/pages/BlueLinkPage.jsx
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect } from 'react';
 import MosaicLayout from '../components/MosaicLayout.jsx';
 import { AuthContext } from '../context/AuthContext.jsx';
+import PendingRequestWidget from '../components/PendingRequestWidget.jsx';
 
 const initialLayout = {
   direction: 'row',
@@ -50,6 +51,7 @@ export default function BlueLinkPage() {
           <div style={{ fontSize: '1.5rem', fontWeight: 'bold' }}>0</div>
         </div>
       </div>
+      <PendingRequestWidget />
       <MosaicLayout initialLayout={initialLayout} />
     </div>
   );

--- a/src/erp.mgt.mn/windows/SalesDashboard.jsx
+++ b/src/erp.mgt.mn/windows/SalesDashboard.jsx
@@ -1,5 +1,10 @@
 import React from 'react';
+import PendingRequestWidget from '../components/PendingRequestWidget.jsx';
 
 export default function SalesDashboard() {
-  return <div>Sales Dashboard Module</div>;
+  return (
+    <div>
+      <PendingRequestWidget />
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- Add sales module route to render TabbedWindows with pending request widget
- Display pending request notifications on main dashboard

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4589e0d5883319cb4076cd0372d51