### PR TITLE
Store original row for edit requests

### DIFF
--- a/db/migrations/2025-10-20_add_original_data_pending_request.sql
+++ b/db/migrations/2025-10-20_add_original_data_pending_request.sql
@@ -1,0 +1,3 @@
+-- Add original_data column to pending_request
+ALTER TABLE pending_request
+  ADD COLUMN original_data JSON NULL AFTER proposed_data;


### PR DESCRIPTION
## Summary
- Add `original_data` column to `pending_request`
- Capture current row when creating edit requests and persist it
- Use stored `original_data` in list API and test accepted edits retain original values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aafd9c86c08331a8fb42acf206db5b