### PR TITLE
feat: real-time request notifications

### DIFF
--- a/src/erp.mgt.mn/components/HeaderMenu.jsx
+++ b/src/erp.mgt.mn/components/HeaderMenu.jsx
@@ -23,6 +23,15 @@ export default function HeaderMenu({ onOpen }) {
     moduleMap[m.module_key] = m;
   });
 
+  const badgeKeys = new Set();
+  if (hasNew && moduleMap['requests']) {
+    let cur = moduleMap['requests'];
+    while (cur) {
+      badgeKeys.add(cur.module_key);
+      cur = cur.parent_key ? moduleMap[cur.parent_key] : null;
+    }
+  }
+
   if (!perms) return null;
 
   return (
@@ -41,9 +50,7 @@ export default function HeaderMenu({ onOpen }) {
               onOpen(modulePath(m, moduleMap), label, m.module_key)
             }
           >
-            {m.module_key === 'dashboard' && hasNew && (
-              <span style={styles.badge} />
-            )}
+            {badgeKeys.has(m.module_key) && <span style={styles.badge} />}
             {label}
           </button>
         );

--- a/src/erp.mgt.mn/components/OutgoingRequestWidget.jsx
+++ b/src/erp.mgt.mn/components/OutgoingRequestWidget.jsx
@@ -1,52 +1,15 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { usePendingRequests } from '../context/PendingRequestContext.jsx';
 
 export default function OutgoingRequestWidget() {
   const navigate = useNavigate();
-  const [counts, setCounts] = useState({ pending: 0, accepted: 0, declined: 0 });
-
-  useEffect(() => {
-    let cancelled = false;
-    const statuses = ['pending', 'accepted', 'declined'];
-
-    async function fetchCounts() {
-      try {
-        const results = await Promise.all(
-          statuses.map(async (status) => {
-            const params = new URLSearchParams({ status });
-            const res = await fetch(
-              `/api/pending_request/outgoing?${params.toString()}`,
-              {
-                credentials: 'include',
-                skipLoader: true,
-              },
-            );
-            if (!res.ok) return 0;
-            const data = await res.json().catch(() => 0);
-            if (typeof data === 'number') return data;
-            if (Array.isArray(data)) return data.length;
-            return Number(data?.count) || 0;
-          }),
-        );
-        if (!cancelled) {
-          setCounts({
-            pending: results[0],
-            accepted: results[1],
-            declined: results[2],
-          });
-        }
-      } catch {
-        if (!cancelled) {
-          setCounts({ pending: 0, accepted: 0, declined: 0 });
-        }
-      }
-    }
-
-    fetchCounts();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  const { outgoing } = usePendingRequests();
+  const counts = {
+    pending: outgoing.pending.count,
+    accepted: outgoing.accepted.count,
+    declined: outgoing.declined.count,
+  };
 
   return (
     <div>

--- a/src/erp.mgt.mn/components/PendingRequestWidget.jsx
+++ b/src/erp.mgt.mn/components/PendingRequestWidget.jsx
@@ -4,7 +4,8 @@ import { usePendingRequests } from '../context/PendingRequestContext.jsx';
 
 export default function PendingRequestWidget() {
   const navigate = useNavigate();
-  const { count } = usePendingRequests();
+  const { incoming } = usePendingRequests();
+  const count = incoming.pending.count;
 
   const badgeStyle = {
     display: 'inline-block',

--- a/src/erp.mgt.mn/context/PendingRequestContext.jsx
+++ b/src/erp.mgt.mn/context/PendingRequestContext.jsx
@@ -1,7 +1,18 @@
 import { createContext, useContext } from 'react';
 
+const defaultStatus = { count: 0, hasNew: false };
+
 export const PendingRequestContext = createContext({
-  count: 0,
+  incoming: {
+    pending: defaultStatus,
+    accepted: defaultStatus,
+    declined: defaultStatus,
+  },
+  outgoing: {
+    pending: defaultStatus,
+    accepted: defaultStatus,
+    declined: defaultStatus,
+  },
   hasNew: false,
   markSeen: () => {},
 });

--- a/src/erp.mgt.mn/hooks/useRequestNotificationCounts.js
+++ b/src/erp.mgt.mn/hooks/useRequestNotificationCounts.js
@@ -1,0 +1,127 @@
+import { useEffect, useState, useCallback } from 'react';
+
+const STATUSES = ['pending', 'accepted', 'declined'];
+
+function createInitial() {
+  return {
+    pending: { count: 0, hasNew: false },
+    accepted: { count: 0, hasNew: false },
+    declined: { count: 0, hasNew: false },
+  };
+}
+
+export default function useRequestNotificationCounts(
+  seniorEmpId,
+  filters = {},
+  interval = 30000,
+) {
+  const [incoming, setIncoming] = useState(createInitial);
+  const [outgoing, setOutgoing] = useState(createInitial);
+
+  const markSeen = useCallback(() => {
+    setIncoming((prev) => {
+      const next = { ...prev };
+      STATUSES.forEach((s) => {
+        localStorage.setItem(`incoming-${s}-seen`, String(prev[s].count));
+        next[s] = { ...prev[s], hasNew: false };
+      });
+      return next;
+    });
+    setOutgoing((prev) => {
+      const next = { ...prev };
+      STATUSES.forEach((s) => {
+        localStorage.setItem(`outgoing-${s}-seen`, String(prev[s].count));
+        next[s] = { ...prev[s], hasNew: false };
+      });
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchCounts() {
+      const newIncoming = createInitial();
+      const newOutgoing = createInitial();
+
+      await Promise.all(
+        STATUSES.map(async (status) => {
+          // Incoming requests (for seniors)
+          if (seniorEmpId) {
+            try {
+              const params = new URLSearchParams({
+                status,
+                senior_empid: String(seniorEmpId),
+              });
+              Object.entries(filters).forEach(([k, v]) => {
+                if (v !== undefined && v !== null && v !== '') {
+                  params.append(k, v);
+                }
+              });
+              const res = await fetch(
+                `/api/pending_request?${params.toString()}`,
+                { credentials: 'include', skipLoader: true },
+              );
+              let c = 0;
+              if (res.ok) {
+                const data = await res.json().catch(() => 0);
+                if (typeof data === 'number') c = data;
+                else if (Array.isArray(data)) c = data.length;
+                else c = Number(data?.count) || 0;
+              }
+              const seen = Number(
+                localStorage.getItem(`incoming-${status}-seen`) || 0,
+              );
+              newIncoming[status] = { count: c, hasNew: c > seen };
+            } catch {
+              newIncoming[status] = { count: 0, hasNew: false };
+            }
+          } else {
+            newIncoming[status] = { count: 0, hasNew: false };
+          }
+
+          // Outgoing requests (always for current user)
+          try {
+            const params = new URLSearchParams({ status });
+            const res = await fetch(
+              `/api/pending_request/outgoing?${params.toString()}`,
+              { credentials: 'include', skipLoader: true },
+            );
+            let c = 0;
+            if (res.ok) {
+              const data = await res.json().catch(() => 0);
+              if (typeof data === 'number') c = data;
+              else if (Array.isArray(data)) c = data.length;
+              else c = Number(data?.count) || 0;
+            }
+            const seen = Number(
+              localStorage.getItem(`outgoing-${status}-seen`) || 0,
+            );
+            newOutgoing[status] = { count: c, hasNew: c > seen };
+          } catch {
+            newOutgoing[status] = { count: 0, hasNew: false };
+          }
+        }),
+      );
+
+      if (!cancelled) {
+        setIncoming(newIncoming);
+        setOutgoing(newOutgoing);
+      }
+    }
+
+    fetchCounts();
+    const timer = setInterval(fetchCounts, interval);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [seniorEmpId, interval, filters]);
+
+  const hasNew =
+    STATUSES.some((s) => incoming[s].hasNew) ||
+    STATUSES.some((s) => outgoing[s].hasNew);
+
+  return { incoming, outgoing, hasNew, markSeen };
+}
+


### PR DESCRIPTION
## Summary
- poll incoming and outgoing request endpoints with new `useRequestNotificationCounts` hook
- surface live request counts throughout layout and widgets
- display red badges for request updates in header and sidebar
- fix incoming requests tab to show counts and avoid hanging requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a73e7f024c8331b67f4f0d862160b7