### PR TITLE
fix: ensure requests page hits correct API base

### DIFF
--- a/src/erp.mgt.mn/pages/Requests.jsx
+++ b/src/erp.mgt.mn/pages/Requests.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import { useAuth } from '../context/AuthContext.jsx';
 import { debugLog } from '../utils/debug.js';
+import { API_BASE } from '../utils/apiBase.js';
 
 export default function RequestsPage() {
   const { user } = useAuth();
@@ -48,7 +49,7 @@ export default function RequestsPage() {
       setError(null);
       try {
         const res = await fetch(
-          `/api/pending_request?status=pending&senior_empid=${encodeURIComponent(
+          `${API_BASE}/pending_request?status=pending&senior_empid=${encodeURIComponent(
             user.empid,
           )}`,
           { credentials: 'include' },
@@ -60,14 +61,14 @@ export default function RequestsPage() {
             let original = null;
             try {
               const res2 = await fetch(
-                `/api/tables/${req.table_name}/${req.record_id}`,
+                `${API_BASE}/tables/${req.table_name}/${req.record_id}`,
                 { credentials: 'include' },
               );
               if (res2.ok) {
                 original = await res2.json();
               } else {
                 const res3 = await fetch(
-                  `/api/tables/${req.table_name}?id=${encodeURIComponent(
+                  `${API_BASE}/tables/${req.table_name}?id=${encodeURIComponent(
                     req.record_id,
                   )}&perPage=1`,
                   { credentials: 'include' },
@@ -112,7 +113,7 @@ export default function RequestsPage() {
   const respond = async (id, status) => {
     const reqItem = requests.find((r) => r.request_id === id);
     try {
-      const res = await fetch(`/api/pending_request/${id}/respond`, {
+      const res = await fetch(`${API_BASE}/pending_request/${id}/respond`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',


### PR DESCRIPTION
## Summary
- use API_BASE for pending requests fetches so page loads data when backend isn't on same origin

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a585f748288331b523cbeb0c8c1b5a