### PR TITLE
Add fallback tenant table listing

### DIFF
--- a/src/erp.mgt.mn/pages/TenantTablesRegistry.jsx
+++ b/src/erp.mgt.mn/pages/TenantTablesRegistry.jsx
@@ -60,49 +60,45 @@ export default function TenantTablesRegistry() {
   return (
     <div>
       <h2>Tenant Tables Registry</h2>
-      {tables.length === 0 ? (
-        <p>No tenant tables.</p>
-      ) : (
-        <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '0.5rem' }}>
-          <thead>
-            <tr style={{ backgroundColor: '#e5e7eb' }}>
-              <th style={styles.th}>Table</th>
-              <th style={styles.th}>Shared</th>
-              <th style={styles.th}>Seed on Create</th>
-              <th style={styles.th}>Action</th>
+      <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '0.5rem' }}>
+        <thead>
+          <tr style={{ backgroundColor: '#e5e7eb' }}>
+            <th style={styles.th}>Table</th>
+            <th style={styles.th}>Shared</th>
+            <th style={styles.th}>Seed on Create</th>
+            <th style={styles.th}>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {tables.map((t, idx) => (
+            <tr key={t.table_name}>
+              <td style={styles.td}>{t.table_name}</td>
+              <td style={styles.td}>
+                <input
+                  type="checkbox"
+                  checked={!!t.is_shared}
+                  onChange={(e) => handleChange(idx, 'is_shared', e.target.checked)}
+                />
+              </td>
+              <td style={styles.td}>
+                <input
+                  type="checkbox"
+                  checked={!!t.seed_on_create}
+                  onChange={(e) => handleChange(idx, 'seed_on_create', e.target.checked)}
+                />
+              </td>
+              <td style={styles.td}>
+                <button
+                  onClick={() => handleSave(t)}
+                  disabled={saving[t.table_name]}
+                >
+                  Save
+                </button>
+              </td>
             </tr>
-          </thead>
-          <tbody>
-            {tables.map((t, idx) => (
-              <tr key={t.table_name}>
-                <td style={styles.td}>{t.table_name}</td>
-                <td style={styles.td}>
-                  <input
-                    type="checkbox"
-                    checked={!!t.is_shared}
-                    onChange={(e) => handleChange(idx, 'is_shared', e.target.checked)}
-                  />
-                </td>
-                <td style={styles.td}>
-                  <input
-                    type="checkbox"
-                    checked={!!t.seed_on_create}
-                    onChange={(e) => handleChange(idx, 'seed_on_create', e.target.checked)}
-                  />
-                </td>
-                <td style={styles.td}>
-                  <button
-                    onClick={() => handleSave(t)}
-                    disabled={saving[t.table_name]}
-                  >
-                    Save
-                  </button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- return default tenant table config when none saved by listing database tables except `tenant_tables`
- ensure UI always renders table with checkboxes for `is_shared` and `seed_on_create`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af5e78cfdc8331a7c6c4306b686202