### PR TITLE
Allow editing system admin actions

### DIFF
--- a/api-server/controllers/permissionsController.js
+++ b/api-server/controllers/permissionsController.js
@@ -73,11 +73,6 @@ export async function getActions(req, res, next) {
 export async function updateActions(req, res, next) {
   try {
     const id = req.params.userLevelId;
-    if (Number(id) === 1) {
-      return res
-        .status(400)
-        .json({ message: 'System admin permissions cannot be modified' });
-    }
     const { modules, buttons, functions, api, permissions } = req.body;
     await setUserLevelActions(id, {
       modules,

--- a/db/index.js
+++ b/db/index.js
@@ -440,7 +440,6 @@ export async function setUserLevelActions(
   userLevelId,
   { modules = [], buttons = [], functions = [], api = [], permissions = [] },
 ) {
-  if (Number(userLevelId) === 1) return;
   await pool.query(
     'DELETE FROM user_level_permissions WHERE userlevel_id = ? AND action IS NOT NULL',
     [userLevelId],

--- a/src/erp.mgt.mn/pages/UserLevelActions.jsx
+++ b/src/erp.mgt.mn/pages/UserLevelActions.jsx
@@ -86,18 +86,6 @@ export default function UserLevelActions() {
       addToast("User Level ID required", "error");
       return;
     }
-    if (userLevelId === "1") {
-      const sel = {
-        modules: flattenModules(groups.modules),
-        buttons: allActions.buttons,
-        functions: allActions.functions,
-        api: allActions.api,
-        permissions: allActions.permissions,
-      };
-      setSelected(sel);
-      addToast("System admin has access to all actions", "info");
-      return;
-    }
     fetch(`/api/permissions/actions/${userLevelId}`, { credentials: "include" })
       .then((res) => {
         if (!res.ok) throw new Error("Failed to load current actions");
@@ -147,10 +135,6 @@ export default function UserLevelActions() {
   async function handleSave() {
     if (!userLevelId) {
       addToast("User Level ID required", "error");
-      return;
-    }
-    if (userLevelId === "1") {
-      addToast("System admin permissions cannot be modified", "error");
       return;
     }
     try {
@@ -331,7 +315,7 @@ export default function UserLevelActions() {
       </button>
       <button
         onClick={handleSave}
-        disabled={userLevelId === "1"}
+        disabled={!userLevelId}
         style={{ marginRight: "0.5rem" }}
       >
         Save

--- a/tests/controllers/permissionsController.test.js
+++ b/tests/controllers/permissionsController.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { updateActions } from '../../api-server/controllers/permissionsController.js';
+import * as db from '../../db/index.js';
+
+function createRes() {
+  return {
+    code: undefined,
+    body: undefined,
+    status(c) {
+      this.code = c;
+      return this;
+    },
+    json(b) {
+      this.body = b;
+    },
+    sendStatus(c) {
+      this.code = c;
+      return this;
+    },
+  };
+}
+
+test('updateActions allows modifying level 1', async () => {
+  const req = {
+    params: { userLevelId: '1' },
+    body: { modules: ['m1'], buttons: [], functions: [], api: [], permissions: [] },
+  };
+  const res = createRes();
+  const original = db.pool.query;
+  let calls = 0;
+  db.pool.query = async (...args) => { calls++; return [[],[]]; };
+  await updateActions(req, res, () => {});
+  assert.equal(res.code, 200);
+  assert(calls > 0);
+  db.pool.query = original;
+});


### PR DESCRIPTION
## Summary
- Let system admin user level load and save actions without special-case blocks
- Permit updating level 1 actions on the server and in the database layer
- Cover system admin action updates with a controller test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aeebf5238c8331bd9ae616ee484dad