### PR TITLE
Expose senior employee ID in session data

### DIFF
--- a/api-server/controllers/authController.js
+++ b/api-server/controllers/authController.js
@@ -43,6 +43,7 @@ export async function login(req, res, next) {
       department_id: department,
       position_id,
       position,
+      senior_empid,
     } = session || {};
 
     const payload = {
@@ -79,6 +80,7 @@ export async function login(req, res, next) {
       department,
       position_id,
       position,
+      senior_empid,
       session,
       permissions,
     });
@@ -109,6 +111,7 @@ export async function getProfile(req, res) {
     department_id: department,
     position_id,
     position,
+    senior_empid,
   } = session || {};
   res.json({
     id: req.user.id,
@@ -122,6 +125,7 @@ export async function getProfile(req, res) {
     department,
     position_id,
     position,
+    senior_empid,
     session,
     permissions,
   });
@@ -160,6 +164,7 @@ export async function refresh(req, res) {
       department_id: department,
       position_id,
       position,
+      senior_empid,
     } = session || {};
     const newPayload = {
       id: user.id,
@@ -194,6 +199,7 @@ export async function refresh(req, res) {
       department,
       position_id,
       position,
+      senior_empid,
       session,
       permissions,
     });

--- a/db/index.js
+++ b/db/index.js
@@ -177,6 +177,7 @@ function mapEmploymentRow(row) {
     branch_id,
     department_id,
     position_id,
+    senior_empid,
     permission_list,
     ...rest
   } = row;
@@ -207,6 +208,7 @@ function mapEmploymentRow(row) {
     branch_id,
     department_id,
     position_id,
+    senior_empid,
     ...rest,
     permissions,
   };
@@ -242,6 +244,7 @@ export async function getEmploymentSessions(empid) {
         e.employment_department_id AS department_id,
         ${deptName} AS department_name,
         e.employment_position_id AS position_id,
+        e.employment_senior_empid AS senior_empid,
         ${empName} AS employee_name,
         e.employment_user_level AS user_level,
         ul.name AS user_level_name,
@@ -254,12 +257,13 @@ export async function getEmploymentSessions(empid) {
      LEFT JOIN user_levels ul ON e.employment_user_level = ul.userlevel_id
      LEFT JOIN user_level_permissions up ON up.userlevel_id = ul.userlevel_id AND up.action = 'permission'
      WHERE e.employment_emp_id = ?
-     GROUP BY e.employment_company_id, company_name,
+    GROUP BY e.employment_company_id, company_name,
               e.employment_branch_id, branch_name,
               e.employment_department_id, department_name,
               e.employment_position_id,
+              e.employment_senior_empid,
               employee_name, e.employment_user_level, ul.name
-     ORDER BY company_name, department_name, branch_name, user_level_name`,
+    ORDER BY company_name, department_name, branch_name, user_level_name`,
     [empid],
   );
   return rows.map(mapEmploymentRow);
@@ -297,6 +301,7 @@ export async function getEmploymentSession(empid, companyId) {
           e.employment_department_id AS department_id,
           ${deptName} AS department_name,
           e.employment_position_id AS position_id,
+          e.employment_senior_empid AS senior_empid,
           ${empName} AS employee_name,
           e.employment_user_level AS user_level,
           ul.name AS user_level_name,
@@ -313,6 +318,7 @@ export async function getEmploymentSession(empid, companyId) {
                 e.employment_branch_id, branch_name,
                 e.employment_department_id, department_name,
                 e.employment_position_id,
+                e.employment_senior_empid,
                 employee_name, e.employment_user_level, ul.name
        ORDER BY company_name, department_name, branch_name, user_level_name
        LIMIT 1`,

--- a/src/erp.mgt.mn/context/AuthContext.jsx
+++ b/src/erp.mgt.mn/context/AuthContext.jsx
@@ -47,6 +47,10 @@ export default function AuthContextProvider({ children }) {
         setDepartment(data.department ?? null);
         trackSetState('AuthContext.setPosition');
         setPosition(data.position ?? null);
+        if (data.senior_empid) {
+          trackSetState('AuthContext.setSession');
+          setSession((s) => ({ ...(s || {}), senior_empid: data.senior_empid }));
+        }
       } catch {
         // ignore parse errors
       }
@@ -55,13 +59,19 @@ export default function AuthContextProvider({ children }) {
 
   useEffect(() => {
     debugLog('AuthContext: persist ids');
-    const data = { company, branch, department, position };
-    if (company || branch || department || position) {
+    const data = {
+      company,
+      branch,
+      department,
+      position,
+      senior_empid: session?.senior_empid,
+    };
+    if (company || branch || department || position || session?.senior_empid) {
       localStorage.setItem('erp_session_ids', JSON.stringify(data));
     } else {
       localStorage.removeItem('erp_session_ids');
     }
-  }, [company, branch, department, position]);
+  }, [company, branch, department, position, session?.senior_empid]);
 
   // On mount, attempt to load the current profile (if a cookie is present)
   useEffect(() => {

--- a/src/erp.mgt.mn/hooks/useAuth.jsx
+++ b/src/erp.mgt.mn/hooks/useAuth.jsx
@@ -40,7 +40,21 @@ export async function login({ empid, password, companyId }) {
     throw new Error(message);
   }
 
-  return res.json();
+  const data = await res.json();
+  if (data?.session) {
+    try {
+      const stored = JSON.parse(localStorage.getItem('erp_session_ids') || '{}');
+      if (data.session.senior_empid) {
+        stored.senior_empid = data.session.senior_empid;
+      } else {
+        delete stored.senior_empid;
+      }
+      localStorage.setItem('erp_session_ids', JSON.stringify(stored));
+    } catch {
+      /* ignore storage errors */
+    }
+  }
+  return data;
 }
 
 /**
@@ -60,6 +74,20 @@ export async function logout() {
 export async function fetchProfile() {
   const res = await fetch(`${API_BASE}/auth/me`, { credentials: 'include' });
   if (!res.ok) throw new Error('Not authenticated');
-  return res.json();
+  const data = await res.json();
+  if (data?.session) {
+    try {
+      const stored = JSON.parse(localStorage.getItem('erp_session_ids') || '{}');
+      if (data.session.senior_empid) {
+        stored.senior_empid = data.session.senior_empid;
+      } else {
+        delete stored.senior_empid;
+      }
+      localStorage.setItem('erp_session_ids', JSON.stringify(stored));
+    } catch {
+      /* ignore storage errors */
+    }
+  }
+  return data;
 }
 


### PR DESCRIPTION
## Summary
- add senior employee ID to employment session queries and mapping
- include senior_empid in auth controller responses
- persist session.senior_empid in auth hooks and context for subordinate checks

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, utime '/workspace/erp-web-next/uploads/txn_images/test_cleanup/old.txt')*

------
https://chatgpt.com/codex/tasks/task_e_68a59e348aa48331bf88ae96373a6c34