### PR TITLE
Allow authenticated users to read general configuration

### DIFF
--- a/api-server/routes/general_config.js
+++ b/api-server/routes/general_config.js
@@ -7,10 +7,6 @@ const router = express.Router();
 
 router.get('/', requireAuth, async (req, res, next) => {
   try {
-    const session =
-      req.session ||
-      (await getEmploymentSession(req.user.empid, req.user.companyId));
-    if (!session?.permissions?.system_settings) return res.sendStatus(403);
     const cfg = await getGeneralConfig();
     res.json(cfg);
   } catch (err) {


### PR DESCRIPTION
## Summary
- Let any authenticated user fetch general configuration without `system_settings` permission
- Keep update permission check

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aed2990f9c83318427af9678bc109a