### PR TITLE
Add tenant tables registry admin page

### DIFF
--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -40,6 +40,7 @@ import { useModules } from './hooks/useModules.js';
 import { useTxnModules } from './hooks/useTxnModules.js';
 import useGeneralConfig from './hooks/useGeneralConfig.js';
 import TabbedWindows from './components/TabbedWindows.jsx';
+import TenantTablesRegistryPage from './pages/TenantTablesRegistry.jsx';
 
 export default function App() {
   useEffect(() => {
@@ -111,6 +112,7 @@ function AuthedApp() {
     change_password: <ChangePasswordPage />,
     requests: <RequestsPage />,
     sales: <TabbedWindows />,
+    tenant_tables_registry: <TenantTablesRegistryPage />,
   };
 
   modules.forEach((m) => {

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -63,6 +63,7 @@ export default function ERPLayout() {
     "/settings/forms-management": "Маягтын удирдлага",
     "/settings/report-management": "Тайлангийн удирдлага",
     "/settings/change-password": "Нууц үг солих",
+    "/settings/tenant-tables-registry": "Tenant Tables Registry",
   };
 
   function titleForPath(path) {

--- a/src/erp.mgt.mn/pages/Settings.jsx
+++ b/src/erp.mgt.mn/pages/Settings.jsx
@@ -44,6 +44,9 @@ export function GeneralSettings() {
       <p style={{ marginTop: '1rem' }}>
         <Link to="/settings/role-permissions">Эрхийн тохиргоо засах</Link>
       </p>
+      <p style={{ marginTop: '0.5rem' }}>
+        <Link to="/settings/tenant-tables-registry">Tenant Tables Registry</Link>
+      </p>
     </div>
   );
 }

--- a/src/erp.mgt.mn/pages/TenantTablesRegistry.jsx
+++ b/src/erp.mgt.mn/pages/TenantTablesRegistry.jsx
@@ -1,0 +1,114 @@
+import React, { useEffect, useState } from 'react';
+import { useToast } from '../context/ToastContext.jsx';
+
+export default function TenantTablesRegistry() {
+  const [tables, setTables] = useState([]);
+  const [saving, setSaving] = useState({});
+  const { addToast } = useToast();
+
+  useEffect(() => {
+    loadTables();
+  }, []);
+
+  async function loadTables() {
+    try {
+      const res = await fetch('/api/tenant_tables', { credentials: 'include' });
+      if (!res.ok) throw new Error('Failed to fetch');
+      const data = await res.json();
+      setTables(data);
+    } catch (err) {
+      console.error('Failed to load tenant tables', err);
+      addToast('Failed to load tenant tables', 'error');
+    }
+  }
+
+  function handleChange(idx, field, value) {
+    setTables((ts) => ts.map((t, i) => (i === idx ? { ...t, [field]: value } : t)));
+  }
+
+  async function handleSave(row) {
+    if (!row.table_name) {
+      addToast('Missing table name', 'error');
+      return;
+    }
+    if (typeof row.is_shared !== 'boolean' || typeof row.seed_on_create !== 'boolean') {
+      addToast('Invalid values', 'error');
+      return;
+    }
+    setSaving((s) => ({ ...s, [row.table_name]: true }));
+    try {
+      const res = await fetch('/api/tenant_tables', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          table_name: row.table_name,
+          is_shared: row.is_shared,
+          seed_on_create: row.seed_on_create,
+        }),
+      });
+      if (!res.ok) throw new Error('Failed to save');
+      addToast('Saved', 'success');
+    } catch (err) {
+      console.error('Failed to save tenant table', err);
+      addToast('Failed to save tenant table', 'error');
+    } finally {
+      setSaving((s) => ({ ...s, [row.table_name]: false }));
+    }
+  }
+
+  return (
+    <div>
+      <h2>Tenant Tables Registry</h2>
+      {tables.length === 0 ? (
+        <p>No tenant tables.</p>
+      ) : (
+        <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '0.5rem' }}>
+          <thead>
+            <tr style={{ backgroundColor: '#e5e7eb' }}>
+              <th style={styles.th}>Table</th>
+              <th style={styles.th}>Shared</th>
+              <th style={styles.th}>Seed on Create</th>
+              <th style={styles.th}>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {tables.map((t, idx) => (
+              <tr key={t.table_name}>
+                <td style={styles.td}>{t.table_name}</td>
+                <td style={styles.td}>
+                  <input
+                    type="checkbox"
+                    checked={!!t.is_shared}
+                    onChange={(e) => handleChange(idx, 'is_shared', e.target.checked)}
+                  />
+                </td>
+                <td style={styles.td}>
+                  <input
+                    type="checkbox"
+                    checked={!!t.seed_on_create}
+                    onChange={(e) => handleChange(idx, 'seed_on_create', e.target.checked)}
+                  />
+                </td>
+                <td style={styles.td}>
+                  <button
+                    onClick={() => handleSave(t)}
+                    disabled={saving[t.table_name]}
+                  >
+                    Save
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+const styles = {
+  th: { padding: '0.5rem', border: '1px solid #d1d5db' },
+  td: { padding: '0.5rem', border: '1px solid #d1d5db', textAlign: 'center' },
+};
+


### PR DESCRIPTION
## Summary
- add TenantTablesRegistry page to manage shared/seed flags
- wire tenant table registry into app routing and settings navigation
- show window title for tenant table registry in layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af4f7221188331ad7ce63417ac11a6