### PR TITLE
Add outgoing pending request endpoint and frontend integration

### DIFF
--- a/api-server/routes/pending_request.js
+++ b/api-server/routes/pending_request.js
@@ -3,6 +3,7 @@ import { requireAuth } from '../middlewares/auth.js';
 import {
   createRequest,
   listRequests,
+  listRequestsByEmp,
   respondRequest,
   ALLOWED_REQUEST_TYPES,
 } from '../services/pendingRequest.js';
@@ -36,6 +37,21 @@ router.post('/', requireAuth, async (req, res, next) => {
     if (err.status === 400 && err.message === 'invalid table_name') {
       return res.status(400).json({ message: 'invalid table_name' });
     }
+    next(err);
+  }
+});
+
+router.get('/outgoing', requireAuth, async (req, res, next) => {
+  try {
+    const { status, table_name, date_from, date_to } = req.query;
+    const requests = await listRequestsByEmp(req.user.empid, {
+      status,
+      table_name,
+      date_from,
+      date_to,
+    });
+    res.json(requests);
+  } catch (err) {
     next(err);
   }
 });

--- a/api-server/services/pendingRequest.js
+++ b/api-server/services/pendingRequest.js
@@ -188,6 +188,19 @@ export async function listRequests(filters) {
   return result;
 }
 
+export async function listRequestsByEmp(
+  emp_id,
+  { status, table_name, date_from, date_to } = {},
+) {
+  return listRequests({
+    requested_empid: emp_id,
+    status,
+    table_name,
+    date_from,
+    date_to,
+  });
+}
+
 export async function respondRequest(
   id,
   responseEmpid,

--- a/src/erp.mgt.mn/components/OutgoingRequestWidget.jsx
+++ b/src/erp.mgt.mn/components/OutgoingRequestWidget.jsx
@@ -16,14 +16,14 @@ export default function OutgoingRequestWidget() {
       try {
         const results = await Promise.all(
           statuses.map(async (status) => {
-            const params = new URLSearchParams({
-              status,
-              requested_empid: user.empid,
-            });
-            const res = await fetch(`/api/pending_request?${params.toString()}`, {
-              credentials: 'include',
-              skipLoader: true,
-            });
+            const params = new URLSearchParams({ status });
+            const res = await fetch(
+              `/api/pending_request/outgoing?${params.toString()}`,
+              {
+                credentials: 'include',
+                skipLoader: true,
+              },
+            );
             if (!res.ok) return 0;
             const data = await res.json().catch(() => 0);
             if (typeof data === 'number') return data;

--- a/src/erp.mgt.mn/pages/Requests.jsx
+++ b/src/erp.mgt.mn/pages/Requests.jsx
@@ -254,15 +254,13 @@ export default function RequestsPage() {
       setOutgoingLoading(true);
       setOutgoingError(null);
       try {
-        const params = new URLSearchParams({
-          requested_empid: user.empid,
-        });
+        const params = new URLSearchParams();
         if (status) params.append('status', status);
         if (tableName) params.append('table_name', tableName);
         if (dateFrom) params.append('date_from', dateFrom);
         if (dateTo) params.append('date_to', dateTo);
         const res = await fetch(
-          `${API_BASE}/pending_request?${params.toString()}`,
+          `${API_BASE}/pending_request/outgoing?${params.toString()}`,
           { credentials: 'include' },
         );
         if (!res.ok) throw new Error('Failed to load requests');

--- a/tests/api/pendingRequest.test.js
+++ b/tests/api/pendingRequest.test.js
@@ -77,3 +77,16 @@ await test('listRequests matches status case-insensitively', async () => {
   assert.ok(queries[0].sql.includes('LOWER(TRIM(status)) = ?'));
   assert.deepEqual(queries[0].params, ['pending']);
 });
+
+await test('listRequestsByEmp filters by requester', async () => {
+  const origQuery = db.pool.query;
+  const queries = [];
+  db.pool.query = async (sql, params) => {
+    queries.push({ sql, params });
+    return [[]];
+  };
+  await service.listRequestsByEmp(' e1 ', { status: 'pending' });
+  db.pool.query = origQuery;
+  assert.ok(queries[0].sql.includes('UPPER(TRIM(emp_id)) = ?'));
+  assert.deepEqual(queries[0].params, ['pending', 'E1']);
+});


### PR DESCRIPTION
## Summary
- expose GET `/api/pending_request/outgoing` returning requests created by the authenticated employee
- add `listRequestsByEmp` service helper
- use new endpoint in OutgoingRequestWidget and Requests page
- cover new service with tests

## Testing
- `npm test` *(fails: renameImages handles images already in folder - ENOTEMPTY)*

------
https://chatgpt.com/codex/tasks/task_e_68a7162b177c8331892547493bcc1392