### PR TITLE
Respect report row toast setting

### DIFF
--- a/src/erp.mgt.mn/components/ReportTable.jsx
+++ b/src/erp.mgt.mn/components/ReportTable.jsx
@@ -86,6 +86,14 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
   const headerMap = useHeaderMappings([procedure]);
   const general = generalConfig.general || {};
 
+  function rowToast(message, type = 'info') {
+    if (general.reportRowToastEnabled) {
+      window.dispatchEvent(
+        new CustomEvent('toast', { detail: { message, type } }),
+      );
+    }
+  }
+
   const columns = rows && rows.length ? Object.keys(rows[0]) : [];
   const columnHeaderMap = useHeaderMappings(columns);
 
@@ -225,11 +233,7 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
 
   useEffect(() => {
     if (procedure) {
-      window.dispatchEvent(
-        new CustomEvent('toast', {
-          detail: { message: `Selected procedure: ${procedure}`, type: 'info' },
-        }),
-      );
+      rowToast(`Selected procedure: ${procedure}`, 'info');
     }
   }, [procedure]);
 
@@ -250,11 +254,7 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
   function handleCellClick(col, value, row) {
     const num = Number(String(value).replace(',', '.'));
     if (!procedure || Number.isNaN(num) || num <= 0) return;
-    window.dispatchEvent(
-      new CustomEvent('toast', {
-        detail: { message: `Procedure: ${procedure}`, type: 'info' },
-      }),
-    );
+    rowToast(`Procedure: ${procedure}`, 'info');
     let displayValue = value;
     if (placeholders[col]) {
       displayValue = formatCellValue(value, placeholders[col]);
@@ -381,46 +381,26 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
             data.original.length > 200
               ? `${data.original.slice(0, 200)}…`
               : data.original;
-          window.dispatchEvent(
-            new CustomEvent('toast', {
-              detail: {
-                message: `Procedure SQL saved to ${data.file || ''}: ${preview}`,
-                type: 'info',
-              },
-            }),
+          rowToast(
+            `Procedure SQL saved to ${data.file || ''}: ${preview}`,
+            'info',
           );
         } else {
-          window.dispatchEvent(
-            new CustomEvent('toast', {
-              detail: { message: 'Procedure SQL not found', type: 'error' },
-            }),
-          );
+          rowToast('Procedure SQL not found', 'error');
         }
         if (data.sql && data.sql !== data.original) {
           const preview =
             data.sql.length > 200 ? `${data.sql.slice(0, 200)}…` : data.sql;
-          window.dispatchEvent(
-            new CustomEvent('toast', {
-              detail: {
-                message: `Transformed SQL saved to ${data.file || ''}: ${preview}`,
-                type: 'info',
-              },
-            }),
+          rowToast(
+            `Transformed SQL saved to ${data.file || ''}: ${preview}`,
+            'info',
           );
         } else {
-          window.dispatchEvent(
-            new CustomEvent('toast', {
-              detail: { message: 'SQL transformation failed', type: 'error' },
-            }),
-          );
+          rowToast('SQL transformation failed', 'error');
         }
-        window.dispatchEvent(
-          new CustomEvent('toast', {
-            detail: {
-              message: `Rows fetched: ${data.rows ? data.rows.length : 0}`,
-              type: data.rows && data.rows.length ? 'success' : 'error',
-            },
-          }),
+        rowToast(
+          `Rows fetched: ${data.rows ? data.rows.length : 0}`,
+          data.rows && data.rows.length ? 'success' : 'error',
         );
       })
       .catch((err) => {
@@ -429,28 +409,13 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
         setTxnInfo({ loading: false, col, value, data: [], sql, displayFields: [] });
         if (sql) {
           const preview = sql.length > 200 ? `${sql.slice(0, 200)}…` : sql;
-          window.dispatchEvent(
-            new CustomEvent('toast', {
-              detail: {
-                message: `SQL saved to ${file}: ${preview}`,
-                type: 'info',
-              },
-            }),
-          );
+          rowToast(`SQL saved to ${file}: ${preview}`, 'info');
         } else {
-          window.dispatchEvent(
-            new CustomEvent('toast', {
-              detail: { message: 'No SQL generated', type: 'error' },
-            }),
-          );
+          rowToast('No SQL generated', 'error');
         }
-        window.dispatchEvent(
-          new CustomEvent('toast', {
-            detail: {
-              message: err && err.message ? err.message : 'Row fetch failed',
-              type: 'error',
-            },
-          }),
+        rowToast(
+          err && err.message ? err.message : 'Row fetch failed',
+          'error',
         );
       });
   }

--- a/tests/components/reportRowToastEnabled.test.js
+++ b/tests/components/reportRowToastEnabled.test.js
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+global.document = { createElement: () => ({}) };
+global.window = {
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  dispatchEvent: () => {},
+};
+
+let React, act, createRoot;
+let haveReact = true;
+try {
+  const reactMod = await import('react');
+  React = reactMod.default || reactMod;
+  ({ act } = await import('react-dom/test-utils'));
+  ({ createRoot } = await import('react-dom/client'));
+} catch {
+  haveReact = false;
+}
+
+if (!haveReact) {
+  test('ReportTable respects reportRowToastEnabled', { skip: true }, () => {});
+} else {
+  test('row toast dispatched when enabled', async (t) => {
+    const dispatched = [];
+    global.window.dispatchEvent = (e) => dispatched.push(e);
+
+    const { default: ReportTable } = await t.mock.import(
+      '../../src/erp.mgt.mn/components/ReportTable.jsx',
+      {
+        '../hooks/useGeneralConfig.js': {
+          default: () => ({ general: { reportRowToastEnabled: true } }),
+        },
+        '../hooks/useHeaderMappings.js': { default: () => ({}) },
+        '../context/AuthContext.jsx': { AuthContext: React.createContext({}) },
+        './Modal.jsx': { default: () => null },
+      },
+    );
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        React.createElement(ReportTable, {
+          procedure: 'proc1',
+          params: {},
+          rows: [],
+        }),
+      );
+    });
+
+    assert.equal(dispatched.length, 1);
+    assert.equal(dispatched[0].detail.message, 'Selected procedure: proc1');
+    root.unmount();
+  });
+
+  test('row toast suppressed when disabled', async (t) => {
+    const dispatched = [];
+    global.window.dispatchEvent = (e) => dispatched.push(e);
+
+    const { default: ReportTable } = await t.mock.import(
+      '../../src/erp.mgt.mn/components/ReportTable.jsx',
+      {
+        '../hooks/useGeneralConfig.js': {
+          default: () => ({ general: { reportRowToastEnabled: false } }),
+        },
+        '../hooks/useHeaderMappings.js': { default: () => ({}) },
+        '../context/AuthContext.jsx': { AuthContext: React.createContext({}) },
+        './Modal.jsx': { default: () => null },
+      },
+    );
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        React.createElement(ReportTable, {
+          procedure: 'proc1',
+          params: {},
+          rows: [],
+        }),
+      );
+    });
+
+    assert.equal(dispatched.length, 0);
+    root.unmount();
+  });
+}
+


### PR DESCRIPTION
## Summary
- honor `general.reportRowToastEnabled` so report row toasts can be disabled
- test that ReportTable only dispatches toast events when the setting is enabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aeb8e14bb88331baa4bc3d722f1102