### PR TITLE
Rename senior_empid to employment_senior_empid across app

### DIFF
--- a/api-server/controllers/authController.js
+++ b/api-server/controllers/authController.js
@@ -43,7 +43,7 @@ export async function login(req, res, next) {
       department_id: department,
       position_id,
       position,
-      senior_empid,
+      employment_senior_empid,
     } = session || {};
 
     const payload = {
@@ -80,7 +80,7 @@ export async function login(req, res, next) {
       department,
       position_id,
       position,
-      senior_empid,
+      employment_senior_empid,
       session,
       permissions,
     });
@@ -111,7 +111,7 @@ export async function getProfile(req, res) {
     department_id: department,
     position_id,
     position,
-    senior_empid,
+    employment_senior_empid,
   } = session || {};
   res.json({
     id: req.user.id,
@@ -125,7 +125,7 @@ export async function getProfile(req, res) {
     department,
     position_id,
     position,
-    senior_empid,
+    employment_senior_empid,
     session,
     permissions,
   });
@@ -164,7 +164,7 @@ export async function refresh(req, res) {
       department_id: department,
       position_id,
       position,
-      senior_empid,
+      employment_senior_empid,
     } = session || {};
     const newPayload = {
       id: user.id,
@@ -199,7 +199,7 @@ export async function refresh(req, res) {
       department,
       position_id,
       position,
-      senior_empid,
+      employment_senior_empid,
       session,
       permissions,
     });

--- a/api-server/routes/pending_request.js
+++ b/api-server/routes/pending_request.js
@@ -55,7 +55,7 @@ router.get('/', requireAuth, async (req, res, next) => {
 
     const requests = await listRequests({
       status,
-      senior_empid: empid,
+      employment_senior_empid: empid,
       requested_empid,
       table_name,
       date_from,

--- a/api-server/services/pendingRequest.js
+++ b/api-server/services/pendingRequest.js
@@ -65,7 +65,7 @@ export async function createRequest({ tableName, recordId, empId, requestType, p
       finalProposed = currentRow;
     }
     const [result] = await conn.query(
-      `INSERT INTO pending_request (table_name, record_id, emp_id, senior_empid, request_type, proposed_data)
+      `INSERT INTO pending_request (table_name, record_id, emp_id, employment_senior_empid, request_type, proposed_data)
        VALUES (?, ?, ?, ?, ?, ?)`,
       [
         tableName,
@@ -96,7 +96,7 @@ export async function createRequest({ tableName, recordId, empId, requestType, p
       );
     }
     await conn.query('COMMIT');
-    return { request_id: requestId, senior_empid: senior };
+    return { request_id: requestId, employment_senior_empid: senior };
   } catch (err) {
     await conn.query('ROLLBACK');
     throw err;
@@ -108,7 +108,7 @@ export async function createRequest({ tableName, recordId, empId, requestType, p
 export async function listRequests(filters) {
   const {
     status,
-    senior_empid,
+    employment_senior_empid,
     requested_empid,
     table_name,
     date_from,
@@ -122,9 +122,9 @@ export async function listRequests(filters) {
     conditions.push('LOWER(TRIM(status)) = ?');
     params.push(String(status).trim().toLowerCase());
   }
-  if (senior_empid) {
-    conditions.push('UPPER(TRIM(senior_empid)) = ?');
-    params.push(String(senior_empid).trim().toUpperCase());
+  if (employment_senior_empid) {
+    conditions.push('UPPER(TRIM(employment_senior_empid)) = ?');
+    params.push(String(employment_senior_empid).trim().toUpperCase());
   }
   if (requested_empid) {
     conditions.push('UPPER(TRIM(emp_id)) = ?');
@@ -204,7 +204,7 @@ export async function respondRequest(
     const req = rows[0];
     if (!req) throw new Error('Request not found');
     if (
-      String(req.senior_empid).trim().toUpperCase() !==
+      String(req.employment_senior_empid).trim().toUpperCase() !==
       String(responseEmpid).trim().toUpperCase()
     )
       throw new Error('Forbidden');

--- a/db/index.js
+++ b/db/index.js
@@ -177,7 +177,7 @@ function mapEmploymentRow(row) {
     branch_id,
     department_id,
     position_id,
-    senior_empid,
+    employment_senior_empid,
     permission_list,
     ...rest
   } = row;
@@ -208,7 +208,7 @@ function mapEmploymentRow(row) {
     branch_id,
     department_id,
     position_id,
-    senior_empid,
+    employment_senior_empid,
     ...rest,
     permissions,
   };
@@ -244,7 +244,7 @@ export async function getEmploymentSessions(empid) {
         e.employment_department_id AS department_id,
         ${deptName} AS department_name,
         e.employment_position_id AS position_id,
-        e.employment_senior_empid AS senior_empid,
+        e.employment_senior_empid AS employment_senior_empid,
         ${empName} AS employee_name,
         e.employment_user_level AS user_level,
         ul.name AS user_level_name,
@@ -301,7 +301,7 @@ export async function getEmploymentSession(empid, companyId) {
           e.employment_department_id AS department_id,
           ${deptName} AS department_name,
           e.employment_position_id AS position_id,
-          e.employment_senior_empid AS senior_empid,
+          e.employment_senior_empid AS employment_senior_empid,
           ${empName} AS employee_name,
           e.employment_user_level AS user_level,
           ul.name AS user_level_name,

--- a/db/migrations/2025-10-15_user_activity_pending_notifications.sql
+++ b/db/migrations/2025-10-15_user_activity_pending_notifications.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS pending_request (
   table_name      VARCHAR(100) NOT NULL,
   record_id       BIGINT NOT NULL,
   emp_id          VARCHAR(10) NOT NULL,
-  senior_empid    VARCHAR(10) NOT NULL,
+  employment_senior_empid    VARCHAR(10) NOT NULL,
   request_type    ENUM('edit','delete') NOT NULL,
   proposed_data   JSON NULL,
   status          ENUM('pending','accepted','declined') NOT NULL DEFAULT 'pending',
@@ -28,10 +28,10 @@ CREATE TABLE IF NOT EXISTS pending_request (
   responded_at    TIMESTAMP NULL,
   response_empid  VARCHAR(10) NULL,
   response_notes  TEXT NULL,
-  KEY idx_pending_status_senior (status, senior_empid),
+  KEY idx_pending_status_senior (status, employment_senior_empid),
   KEY idx_pending_emp (emp_id),
   CONSTRAINT fk_pending_emp FOREIGN KEY (emp_id) REFERENCES tbl_employment(employment_emp_id),
-  CONSTRAINT fk_pending_senior FOREIGN KEY (senior_empid) REFERENCES tbl_employment(employment_emp_id)
+  CONSTRAINT fk_pending_senior FOREIGN KEY (employment_senior_empid) REFERENCES tbl_employment(employment_emp_id)
 );
 
 -- 3. Notifications table for dashboard alerts

--- a/src/erp.mgt.mn/components/PendingRequestWidget.jsx
+++ b/src/erp.mgt.mn/components/PendingRequestWidget.jsx
@@ -18,7 +18,7 @@ export default function PendingRequestWidget({ filters = {} }) {
       try {
         const params = new URLSearchParams({
           status: 'pending',
-          senior_empid: String(user.empid),
+          employment_senior_empid: String(user.empid),
         });
         Object.entries(filters).forEach(([k, v]) => {
           if (v !== undefined && v !== null && v !== '') params.append(k, v);

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -174,7 +174,7 @@ const TableManager = forwardRef(function TableManager({
     [requestIdSet],
   );
   const { user, company, branch, department, session } = useContext(AuthContext);
-  const isSubordinate = Boolean(session?.senior_empid);
+  const isSubordinate = Boolean(session?.employment_senior_empid);
   const generalConfig = useGeneralConfig();
   const { addToast } = useToast();
   const canRequestStatus = isSubordinate;
@@ -488,7 +488,7 @@ const TableManager = forwardRef(function TableManager({
       try {
         const params = new URLSearchParams({
           status: requestStatus,
-          senior_empid: user?.empid,
+          employment_senior_empid: user?.empid,
           table_name: table,
         });
         const res = await fetch(

--- a/src/erp.mgt.mn/context/AuthContext.jsx
+++ b/src/erp.mgt.mn/context/AuthContext.jsx
@@ -47,9 +47,9 @@ export default function AuthContextProvider({ children }) {
         setDepartment(data.department ?? null);
         trackSetState('AuthContext.setPosition');
         setPosition(data.position ?? null);
-        if (data.senior_empid) {
+        if (data.employment_senior_empid) {
           trackSetState('AuthContext.setSession');
-          setSession((s) => ({ ...(s || {}), senior_empid: data.senior_empid }));
+          setSession((s) => ({ ...(s || {}), employment_senior_empid: data.employment_senior_empid }));
         }
       } catch {
         // ignore parse errors
@@ -64,14 +64,14 @@ export default function AuthContextProvider({ children }) {
       branch,
       department,
       position,
-      senior_empid: session?.senior_empid,
+      employment_senior_empid: session?.employment_senior_empid,
     };
-    if (company || branch || department || position || session?.senior_empid) {
+    if (company || branch || department || position || session?.employment_senior_empid) {
       localStorage.setItem('erp_session_ids', JSON.stringify(data));
     } else {
       localStorage.removeItem('erp_session_ids');
     }
-  }, [company, branch, department, position, session?.senior_empid]);
+  }, [company, branch, department, position, session?.employment_senior_empid]);
 
   // On mount, attempt to load the current profile (if a cookie is present)
   useEffect(() => {

--- a/src/erp.mgt.mn/hooks/useAuth.jsx
+++ b/src/erp.mgt.mn/hooks/useAuth.jsx
@@ -44,10 +44,10 @@ export async function login({ empid, password, companyId }) {
   if (data?.session) {
     try {
       const stored = JSON.parse(localStorage.getItem('erp_session_ids') || '{}');
-      if (data.session.senior_empid) {
-        stored.senior_empid = data.session.senior_empid;
+      if (data.session.employment_senior_empid) {
+        stored.employment_senior_empid = data.session.employment_senior_empid;
       } else {
-        delete stored.senior_empid;
+        delete stored.employment_senior_empid;
       }
       localStorage.setItem('erp_session_ids', JSON.stringify(stored));
     } catch {
@@ -78,10 +78,10 @@ export async function fetchProfile() {
   if (data?.session) {
     try {
       const stored = JSON.parse(localStorage.getItem('erp_session_ids') || '{}');
-      if (data.session.senior_empid) {
-        stored.senior_empid = data.session.senior_empid;
+      if (data.session.employment_senior_empid) {
+        stored.employment_senior_empid = data.session.employment_senior_empid;
       } else {
-        delete stored.senior_empid;
+        delete stored.employment_senior_empid;
       }
       localStorage.setItem('erp_session_ids', JSON.stringify(stored));
     } catch {

--- a/src/erp.mgt.mn/hooks/usePendingRequestCount.js
+++ b/src/erp.mgt.mn/hooks/usePendingRequestCount.js
@@ -8,21 +8,21 @@ import { useEffect, useState } from 'react';
  * @returns {number} Count of pending requests
  */
 export default function usePendingRequestCount(
-  seniorEmpId,
+  employmentSeniorEmpId,
   filters = {},
   interval = 30000,
 ) {
   const [count, setCount] = useState(0);
 
   useEffect(() => {
-    if (!seniorEmpId) {
+    if (!employmentSeniorEmpId) {
       setCount(0);
       return undefined;
     }
 
     const params = new URLSearchParams({
       status: 'pending',
-      senior_empid: String(seniorEmpId),
+      employment_senior_empid: String(employmentSeniorEmpId),
     });
     Object.entries(filters).forEach(([k, v]) => {
       if (v !== undefined && v !== null && v !== '') {
@@ -59,7 +59,7 @@ export default function usePendingRequestCount(
       clearInterval(timer);
       window.removeEventListener('pending-request-refresh', fetchCount);
     };
-  }, [seniorEmpId, interval, filters]);
+  }, [employmentSeniorEmpId, interval, filters]);
 
   return count;
 }

--- a/src/erp.mgt.mn/pages/Requests.jsx
+++ b/src/erp.mgt.mn/pages/Requests.jsx
@@ -65,7 +65,7 @@ export default function RequestsPage() {
       setError(null);
       try {
         const params = new URLSearchParams({
-          senior_empid: user.empid,
+          employment_senior_empid: user.empid,
         });
         if (status) params.append('status', status);
         if (requestedEmpid) params.append('requested_empid', requestedEmpid);
@@ -190,7 +190,7 @@ export default function RequestsPage() {
           status: respStatus,
           response_notes: reqItem?.notes || undefined,
           response_empid: user.empid,
-          senior_empid: reqItem?.senior_empid || user.empid,
+          employment_senior_empid: reqItem?.employment_senior_empid || user.empid,
         }),
       });
       if (!res.ok) {
@@ -321,8 +321,9 @@ export default function RequestsPage() {
         const requestStatus = req.status || req.response_status;
         const canRespond =
           (requestStatus === 'pending' || !requestStatus) &&
-          req.senior_empid &&
-          String(req.senior_empid).trim() === String(user.empid).trim();
+          req.employment_senior_empid &&
+          String(req.employment_senior_empid).trim() ===
+            String(user.empid).trim();
 
         return (
           <div

--- a/tests/api/pendingRequest.test.js
+++ b/tests/api/pendingRequest.test.js
@@ -9,7 +9,7 @@ function setupRequest(overrides = {}) {
     table_name: 't',
     record_id: 1,
     emp_id: 'E1',
-    senior_empid: 'S1',
+    employment_senior_empid: 'S1',
     request_type: 'edit',
     proposed_data: null,
     ...overrides,
@@ -58,9 +58,9 @@ await test('listRequests normalizes empids in filters', async () => {
     queries.push({ sql, params });
     return [[]];
   };
-  await service.listRequests({ senior_empid: 's1 ', requested_empid: ' e2 ' });
+  await service.listRequests({ employment_senior_empid: 's1 ', requested_empid: ' e2 ' });
   db.pool.query = origQuery;
-  assert.ok(queries[0].sql.includes('UPPER(TRIM(senior_empid))'));
+  assert.ok(queries[0].sql.includes('UPPER(TRIM(employment_senior_empid))'));
   assert.ok(queries[0].sql.includes('UPPER(TRIM(emp_id))'));
   assert.deepEqual(queries[0].params, ['S1', 'E2']);
 });


### PR DESCRIPTION
## Summary
- use `employment_senior_empid` instead of `senior_empid` in database mappings and auth responses
- update pending request service, routes, and migrations to new column
- align React context, hooks, and components with `employment_senior_empid`

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68a5e29bcab08331b46aa3d8baaa089e