### PR TITLE
Add fallback tenant table listing

### DIFF
--- a/api-server/controllers/tenantTablesController.js
+++ b/api-server/controllers/tenantTablesController.js
@@ -2,13 +2,35 @@ import {
   listTenantTables as listTenantTablesDb,
   upsertTenantTable,
   getEmploymentSession,
+  listDatabaseTables,
 } from '../../db/index.js';
 import { hasAction } from '../utils/hasAction.js';
 
 export async function listTenantTables(req, res, next) {
   try {
     const tables = await listTenantTablesDb();
-    res.json(tables);
+    if (!tables.length) {
+      try {
+        const dbTables = await listDatabaseTables();
+        const mapped = dbTables
+          .filter((t) => t !== 'tenant_tables')
+          .map((table_name) => ({
+            table_name,
+            is_shared: false,
+            seed_on_create: false,
+          }));
+        return res.json(mapped);
+      } catch (err) {
+        // If listing database tables fails, fall back to empty list
+        return res.json([]);
+      }
+    }
+    const mappedExisting = tables.map((t) => ({
+      table_name: t.table_name ?? t.tableName,
+      is_shared: t.is_shared ?? t.isShared,
+      seed_on_create: t.seed_on_create ?? t.seedOnCreate,
+    }));
+    res.json(mappedExisting);
   } catch (err) {
     next(err);
   }

--- a/src/erp.mgt.mn/pages/TenantTablesRegistry.jsx
+++ b/src/erp.mgt.mn/pages/TenantTablesRegistry.jsx
@@ -37,16 +37,18 @@ export default function TenantTablesRegistry() {
     }
     setSaving((s) => ({ ...s, [row.table_name]: true }));
     try {
-      const res = await fetch('/api/tenant_tables', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          table_name: row.table_name,
-          is_shared: row.is_shared,
-          seed_on_create: row.seed_on_create,
-        }),
-      });
+      const res = await fetch(
+        `/api/tenant_tables/${encodeURIComponent(row.table_name)}`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            isShared: row.is_shared,
+            seedOnCreate: row.seed_on_create,
+          }),
+        }
+      );
       if (!res.ok) throw new Error('Failed to save');
       addToast('Saved', 'success');
     } catch (err) {
@@ -60,49 +62,45 @@ export default function TenantTablesRegistry() {
   return (
     <div>
       <h2>Tenant Tables Registry</h2>
-      {tables.length === 0 ? (
-        <p>No tenant tables.</p>
-      ) : (
-        <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '0.5rem' }}>
-          <thead>
-            <tr style={{ backgroundColor: '#e5e7eb' }}>
-              <th style={styles.th}>Table</th>
-              <th style={styles.th}>Shared</th>
-              <th style={styles.th}>Seed on Create</th>
-              <th style={styles.th}>Action</th>
+      <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '0.5rem' }}>
+        <thead>
+          <tr style={{ backgroundColor: '#e5e7eb' }}>
+            <th style={styles.th}>Table</th>
+            <th style={styles.th}>Shared</th>
+            <th style={styles.th}>Seed on Create</th>
+            <th style={styles.th}>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {tables.map((t, idx) => (
+            <tr key={t.table_name}>
+              <td style={styles.td}>{t.table_name}</td>
+              <td style={styles.td}>
+                <input
+                  type="checkbox"
+                  checked={!!t.is_shared}
+                  onChange={(e) => handleChange(idx, 'is_shared', e.target.checked)}
+                />
+              </td>
+              <td style={styles.td}>
+                <input
+                  type="checkbox"
+                  checked={!!t.seed_on_create}
+                  onChange={(e) => handleChange(idx, 'seed_on_create', e.target.checked)}
+                />
+              </td>
+              <td style={styles.td}>
+                <button
+                  onClick={() => handleSave(t)}
+                  disabled={saving[t.table_name]}
+                >
+                  Save
+                </button>
+              </td>
             </tr>
-          </thead>
-          <tbody>
-            {tables.map((t, idx) => (
-              <tr key={t.table_name}>
-                <td style={styles.td}>{t.table_name}</td>
-                <td style={styles.td}>
-                  <input
-                    type="checkbox"
-                    checked={!!t.is_shared}
-                    onChange={(e) => handleChange(idx, 'is_shared', e.target.checked)}
-                  />
-                </td>
-                <td style={styles.td}>
-                  <input
-                    type="checkbox"
-                    checked={!!t.seed_on_create}
-                    onChange={(e) => handleChange(idx, 'seed_on_create', e.target.checked)}
-                  />
-                </td>
-                <td style={styles.td}>
-                  <button
-                    onClick={() => handleSave(t)}
-                    disabled={saving[t.table_name]}
-                  >
-                    Save
-                  </button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- return default tenant table config when none saved by listing database tables except `tenant_tables`
- ensure UI always renders table with checkboxes for `is_shared` and `seed_on_create`
- handle missing table list gracefully and send updates to per-table endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af5e78cfdc8331a7c6c4306b686202