### PR TITLE
feat: push pending request notifications over Socket.IO

### DIFF
--- a/api-server/routes/pending_request.js
+++ b/api-server/routes/pending_request.js
@@ -30,6 +30,15 @@ router.post('/', requireAuth, async (req, res, next) => {
       requestType: request_type,
       proposedData: proposed_data,
     });
+    const io = req.app.get('io');
+    if (io && result.senior_empid) {
+      io.to(`user:${result.senior_empid}`).emit('newRequest', {
+        requestId: result.request_id,
+        tableName: table_name,
+        recordId: record_id,
+        requestType: request_type,
+      });
+    }
     res.status(201).json(result);
   } catch (err) {
     if (err.status === 400 && err.message === 'invalid table_name') {

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,22 @@
+# Push-based Notifications
+
+The application now uses [Socket.IO](https://socket.io/) to deliver request
+notifications in real time.
+
+## Server
+
+The Express API attaches a Socket.IO server that authenticates each connection
+using the same JWT cookie as the REST routes. Every socket joins a room keyed by
+`empid` (e.g. `user:EMP001`). When a new pending request is created the API
+emits a `newRequest` event to the relevant room so only the affected user
+receives the update.
+
+## Client
+
+React hooks connect to the Socket.IO server on mount and listen for
+`newRequest` events. Counts and badges update immediately when events arrive.
+If the WebSocket connection cannot be established the hooks fall back to the
+previous polling behaviour.
+
+Set the WebSocket endpoint with the `VITE_SOCKET_URL` environment variable. If
+undefined the client connects to the same origin as the page.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "openai": "^4.24.0",
     "react-mosaic-component": "^6.0.0",
     "sharp": "^0.33.2",
+    "socket.io": "^4.7.5",
+    "socket.io-client": "^4.7.5",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {

--- a/src/erp.mgt.mn/utils/socket.js
+++ b/src/erp.mgt.mn/utils/socket.js
@@ -1,0 +1,6 @@
+import { io } from 'socket.io-client';
+
+export function connectSocket() {
+  const url = import.meta.env.VITE_SOCKET_URL || '';
+  return io(url, { withCredentials: true });
+}


### PR DESCRIPTION
## Summary
- remove aggressive polling hooks for pending request counts
- attach authenticated Socket.IO server and emit `newRequest` events
- add client socket helpers and documentation for push notifications

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a829e6bba08331939a1d13813bf200