### PR TITLE
Refresh module cache after transaction form updates

### DIFF
--- a/src/erp.mgt.mn/hooks/usePendingRequestCount.js
+++ b/src/erp.mgt.mn/hooks/usePendingRequestCount.js
@@ -35,6 +35,7 @@ export default function usePendingRequestCount(
       try {
         const res = await fetch(`/api/pending_request?${params.toString()}`, {
           credentials: 'include',
+          skipLoader: true,
         });
         if (!res.ok) {
           if (!cancelled) setCount(0);

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
-import { useModules } from '../hooks/useModules.js';
+import { useModules, refreshModules } from '../hooks/useModules.js';
 import { refreshTxnModules } from '../hooks/useTxnModules.js';
 import { debugLog } from '../utils/debug.js';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
@@ -439,6 +439,7 @@ export default function FormsManagement() {
       }),
     });
     refreshTxnModules();
+    refreshModules();
     alert('Saved');
     if (!names.includes(name)) setNames((n) => [...n, name]);
   }
@@ -451,6 +452,7 @@ export default function FormsManagement() {
       credentials: 'include',
     });
     refreshTxnModules();
+    refreshModules();
     setNames((n) => n.filter((x) => x !== name));
     setName('');
     setConfig({

--- a/src/erp.mgt.mn/pages/PosTxnConfig.jsx
+++ b/src/erp.mgt.mn/pages/PosTxnConfig.jsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useToast } from '../context/ToastContext.jsx';
+import { refreshTxnModules } from '../hooks/useTxnModules.js';
+import { refreshModules } from '../hooks/useModules.js';
 
 const emptyConfig = {
   label: '',
@@ -278,6 +280,8 @@ export default function PosTxnConfig() {
       credentials: 'include',
       body: JSON.stringify({ name, config: saveCfg }),
     });
+    refreshTxnModules();
+    refreshModules();
     addToast('Saved', 'success');
     fetch('/api/pos_txn_config', { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : {}))
@@ -292,6 +296,8 @@ export default function PosTxnConfig() {
       method: 'DELETE',
       credentials: 'include',
     });
+    refreshTxnModules();
+    refreshModules();
     addToast('Deleted', 'success');
     setName('');
     setConfig({ ...emptyConfig });


### PR DESCRIPTION
## Summary
- refresh module cache when saving or deleting transaction forms so sidebar immediately reflects dynamic transaction menus

## Testing
- `npm test` *(fails: renameImages handles images already in folder)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ef13108c83318693057cfa86c63b