### PR TITLE
feat: enhance pending request filtering

### DIFF
--- a/api-server/routes/pending_request.js
+++ b/api-server/routes/pending_request.js
@@ -42,17 +42,35 @@ router.post('/', requireAuth, async (req, res, next) => {
 
 router.get('/', requireAuth, async (req, res, next) => {
   try {
-    const { status, senior_empid } = req.query;
+    const {
+      status,
+      senior_empid,
+      requested_empid,
+      table_name,
+      date_from,
+      date_to,
+    } = req.query;
     if (!status || !senior_empid) {
-      return res.status(400).json({ message: 'status and senior_empid are required' });
+      return res
+        .status(400)
+        .json({ message: 'status and senior_empid are required' });
     }
+
     const session = await getEmploymentSession(req.user.empid, req.user.companyId);
     const isSelf = String(req.user.empid) === String(senior_empid);
-    if (!isSelf && !session?.permissions?.supervisor) {
+    const isSupervisor = !!session?.permissions?.supervisor;
+    if (!isSelf && !isSupervisor) {
       return res.sendStatus(403);
     }
 
-    const requests = await listRequests(status, senior_empid);
+    const requests = await listRequests({
+      status,
+      senior_empid,
+      requested_empid,
+      table_name,
+      date_from,
+      date_to,
+    });
     res.json(requests);
   } catch (err) {
     next(err);

--- a/src/erp.mgt.mn/components/PendingRequestWidget.jsx
+++ b/src/erp.mgt.mn/components/PendingRequestWidget.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext.jsx';
 
-export default function PendingRequestWidget() {
+export default function PendingRequestWidget({ filters = {} }) {
   const { user } = useContext(AuthContext);
   const [count, setCount] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -13,12 +13,17 @@ export default function PendingRequestWidget() {
       if (!user?.empid) return;
       setLoading(true);
       try {
-        const res = await fetch(
-          `/api/pending_request?status=pending&senior_empid=${encodeURIComponent(
-            user.empid,
-          )}`,
-          { credentials: 'include' },
-        );
+        const params = new URLSearchParams({
+          status: 'pending',
+          senior_empid: String(user.empid),
+        });
+        Object.entries(filters).forEach(([k, v]) => {
+          if (v !== undefined && v !== null && v !== '') params.append(k, v);
+        });
+
+        const res = await fetch(`/api/pending_request?${params.toString()}`, {
+          credentials: 'include',
+        });
         if (res.ok) {
           const data = await res.json();
           if (typeof data === 'number') {
@@ -39,7 +44,7 @@ export default function PendingRequestWidget() {
     }
 
     load();
-  }, [user?.empid]);
+  }, [user?.empid, filters]);
 
   if (!user?.empid) return null;
 

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -486,8 +486,13 @@ const TableManager = forwardRef(function TableManager({
         return;
       }
       try {
+        const params = new URLSearchParams({
+          status: requestStatus,
+          senior_empid: user?.empid,
+          table_name: table,
+        });
         const res = await fetch(
-          `/api/pending_request?status=${encodeURIComponent(requestStatus)}&senior_empid=${user?.empid}`,
+          `/api/pending_request?${params.toString()}`,
           { credentials: 'include' },
         );
         if (res.ok) {

--- a/src/erp.mgt.mn/pages/Requests.jsx
+++ b/src/erp.mgt.mn/pages/Requests.jsx
@@ -38,10 +38,12 @@ export default function RequestsPage() {
       setLoading(true);
       setError(null);
       try {
+        const params = new URLSearchParams({
+          status: 'pending',
+          senior_empid: user.empid,
+        });
         const res = await fetch(
-          `${API_BASE}/pending_request?status=pending&senior_empid=${encodeURIComponent(
-            user.empid,
-          )}`,
+          `${API_BASE}/pending_request?${params.toString()}`,
           { credentials: 'include' },
         );
         if (!res.ok) throw new Error('Failed to load requests');


### PR DESCRIPTION
## Summary
- add flexible `listRequests` filtering and include original records
- support new filters and access control in pending request API
- wire widgets/hooks to send filters when counting pending requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5a107df7c8331bd80741483d10c72