### PR TITLE
feat: enforce pending request uniqueness via generated column

### DIFF
--- a/db/migrations/2025-10-21_pending_request_is_pending.sql
+++ b/db/migrations/2025-10-21_pending_request_is_pending.sql
@@ -1,0 +1,6 @@
+-- Replace status column in pending_request unique index with generated is_pending flag
+ALTER TABLE pending_request
+  DROP INDEX idx_pending_unique,
+  ADD COLUMN is_pending TINYINT(1)
+    GENERATED ALWAYS AS (CASE WHEN status = 'pending' THEN 1 ELSE NULL END) STORED,
+  ADD UNIQUE KEY idx_pending_unique (table_name, record_id, emp_id, request_type, is_pending);

--- a/tests/api/pendingRequest.test.js
+++ b/tests/api/pendingRequest.test.js
@@ -204,3 +204,97 @@ await test('accepted edit requests show original data', async () => {
   assert.deepEqual(result.rows[0].original, { name: 'old' });
   assert.equal(queries.length, 2);
 });
+
+await test('respondRequest succeeds with prior non-pending entries', async () => {
+  const rows = [
+    {
+      request_id: 1,
+      table_name: 't',
+      record_id: 1,
+      emp_id: 'E1',
+      senior_empid: 'S1',
+      request_type: 'edit',
+      status: 'accepted',
+      proposed_data: null,
+    },
+    {
+      request_id: 2,
+      table_name: 't',
+      record_id: 1,
+      emp_id: 'E1',
+      senior_empid: 'S1',
+      request_type: 'edit',
+      status: 'pending',
+      proposed_data: null,
+    },
+  ];
+  const conn = {
+    queries: [],
+    async query(sql, params) {
+      this.queries.push({ sql, params });
+      if (sql.startsWith('SELECT')) {
+        const row = rows.find((r) => r.request_id === params[0]);
+        return [[row]];
+      }
+      if (sql.startsWith("UPDATE pending_request SET status = 'accepted'")) {
+        const row = rows.find((r) => r.request_id === params[2]);
+        row.status = 'accepted';
+        return [{}];
+      }
+      return [{}];
+    },
+    release() {},
+  };
+  const origGet = db.pool.getConnection;
+  db.pool.getConnection = async () => conn;
+  try {
+    await service.respondRequest(2, 's1', 'accepted', 'ok');
+  } finally {
+    db.pool.getConnection = origGet;
+  }
+  const accepted = rows.filter((r) => r.status === 'accepted');
+  assert.equal(accepted.length, 2);
+});
+
+await test('second pending request for same record is rejected', async () => {
+  const conn = {
+    async query(sql, params) {
+      if (sql.startsWith('SELECT employment_senior_empid')) {
+        return [[{ employment_senior_empid: null }]];
+      }
+      if (sql.startsWith('SELECT request_id, proposed_data FROM pending_request')) {
+        return [[{ request_id: 1, proposed_data: JSON.stringify({ a: 1 }) }]];
+      }
+      if (sql.startsWith('INSERT INTO pending_request')) {
+        const err = new Error('Duplicate entry');
+        err.code = 'ER_DUP_ENTRY';
+        throw err;
+      }
+      return [{}];
+    },
+    release() {},
+  };
+  const origGet = db.pool.getConnection;
+  const origQuery = db.pool.query;
+  db.pool.getConnection = async () => conn;
+  db.pool.query = async (sql) => {
+    if (sql.includes('information_schema')) return [[{ COLUMN_NAME: 'id' }]];
+    return [[]];
+  };
+  try {
+    await assert.rejects(
+      service.createRequest({
+        tableName: 't',
+        recordId: 1,
+        empId: 'e1',
+        requestType: 'edit',
+        proposedData: { a: 2 },
+        requestReason: 'test',
+      }),
+      (err) => err.code === 'ER_DUP_ENTRY',
+    );
+  } finally {
+    db.pool.getConnection = origGet;
+    db.pool.query = origQuery;
+  }
+});


### PR DESCRIPTION
## Summary
- enforce uniqueness on pending requests using generated `is_pending` column
- add tests for duplicate pending requests and respondRequest behavior with historical rows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab0004a6308331a4ca31c4cda6043f