### PR TITLE
fix: ensure requests page hits correct API base

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "openai": "^4.24.0",
     "express-rate-limit": "^7.5.0",
     "sharp": "^0.33.2",
-    "mime-types": "^2.1.35",
-    "jsondiffpatch": "^0.5.0"
+    "mime-types": "^2.1.35"
   },
   "devDependencies": {
     "vite": "^6.3.5",


### PR DESCRIPTION
## Summary
- use API_BASE for pending requests fetches so page loads data when backend isn't on same origin
- drop jsondiffpatch dependency and fall back to simple diff to prevent build failures

## Testing
- `npm test`
- `npm run build:erp` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a585f748288331b523cbeb0c8c1b5a