### PR TITLE
Stop polling when socket reconnects

### DIFF
--- a/src/erp.mgt.mn/hooks/usePendingRequestCount.js
+++ b/src/erp.mgt.mn/hooks/usePendingRequestCount.js
@@ -84,6 +84,12 @@ export default function usePendingRequestCount(
     try {
       socket = connectSocket();
       socket.on('newRequest', fetchCount);
+      socket.on('connect', () => {
+        if (timer) {
+          clearInterval(timer);
+          timer = undefined;
+        }
+      });
       socket.on('connect_error', startPolling);
       socket.on('disconnect', startPolling);
     } catch {

--- a/src/erp.mgt.mn/hooks/useRequestNotificationCounts.js
+++ b/src/erp.mgt.mn/hooks/useRequestNotificationCounts.js
@@ -130,6 +130,12 @@ export default function useRequestNotificationCounts(
     try {
       socket = connectSocket();
       socket.on('newRequest', fetchCounts);
+      socket.on('connect', () => {
+        if (timer) {
+          clearInterval(timer);
+          timer = undefined;
+        }
+      });
       socket.on('connect_error', startPolling);
       socket.on('disconnect', startPolling);
     } catch {


### PR DESCRIPTION
## Summary
- Clear polling timers when the socket connects to prevent duplicate intervals
- Restart polling only after subsequent disconnects or connection errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a82f236e3c8331b547760f7738228a