### PR TITLE
Use shared date picker and verify date filtering

### DIFF
--- a/src/erp.mgt.mn/pages/Requests.jsx
+++ b/src/erp.mgt.mn/pages/Requests.jsx
@@ -8,6 +8,8 @@ import useHeaderMappings from '../hooks/useHeaderMappings.js';
 import { translateToMn } from '../utils/translateToMn.js';
 import { usePendingRequests } from '../context/PendingRequestContext.jsx';
 import { useSearchParams } from 'react-router-dom';
+import CustomDatePicker from '../components/CustomDatePicker.jsx';
+import formatTimestamp from '../utils/formatTimestamp.js';
 
 function ch(n) {
   return Math.round(n * 8);
@@ -46,11 +48,7 @@ function normalizeEmpId(id) {
     .replace(/^0+/, '');
 }
 
-// Fallback date picker used by bundlers that replace native date inputs
-// with a custom component. It simply renders a standard date input.
-function CustomDatePicker(props) {
-  return <input type="date" {...props} />;
-}
+const today = formatTimestamp(new Date()).slice(0, 10);
 
 export default function RequestsPage() {
   const { user, session } = useAuth();
@@ -82,8 +80,8 @@ export default function RequestsPage() {
   const [requestedEmpid, setRequestedEmpid] = useState('');
   const [tableName, setTableName] = useState('');
   const [status, setStatus] = useState(initialStatus || 'pending');
-  const [dateFrom, setDateFrom] = useState('');
-  const [dateTo, setDateTo] = useState('');
+  const [dateFrom, setDateFrom] = useState(today);
+  const [dateTo, setDateTo] = useState(today);
   const [incomingReloadKey, setIncomingReloadKey] = useState(0);
   const [outgoingReloadKey, setOutgoingReloadKey] = useState(0);
   const [incomingPage, setIncomingPage] = useState(1);

--- a/tests/api/pendingRequest.test.js
+++ b/tests/api/pendingRequest.test.js
@@ -100,3 +100,18 @@ await test('listRequestsByEmp filters by requester', async () => {
   assert.ok(queries[0].sql.includes('LIMIT ? OFFSET ?'));
   assert.deepEqual(queries[0].params, ['pending', 'E1', 20, 0]);
 });
+
+await test('listRequests filters by date range', async () => {
+  const origQuery = db.pool.query;
+  const queries = [];
+  db.pool.query = async (sql, params) => {
+    queries.push({ sql, params });
+    return [[]];
+  };
+  await service.listRequests({ date_from: '2024-01-01', date_to: '2024-01-31' });
+  db.pool.query = origQuery;
+  assert.ok(queries[0].sql.includes('created_at >= ?'));
+  assert.ok(queries[0].sql.includes('created_at <= ?'));
+  assert.ok(queries[0].sql.includes('LIMIT ? OFFSET ?'));
+  assert.deepEqual(queries[0].params, ['2024-01-01', '2024-01-31', 20, 0]);
+});


### PR DESCRIPTION
## Summary
- Replace local date picker in Requests page with shared component
- Default request filters to today's date and reload on change
- Add test ensuring pending request API respects date range filters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aad2aaaefc8331bf1f3827961edc5b