### PR TITLE
feat: manage tenant tables registry

### DIFF
--- a/src/erp.mgt.mn/pages/TenantTablesRegistry.jsx
+++ b/src/erp.mgt.mn/pages/TenantTablesRegistry.jsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { useToast } from '../context/ToastContext.jsx';
+import Spinner from '../components/Spinner.jsx';
 
 export default function TenantTablesRegistry() {
   const [tables, setTables] = useState([]);
   const [saving, setSaving] = useState({});
+  const [loading, setLoading] = useState(true);
   const { addToast } = useToast();
 
   useEffect(() => {
@@ -11,14 +13,35 @@ export default function TenantTablesRegistry() {
   }, []);
 
   async function loadTables() {
+    setLoading(true);
     try {
-      const res = await fetch('/api/tenant_tables', { credentials: 'include' });
-      if (!res.ok) throw new Error('Failed to fetch');
-      const data = await res.json();
-      setTables(data);
+      const [tablesRes, registryRes] = await Promise.all([
+        fetch('/api/tables', { credentials: 'include' }),
+        fetch('/api/tenant_tables', { credentials: 'include' }),
+      ]);
+      if (!tablesRes.ok || !registryRes.ok) throw new Error('Failed to fetch');
+      const allTables = await tablesRes.json();
+      const registry = await registryRes.json();
+      const map = new Map(
+        Array.isArray(registry)
+          ? registry.map((r) => [r.tableName, r])
+          : [],
+      );
+      const merged = Array.isArray(allTables)
+        ? allTables.map((name) =>
+            map.get(name) || {
+              tableName: name,
+              isShared: false,
+              seedOnCreate: false,
+            },
+          )
+        : [];
+      setTables(merged);
     } catch (err) {
       console.error('Failed to load tenant tables', err);
       addToast('Failed to load tenant tables', 'error');
+    } finally {
+      setLoading(false);
     }
   }
 
@@ -27,43 +50,40 @@ export default function TenantTablesRegistry() {
   }
 
   async function handleSave(row) {
-    if (!row.table_name) {
-      addToast('Missing table name', 'error');
-      return;
-    }
-    if (typeof row.is_shared !== 'boolean' || typeof row.seed_on_create !== 'boolean') {
-      addToast('Invalid values', 'error');
-      return;
-    }
-    setSaving((s) => ({ ...s, [row.table_name]: true }));
+    setSaving((s) => ({ ...s, [row.tableName]: true }));
     try {
-      const res = await fetch('/api/tenant_tables', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          table_name: row.table_name,
-          is_shared: row.is_shared,
-          seed_on_create: row.seed_on_create,
-        }),
-      });
+      const res = await fetch(
+        `/api/tenant_tables/${encodeURIComponent(row.tableName)}`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            isShared: row.isShared,
+            seedOnCreate: row.seedOnCreate,
+          }),
+        },
+      );
       if (!res.ok) throw new Error('Failed to save');
       addToast('Saved', 'success');
+      loadTables();
     } catch (err) {
       console.error('Failed to save tenant table', err);
       addToast('Failed to save tenant table', 'error');
     } finally {
-      setSaving((s) => ({ ...s, [row.table_name]: false }));
+      setSaving((s) => ({ ...s, [row.tableName]: false }));
     }
   }
 
   return (
     <div>
       <h2>Tenant Tables Registry</h2>
-      {tables.length === 0 ? (
-        <p>No tenant tables.</p>
+      {loading ? (
+        <Spinner />
       ) : (
-        <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '0.5rem' }}>
+        <table
+          style={{ width: '100%', borderCollapse: 'collapse', marginTop: '0.5rem' }}
+        >
           <thead>
             <tr style={{ backgroundColor: '#e5e7eb' }}>
               <th style={styles.th}>Table</th>
@@ -73,33 +93,43 @@ export default function TenantTablesRegistry() {
             </tr>
           </thead>
           <tbody>
-            {tables.map((t, idx) => (
-              <tr key={t.table_name}>
-                <td style={styles.td}>{t.table_name}</td>
-                <td style={styles.td}>
-                  <input
-                    type="checkbox"
-                    checked={!!t.is_shared}
-                    onChange={(e) => handleChange(idx, 'is_shared', e.target.checked)}
-                  />
-                </td>
-                <td style={styles.td}>
-                  <input
-                    type="checkbox"
-                    checked={!!t.seed_on_create}
-                    onChange={(e) => handleChange(idx, 'seed_on_create', e.target.checked)}
-                  />
-                </td>
-                <td style={styles.td}>
-                  <button
-                    onClick={() => handleSave(t)}
-                    disabled={saving[t.table_name]}
-                  >
-                    Save
-                  </button>
+            {tables.length === 0 ? (
+              <tr>
+                <td style={styles.td} colSpan="4">
+                  No tables found.
                 </td>
               </tr>
-            ))}
+            ) : (
+              tables.map((t, idx) => (
+                <tr key={t.tableName || idx}>
+                  <td style={styles.td}>{t.tableName}</td>
+                  <td style={styles.td}>
+                    <input
+                      type="checkbox"
+                      checked={!!t.isShared}
+                      onChange={(e) => handleChange(idx, 'isShared', e.target.checked)}
+                    />
+                  </td>
+                  <td style={styles.td}>
+                    <input
+                      type="checkbox"
+                      checked={!!t.seedOnCreate}
+                      onChange={(e) =>
+                        handleChange(idx, 'seedOnCreate', e.target.checked)
+                      }
+                    />
+                  </td>
+                  <td style={styles.td}>
+                    <button
+                      onClick={() => handleSave(t)}
+                      disabled={saving[t.tableName]}
+                    >
+                      Save
+                    </button>
+                  </td>
+                </tr>
+              ))
+            )}
           </tbody>
         </table>
       )}


### PR DESCRIPTION
## Summary
- list all database tables and merge with tenant registry for configuration
- allow inline editing of shared/seed flags and save via tenant_tables API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af551003708331afe79ecc128922e2