### PR TITLE
Add tenant table registry endpoints with admin checks

### DIFF
--- a/api-server/app.js
+++ b/api-server/app.js
@@ -22,6 +22,7 @@ import codingTableConfigRoutes from "./routes/coding_table_configs.js";
 import generatedSqlRoutes from "./routes/generated_sql.js";
 import generalConfigRoutes from "./routes/general_config.js";
 import permissionsRoutes from "./routes/permissions.js";
+import tenantTablesRoutes from "./routes/tenant_tables.js";
 import { getGeneralConfig } from "./services/generalConfig.js";
 
 // Polyfill for __dirname in ES modules
@@ -82,6 +83,7 @@ app.use("/api/coding_table_configs", codingTableConfigRoutes);
 app.use("/api/generated_sql", generatedSqlRoutes);
 app.use("/api/general_config", generalConfigRoutes);
 app.use("/api/permissions", permissionsRoutes);
+app.use("/api/tenant_tables", tenantTablesRoutes);
 
 // Serve static React build and fallback to index.html
 // NOTE: adjust this path to where your SPA build actually lives.

--- a/api-server/controllers/tenantTablesController.js
+++ b/api-server/controllers/tenantTablesController.js
@@ -1,0 +1,46 @@
+import {
+  listTenantTables as listTenantTablesDb,
+  upsertTenantTable,
+  getEmploymentSession,
+} from '../../db/index.js';
+import { hasAction } from '../utils/hasAction.js';
+
+export async function listTenantTables(req, res, next) {
+  try {
+    const tables = await listTenantTablesDb();
+    res.json(tables);
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function ensureAdmin(req) {
+  const session = await getEmploymentSession(req.user.empid, req.user.companyId);
+  return hasAction(session, 'system_settings');
+}
+
+export async function createTenantTable(req, res, next) {
+  try {
+    if (!(await ensureAdmin(req))) return res.sendStatus(403);
+    const { tableName, isShared, seedOnCreate } = req.body || {};
+    if (!tableName) {
+      return res.status(400).json({ message: 'tableName is required' });
+    }
+    const result = await upsertTenantTable(tableName, isShared, seedOnCreate);
+    res.status(201).json(result);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function updateTenantTable(req, res, next) {
+  try {
+    if (!(await ensureAdmin(req))) return res.sendStatus(403);
+    const tableName = req.params.table_name;
+    const { isShared, seedOnCreate } = req.body || {};
+    const result = await upsertTenantTable(tableName, isShared, seedOnCreate);
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/api-server/routes/tenant_tables.js
+++ b/api-server/routes/tenant_tables.js
@@ -1,0 +1,15 @@
+import express from 'express';
+import { requireAuth } from '../middlewares/auth.js';
+import {
+  listTenantTables,
+  createTenantTable,
+  updateTenantTable,
+} from '../controllers/tenantTablesController.js';
+
+const router = express.Router();
+
+router.get('/', requireAuth, listTenantTables);
+router.post('/', requireAuth, createTenantTable);
+router.put('/:table_name', requireAuth, updateTenantTable);
+
+export default router;


### PR DESCRIPTION
## Summary
- implement tenant tables controller with create/update/list handlers
- secure modification operations to admin users
- expose `/api/tenant_tables` routes and register in app

## Testing
- `npm test` *(fails: ENOENT no such file or directory old.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68af4191e1f483318cacc36888c3ec35