### PR TITLE
Log response details for pending requests

### DIFF
--- a/api-server/services/pendingRequest.js
+++ b/api-server/services/pendingRequest.js
@@ -251,8 +251,10 @@ export async function respondRequest(
     if (responder !== requester && responder !== senior)
       throw new Error('Forbidden');
 
+    const proposedData = parseProposedData(req.proposed_data);
+
     if (status === 'accepted') {
-      const data = parseProposedData(req.proposed_data);
+      const data = proposedData;
       if (req.request_type === 'edit' && data) {
         await updateTableRow(req.table_name, req.record_id, data, conn);
         await logUserAction(
@@ -289,6 +291,7 @@ export async function respondRequest(
           table_name: req.table_name,
           record_id: req.record_id,
           action: 'approve',
+          details: { proposed_data: proposedData, notes: notes || null },
           request_id: id,
         },
         conn,
@@ -309,6 +312,7 @@ export async function respondRequest(
           table_name: req.table_name,
           record_id: req.record_id,
           action: 'decline',
+          details: { proposed_data: proposedData, notes: notes || null },
           request_id: id,
         },
         conn,

--- a/api-server/services/userActivityLog.js
+++ b/api-server/services/userActivityLog.js
@@ -4,9 +4,16 @@ export async function logUserAction(
   { emp_id, table_name, record_id, action, details = null, request_id = null },
   conn = pool,
 ) {
+  const formattedDetails =
+    details == null
+      ? null
+      : typeof details === 'string'
+      ? details
+      : JSON.stringify(details);
+
   await conn.query(
     `INSERT INTO user_activity_log (emp_id, table_name, record_id, action, details, request_id)
      VALUES (?, ?, ?, ?, ?, ?)`,
-    [emp_id, table_name, record_id, action, details ? JSON.stringify(details) : null, request_id]
+    [emp_id, table_name, record_id, action, formattedDetails, request_id]
   );
 }

--- a/db/migrations/2025-10-18_user_activity_log_details_json.sql
+++ b/db/migrations/2025-10-18_user_activity_log_details_json.sql
@@ -1,0 +1,3 @@
+-- Ensure user_activity_log.details can store large payloads
+ALTER TABLE user_activity_log
+  MODIFY COLUMN details JSON NULL;


### PR DESCRIPTION
## Summary
- Record approve/decline response context (proposed data and notes) in activity logs
- Ensure activity log details are always JSON-encoded
- Allow larger details payloads by altering `user_activity_log.details` column to JSON

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aae484482c833185a19b0be07fd20c