### PR TITLE
feat: enhance pending requests view

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "openai": "^4.24.0",
     "express-rate-limit": "^7.5.0",
     "sharp": "^0.33.2",
-    "mime-types": "^2.1.35"
+    "mime-types": "^2.1.35",
+    "jsondiffpatch": "^1.1.1"
   },
   "devDependencies": {
     "vite": "^6.3.5",


### PR DESCRIPTION
## Summary
- use transaction display configuration to show visible fields and highlight differences between original and proposed data
- add requester, transaction type, status, and date-range filters when querying pending requests
- include jsondiffpatch dependency for nested JSON comparisons
- lazily import jsondiffpatch after mount and load its stylesheet from a CDN to avoid redeclaration build errors

## Testing
- `npm test`
- `npm run build:erp` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a44a28a48331bb9eba54b870398f