### PR TITLE
feat: notify on outgoing request changes

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -16,6 +16,7 @@ import Spinner from "./Spinner.jsx";
 import useHeaderMappings from "../hooks/useHeaderMappings.js";
 import usePendingRequestCount from "../hooks/usePendingRequestCount.js";
 import { PendingRequestContext } from "../context/PendingRequestContext.jsx";
+import useOutgoingRequestCount from "../hooks/useOutgoingRequestCount.js";
 
 /**
  * A desktop‐style “ERPLayout” with:
@@ -90,6 +91,18 @@ export default function ERPLayout() {
     markSeen: markPendingSeen,
   } = usePendingRequestCount(user?.empid);
 
+  const {
+    counts: outgoingCounts,
+    hasNew: outgoingHasNewObj,
+    markSeen: markOutgoingSeen,
+  } = useOutgoingRequestCount();
+
+  const outgoingHasNew =
+    outgoingHasNewObj.pending ||
+    outgoingHasNewObj.accepted ||
+    outgoingHasNewObj.declined;
+  const combinedHasNew = pendingHasNew || outgoingHasNew;
+
   useEffect(() => {
     const title = titleForPath(location.pathname);
     openTab({ key: location.pathname, label: title });
@@ -117,7 +130,19 @@ export default function ERPLayout() {
 
   return (
     <PendingRequestContext.Provider
-      value={{ count: pendingCount, hasNew: pendingHasNew, markSeen: markPendingSeen }}
+      value={{
+        count: pendingCount,
+        hasNew: combinedHasNew,
+        markSeen: () => {
+          markPendingSeen();
+          markOutgoingSeen();
+        },
+        outgoing: {
+          counts: outgoingCounts,
+          hasNew: outgoingHasNew,
+          markSeen: markOutgoingSeen,
+        },
+      }}
     >
       <div style={styles.container}>
         <Header

--- a/src/erp.mgt.mn/components/OutgoingRequestWidget.jsx
+++ b/src/erp.mgt.mn/components/OutgoingRequestWidget.jsx
@@ -1,56 +1,30 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import useOutgoingRequestCount from '../hooks/useOutgoingRequestCount.js';
 
 export default function OutgoingRequestWidget() {
   const navigate = useNavigate();
-  const [counts, setCounts] = useState({ pending: 0, accepted: 0, declined: 0 });
+  const { counts, hasNew } = useOutgoingRequestCount();
 
-  useEffect(() => {
-    let cancelled = false;
-    const statuses = ['pending', 'accepted', 'declined'];
+  const badgeStyle = {
+    display: 'inline-block',
+    backgroundColor: 'red',
+    color: 'white',
+    borderRadius: '50%',
+    padding: '0.25rem 0.5rem',
+    minWidth: '1.5rem',
+    textAlign: 'center',
+    marginLeft: '0.5rem',
+  };
 
-    async function fetchCounts() {
-      try {
-        const results = await Promise.all(
-          statuses.map(async (status) => {
-            const params = new URLSearchParams({ status });
-            const res = await fetch(
-              `/api/pending_request/outgoing?${params.toString()}`,
-              {
-                credentials: 'include',
-                skipLoader: true,
-              },
-            );
-            if (!res.ok) return 0;
-            const data = await res.json().catch(() => 0);
-            if (typeof data === 'number') return data;
-            if (Array.isArray(data)) return data.length;
-            return Number(data?.count) || 0;
-          }),
-        );
-        if (!cancelled) {
-          setCounts({
-            pending: results[0],
-            accepted: results[1],
-            declined: results[2],
-          });
-        }
-      } catch {
-        if (!cancelled) {
-          setCounts({ pending: 0, accepted: 0, declined: 0 });
-        }
-      }
-    }
-
-    fetchCounts();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  const anyNew = hasNew.pending || hasNew.accepted || hasNew.declined;
 
   return (
     <div>
-      <h3>Outgoing requests</h3>
+      <h3>
+        Outgoing requests
+        {anyNew && <span style={badgeStyle}>!</span>}
+      </h3>
       <div style={{ display: 'flex', gap: '1rem' }}>
         <div style={{ flex: 1 }}>
           <div style={{ fontSize: '0.9rem', color: '#555' }}>Pending</div>

--- a/src/erp.mgt.mn/context/PendingRequestContext.jsx
+++ b/src/erp.mgt.mn/context/PendingRequestContext.jsx
@@ -4,6 +4,11 @@ export const PendingRequestContext = createContext({
   count: 0,
   hasNew: false,
   markSeen: () => {},
+  outgoing: {
+    counts: { pending: 0, accepted: 0, declined: 0 },
+    hasNew: false,
+    markSeen: () => {},
+  },
 });
 
 export function usePendingRequests() {

--- a/src/erp.mgt.mn/hooks/useOutgoingRequestCount.js
+++ b/src/erp.mgt.mn/hooks/useOutgoingRequestCount.js
@@ -1,0 +1,94 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Polls the outgoing request endpoint and returns counts for each status.
+ * Tracks "seen" counts in localStorage per status and exposes whether
+ * new updates exist for any category. A seen count is stored under keys
+ * `outgoingSeen_<status>`.
+ *
+ * @param {number} [interval=30000] Polling interval in milliseconds
+ * @returns {{counts:object, hasNew:object, markSeen:(status?:string)=>void}}
+ */
+export default function useOutgoingRequestCount(interval = 30000) {
+  const statuses = ['pending', 'accepted', 'declined'];
+  const [counts, setCounts] = useState({ pending: 0, accepted: 0, declined: 0 });
+  const [hasNew, setHasNew] = useState({ pending: false, accepted: false, declined: false });
+
+  const markSeen = (status) => {
+    const update = (s) => {
+      localStorage.setItem(`outgoingSeen_${s}`, String(counts[s] || 0));
+    };
+    if (status) update(status);
+    else statuses.forEach(update);
+    setHasNew((prev) => ({
+      pending: status && status !== 'pending' ? prev.pending : false,
+      accepted: status && status !== 'accepted' ? prev.accepted : false,
+      declined: status && status !== 'declined' ? prev.declined : false,
+    }));
+    window.dispatchEvent(new Event('outgoing-request-seen'));
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchCounts() {
+      try {
+        const results = await Promise.all(
+          statuses.map(async (status) => {
+            const params = new URLSearchParams({ status });
+            const res = await fetch(`/api/pending_request/outgoing?${params.toString()}`, {
+              credentials: 'include',
+              skipLoader: true,
+            });
+            if (!res.ok) return 0;
+            const data = await res.json().catch(() => 0);
+            if (typeof data === 'number') return data;
+            if (Array.isArray(data)) return data.length;
+            return Number(data?.count) || 0;
+          }),
+        );
+        if (!cancelled) {
+          const newCounts = { pending: results[0], accepted: results[1], declined: results[2] };
+          setCounts(newCounts);
+          const newHasNew = {
+            pending: newCounts.pending > Number(localStorage.getItem('outgoingSeen_pending') || 0),
+            accepted: newCounts.accepted > Number(localStorage.getItem('outgoingSeen_accepted') || 0),
+            declined: newCounts.declined > Number(localStorage.getItem('outgoingSeen_declined') || 0),
+          };
+          setHasNew(newHasNew);
+          if (Object.values(newHasNew).some(Boolean)) {
+            window.dispatchEvent(new Event('outgoing-request-new'));
+          }
+        }
+      } catch {
+        if (!cancelled) {
+          setCounts({ pending: 0, accepted: 0, declined: 0 });
+          setHasNew({ pending: false, accepted: false, declined: false });
+        }
+      }
+    }
+
+    fetchCounts();
+    const timer = setInterval(fetchCounts, interval);
+
+    function handleSeen() {
+      setHasNew({
+        pending: counts.pending > Number(localStorage.getItem('outgoingSeen_pending') || 0),
+        accepted: counts.accepted > Number(localStorage.getItem('outgoingSeen_accepted') || 0),
+        declined: counts.declined > Number(localStorage.getItem('outgoingSeen_declined') || 0),
+      });
+    }
+
+    window.addEventListener('outgoing-request-refresh', fetchCounts);
+    window.addEventListener('outgoing-request-seen', handleSeen);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+      window.removeEventListener('outgoing-request-refresh', fetchCounts);
+      window.removeEventListener('outgoing-request-seen', handleSeen);
+    };
+  }, [interval, counts.pending, counts.accepted, counts.declined]);
+
+  return { counts, hasNew, markSeen };
+}
+


### PR DESCRIPTION
## Summary
- poll outgoing request counts and track seen values
- show badge for new outgoing updates
- surface outgoing request notifications across dashboard

## Testing
- `npm test` *(fails: ENOTEMPTY: directory not empty, rmdir '/workspace/erp-web-next/uploads/txn_images')*


------
https://chatgpt.com/codex/tasks/task_e_68a72d93409883319318a9091549790c