### PR TITLE
feat: enhance pending requests view

### DIFF
--- a/src/erp.mgt.mn/hooks/usePendingRequestCount.js
+++ b/src/erp.mgt.mn/hooks/usePendingRequestCount.js
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
 
 /**
- * Polls the pending request endpoint for a supervisor and returns the count.
- * @param {string|number} seniorEmpId Employee ID of the supervisor
- * @param {object} [filters] Optional filters (requested_empid, table_name, date_from, date_to)
+ * Polls the pending request endpoint for a senior employee and returns the
+ * count.
+ * @param {string|number} seniorEmpId Employee ID of the senior
+ * @param {object} [filters] Optional filters (requested_empid, table_name,
+ * date_from, date_to)
  * @param {number} [interval=30000] Polling interval in milliseconds
  * @returns {number} Count of pending requests
  */


### PR DESCRIPTION
## Summary
- filter out empty request columns and translate header labels
- ensure accept/decline buttons appear only for pending requests a user can answer
- prevent false "not authorized" message by checking senior status instead of supervisor roles
- restrict pending requests and responses to employees where the viewer is the configured senior
- clarify pending-request polling docs to reference senior employees

## Testing
- `npm test`
- `npm run build:erp` *(fails: vite: not found)*
- `npm install vite@6.3.5 --no-fund --no-audit` *(hangs: MaxListenersExceededWarning)*


------
https://chatgpt.com/codex/tasks/task_e_68a5c04c93e88331b08926c77056793e