### PR TITLE
Handle pending request refetch and messages

### DIFF
--- a/src/erp.mgt.mn/hooks/usePendingRequestCount.js
+++ b/src/erp.mgt.mn/hooks/usePendingRequestCount.js
@@ -53,9 +53,11 @@ export default function usePendingRequestCount(
 
     fetchCount();
     const timer = setInterval(fetchCount, interval);
+    window.addEventListener('pending-request-refresh', fetchCount);
     return () => {
       cancelled = true;
       clearInterval(timer);
+      window.removeEventListener('pending-request-refresh', fetchCount);
     };
   }, [seniorEmpId, interval, filters]);
 

--- a/src/erp.mgt.mn/pages/Requests.jsx
+++ b/src/erp.mgt.mn/pages/Requests.jsx
@@ -230,6 +230,18 @@ export default function RequestsPage() {
         }),
       });
       if (!res.ok) throw new Error('Failed to respond');
+      const data = await res.json().catch(() => ({}));
+      const messages = [];
+      if (Array.isArray(data?.messages)) messages.push(...data.messages);
+      if (data?.message) messages.push(data.message);
+      messages.forEach((m) =>
+        window.dispatchEvent(
+          new CustomEvent('toast', {
+            detail: { message: m, type: 'success' },
+          })
+        )
+      );
+      window.dispatchEvent(new Event('pending-request-refresh'));
       setRequests((reqs) =>
         reqs.map((r) =>
           r.request_id === id


### PR DESCRIPTION
## Summary
- Build pending request URL with `status=pending` and supervisor filters
- Poll pending requests and refresh counts on custom `pending-request-refresh` event
- After responding to a request, toast server messages and trigger a refresh event

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5a5fcf3d88331a66d43eab57c1b9a