### PR TITLE
feat: add audition tab and outgoing request widget

### DIFF
--- a/src/erp.mgt.mn/components/OutgoingRequestWidget.jsx
+++ b/src/erp.mgt.mn/components/OutgoingRequestWidget.jsx
@@ -1,0 +1,74 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext.jsx';
+
+export default function OutgoingRequestWidget() {
+  const { user } = useContext(AuthContext);
+  const navigate = useNavigate();
+  const [counts, setCounts] = useState({ pending: 0, accepted: 0, declined: 0 });
+
+  useEffect(() => {
+    if (!user?.empid) return;
+    let cancelled = false;
+    const statuses = ['pending', 'accepted', 'declined'];
+
+    async function fetchCounts() {
+      try {
+        const results = await Promise.all(
+          statuses.map(async (status) => {
+            const params = new URLSearchParams({
+              status,
+              requested_empid: user.empid,
+            });
+            const res = await fetch(`/api/pending_request?${params.toString()}`, {
+              credentials: 'include',
+              skipLoader: true,
+            });
+            if (!res.ok) return 0;
+            const data = await res.json().catch(() => 0);
+            if (typeof data === 'number') return data;
+            if (Array.isArray(data)) return data.length;
+            return Number(data?.count) || 0;
+          }),
+        );
+        if (!cancelled) {
+          setCounts({
+            pending: results[0],
+            accepted: results[1],
+            declined: results[2],
+          });
+        }
+      } catch {
+        if (!cancelled) {
+          setCounts({ pending: 0, accepted: 0, declined: 0 });
+        }
+      }
+    }
+
+    fetchCounts();
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.empid]);
+
+  return (
+    <div>
+      <h3>Outgoing requests</h3>
+      <div style={{ display: 'flex', gap: '1rem' }}>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: '0.9rem', color: '#555' }}>Pending</div>
+          <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>{counts.pending}</div>
+        </div>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: '0.9rem', color: '#555' }}>Accepted</div>
+          <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>{counts.accepted}</div>
+        </div>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: '0.9rem', color: '#555' }}>Declined</div>
+          <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>{counts.declined}</div>
+        </div>
+      </div>
+      <button onClick={() => navigate('/requests?mine=1')}>View requests</button>
+    </div>
+  );
+}

--- a/src/erp.mgt.mn/components/PendingRequestWidget.jsx
+++ b/src/erp.mgt.mn/components/PendingRequestWidget.jsx
@@ -29,17 +29,17 @@ export default function PendingRequestWidget() {
   return (
     <div>
       <h3>
-        Pending Requests
+        Incoming requests
         {count > 0 && <span style={badgeStyle}>{count}</span>}
       </h3>
       {count > 0 ? (
         <p>
-          {count} pending request{count === 1 ? '' : 's'}
+          {count} incoming request{count === 1 ? '' : 's'}
         </p>
       ) : (
-        <p>No pending requests</p>
+        <p>No incoming requests</p>
       )}
-      <button onClick={() => navigate('/requests')}>View Requests</button>
+      <button onClick={() => navigate('/requests')}>View requests</button>
     </div>
   );
 }

--- a/src/erp.mgt.mn/pages/DashboardPage.jsx
+++ b/src/erp.mgt.mn/pages/DashboardPage.jsx
@@ -1,6 +1,7 @@
 import React, { useContext, useState, useEffect } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
 import PendingRequestWidget from '../components/PendingRequestWidget.jsx';
+import OutgoingRequestWidget from '../components/OutgoingRequestWidget.jsx';
 import { usePendingRequests } from '../context/PendingRequestContext.jsx';
 
 export default function DashboardPage() {
@@ -14,7 +15,7 @@ export default function DashboardPage() {
   const isSenior = Boolean(seniorEmpId);
 
   useEffect(() => {
-    if (isSenior && active === 'activity') markSeen();
+    if (isSenior && active === 'audition') markSeen();
   }, [active, markSeen, isSenior]);
 
   const badgeStyle = {
@@ -57,7 +58,8 @@ export default function DashboardPage() {
     <div style={{ padding: '1rem' }}>
       <div style={{ display: 'flex', borderBottom: '1px solid #ddd', marginBottom: '1rem' }}>
         {tabButton('general', 'General')}
-        {tabButton('activity', 'Activity', isSenior && hasNew)}
+        {tabButton('activity', 'Activity')}
+        {tabButton('audition', 'Audition', isSenior && hasNew)}
         {tabButton('plans', 'Plans')}
       </div>
 
@@ -86,7 +88,20 @@ export default function DashboardPage() {
 
       {active === 'activity' && (
         <div>
-          {isSenior ? <PendingRequestWidget /> : <p>No activity to display.</p>}
+          <p>No activity to display.</p>
+        </div>
+      )}
+
+      {active === 'audition' && (
+        <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+          {isSenior && (
+            <div style={{ ...cardStyle, flex: '1 1 300px' }}>
+              <PendingRequestWidget />
+            </div>
+          )}
+          <div style={{ ...cardStyle, flex: '1 1 300px' }}>
+            <OutgoingRequestWidget />
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- add new "Audition" tab to dashboard housing incoming and outgoing requests
- rename PendingRequestWidget UI to "Incoming requests"
- implement OutgoingRequestWidget to show user's request counts and link to requests page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7124f36e48331bf2c324fb8746e34