### PR TITLE
Allow related users to manage pending requests

### DIFF
--- a/api-server/routes/pending_request.js
+++ b/api-server/routes/pending_request.js
@@ -7,14 +7,12 @@ import {
   respondRequest,
   ALLOWED_REQUEST_TYPES,
 } from '../services/pendingRequest.js';
-import { getEmploymentSession, pool } from '../../db/index.js';
+
 
 const router = express.Router();
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {
-    const session = await getEmploymentSession(req.user.empid, req.user.companyId);
-    if (!session?.permissions?.edit_delete_request) return res.sendStatus(403);
     const { table_name, record_id, request_type, proposed_data } = req.body;
     if (!table_name || !record_id || !request_type) {
       return res
@@ -43,14 +41,6 @@ router.post('/', requireAuth, async (req, res, next) => {
 
 router.get('/outgoing', requireAuth, async (req, res, next) => {
   try {
-    const session = await getEmploymentSession(
-      req.user.empid,
-      req.user.companyId,
-    );
-    if (!session?.permissions?.edit_delete_request) {
-      return res.sendStatus(403);
-    }
-
     const { status, table_name, date_from, date_to } = req.query;
     const requests = await listRequestsByEmp(req.user.empid, {
       status,
@@ -69,13 +59,6 @@ router.get('/', requireAuth, async (req, res, next) => {
     const { status, requested_empid, table_name, date_from, date_to } = req.query;
 
     const empid = String(req.user.empid).trim().toUpperCase();
-    const [rows] = await pool.query(
-      'SELECT 1 FROM tbl_employment WHERE UPPER(TRIM(employment_senior_empid)) = ? LIMIT 1',
-      [empid],
-    );
-    if (rows.length === 0) {
-      return res.sendStatus(403);
-    }
 
     const requests = await listRequests({
       status,

--- a/api-server/services/pendingRequest.js
+++ b/api-server/services/pendingRequest.js
@@ -216,10 +216,12 @@ export async function respondRequest(
     );
     const req = rows[0];
     if (!req) throw new Error('Request not found');
-    if (
-      String(req.senior_empid).trim().toUpperCase() !==
-      String(responseEmpid).trim().toUpperCase()
-    )
+    const responder = String(responseEmpid).trim().toUpperCase();
+    const senior = req.senior_empid
+      ? String(req.senior_empid).trim().toUpperCase()
+      : null;
+    const requester = String(req.emp_id).trim().toUpperCase();
+    if (responder !== requester && responder !== senior)
       throw new Error('Forbidden');
 
     if (status === 'accepted') {


### PR DESCRIPTION
## Summary
- Permit any authenticated user to create pending requests and view their own incoming/outgoing requests
- Relax pending request response checks to allow either requester or senior to respond
- Restore uploads placeholder files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a73c73b6a08331bd669fe5253221ce