### PR TITLE
Add requests module and menu support

### DIFF
--- a/db/defaultModules.js
+++ b/db/defaultModules.js
@@ -19,6 +19,7 @@ export default [
   { moduleKey: 'change_password', label: 'Нууц үг солих', parentKey: 'settings', showInSidebar: true, showInHeader: false },
   { moduleKey: 'pos_transaction_management', label: 'POS Transactions', parentKey: 'developer', showInSidebar: true, showInHeader: false },
   { moduleKey: 'pos_transactions', label: 'POS POS', parentKey: null, showInSidebar: true, showInHeader: false },
+  { moduleKey: 'requests', label: 'Requests', parentKey: null, showInSidebar: false, showInHeader: true },
   { moduleKey: 'gl', label: 'Ерөнхий журнал', parentKey: null, showInSidebar: false, showInHeader: true },
   { moduleKey: 'po', label: 'Худалдан авалтын захиалга', parentKey: null, showInSidebar: false, showInHeader: true },
   { moduleKey: 'sales', label: 'Борлуулалтын самбар', parentKey: null, showInSidebar: false, showInHeader: true }

--- a/db/migrations/2025-10-17_requests_module.sql
+++ b/db/migrations/2025-10-17_requests_module.sql
@@ -1,0 +1,18 @@
+-- Add Requests module
+INSERT INTO modules (module_key, label, parent_key, show_in_sidebar, show_in_header)
+VALUES ('requests', 'Requests', NULL, 0, 1)
+ON DUPLICATE KEY UPDATE
+  label=VALUES(label),
+  parent_key=VALUES(parent_key),
+  show_in_sidebar=VALUES(show_in_sidebar),
+  show_in_header=VALUES(show_in_header);
+
+-- Default permissions for the new module
+INSERT IGNORE INTO role_default_modules (role_id, module_key, allowed) VALUES
+  (1, 'requests', 1),
+  (2, 'requests', 0);
+
+INSERT IGNORE INTO role_module_permissions (company_id, position_id, module_key, allowed)
+SELECT c.id, rdm.role_id, rdm.module_key, rdm.allowed
+  FROM companies c
+  JOIN role_default_modules rdm ON rdm.module_key = 'requests';

--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -35,6 +35,7 @@ import useHeaderMappings from './hooks/useHeaderMappings.js';
 import InventoryPage from './pages/InventoryPage.jsx';
 import ImageManagementPage from './pages/ImageManagement.jsx';
 import FinanceTransactionsPage from './pages/FinanceTransactions.jsx';
+import RequestsPage from './pages/Requests.jsx';
 import { useModules } from './hooks/useModules.js';
 import { useTxnModules } from './hooks/useTxnModules.js';
 import useGeneralConfig from './hooks/useGeneralConfig.js';
@@ -108,6 +109,7 @@ function AuthedApp() {
     general_configuration: <GeneralConfigurationPage />,
     image_management: <ImageManagementPage />,
     change_password: <ChangePasswordPage />,
+    requests: <RequestsPage />,
     sales: <TabbedWindows />,
   };
 

--- a/src/erp.mgt.mn/components/HeaderMenu.jsx
+++ b/src/erp.mgt.mn/components/HeaderMenu.jsx
@@ -6,13 +6,14 @@ import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import useHeaderMappings from '../hooks/useHeaderMappings.js';
 import usePendingRequestCount from '../hooks/usePendingRequestCount.js';
 import modulePath from '../utils/modulePath.js';
+import filterHeaderModules from '../utils/filterHeaderModules.js';
 
 export default function HeaderMenu({ onOpen }) {
   const { permissions: perms, user } = useContext(AuthContext);
   const modules = useModules();
   const txnModules = useTxnModules();
   const generalConfig = useGeneralConfig();
-  const items = modules.filter((r) => r.show_in_header);
+  const items = filterHeaderModules(modules, perms, txnModules);
   const headerMap = useHeaderMappings(items.map((m) => m.module_key));
   const pendingCount = usePendingRequestCount(user?.empid);
 
@@ -27,9 +28,6 @@ export default function HeaderMenu({ onOpen }) {
   return (
     <nav style={styles.menu}>
       {items.map((m) => {
-        const isTxn = txnModules && txnModules.keys.has(m.module_key);
-        if (!isTxn && !perms[m.module_key]) return null;
-
         const label =
           generalConfig.general?.procLabels?.[m.module_key] ||
           headerMap[m.module_key] ||

--- a/src/erp.mgt.mn/pages/Requests.jsx
+++ b/src/erp.mgt.mn/pages/Requests.jsx
@@ -1,0 +1,16 @@
+// src/erp.mgt.mn/pages/Requests.jsx
+import React, { useEffect } from 'react';
+import { debugLog } from '../utils/debug.js';
+
+export default function RequestsPage() {
+  useEffect(() => {
+    debugLog('Component mounted: Requests');
+  }, []);
+
+  return (
+    <div>
+      <h2>Requests</h2>
+      <p>List of requests will appear here.</p>
+    </div>
+  );
+}

--- a/src/erp.mgt.mn/utils/filterHeaderModules.js
+++ b/src/erp.mgt.mn/utils/filterHeaderModules.js
@@ -1,0 +1,7 @@
+export default function filterHeaderModules(modules, perms = {}, txnModules = null) {
+  return modules.filter((m) => {
+    if (!m.show_in_header) return false;
+    const isTxn = txnModules && txnModules.keys && txnModules.keys.has(m.module_key);
+    return isTxn || perms[m.module_key];
+  });
+}

--- a/tests/utils/filterHeaderModules.test.js
+++ b/tests/utils/filterHeaderModules.test.js
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import filterHeaderModules from '../../src/erp.mgt.mn/utils/filterHeaderModules.js';
+
+test('includes requests when permitted', () => {
+  const modules = [
+    { module_key: 'requests', label: 'Requests', show_in_header: 1 },
+  ];
+  const perms = { requests: 1 };
+  const result = filterHeaderModules(modules, perms, { keys: new Set() });
+  assert.ok(result.find((m) => m.module_key === 'requests'));
+});


### PR DESCRIPTION
## Summary
- add Requests module migration and default seed
- expose Requests page and component mapping
- ensure header menu generator handles Requests module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a48590e38c8331baccc2bd3e2553bc