### PR TITLE
Normalize date inputs in report and transaction filters

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -17,6 +17,7 @@ import RowImageViewModal from './RowImageViewModal.jsx';
 import RowImageUploadModal from './RowImageUploadModal.jsx';
 import ImageSearchModal from './ImageSearchModal.jsx';
 import Modal from './Modal.jsx';
+import CustomDatePicker from './CustomDatePicker.jsx';
 import formatTimestamp from '../utils/formatTimestamp.js';
 import buildImageName from '../utils/buildImageName.js';
 import slugify from '../utils/slugify.js';
@@ -1753,16 +1754,18 @@ const TableManager = forwardRef(function TableManager({
           </select>
           {datePreset === 'custom' && (
             <>
-              <input
-                type="date"
+              <CustomDatePicker
                 value={customStartDate}
-                onChange={(e) => setCustomStartDate(e.target.value)}
+                onChange={(v) =>
+                  setCustomStartDate(normalizeDateInput(v, 'YYYY-MM-DD'))
+                }
                 style={{ marginRight: '0.25rem' }}
               />
-              <input
-                type="date"
+              <CustomDatePicker
                 value={customEndDate}
-                onChange={(e) => setCustomEndDate(e.target.value)}
+                onChange={(v) =>
+                  setCustomEndDate(normalizeDateInput(v, 'YYYY-MM-DD'))
+                }
                 style={{ marginRight: '0.5rem' }}
               />
             </>


### PR DESCRIPTION
## Summary
- Use `CustomDatePicker` for custom date filters in `TableManager`
- Replace text-based date fields in Reports and FinanceTransactions with `CustomDatePicker` and normalize values
- Normalize session and preset dates to ensure consistent `YYYY-MM-DD` payloads

## Testing
- `npm test` *(fails: deleteImageMovesFile, detectIncompleteImages finds and fixes files)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0271070c8331bb3a10be7beb8871