### PR TITLE
Handle requester pending request display

### DIFF
--- a/src/erp.mgt.mn/pages/Requests.jsx
+++ b/src/erp.mgt.mn/pages/Requests.jsx
@@ -7,28 +7,16 @@ import { debugLog } from '../utils/debug.js';
 import useHeaderMappings from '../hooks/useHeaderMappings.js';
 import { translateToMn } from '../utils/translateToMn.js';
 
-function ch(n) {
-  return Math.round(n * 8);
-}
-
-const MAX_WIDTH = ch(40);
-
-function getAverageLength(values) {
-  const list = values
-    .filter((v) => v !== null && v !== undefined)
-    .map((v) =>
-      typeof v === 'object' ? JSON.stringify(v) : String(v),
-    )
-    .slice(0, 20);
-  if (list.length === 0) return 0;
-  return Math.round(list.reduce((s, v) => s + v.length, 0) / list.length);
-}
-
 function renderValue(val) {
+  const style = { whiteSpace: 'pre-wrap', wordBreak: 'break-word' };
   if (typeof val === 'object' && val !== null) {
-    return <pre>{JSON.stringify(val, null, 2)}</pre>;
+    return (
+      <pre style={{ ...style, margin: 0 }}>
+        {JSON.stringify(val, null, 2)}
+      </pre>
+    );
   }
-  return String(val ?? '');
+  return <span style={style}>{String(val ?? '')}</span>;
 }
 
 export default function RequestsPage() {
@@ -87,7 +75,12 @@ export default function RequestsPage() {
                 `${API_BASE}/tables/${req.table_name}/${req.record_id}`,
                 { credentials: 'include' },
               );
-              if (res2.ok) {
+              if (
+                res2.ok &&
+                res2.headers
+                  .get('content-type')
+                  ?.includes('application/json')
+              ) {
                 original = await res2.json();
               } else {
                 const res3 = await fetch(
@@ -96,13 +89,18 @@ export default function RequestsPage() {
                   )}&perPage=1`,
                   { credentials: 'include' },
                 );
-                if (res3.ok) {
+                if (
+                  res3.ok &&
+                  res3.headers
+                    .get('content-type')
+                    ?.includes('application/json')
+                ) {
                   const json = await res3.json();
                   original = json.rows?.[0] || null;
                 }
               }
             } catch (err) {
-              console.error('Failed to fetch original record', err);
+              debugLog('Failed to fetch original record', err);
             }
 
             let cfg = configCache.current[req.table_name];
@@ -289,14 +287,6 @@ export default function RequestsPage() {
         req.fields.forEach((f) => {
           fieldMap[f.name] = f;
         });
-        const placeholders = {};
-        columns.forEach((c) => {
-          const lower = c.toLowerCase();
-          if (lower.includes('time') && !lower.includes('date'))
-            placeholders[c] = 'HH:MM:SS';
-          else if (lower.includes('timestamp') || lower.includes('date'))
-            placeholders[c] = 'YYYY-MM-DD';
-        });
         const columnAlign = {};
         columns.forEach((c) => {
           const sample =
@@ -305,24 +295,23 @@ export default function RequestsPage() {
               : fieldMap[c].after;
           columnAlign[c] = typeof sample === 'number' ? 'right' : 'left';
         });
-        const columnWidths = {};
-        columns.forEach((c) => {
-          const f = fieldMap[c];
-          const avg = getAverageLength([f.before, f.after]);
-          let w;
-          if (avg <= 4) w = ch(Math.max(avg + 1, 5));
-          else if (placeholders[c] && placeholders[c].includes('YYYY-MM-DD'))
-            w = ch(12);
-          else if (avg <= 10) w = ch(12);
-          else w = ch(20);
-          columnWidths[c] = Math.min(w, MAX_WIDTH);
-        });
-
         const requestStatus = req.status || req.response_status;
+        const requestStatusLower = requestStatus
+          ? String(requestStatus).trim().toLowerCase()
+          : undefined;
+        const isRequester =
+          String(req.emp_id).trim() === String(user.empid).trim();
+        const assignedSenior =
+          req.senior_empid !== undefined && req.senior_empid !== null &&
+          String(req.senior_empid).trim() !== '0'
+            ? String(req.senior_empid).trim()
+            : null;
+        const isPending =
+          !requestStatusLower || requestStatusLower === 'pending';
         const canRespond =
-          (requestStatus === 'pending' || !requestStatus) &&
-          req.senior_empid &&
-          String(req.senior_empid).trim() === String(user.empid).trim();
+          !isRequester &&
+          isPending &&
+          (!assignedSenior || assignedSenior === String(user.empid).trim());
 
         return (
           <div
@@ -346,7 +335,6 @@ export default function RequestsPage() {
               style={{
                 width: '100%',
                 borderCollapse: 'collapse',
-                tableLayout: 'fixed',
               }}
             >
               <thead>
@@ -359,11 +347,9 @@ export default function RequestsPage() {
                         border: '1px solid #ccc',
                         padding: '0.25em',
                         textAlign: columnAlign[c],
-                        width: columnWidths[c],
-                        minWidth: columnWidths[c],
-                        maxWidth: MAX_WIDTH,
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
+                        whiteSpace: 'pre-wrap',
+                        wordBreak: 'break-word',
+                        verticalAlign: 'top',
                       }}
                     >
                       {headerMap[c] || translateToMn(c)}
@@ -384,11 +370,9 @@ export default function RequestsPage() {
                         padding: '0.25em',
                         background: fieldMap[c].changed ? '#ffe6e6' : undefined,
                         textAlign: columnAlign[c],
-                        width: columnWidths[c],
-                        minWidth: columnWidths[c],
-                        maxWidth: MAX_WIDTH,
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
+                        whiteSpace: 'pre-wrap',
+                        wordBreak: 'break-word',
+                        verticalAlign: 'top',
                       }}
                     >
                       {renderValue(fieldMap[c].before)}
@@ -410,11 +394,9 @@ export default function RequestsPage() {
                             ? '#e6ffe6'
                             : undefined,
                           textAlign: columnAlign[c],
-                          width: columnWidths[c],
-                          minWidth: columnWidths[c],
-                          maxWidth: MAX_WIDTH,
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
+                          whiteSpace: 'pre-wrap',
+                          wordBreak: 'break-word',
+                          verticalAlign: 'top',
                         }}
                       >
                         {renderValue(fieldMap[c].after)}
@@ -424,7 +406,7 @@ export default function RequestsPage() {
                 )}
               </tbody>
             </table>
-            {requestStatus && requestStatus !== 'pending' ? (
+            {!isPending ? (
               <p>Request {requestStatus}</p>
             ) : canRespond ? (
               <>
@@ -446,9 +428,9 @@ export default function RequestsPage() {
                   </button>
                 </div>
               </>
-            ) : (
-              <p>You are not authorized to respond.</p>
-            )}
+            ) : isRequester ? (
+              <p>Awaiting senior response…</p>
+            ) : null}
             {req.error && <p style={{ color: 'red' }}>{req.error}</p>}
           </div>
         );


### PR DESCRIPTION
## Summary
- Allow seniors or unassigned reviewers to respond to pending requests while requesters see an awaiting message
- Wrap original and proposed field values so long text displays vertically

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5ec377b14833182562b0cc5432f70