### PR TITLE
fix: submit proper data for pending requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "openai": "^4.24.0",
     "express-rate-limit": "^7.5.0",
     "sharp": "^0.33.2",
-    "mime-types": "^2.1.35",
-    "jsondiffpatch": "^0.5.0"
+    "mime-types": "^2.1.35"
   },
   "devDependencies": {
     "vite": "^6.3.5",

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -20,6 +20,7 @@ import formatTimestamp from '../utils/formatTimestamp.js';
 import buildImageName from '../utils/buildImageName.js';
 import slugify from '../utils/slugify.js';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
+import { API_BASE } from '../utils/apiBase.js';
 
 function ch(n) {
   return Math.round(n * 8);
@@ -1103,7 +1104,7 @@ const TableManager = forwardRef(function TableManager({
 
     if (requestType === 'edit') {
       try {
-        const res = await fetch('/api/pending_request', {
+        const res = await fetch(`${API_BASE}/pending_request`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
@@ -1311,7 +1312,13 @@ const TableManager = forwardRef(function TableManager({
     }
     if (!window.confirm('Request delete?')) return;
     try {
-      const res = await fetch('/api/pending_request', {
+      const cleaned = {};
+      const skipFields = new Set([...autoCols, ...generatedCols, 'id']);
+      Object.entries(row).forEach(([k, v]) => {
+        if (skipFields.has(k) || k.startsWith('_')) return;
+        if (v !== '') cleaned[k] = v;
+      });
+      const res = await fetch(`${API_BASE}/pending_request`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -1319,6 +1326,7 @@ const TableManager = forwardRef(function TableManager({
           table_name: table,
           record_id: id,
           request_type: 'delete',
+          proposed_data: cleaned,
         }),
       });
       if (res.ok) addToast('Delete request submitted', 'success');


### PR DESCRIPTION
## Summary
- use API_BASE when sending edit and delete requests so forms post to correct backend
- include cleaned record data in delete request `proposed_data` so reviewers can see what will be removed
- use API_BASE for pending request page fetches and replace jsondiffpatch with simple diff

## Testing
- `npm test`
- `npm run build:erp` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a585f748288331b523cbeb0c8c1b5a