### PR TITLE
Remove senior-specific checks from pending request routes

### DIFF
--- a/api-server/routes/pending_request.js
+++ b/api-server/routes/pending_request.js
@@ -7,14 +7,11 @@ import {
   respondRequest,
   ALLOWED_REQUEST_TYPES,
 } from '../services/pendingRequest.js';
-import { getEmploymentSession, pool } from '../../db/index.js';
 
 const router = express.Router();
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {
-    const session = await getEmploymentSession(req.user.empid, req.user.companyId);
-    if (!session?.permissions?.edit_delete_request) return res.sendStatus(403);
     const { table_name, record_id, request_type, proposed_data } = req.body;
     if (!table_name || !record_id || !request_type) {
       return res
@@ -43,14 +40,6 @@ router.post('/', requireAuth, async (req, res, next) => {
 
 router.get('/outgoing', requireAuth, async (req, res, next) => {
   try {
-    const session = await getEmploymentSession(
-      req.user.empid,
-      req.user.companyId,
-    );
-    if (!session?.permissions?.edit_delete_request) {
-      return res.sendStatus(403);
-    }
-
     const { status, table_name, date_from, date_to } = req.query;
     const requests = await listRequestsByEmp(req.user.empid, {
       status,
@@ -68,18 +57,8 @@ router.get('/', requireAuth, async (req, res, next) => {
   try {
     const { status, requested_empid, table_name, date_from, date_to } = req.query;
 
-    const empid = String(req.user.empid).trim().toUpperCase();
-    const [rows] = await pool.query(
-      'SELECT 1 FROM tbl_employment WHERE UPPER(TRIM(employment_senior_empid)) = ? LIMIT 1',
-      [empid],
-    );
-    if (rows.length === 0) {
-      return res.sendStatus(403);
-    }
-
     const requests = await listRequests({
       status,
-      senior_empid: empid,
       requested_empid,
       table_name,
       date_from,


### PR DESCRIPTION
## Summary
- Allow authenticated users to create pending requests without `edit_delete_request` permission
- Allow outgoing pending request listings without `edit_delete_request` permission
- Remove senior-only filtering from pending request listings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7377297488331a7da73c78bce5a68