### PR TITLE
feat: highlight rows by request status

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -97,6 +97,12 @@ const deleteBtnStyle = {
   color: '#b91c1c',
 };
 
+const requestStatusColors = {
+  pending: '#fef9c3',
+  accepted: '#d1fae5',
+  declined: '#fee2e2',
+};
+
 const TableManager = forwardRef(function TableManager({
   table,
   refreshId = 0,
@@ -2089,7 +2095,12 @@ const TableManager = forwardRef(function TableManager({
                   openDetail(r);
                 }
               }}
-              style={{ cursor: 'pointer' }}
+              style={{
+                cursor: 'pointer',
+                ...(requestStatusColors[requestStatus]
+                  ? { backgroundColor: requestStatusColors[requestStatus] }
+                  : {}),
+              }}
             >
               <td style={{ padding: '0.5rem', border: '1px solid #d1d5db', width: 60, textAlign: 'center' }}>
                 {(() => {


### PR DESCRIPTION
## Summary
- color-code rows based on request status in TableManager
- map pending to yellow, accepted to green, and declined to red

## Testing
- `npm test` *(fails: ENOTEMPTY rmdir '/workspace/erp-web-next/uploads')*


------
https://chatgpt.com/codex/tasks/task_e_68ab0d5a94b483319e9a551d7866dbdc