### PR TITLE
Expose pending request widget to all users

### DIFF
--- a/src/erp.mgt.mn/components/PendingRequestWidget.jsx
+++ b/src/erp.mgt.mn/components/PendingRequestWidget.jsx
@@ -1,19 +1,10 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { AuthContext } from '../context/AuthContext.jsx';
 import { usePendingRequests } from '../context/PendingRequestContext.jsx';
 
 export default function PendingRequestWidget() {
-  const { user, session } = useContext(AuthContext);
   const navigate = useNavigate();
-  const seniorEmpId =
-    session && user?.empid && !(Number(session.senior_empid) > 0)
-      ? user.empid
-      : null;
-  const isSenior = Boolean(seniorEmpId);
   const { count } = usePendingRequests();
-
-  if (!isSenior) return null;
 
   const badgeStyle = {
     display: 'inline-block',

--- a/src/erp.mgt.mn/pages/DashboardPage.jsx
+++ b/src/erp.mgt.mn/pages/DashboardPage.jsx
@@ -8,15 +8,10 @@ export default function DashboardPage() {
   const { user, session } = useContext(AuthContext);
   const { hasNew, markSeen } = usePendingRequests();
   const [active, setActive] = useState('general');
-  const seniorEmpId =
-    session && user?.empid && !(Number(session.senior_empid) > 0)
-      ? user.empid
-      : null;
-  const isSenior = Boolean(seniorEmpId);
 
   useEffect(() => {
-    if (isSenior && active === 'audition') markSeen();
-  }, [active, markSeen, isSenior]);
+    if (active === 'audition') markSeen();
+  }, [active, markSeen]);
 
   const badgeStyle = {
     background: 'red',
@@ -59,7 +54,7 @@ export default function DashboardPage() {
       <div style={{ display: 'flex', borderBottom: '1px solid #ddd', marginBottom: '1rem' }}>
         {tabButton('general', 'General')}
         {tabButton('activity', 'Activity')}
-        {tabButton('audition', 'Audition', isSenior && hasNew)}
+        {tabButton('audition', 'Audition', hasNew)}
         {tabButton('plans', 'Plans')}
       </div>
 
@@ -94,11 +89,9 @@ export default function DashboardPage() {
 
       {active === 'audition' && (
         <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
-          {isSenior && (
-            <div style={{ ...cardStyle, flex: '1 1 300px' }}>
-              <PendingRequestWidget />
-            </div>
-          )}
+          <div style={{ ...cardStyle, flex: '1 1 300px' }}>
+            <PendingRequestWidget />
+          </div>
           <div style={{ ...cardStyle, flex: '1 1 300px' }}>
             <OutgoingRequestWidget />
           </div>


### PR DESCRIPTION
## Summary
- Always render PendingRequestWidget, defaulting to zero pending requests when not a supervisor
- Show Audition tab badge and pending request widget on Dashboard for all users
- Remove senior-specific conditionals to support general user experience

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a723bd4ec48331aa617f58c74d7543