### PR TITLE
Allow user-level permissions to govern system actions

### DIFF
--- a/api-server/controllers/companyModuleController.js
+++ b/api-server/controllers/companyModuleController.js
@@ -3,6 +3,7 @@ import {
   setCompanyModuleLicense,
   getEmploymentSession,
 } from '../../db/index.js';
+import { hasAction } from '../utils/hasAction.js';
 
 export async function listLicenses(req, res, next) {
   try {
@@ -16,11 +17,10 @@ export async function listLicenses(req, res, next) {
 
 export async function updateLicense(req, res, next) {
   try {
-    const session = await getEmploymentSession(
-      req.user.empid,
-      req.user.companyId,
-    );
-    if (!session?.permissions?.license_settings) {
+    const session =
+      req.session ||
+      (await getEmploymentSession(req.user.empid, req.user.companyId));
+    if (!(await hasAction(session, 'license_settings'))) {
       return res.sendStatus(403);
     }
     const { companyId, moduleKey, licensed } = req.body;

--- a/api-server/controllers/generalConfigController.js
+++ b/api-server/controllers/generalConfigController.js
@@ -1,12 +1,13 @@
 import * as cfgSvc from '../services/generalConfig.js';
 import { getEmploymentSession } from '../../db/index.js';
+import { hasAction } from '../utils/hasAction.js';
 
 export async function fetchGeneralConfig(req, res, next) {
   try {
     const session =
       req.session ||
       (await getEmploymentSession(req.user.empid, req.user.companyId));
-    if (!session?.permissions?.system_settings) return res.sendStatus(403);
+    if (!(await hasAction(session, 'system_settings'))) return res.sendStatus(403);
     const getter = req.getGeneralConfig || cfgSvc.getGeneralConfig;
     const cfg = await getter();
     res.json(cfg);
@@ -20,7 +21,7 @@ export async function saveGeneralConfig(req, res, next) {
     const session =
       req.session ||
       (await getEmploymentSession(req.user.empid, req.user.companyId));
-    if (!session?.permissions?.system_settings) return res.sendStatus(403);
+    if (!(await hasAction(session, 'system_settings'))) return res.sendStatus(403);
     const updater = req.updateGeneralConfig || cfgSvc.updateGeneralConfig;
     const cfg = await updater(req.body || {});
     res.json(cfg);

--- a/api-server/controllers/moduleController.js
+++ b/api-server/controllers/moduleController.js
@@ -7,6 +7,7 @@ import {
   getEmploymentSession,
 } from "../../db/index.js";
 import { logActivity } from "../utils/activityLog.js";
+import { hasAction } from "../utils/hasAction.js";
 
 export async function listModules(req, res, next) {
   try {
@@ -37,7 +38,7 @@ export async function saveModule(req, res, next) {
       req.user.empid,
       req.user.companyId,
     );
-    if (!session?.permissions?.system_settings) return res.sendStatus(403);
+    if (!(await hasAction(session, "system_settings"))) return res.sendStatus(403);
     const label = req.body.label;
     const parentKey = req.body.parentKey || null;
     const showInSidebar = req.body.showInSidebar ?? true;
@@ -63,7 +64,7 @@ export async function populatePermissions(req, res, next) {
       req.user.empid,
       req.user.companyId,
     );
-    if (!session?.permissions?.system_settings) return res.sendStatus(403);
+    if (!(await hasAction(session, "system_settings"))) return res.sendStatus(403);
     await populateDefaultModules();
     await populateCompanyModuleLicenses();
     await populateUserLevelModulePermissions();

--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -15,6 +15,7 @@ import {
 } from '../../db/index.js';
 import { moveImagesToDeleted } from '../services/transactionImageService.js';
 import { addMappings } from '../services/headerMappings.js';
+import { hasAction } from '../utils/hasAction.js';
 let bcrypt;
 try {
   const mod = await import('bcryptjs');
@@ -177,7 +178,7 @@ export async function saveColumnLabels(req, res, next) {
       req.user.empid,
       req.user.companyId,
     );
-    if (!session?.permissions?.system_settings) return res.sendStatus(403);
+    if (!(await hasAction(session, 'system_settings'))) return res.sendStatus(403);
     const labels = req.body.labels || {};
     await addMappings(labels);
     res.sendStatus(204);

--- a/api-server/controllers/userCompanyController.js
+++ b/api-server/controllers/userCompanyController.js
@@ -6,6 +6,7 @@ import {
   listAllUserCompanies,
   getEmploymentSession,
 } from '../../db/index.js';
+import { hasAction } from '../utils/hasAction.js';
 
 export async function listAssignments(req, res, next) {
   try {
@@ -31,7 +32,7 @@ export async function assignCompany(req, res, next) {
       req.user.empid,
       req.user.companyId,
     );
-    if (!session?.permissions?.system_settings) {
+    if (!(await hasAction(session, 'system_settings'))) {
       return res.sendStatus(403);
     }
     const { empid, companyId, positionId, branchId } = req.body;
@@ -51,7 +52,7 @@ export async function updateAssignment(req, res, next) {
       req.user.empid,
       req.user.companyId,
     );
-    if (!session?.permissions?.system_settings) {
+    if (!(await hasAction(session, 'system_settings'))) {
       return res.sendStatus(403);
     }
     const { empid, companyId, positionId, branchId } = req.body;
@@ -68,7 +69,7 @@ export async function removeAssignment(req, res, next) {
       req.user.empid,
       req.user.companyId,
     );
-    if (!session?.permissions?.system_settings) {
+    if (!(await hasAction(session, 'system_settings'))) {
       return res.sendStatus(403);
     }
     const { empid, companyId } = req.body;

--- a/api-server/utils/hasAction.js
+++ b/api-server/utils/hasAction.js
@@ -1,0 +1,12 @@
+import { getUserLevelActions } from '../../db/index.js';
+
+export async function hasAction(session, action) {
+  if (session?.permissions?.[action]) return true;
+  if (!session?.user_level) return false;
+  if (!session.__userLevelActions) {
+    session.__userLevelActions = await getUserLevelActions(session.user_level);
+  }
+  return !!session.__userLevelActions?.permissions?.[action];
+}
+
+export default hasAction;

--- a/tests/controllers/companyModuleController.test.js
+++ b/tests/controllers/companyModuleController.test.js
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { updateLicense } from '../../api-server/controllers/companyModuleController.js';
+import * as db from '../../db/index.js';
+
+function createRes() {
+  return {
+    code: undefined,
+    body: undefined,
+    status(c) { this.code = c; return this; },
+    json(b) { this.body = b; },
+    sendStatus(c) { this.code = c; return this; },
+  };
+}
+
+test('updateLicense requires license_settings permission', async () => {
+  const req = {
+    user: { empid: 1, companyId: 1 },
+    session: { permissions: { license_settings: 0 } },
+    body: { companyId: 1, moduleKey: 'x', licensed: true },
+  };
+  const res = createRes();
+  await updateLicense(req, res, () => {});
+  assert.equal(res.code, 403);
+});
+
+test('updateLicense allows update with user-level permission', async () => {
+  const req = {
+    user: { empid: 1, companyId: 1 },
+    session: {
+      permissions: { license_settings: 0 },
+      user_level: 3,
+      __userLevelActions: { permissions: { license_settings: true } },
+    },
+    body: { companyId: 1, moduleKey: 'x', licensed: true },
+  };
+  const res = createRes();
+  let called = false;
+  const orig = db.pool.query;
+  db.pool.query = async () => { called = true; return [{}]; };
+  await updateLicense(req, res, () => {});
+  assert.equal(res.code, 200);
+  assert.equal(called, true);
+  db.pool.query = orig;
+});

--- a/tests/controllers/generalConfigController.test.js
+++ b/tests/controllers/generalConfigController.test.js
@@ -56,3 +56,19 @@ test('saveGeneralConfig allows update with permission', async () => {
   await saveGeneralConfig(req, res, () => {});
   assert.deepEqual(res.body, { general: { aiApiEnabled: true } });
 });
+
+test('saveGeneralConfig allows update with user-level permission', async () => {
+  const req = {
+    user: { empid: 1, companyId: 1 },
+    body: { general: { aiApiEnabled: true } },
+    session: {
+      permissions: { system_settings: 0 },
+      user_level: 3,
+      __userLevelActions: { permissions: { system_settings: true } },
+    },
+    updateGeneralConfig: async (body) => body,
+  };
+  const res = createRes();
+  await saveGeneralConfig(req, res, () => {});
+  assert.deepEqual(res.body, { general: { aiApiEnabled: true } });
+});


### PR DESCRIPTION
## Summary
- add `hasAction` helper to check session-level and user-level permissions
- gate system and license settings controllers using `hasAction`
- permit modifying level 1 permissions and respect stored actions
- add tests for user-level `system_settings` and `license_settings` actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aeee38bb9c8331bdf81be561774708