### PR TITLE
Use senior_empid column for employment lookups

### DIFF
--- a/api-server/controllers/activityLogController.js
+++ b/api-server/controllers/activityLogController.js
@@ -37,10 +37,10 @@ export async function restoreLogEntry(req, res, next) {
     if (!entry) return res.sendStatus(404);
 
     const [rows] = await pool.query(
-      'SELECT employment_senior_empid FROM tbl_employment WHERE employment_emp_id = ? LIMIT 1',
+      'SELECT senior_empid FROM tbl_employment WHERE employment_emp_id = ? LIMIT 1',
       [entry.emp_id],
     );
-    const senior = rows[0]?.employment_senior_empid;
+    const senior = rows[0]?.senior_empid;
     if (senior !== req.user.empid) return res.sendStatus(403);
 
     const data = entry.details ? JSON.parse(entry.details) : null;

--- a/api-server/routes/pending_request.js
+++ b/api-server/routes/pending_request.js
@@ -46,7 +46,7 @@ router.get('/', requireAuth, async (req, res, next) => {
 
     const empid = String(req.user.empid).trim().toUpperCase();
     const [rows] = await pool.query(
-      'SELECT 1 FROM tbl_employment WHERE UPPER(TRIM(employment_senior_empid)) = ? LIMIT 1',
+      'SELECT 1 FROM tbl_employment WHERE UPPER(TRIM(senior_empid)) = ? LIMIT 1',
       [empid],
     );
     if (rows.length === 0) {

--- a/api-server/services/pendingRequest.js
+++ b/api-server/services/pendingRequest.js
@@ -36,10 +36,10 @@ export async function createRequest({ tableName, recordId, empId, requestType, p
   try {
     await conn.query('BEGIN');
     const [rows] = await conn.query(
-      'SELECT employment_senior_empid FROM tbl_employment WHERE employment_emp_id = ? LIMIT 1',
+      'SELECT senior_empid FROM tbl_employment WHERE employment_emp_id = ? LIMIT 1',
       [empId],
     );
-    const seniorRaw = rows[0]?.employment_senior_empid;
+    const seniorRaw = rows[0]?.senior_empid;
     const senior = seniorRaw ? String(seniorRaw).trim().toUpperCase() : null;
     let finalProposed = proposedData;
     if (requestType === 'delete') {

--- a/db/index.js
+++ b/db/index.js
@@ -244,7 +244,7 @@ export async function getEmploymentSessions(empid) {
         e.employment_department_id AS department_id,
         ${deptName} AS department_name,
         e.employment_position_id AS position_id,
-        e.employment_senior_empid AS senior_empid,
+        e.senior_empid AS senior_empid,
         ${empName} AS employee_name,
         e.employment_user_level AS user_level,
         ul.name AS user_level_name,
@@ -261,7 +261,7 @@ export async function getEmploymentSessions(empid) {
               e.employment_branch_id, branch_name,
               e.employment_department_id, department_name,
               e.employment_position_id,
-              e.employment_senior_empid,
+              e.senior_empid,
               employee_name, e.employment_user_level, ul.name
     ORDER BY company_name, department_name, branch_name, user_level_name`,
     [empid],
@@ -301,7 +301,7 @@ export async function getEmploymentSession(empid, companyId) {
           e.employment_department_id AS department_id,
           ${deptName} AS department_name,
           e.employment_position_id AS position_id,
-          e.employment_senior_empid AS senior_empid,
+          e.senior_empid AS senior_empid,
           ${empName} AS employee_name,
           e.employment_user_level AS user_level,
           ul.name AS user_level_name,
@@ -318,7 +318,7 @@ export async function getEmploymentSession(empid, companyId) {
                 e.employment_branch_id, branch_name,
                 e.employment_department_id, department_name,
                 e.employment_position_id,
-                e.employment_senior_empid,
+                e.senior_empid,
                 employee_name, e.employment_user_level, ul.name
        ORDER BY company_name, department_name, branch_name, user_level_name
        LIMIT 1`,


### PR DESCRIPTION
## Summary
- replace legacy `employment_senior_empid` references with `senior_empid` in employment queries
- keep pending request and activity log flows in sync with new column name

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a59cd1cf3c8331afca4f391124bd33