### PR TITLE
Handle subordinate edit/delete requests

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -174,10 +174,10 @@ const TableManager = forwardRef(function TableManager({
     [requestIdSet],
   );
   const { user, company, branch, department, session } = useContext(AuthContext);
+  const isSubordinate = Boolean(session?.senior_empid);
   const generalConfig = useGeneralConfig();
   const { addToast } = useToast();
-  const canRequestStatus =
-    session?.permissions?.edit_delete_request || session?.permissions?.supervisor;
+  const canRequestStatus = isSubordinate || session?.permissions?.supervisor;
 
   useEffect(() => {
     function hideMenu() {
@@ -2115,25 +2115,28 @@ const TableManager = forwardRef(function TableManager({
                       >
                         ➕ Add Img
                       </button>
-                      {buttonPerms['Edit transaction'] && (
-                        <button
-                          onClick={() => openEdit(r)}
-                          disabled={rid === undefined}
-                          style={actionBtnStyle}
-                        >
-                          🖉 Edit
-                        </button>
-                      )}
-                      {buttonPerms['Delete transaction'] && (
-                        <button
-                          onClick={() => handleDelete(r)}
-                          disabled={rid === undefined}
-                          style={deleteBtnStyle}
-                        >
-                          ❌ Delete
-                        </button>
-                      )}
-                      {session?.permissions?.edit_delete_request && (
+                      {!isSubordinate ? (
+                        <>
+                          {buttonPerms['Edit transaction'] && (
+                            <button
+                              onClick={() => openEdit(r)}
+                              disabled={rid === undefined}
+                              style={actionBtnStyle}
+                            >
+                              🖉 Edit
+                            </button>
+                          )}
+                          {buttonPerms['Delete transaction'] && (
+                            <button
+                              onClick={() => handleDelete(r)}
+                              disabled={rid === undefined}
+                              style={deleteBtnStyle}
+                            >
+                              ❌ Delete
+                            </button>
+                          )}
+                        </>
+                      ) : (
                         <>
                           <button
                             onClick={() => openRequestEdit(r)}


### PR DESCRIPTION
## Summary
- Detect subordinates via `session.senior_empid`
- Show edit/delete buttons only for non-subordinates and request equivalents otherwise
- Base request status filter on subordinate or supervisor access

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5a32b9bfc8331ae32873367ed53cd