### PR TITLE
refactor: propagate listDatabaseTables errors

### DIFF
--- a/api-server/controllers/tenantTablesController.js
+++ b/api-server/controllers/tenantTablesController.js
@@ -22,15 +22,10 @@ export async function listTenantTables(req, res, next) {
       seed_on_create: t.seed_on_create ?? t.seedOnCreate,
     }));
 
-    let dbTables = [];
-    try {
-      dbTables = await listDatabaseTables();
-    } catch (err) {
-      dbTables = [];
-    }
+    const dbTables = await listDatabaseTables();
 
     const existingNames = new Set(mappedExisting.map((t) => t.table_name));
-    const unmapped = dbTables
+    const unmapped = (dbTables ?? [])
       .filter((t) => t !== 'tenant_tables' && !existingNames.has(t))
       .map((table_name) => ({
         table_name,


### PR DESCRIPTION
## Summary
- call listDatabaseTables without suppressing errors in tenant tables controller
- preserve unmapped table filtering using returned data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68afee669c248331a6a93556e079d811