### PR TITLE
Show activity tab for all users with senior badges

### DIFF
--- a/src/erp.mgt.mn/components/PendingRequestWidget.jsx
+++ b/src/erp.mgt.mn/components/PendingRequestWidget.jsx
@@ -6,10 +6,11 @@ import { usePendingRequests } from '../context/PendingRequestContext.jsx';
 export default function PendingRequestWidget() {
   const { user, session } = useContext(AuthContext);
   const navigate = useNavigate();
-  const seniorEmpId = Number(session?.senior_empid) > 0 ? null : user?.empid;
+  const isSenior = Number(session?.senior_empid) <= 0;
+  const seniorEmpId = isSenior ? user?.empid : null;
   const { count } = usePendingRequests();
 
-  if (!seniorEmpId) return null;
+  if (!isSenior || !seniorEmpId) return null;
 
   const badgeStyle = {
     display: 'inline-block',

--- a/src/erp.mgt.mn/pages/DashboardPage.jsx
+++ b/src/erp.mgt.mn/pages/DashboardPage.jsx
@@ -7,11 +7,11 @@ export default function DashboardPage() {
   const { user, session } = useContext(AuthContext);
   const { hasNew, markSeen } = usePendingRequests();
   const [active, setActive] = useState('general');
-  const showActivity = Number(session?.senior_empid) <= 0;
+  const isSenior = Number(session?.senior_empid) <= 0;
 
   useEffect(() => {
-    if (showActivity && active === 'activity') markSeen();
-  }, [active, markSeen, showActivity]);
+    if (isSenior && active === 'activity') markSeen();
+  }, [active, markSeen, isSenior]);
 
   const badgeStyle = {
     background: 'red',
@@ -53,7 +53,7 @@ export default function DashboardPage() {
     <div style={{ padding: '1rem' }}>
       <div style={{ display: 'flex', borderBottom: '1px solid #ddd', marginBottom: '1rem' }}>
         {tabButton('general', 'General')}
-        {showActivity && tabButton('activity', 'Activity', hasNew)}
+        {tabButton('activity', 'Activity', isSenior && hasNew)}
         {tabButton('plans', 'Plans')}
       </div>
 
@@ -80,9 +80,9 @@ export default function DashboardPage() {
         </div>
       )}
 
-      {showActivity && active === 'activity' && (
+      {active === 'activity' && (
         <div>
-          <PendingRequestWidget />
+          {isSenior ? <PendingRequestWidget /> : <p>No activity to display.</p>}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Display dashboard activity tab for every user
- Only senior-configured users fetch pending request summary and show a badge
- Use consistent senior check across dashboard and pending request widget

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6dc20b12883319236777c9cab5bcc