### PR TITLE
Restrict request actions to assigned seniors

### DIFF
--- a/api-server/routes/pending_request.js
+++ b/api-server/routes/pending_request.js
@@ -6,7 +6,7 @@ import {
   respondRequest,
   ALLOWED_REQUEST_TYPES,
 } from '../services/pendingRequest.js';
-import { getEmploymentSession } from '../../db/index.js';
+import { getEmploymentSession, pool } from '../../db/index.js';
 
 const router = express.Router();
 
@@ -42,30 +42,19 @@ router.post('/', requireAuth, async (req, res, next) => {
 
 router.get('/', requireAuth, async (req, res, next) => {
   try {
-    const {
-      status,
-      senior_empid,
-      requested_empid,
-      table_name,
-      date_from,
-      date_to,
-    } = req.query;
-    if (!status || !senior_empid) {
-      return res
-        .status(400)
-        .json({ message: 'status and senior_empid are required' });
-    }
+    const { status, requested_empid, table_name, date_from, date_to } = req.query;
 
-    const session = await getEmploymentSession(req.user.empid, req.user.companyId);
-    const isSelf = String(req.user.empid) === String(senior_empid);
-    const isSupervisor = !!session?.permissions?.supervisor;
-    if (!isSelf && !isSupervisor) {
+    const [rows] = await pool.query(
+      'SELECT 1 FROM tbl_employment WHERE employment_senior_empid = ? LIMIT 1',
+      [req.user.empid],
+    );
+    if (rows.length === 0) {
       return res.sendStatus(403);
     }
 
     const requests = await listRequests({
       status,
-      senior_empid,
+      senior_empid: req.user.empid,
       requested_empid,
       table_name,
       date_from,
@@ -83,14 +72,11 @@ router.put('/:id/respond', requireAuth, async (req, res, next) => {
     if (!['accepted', 'declined'].includes(status)) {
       return res.status(400).json({ message: 'invalid status' });
     }
-    const session = await getEmploymentSession(req.user.empid, req.user.companyId);
-    const isSupervisor = !!session?.permissions?.supervisor;
     await respondRequest(
       req.params.id,
       req.user.empid,
       status,
       response_notes,
-      isSupervisor,
     );
     res.sendStatus(204);
   } catch (err) {

--- a/api-server/services/pendingRequest.js
+++ b/api-server/services/pendingRequest.js
@@ -193,7 +193,6 @@ export async function respondRequest(
   responseEmpid,
   status,
   notes,
-  isSupervisor = false,
 ) {
   const conn = await pool.getConnection();
   try {
@@ -205,7 +204,6 @@ export async function respondRequest(
     const req = rows[0];
     if (!req) throw new Error('Request not found');
     if (
-      !isSupervisor &&
       String(req.senior_empid).trim() !== String(responseEmpid).trim()
     )
       throw new Error('Forbidden');

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -177,7 +177,7 @@ const TableManager = forwardRef(function TableManager({
   const isSubordinate = Boolean(session?.senior_empid);
   const generalConfig = useGeneralConfig();
   const { addToast } = useToast();
-  const canRequestStatus = isSubordinate || session?.permissions?.supervisor;
+  const canRequestStatus = isSubordinate;
 
   useEffect(() => {
     function hideMenu() {

--- a/src/erp.mgt.mn/pages/Requests.jsx
+++ b/src/erp.mgt.mn/pages/Requests.jsx
@@ -32,7 +32,7 @@ function renderValue(val) {
 }
 
 export default function RequestsPage() {
-  const { user, session, permissions } = useAuth();
+  const { user } = useAuth();
   const [requests, setRequests] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -54,10 +54,6 @@ export default function RequestsPage() {
   }, [requests]);
 
   const headerMap = useHeaderMappings(allFields);
-  const isSupervisor = !!(
-    session?.permissions?.supervisor || permissions?.supervisor
-  );
-
   useEffect(() => {
     async function load() {
       if (!user?.empid) {
@@ -325,9 +321,8 @@ export default function RequestsPage() {
         const requestStatus = req.status || req.response_status;
         const canRespond =
           (requestStatus === 'pending' || !requestStatus) &&
-          (isSupervisor ||
-            (req.senior_empid &&
-              String(req.senior_empid).trim() === String(user.empid).trim()));
+          req.senior_empid &&
+          String(req.senior_empid).trim() === String(user.empid).trim();
 
         return (
           <div

--- a/tests/api/pendingRequest.test.js
+++ b/tests/api/pendingRequest.test.js
@@ -37,7 +37,7 @@ function setupRequest(overrides = {}) {
 
 await test('direct senior can approve request', async () => {
   const { conn, restore } = setupRequest();
-  await service.respondRequest(1, 'S1', 'accepted', null, false);
+  await service.respondRequest(1, 'S1', 'accepted', null);
   restore();
   const upd = conn.queries.find((q) => q.sql.includes("status = 'accepted'"));
   assert.ok(upd, 'should update status to accepted');
@@ -45,24 +45,8 @@ await test('direct senior can approve request', async () => {
 
 await test('direct senior can decline request', async () => {
   const { conn, restore } = setupRequest();
-  await service.respondRequest(1, 'S1', 'declined', null, false);
+  await service.respondRequest(1, 'S1', 'declined', null);
   restore();
   const upd = conn.queries.find((q) => q.sql.includes("status = 'declined'"));
   assert.ok(upd, 'should update status to declined');
-});
-
-await test('supervisor can approve request', async () => {
-  const { conn, restore } = setupRequest();
-  await service.respondRequest(1, 'SUP', 'accepted', null, true);
-  restore();
-  const upd = conn.queries.find((q) => q.sql.includes("status = 'accepted'"));
-  assert.ok(upd, 'supervisor should update status to accepted');
-});
-
-await test('supervisor can decline request', async () => {
-  const { conn, restore } = setupRequest();
-  await service.respondRequest(1, 'SUP', 'declined', null, true);
-  restore();
-  const upd = conn.queries.find((q) => q.sql.includes("status = 'declined'"));
-  assert.ok(upd, 'supervisor should update status to declined');
 });


### PR DESCRIPTION
## Summary
- ensure only configured senior employees can view or respond to pending requests
- remove supervisor overrides when handling requests
- limit request status features to employees with a configured senior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5d6b28dcc8331b50068e0ea29c8cb