### PR TITLE
Add tenant table helpers and migration

### DIFF
--- a/db/migrations/2025-06-16_tenant_tables.sql
+++ b/db/migrations/2025-06-16_tenant_tables.sql
@@ -1,0 +1,5 @@
+CREATE TABLE tenant_tables (
+  table_name VARCHAR(100) PRIMARY KEY,
+  is_shared BOOLEAN DEFAULT 0,
+  seed_on_create BOOLEAN DEFAULT 0
+);


### PR DESCRIPTION
## Summary
- add migration creating `tenant_tables` tracking table metadata
- add database helpers for listing, upserting, and retrieving tenant table flags

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af40a5578c8331b19b829ec1b38196