### PR TITLE
feat: improve request notifications for requesters

### DIFF
--- a/src/erp.mgt.mn/components/OutgoingRequestWidget.jsx
+++ b/src/erp.mgt.mn/components/OutgoingRequestWidget.jsx
@@ -5,10 +5,15 @@ import { usePendingRequests } from '../context/PendingRequestContext.jsx';
 export default function OutgoingRequestWidget() {
   const navigate = useNavigate();
   const { outgoing } = usePendingRequests();
-  const counts = {
-    pending: outgoing.pending.count,
-    accepted: outgoing.accepted.count,
-    declined: outgoing.declined.count,
+
+  const badgeStyle = {
+    display: 'inline-block',
+    backgroundColor: 'red',
+    color: 'white',
+    borderRadius: '50%',
+    padding: '0 0.4rem',
+    fontSize: '0.8rem',
+    marginLeft: '0.25rem',
   };
 
   return (
@@ -17,18 +22,36 @@ export default function OutgoingRequestWidget() {
       <div style={{ display: 'flex', gap: '1rem' }}>
         <div style={{ flex: 1 }}>
           <div style={{ fontSize: '0.9rem', color: '#555' }}>Pending</div>
-          <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>{counts.pending}</div>
+          <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>
+            {outgoing.pending.count}
+          </div>
         </div>
         <div style={{ flex: 1 }}>
-          <div style={{ fontSize: '0.9rem', color: '#555' }}>Accepted</div>
-          <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>{counts.accepted}</div>
+          <div style={{ fontSize: '0.9rem', color: '#555' }}>
+            Accepted
+            {outgoing.accepted.hasNew && (
+              <span style={badgeStyle}>{outgoing.accepted.count}</span>
+            )}
+          </div>
+          <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>
+            {outgoing.accepted.count}
+          </div>
         </div>
         <div style={{ flex: 1 }}>
-          <div style={{ fontSize: '0.9rem', color: '#555' }}>Declined</div>
-          <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>{counts.declined}</div>
+          <div style={{ fontSize: '0.9rem', color: '#555' }}>
+            Declined
+            {outgoing.declined.hasNew && (
+              <span style={badgeStyle}>{outgoing.declined.count}</span>
+            )}
+          </div>
+          <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>
+            {outgoing.declined.count}
+          </div>
         </div>
       </div>
-      <button onClick={() => navigate('/requests?mine=1')}>View requests</button>
+      <button onClick={() => navigate('/requests?tab=outgoing')}>
+        View requests
+      </button>
     </div>
   );
 }

--- a/src/erp.mgt.mn/components/PendingRequestWidget.jsx
+++ b/src/erp.mgt.mn/components/PendingRequestWidget.jsx
@@ -31,7 +31,9 @@ export default function PendingRequestWidget() {
       ) : (
         <p>No incoming requests</p>
       )}
-      <button onClick={() => navigate('/requests')}>View requests</button>
+      <button onClick={() => navigate('/requests?tab=incoming')}>
+        View requests
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show badge counts for accepted/declined requests and drop new-request badges for requesters
- allow widgets to open the correct request tab via URL params
- add refresh buttons and URL sync for request pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a73ba903548331af06532749f9d5b7