### PR TITLE
Show activity tab for all users with senior badges

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -84,7 +84,11 @@ export default function ERPLayout() {
   const { tabs, activeKey, openTab, closeTab, switchTab, setTabContent, cache } = useTabs();
   const txnModules = useTxnModules();
 
-  const seniorEmpId = Number(session?.senior_empid) > 0 ? null : user?.empid;
+  const seniorEmpId =
+    session && user?.empid && !(Number(session.senior_empid) > 0)
+      ? user.empid
+      : null;
+  const isSenior = Boolean(seniorEmpId);
   const {
     count: pendingCount,
     hasNew: pendingHasNew,
@@ -116,10 +120,12 @@ export default function ERPLayout() {
     navigate('/');
   }
 
+  const pendingContextValue = isSenior
+    ? { count: pendingCount, hasNew: pendingHasNew, markSeen: markPendingSeen }
+    : { count: 0, hasNew: false, markSeen: () => {} };
+
   return (
-    <PendingRequestContext.Provider
-      value={{ count: pendingCount, hasNew: pendingHasNew, markSeen: markPendingSeen }}
-    >
+    <PendingRequestContext.Provider value={pendingContextValue}>
       <div style={styles.container}>
         <Header
           user={user}
@@ -150,7 +156,7 @@ export default function ERPLayout() {
 }
 
 /** Top header bar **/
-function Header({ user, onLogout, onHome, isMobile, onToggleSidebar, onOpen, pendingCount }) {
+function Header({ user, onLogout, onHome, isMobile, onToggleSidebar, onOpen }) {
   const { session } = useContext(AuthContext);
 
   return (
@@ -177,7 +183,7 @@ function Header({ user, onLogout, onHome, isMobile, onToggleSidebar, onOpen, pen
         <button style={styles.iconBtn}>🗗 Цонхнууд</button>
         <button style={styles.iconBtn}>❔ Тусламж</button>
       </nav>
-      <HeaderMenu onOpen={onOpen} pendingCount={pendingCount} />
+      <HeaderMenu onOpen={onOpen} />
       {session && (
         <span style={styles.locationInfo}>
           🏢 {session.company_name}

--- a/src/erp.mgt.mn/components/HeaderMenu.jsx
+++ b/src/erp.mgt.mn/components/HeaderMenu.jsx
@@ -9,13 +9,18 @@ import filterHeaderModules from '../utils/filterHeaderModules.js';
 import { usePendingRequests } from '../context/PendingRequestContext.jsx';
 
 export default function HeaderMenu({ onOpen }) {
-  const { permissions: perms } = useContext(AuthContext);
+  const { permissions: perms, session, user } = useContext(AuthContext);
   const modules = useModules();
   const txnModules = useTxnModules();
   const generalConfig = useGeneralConfig();
   const items = filterHeaderModules(modules, perms, txnModules);
   const headerMap = useHeaderMappings(items.map((m) => m.module_key));
   const { hasNew } = usePendingRequests();
+  const seniorEmpId =
+    session && user?.empid && !(Number(session.senior_empid) > 0)
+      ? user.empid
+      : null;
+  const isSenior = Boolean(seniorEmpId);
 
   // Build a quick lookup map so we can resolve module paths
   const moduleMap = {};
@@ -41,7 +46,7 @@ export default function HeaderMenu({ onOpen }) {
               onOpen(modulePath(m, moduleMap), label, m.module_key)
             }
           >
-            {m.module_key === 'dashboard' && hasNew && (
+            {m.module_key === 'dashboard' && isSenior && hasNew && (
               <span style={styles.badge} />
             )}
             {label}

--- a/src/erp.mgt.mn/components/PendingRequestWidget.jsx
+++ b/src/erp.mgt.mn/components/PendingRequestWidget.jsx
@@ -6,7 +6,10 @@ import { usePendingRequests } from '../context/PendingRequestContext.jsx';
 export default function PendingRequestWidget() {
   const { user, session } = useContext(AuthContext);
   const navigate = useNavigate();
-  const seniorEmpId = Number(session?.senior_empid) > 0 ? null : user?.empid;
+  const seniorEmpId =
+    session && user?.empid && !(Number(session.senior_empid) > 0)
+      ? user.empid
+      : null;
   const { count } = usePendingRequests();
 
   if (!seniorEmpId) return null;

--- a/src/erp.mgt.mn/pages/DashboardPage.jsx
+++ b/src/erp.mgt.mn/pages/DashboardPage.jsx
@@ -7,11 +7,15 @@ export default function DashboardPage() {
   const { user, session } = useContext(AuthContext);
   const { hasNew, markSeen } = usePendingRequests();
   const [active, setActive] = useState('general');
-  const showActivity = Number(session?.senior_empid) <= 0;
+  const seniorEmpId =
+    session && user?.empid && !(Number(session.senior_empid) > 0)
+      ? user.empid
+      : null;
+  const isSenior = Boolean(seniorEmpId);
 
   useEffect(() => {
-    if (showActivity && active === 'activity') markSeen();
-  }, [active, markSeen, showActivity]);
+    if (isSenior && active === 'activity') markSeen();
+  }, [active, markSeen, isSenior]);
 
   const badgeStyle = {
     background: 'red',
@@ -53,7 +57,7 @@ export default function DashboardPage() {
     <div style={{ padding: '1rem' }}>
       <div style={{ display: 'flex', borderBottom: '1px solid #ddd', marginBottom: '1rem' }}>
         {tabButton('general', 'General')}
-        {showActivity && tabButton('activity', 'Activity', hasNew)}
+        {tabButton('activity', 'Activity', isSenior && hasNew)}
         {tabButton('plans', 'Plans')}
       </div>
 
@@ -80,9 +84,9 @@ export default function DashboardPage() {
         </div>
       )}
 
-      {showActivity && active === 'activity' && (
+      {active === 'activity' && (
         <div>
-          <PendingRequestWidget />
+          {isSenior ? <PendingRequestWidget /> : <p>No activity to display.</p>}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Guard pending-request polling behind session and employee checks so non-senior users never start the module
- Render badges and pending-request summaries only when a senior employee ID is present

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6dc20b12883319236777c9cab5bcc