### PR TITLE
feat: add pending request badge to dashboard

### DIFF
--- a/src/erp.mgt.mn/components/HeaderMenu.jsx
+++ b/src/erp.mgt.mn/components/HeaderMenu.jsx
@@ -4,15 +4,17 @@ import { useModules } from '../hooks/useModules.js';
 import { useTxnModules } from '../hooks/useTxnModules.js';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import useHeaderMappings from '../hooks/useHeaderMappings.js';
+import usePendingRequestCount from '../hooks/usePendingRequestCount.js';
 import modulePath from '../utils/modulePath.js';
 
 export default function HeaderMenu({ onOpen }) {
-  const { permissions: perms } = useContext(AuthContext);
+  const { permissions: perms, user } = useContext(AuthContext);
   const modules = useModules();
   const txnModules = useTxnModules();
   const generalConfig = useGeneralConfig();
   const items = modules.filter((r) => r.show_in_header);
   const headerMap = useHeaderMappings(items.map((m) => m.module_key));
+  const pendingCount = usePendingRequestCount(user?.empid);
 
   // Build a quick lookup map so we can resolve module paths
   const moduleMap = {};
@@ -42,6 +44,9 @@ export default function HeaderMenu({ onOpen }) {
             }
           >
             {label}
+            {m.module_key === 'dashboard' && pendingCount > 0 && (
+              <span style={styles.badge}>{pendingCount}</span>
+            )}
           </button>
         );
       })}
@@ -57,6 +62,15 @@ const styles = {
     color: '#fff',
     cursor: 'pointer',
     fontSize: '0.9rem',
-    marginRight: '0.75rem'
+    marginRight: '0.75rem',
+    position: 'relative'
+  },
+  badge: {
+    background: 'red',
+    borderRadius: '50%',
+    color: '#fff',
+    fontSize: '0.7rem',
+    marginLeft: '4px',
+    padding: '0 6px'
   }
 };

--- a/src/erp.mgt.mn/hooks/usePendingRequestCount.js
+++ b/src/erp.mgt.mn/hooks/usePendingRequestCount.js
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Polls the pending request endpoint for a supervisor and returns the count.
+ * @param {string|number} seniorEmpId Employee ID of the supervisor
+ * @param {number} [interval=30000] Polling interval in milliseconds
+ * @returns {number} Count of pending requests
+ */
+export default function usePendingRequestCount(seniorEmpId, interval = 30000) {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!seniorEmpId) {
+      setCount(0);
+      return undefined;
+    }
+
+    let cancelled = false;
+    async function fetchCount() {
+      try {
+        const res = await fetch(
+          `/api/pending_request?status=pending&senior_empid=${encodeURIComponent(
+            seniorEmpId,
+          )}`,
+          { credentials: 'include' },
+        );
+        if (!res.ok) {
+          if (!cancelled) setCount(0);
+          return;
+        }
+        const data = await res.json().catch(() => 0);
+        let c = 0;
+        if (typeof data === 'number') c = data;
+        else if (Array.isArray(data)) c = data.length;
+        else c = Number(data?.count) || 0;
+        if (!cancelled) setCount(c);
+      } catch {
+        if (!cancelled) setCount(0);
+      }
+    }
+
+    fetchCount();
+    const timer = setInterval(fetchCount, interval);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [seniorEmpId, interval]);
+
+  return count;
+}
+


### PR DESCRIPTION
## Summary
- add `usePendingRequestCount` hook to poll pending requests
- show red badge on Dashboard when supervisor has pending requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a48480f5dc833190e80140faef71e3