### PR TITLE
Format pending request timestamps and render ISO dates

### DIFF
--- a/api-server/services/pendingRequest.js
+++ b/api-server/services/pendingRequest.js
@@ -225,7 +225,7 @@ export async function listRequests(filters) {
   const total = countRows[0]?.count || 0;
 
   const [rows] = await pool.query(
-    `SELECT * FROM pending_request ${where} LIMIT ? OFFSET ?`,
+    `SELECT *, DATE_FORMAT(created_at, '%Y-%m-%d %H:%i:%s') AS created_at_fmt, DATE_FORMAT(responded_at, '%Y-%m-%d %H:%i:%s') AS responded_at_fmt FROM pending_request ${where} LIMIT ? OFFSET ?`,
     [...params, limit, offset],
   );
 
@@ -260,8 +260,11 @@ export async function listRequests(filters) {
           }
         }
 
+        const { created_at_fmt, responded_at_fmt, ...rest } = row;
         return {
-          ...row,
+          ...rest,
+          created_at: created_at_fmt || null,
+          responded_at: responded_at_fmt || null,
           proposed_data: parsed,
           original,
         };

--- a/src/erp.mgt.mn/pages/Requests.jsx
+++ b/src/erp.mgt.mn/pages/Requests.jsx
@@ -37,6 +37,15 @@ function renderValue(val) {
       </pre>
     );
   }
+  if (
+    typeof val === 'string' &&
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(val)
+  ) {
+    const d = new Date(val);
+    if (!Number.isNaN(d.getTime())) {
+      val = formatTimestamp(d);
+    }
+  }
   return <span style={style}>{String(val ?? '')}</span>;
 }
 


### PR DESCRIPTION
## Summary
- Format pending request `created_at` and `responded_at` fields with `DATE_FORMAT` and return formatted strings
- Render ISO date strings in Requests page using local timestamp formatting

## Testing
- `npm test` *(fails: detectIncompleteImages finds and fixes files ENOTEMPTY)*

------
https://chatgpt.com/codex/tasks/task_e_68ab01738d3c83319a046ac1731377c6