### PR TITLE
Add response notification API and hooks

### DIFF
--- a/api-server/app.js
+++ b/api-server/app.js
@@ -22,6 +22,7 @@ import codingTableConfigRoutes from "./routes/coding_table_configs.js";
 import generatedSqlRoutes from "./routes/generated_sql.js";
 import generalConfigRoutes from "./routes/general_config.js";
 import permissionsRoutes from "./routes/permissions.js";
+import notificationRoutes from "./routes/notifications.js";
 import { getGeneralConfig } from "./services/generalConfig.js";
 
 // Polyfill for __dirname in ES modules
@@ -82,6 +83,7 @@ app.use("/api/coding_table_configs", codingTableConfigRoutes);
 app.use("/api/generated_sql", generatedSqlRoutes);
 app.use("/api/general_config", generalConfigRoutes);
 app.use("/api/permissions", permissionsRoutes);
+app.use("/api/notifications", notificationRoutes);
 
 // Serve static React build and fallback to index.html
 // NOTE: adjust this path to where your SPA build actually lives.

--- a/api-server/routes/notifications.js
+++ b/api-server/routes/notifications.js
@@ -1,0 +1,29 @@
+import express from 'express';
+import { requireAuth } from '../middlewares/auth.js';
+import {
+  getUnreadResponseNotifications,
+  markNotificationsRead,
+} from '../services/notificationService.js';
+
+const router = express.Router();
+
+router.get('/', requireAuth, async (req, res, next) => {
+  try {
+    const rows = await getUnreadResponseNotifications(req.user.empid);
+    res.json(rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/mark-seen', requireAuth, async (req, res, next) => {
+  try {
+    const ids = Array.isArray(req.body?.ids) ? req.body.ids : [];
+    await markNotificationsRead(req.user.empid, ids);
+    res.json({ success: true });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/api-server/services/notificationService.js
+++ b/api-server/services/notificationService.js
@@ -1,0 +1,29 @@
+import { pool } from '../../db/index.js';
+
+export async function getUnreadResponseNotifications(empid) {
+  const [rows] = await pool.query(
+    `SELECT n.notification_id, n.related_id AS request_id, n.message, pr.status, n.created_at
+     FROM notifications n
+     JOIN pending_request pr ON pr.request_id = n.related_id
+     WHERE n.recipient_empid = ? AND n.type = 'response' AND n.is_read = 0
+     ORDER BY n.created_at DESC`,
+    [empid]
+  );
+  return rows;
+}
+
+export async function markNotificationsRead(empid, ids = []) {
+  if (ids.length === 0) {
+    await pool.query(
+      `UPDATE notifications SET is_read = 1
+       WHERE recipient_empid = ? AND type = 'response' AND is_read = 0`,
+      [empid]
+    );
+  } else {
+    await pool.query(
+      `UPDATE notifications SET is_read = 1
+       WHERE recipient_empid = ? AND notification_id IN (?)`,
+      [empid, ids]
+    );
+  }
+}

--- a/src/erp.mgt.mn/components/OutgoingRequestWidget.jsx
+++ b/src/erp.mgt.mn/components/OutgoingRequestWidget.jsx
@@ -1,15 +1,26 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { usePendingRequests } from '../context/PendingRequestContext.jsx';
+import useResponseNotifications from '../hooks/useResponseNotifications.js';
 
 export default function OutgoingRequestWidget() {
   const navigate = useNavigate();
-  const { outgoing } = usePendingRequests();
+  const { outgoing, markSeen: markCountsSeen } = usePendingRequests();
+  const {
+    counts: responseCounts,
+    markSeen: markResponsesSeen,
+  } = useResponseNotifications();
   const counts = {
     pending: outgoing.pending.count,
     accepted: outgoing.accepted.count,
     declined: outgoing.declined.count,
   };
+
+  function handleView() {
+    markCountsSeen();
+    markResponsesSeen();
+    navigate('/requests?mine=1');
+  }
 
   return (
     <div>
@@ -19,16 +30,48 @@ export default function OutgoingRequestWidget() {
           <div style={{ fontSize: '0.9rem', color: '#555' }}>Pending</div>
           <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>{counts.pending}</div>
         </div>
-        <div style={{ flex: 1 }}>
+        <div style={{ flex: 1, position: 'relative' }}>
           <div style={{ fontSize: '0.9rem', color: '#555' }}>Accepted</div>
           <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>{counts.accepted}</div>
+          {responseCounts.accepted > 0 && (
+            <span
+              style={{
+                position: 'absolute',
+                top: 0,
+                right: 0,
+                background: 'red',
+                color: '#fff',
+                borderRadius: '50%',
+                padding: '0 4px',
+                fontSize: '0.75rem',
+              }}
+            >
+              {responseCounts.accepted}
+            </span>
+          )}
         </div>
-        <div style={{ flex: 1 }}>
+        <div style={{ flex: 1, position: 'relative' }}>
           <div style={{ fontSize: '0.9rem', color: '#555' }}>Declined</div>
           <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>{counts.declined}</div>
+          {responseCounts.declined > 0 && (
+            <span
+              style={{
+                position: 'absolute',
+                top: 0,
+                right: 0,
+                background: 'red',
+                color: '#fff',
+                borderRadius: '50%',
+                padding: '0 4px',
+                fontSize: '0.75rem',
+              }}
+            >
+              {responseCounts.declined}
+            </span>
+          )}
         </div>
       </div>
-      <button onClick={() => navigate('/requests?mine=1')}>View requests</button>
+      <button onClick={handleView}>View requests</button>
     </div>
   );
 }

--- a/src/erp.mgt.mn/hooks/useResponseNotifications.js
+++ b/src/erp.mgt.mn/hooks/useResponseNotifications.js
@@ -1,0 +1,50 @@
+import { useEffect, useState, useCallback } from 'react';
+
+export default function useResponseNotifications(interval = 30000) {
+  const [notifications, setNotifications] = useState([]);
+  const [counts, setCounts] = useState({ accepted: 0, declined: 0 });
+  const [hasNew, setHasNew] = useState(false);
+
+  const markSeen = useCallback(async () => {
+    const ids = notifications.map((n) => n.notification_id);
+    try {
+      await fetch('/api/notifications/mark-seen', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids }),
+      });
+    } catch {}
+    setNotifications([]);
+    setCounts({ accepted: 0, declined: 0 });
+    setHasNew(false);
+  }, [notifications]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchNotifications() {
+      try {
+        const res = await fetch('/api/notifications', {
+          credentials: 'include',
+          skipLoader: true,
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        if (cancelled) return;
+        setNotifications(data);
+        const acc = data.filter((n) => n.status === 'accepted').length;
+        const dec = data.filter((n) => n.status === 'declined').length;
+        setCounts({ accepted: acc, declined: dec });
+        setHasNew(data.length > 0);
+      } catch {}
+    }
+    fetchNotifications();
+    const timer = setInterval(fetchNotifications, interval);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [interval]);
+
+  return { notifications, counts, hasNew, markSeen };
+}

--- a/src/erp.mgt.mn/pages/Requests.jsx
+++ b/src/erp.mgt.mn/pages/Requests.jsx
@@ -7,6 +7,7 @@ import { debugLog } from '../utils/debug.js';
 import useHeaderMappings from '../hooks/useHeaderMappings.js';
 import { translateToMn } from '../utils/translateToMn.js';
 import { usePendingRequests } from '../context/PendingRequestContext.jsx';
+import useResponseNotifications from '../hooks/useResponseNotifications.js';
 
 function ch(n) {
   return Math.round(n * 8);
@@ -54,6 +55,7 @@ export default function RequestsPage() {
   const { user, session } = useAuth();
   const { incoming: incomingCounts, outgoing: outgoingCounts, markSeen } =
     usePendingRequests();
+  const { markSeen: markResponsesSeen } = useResponseNotifications();
 
   const seniorEmpId =
     session && user?.empid && !(Number(session.senior_empid) > 0)
@@ -198,6 +200,11 @@ export default function RequestsPage() {
       }),
     );
   }
+
+  useEffect(() => {
+    markSeen();
+    markResponsesSeen();
+  }, [markSeen, markResponsesSeen]);
 
   useEffect(() => {
     if (activeTab !== 'incoming' || !seniorEmpId) return;
@@ -477,6 +484,23 @@ export default function RequestsPage() {
           >
             <h4>
               {req.table_name} #{req.record_id} ({req.request_type})
+              {requestStatus && (
+                <span
+                  style={{
+                    marginLeft: '0.5em',
+                    fontWeight: 'bold',
+                    color:
+                      requestStatus === 'accepted'
+                        ? 'green'
+                        : requestStatus === 'declined'
+                        ? 'red'
+                        : '#555',
+                  }}
+                >
+                  {requestStatus.charAt(0).toUpperCase() +
+                    requestStatus.slice(1)}
+                </span>
+              )}
             </h4>
             <table
               style={{ width: '100%', borderCollapse: 'collapse' }}


### PR DESCRIPTION
## Summary
- add `/api/notifications` endpoint to fetch and mark unread request responses
- poll response notifications in a new `useResponseNotifications` hook
- show unread response badges in OutgoingRequestWidget and mark notifications seen on Requests page

## Testing
- `npm test` *(fails: deleteImageMovesFile moves file test)*

------
https://chatgpt.com/codex/tasks/task_e_68a74d9068d0833196c580470574b65e