### PR TITLE
refactor: share socket connection across hooks

### DIFF
--- a/src/erp.mgt.mn/utils/socket.js
+++ b/src/erp.mgt.mn/utils/socket.js
@@ -1,6 +1,28 @@
 import { io } from 'socket.io-client';
 
+/**
+ * Module-level socket connection shared across hooks.
+ * Reference counting ensures the underlying connection
+ * is closed only when no consumers remain.
+ */
+let socket;
+let refCount = 0;
+
 export function connectSocket() {
-  const url = import.meta.env.VITE_SOCKET_URL || '';
-  return io(url, { withCredentials: true });
+  if (!socket) {
+    const url = import.meta.env.VITE_SOCKET_URL || '';
+    socket = io(url, { withCredentials: true });
+  }
+  refCount += 1;
+  return socket;
+}
+
+export function disconnectSocket() {
+  if (refCount > 0) {
+    refCount -= 1;
+    if (refCount === 0 && socket) {
+      socket.disconnect();
+      socket = undefined;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- refactor socket util to maintain a shared connection with reference counting
- update pending request hooks to reuse the singleton connection and clean up listeners

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a83119a9288331980670485ae01ae7