### PR TITLE
Preserve notification counts across logout

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -28,7 +28,6 @@ undefined the client connects to the same origin as the page.
 
 Hooks that track notification counts store "seen" markers in `localStorage`
 using a key that includes the employee ID and ends with `-seen`, for example
-`${empid}-incoming-pending-seen`. The `logout()` helper and the AuthContext's
-`auth:logout` handler remove any entries matching `/\b${empid}-.*-seen$/` during
-logout so that counts do not leak between users. New hooks should follow the
-same naming pattern to benefit from the automatic cleanup.
+`${empid}-incoming-pending-seen`. These markers persist across logouts so that
+counts are retained between sessions. New hooks should follow the same naming
+pattern to maintain per-user tracking.

--- a/src/erp.mgt.mn/context/AuthContext.jsx
+++ b/src/erp.mgt.mn/context/AuthContext.jsx
@@ -139,17 +139,6 @@ export default function AuthContextProvider({ children }) {
 
   useEffect(() => {
     function handleLogout() {
-      const empid = user?.empid;
-      if (empid) {
-        try {
-          const pattern = new RegExp(`\\b${empid}-.*-seen$`);
-          for (const key of Object.keys(localStorage)) {
-            if (pattern.test(key)) localStorage.removeItem(key);
-          }
-        } catch {
-          /* ignore storage errors */
-        }
-      }
       trackSetState('AuthContext.setUser');
       setUser(null);
       trackSetState('AuthContext.setSession');
@@ -167,7 +156,7 @@ export default function AuthContextProvider({ children }) {
     }
     window.addEventListener('auth:logout', handleLogout);
     return () => window.removeEventListener('auth:logout', handleLogout);
-  }, [user]);
+  }, []);
 
   const value = useMemo(
     () => ({

--- a/src/erp.mgt.mn/hooks/useAuth.jsx
+++ b/src/erp.mgt.mn/hooks/useAuth.jsx
@@ -58,23 +58,21 @@ export async function login({ empid, password, companyId }) {
 }
 
 /**
- * Calls logout endpoint to clear the JWT cookie and related notification
- * markers in `localStorage`.
+ * Calls the logout endpoint to clear the JWT cookie. Any additional cleanup
+ * is handled by the `auth:logout` event listener in `AuthContext` so that the
+ * logic remains centralised.
  */
 export async function logout(empid) {
   await fetch(`${API_BASE}/auth/logout`, {
     method: 'POST',
     credentials: 'include',
   });
-  if (empid) {
-    try {
-      const pattern = new RegExp(`\\b${empid}-.*-seen$`);
-      for (const key of Object.keys(localStorage)) {
-        if (pattern.test(key)) localStorage.removeItem(key);
-      }
-    } catch {
-      /* ignore storage errors */
-    }
+  // Notify the AuthContext that a logout occurred so that it can reset state.
+  if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+    const evt = typeof CustomEvent === 'function'
+      ? new CustomEvent('auth:logout')
+      : { type: 'auth:logout' };
+    window.dispatchEvent(evt);
   }
 }
 


### PR DESCRIPTION
## Summary
- avoid clearing `*-seen` notification keys during logout
- centralize logout cleanup in `AuthContext` via `auth:logout` event
- document persistent notification markers

## Testing
- `npm test tests/hooks/requestNotifications.test.js` *(fails: missing React, test skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68aac28eb79483319e611febffe0fcd7