### PR TITLE
Allow Requests table to scroll horizontally

### DIFF
--- a/src/erp.mgt.mn/pages/Requests.jsx
+++ b/src/erp.mgt.mn/pages/Requests.jsx
@@ -550,9 +550,9 @@ export default function RequestsPage() {
             <h4>
               {req.table_name} #{req.record_id} ({req.request_type})
             </h4>
-            <div style={{ overflowX: 'auto' }}>
+            <div style={{ overflow: 'auto' }}>
               <table
-                style={{ width: '100%', borderCollapse: 'collapse' }}
+                style={{ minWidth: 'max-content', borderCollapse: 'collapse' }}
               >
                 <thead>
                 <tr>


### PR DESCRIPTION
## Summary
- Allow Requests table to overflow with scrollbars
- Let table grow to full width without forced 100% width

## Testing
- `npm test` *(fails: ENOTEMPTY: directory not empty, rmdir '/workspace/erp-web-next/uploads/txn_images')*

------
https://chatgpt.com/codex/tasks/task_e_68aae68beb308331a2692dcb12bf13b8