### PR TITLE
feat: add system settings permission

### DIFF
--- a/configs/permissionActions.json
+++ b/configs/permissionActions.json
@@ -1,6 +1,7 @@
 {
   "permissions": [
-    { "key": "edit_delete_request", "name": "Edit/Delete Request" }
+    { "key": "edit_delete_request", "name": "Edit/Delete Request" },
+    { "key": "system_settings", "name": "System Settings" }
   ],
   "forms": {
     "finance_transactions": {

--- a/db/index.js
+++ b/db/index.js
@@ -346,7 +346,7 @@ export async function getUserLevelActions(userLevelId) {
        WHERE userlevel_id = ? AND action IS NOT NULL`,
     [userLevelId],
   );
-  if (id === 1 && rows.length === 0) {
+  if (id === 1) {
     const perms = {};
     const [mods] = await pool.query('SELECT module_key FROM modules');
     for (const { module_key } of mods) perms[module_key] = true;

--- a/db/scripts/populate_user_level_permissions.sql
+++ b/db/scripts/populate_user_level_permissions.sql
@@ -5,6 +5,9 @@ SET @json = LOAD_FILE('configs/permissionActions.json');
 DELETE FROM user_level_permissions WHERE userlevel_id = 1;
 
 INSERT INTO user_level_permissions (userlevel_id, action, action_key)
+VALUES (1, 'permission', 'system_settings');
+
+INSERT INTO user_level_permissions (userlevel_id, action, action_key)
 SELECT ul.userlevel_id, a.action, a.action_key
   FROM user_levels ul
   JOIN (

--- a/tests/db/getEmploymentSession.test.js
+++ b/tests/db/getEmploymentSession.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as db from '../../db/index.js';
+
+test('getEmploymentSession populates system_settings permission', async () => {
+  const orig = db.pool.query;
+  db.pool.query = async () => [[{
+    company_id: 1,
+    company_name: 'Comp',
+    branch_id: 1,
+    branch_name: 'Branch',
+    department_id: 1,
+    department_name: 'Dept',
+    position_id: 1,
+    senior_empid: null,
+    employee_name: 'Emp',
+    user_level: 1,
+    user_level_name: 'Admin',
+    permission_list: 'system_settings',
+  }]];
+  const session = await db.getEmploymentSession(1, 1);
+  db.pool.query = orig;
+  assert.equal(session.permissions.system_settings, true);
+});
+


### PR DESCRIPTION
## Summary
- allow explicit `system_settings` permission
- seed admin with `system_settings` permission
- test permission checks and module population

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af37dfc5a48331bbedfda881d66057