### PR TITLE
feat: gate field label editing by button permissions

### DIFF
--- a/configs/permissionActions.json
+++ b/configs/permissionActions.json
@@ -16,6 +16,7 @@
         { "key": "Delete", "group": "Transactions" },
         { "key": "POST", "group": "Transactions" },
         { "key": "Run", "group": "Transactions" },
+        { "key": "Edit Field Labels", "group": "Transactions" },
         { "key": "Clear Date Filter", "group": "Filters" },
         { "key": "Clear Transaction Type Filter", "group": "Filters" },
         { "key": "Clear Branch Filter", "group": "Filters" },
@@ -35,7 +36,9 @@
       "scope": "app",
       "buttons": [
         { "key": "Run", "group": "Reports" },
-        { "key": "Export", "group": "Reports" }
+        { "key": "Export", "group": "Reports" },
+        { "key": "Edit Field Labels", "group": "Reports" },
+        { "key": "Edit label", "group": "Reports" }
       ],
       "functions": [],
       "api": [

--- a/src/erp.mgt.mn/components/ReportTable.jsx
+++ b/src/erp.mgt.mn/components/ReportTable.jsx
@@ -64,8 +64,8 @@ function isCountColumn(name) {
   return f === 'count' || f === 'count()' || f.startsWith('count(');
 }
 
-export default function ReportTable({ procedure = '', params = {}, rows = [] }) {
-  const { user, company, branch, department, session } = useContext(AuthContext);
+export default function ReportTable({ procedure = '', params = {}, rows = [], buttonPerms = {} }) {
+  const { user, company, branch, department } = useContext(AuthContext);
   const generalConfig = useGeneralConfig();
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
@@ -473,7 +473,7 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
       <div>
         <h4>
           {procLabel}
-          {session?.permissions?.system_settings && generalConfig.general?.editLabelsEnabled && (
+          {buttonPerms['Edit label'] && generalConfig.general?.editLabelsEnabled && (
             <button
               onClick={handleEditProcLabel}
               style={{ marginLeft: '0.5rem' }}
@@ -492,7 +492,7 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
     <div style={{ marginTop: '1rem' }}>
       <h4>
         {procLabel}
-        {session?.permissions?.system_settings && generalConfig.general?.editLabelsEnabled && (
+        {buttonPerms['Edit label'] && generalConfig.general?.editLabelsEnabled && (
           <button onClick={handleEditProcLabel} style={{ marginLeft: '0.5rem' }}>
             Edit label
           </button>
@@ -754,7 +754,7 @@ export default function ReportTable({ procedure = '', params = {}, rows = [] }) 
           )}
         </Modal>
       )}
-      {session?.permissions?.system_settings && generalConfig.general?.editLabelsEnabled && (
+      {buttonPerms['Edit Field Labels'] && generalConfig.general?.editLabelsEnabled && (
         <button
           onClick={() => {
             const map = {};

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -2511,7 +2511,7 @@ const TableManager = forwardRef(function TableManager({
           </li>
         </ul>
       )}
-      {session?.permissions?.system_settings && generalConfig.general?.editLabelsEnabled && (
+      {buttonPerms['Edit Field Labels'] && generalConfig.general?.editLabelsEnabled && (
         <button onClick={() => {
           const map = {};
           columnMeta.forEach((c) => { map[c.name] = c.label || ''; });

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -625,6 +625,7 @@ useEffect(() => {
           procedure={reportResult.name}
           params={reportResult.params}
           rows={reportResult.rows}
+          buttonPerms={perms?.buttons || {}}
         />
       )}
       {transactionNames.length === 0 && (

--- a/src/erp.mgt.mn/pages/Reports.jsx
+++ b/src/erp.mgt.mn/pages/Reports.jsx
@@ -19,7 +19,7 @@ function normalizeDateInput(value, format) {
 }
 
 export default function Reports() {
-  const { company, branch, user } = useContext(AuthContext);
+  const { company, branch, user, permissions: perms } = useContext(AuthContext);
   const { addToast } = useToast();
   const generalConfig = useGeneralConfig();
   const [procedures, setProcedures] = useState([]);
@@ -283,6 +283,7 @@ export default function Reports() {
           procedure={result.name}
           params={result.params}
           rows={result.rows}
+          buttonPerms={perms?.buttons || {}}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- allow per-button permissions for editing field labels and report titles
- surface "Edit Field Labels" and "Edit label" actions for finance transactions and reports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aed7f3c2548331b799aa37aef4b92b