### PR TITLE
feat: add user activity log listing

### DIFF
--- a/api-server/controllers/activityLogController.js
+++ b/api-server/controllers/activityLogController.js
@@ -1,6 +1,31 @@
 import { pool, getPrimaryKeyColumns } from '../../db/index.js';
 import { logUserAction } from '../services/userActivityLog.js';
 
+export async function listActivityLogs(req, res, next) {
+  try {
+    const { emp_id, record_id } = req.query;
+    const params = [];
+    const where = [];
+    if (emp_id) {
+      where.push('emp_id = ?');
+      params.push(emp_id);
+    }
+    if (record_id) {
+      where.push('record_id = ?');
+      params.push(record_id);
+    }
+    let sql = 'SELECT * FROM user_activity_log';
+    if (where.length) {
+      sql += ' WHERE ' + where.join(' AND ');
+    }
+    sql += ' ORDER BY timestamp DESC LIMIT 200';
+    const [rows] = await pool.query(sql, params);
+    res.json(rows);
+  } catch (err) {
+    next(err);
+  }
+}
+
 export async function restoreLogEntry(req, res, next) {
   try {
     const { id } = req.params;

--- a/api-server/routes/user_activity_log.js
+++ b/api-server/routes/user_activity_log.js
@@ -1,9 +1,10 @@
 import express from 'express';
 import { requireAuth } from '../middlewares/auth.js';
-import { restoreLogEntry } from '../controllers/activityLogController.js';
+import { listActivityLogs, restoreLogEntry } from '../controllers/activityLogController.js';
 
 const router = express.Router();
 
+router.get('/', requireAuth, listActivityLogs);
 router.post('/:id/restore', requireAuth, restoreLogEntry);
 
 export default router;

--- a/src/erp.mgt.mn/pages/UserActivityLog.jsx
+++ b/src/erp.mgt.mn/pages/UserActivityLog.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import TableManager from '../components/TableManager.jsx';
+
+export default function UserActivityLogPage() {
+  return (
+    <div>
+      <h2>User Activity Log</h2>
+      <TableManager table="user_activity_log" initialPerPage={20} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add API to list user activity logs filtered by employee or record
- expose user activity log page using TableManager

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5c62e39a88331923c4638457f364e