### PR TITLE
feat: add tenant table options endpoint

### DIFF
--- a/api-server/controllers/tenantTablesController.js
+++ b/api-server/controllers/tenantTablesController.js
@@ -2,12 +2,23 @@ import {
   listTenantTables as listTenantTablesDb,
   upsertTenantTable,
   getEmploymentSession,
+  listAllTenantTableOptions,
 } from '../../db/index.js';
 import { hasAction } from '../utils/hasAction.js';
 
 export async function listTenantTables(req, res, next) {
   try {
     const tables = await listTenantTablesDb();
+    res.json(tables);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function listTenantTableOptions(req, res, next) {
+  try {
+    if (!(await ensureAdmin(req))) return res.sendStatus(403);
+    const tables = await listAllTenantTableOptions();
     res.json(tables);
   } catch (err) {
     next(err);

--- a/api-server/routes/tenant_tables.js
+++ b/api-server/routes/tenant_tables.js
@@ -4,6 +4,7 @@ import {
   listTenantTables,
   createTenantTable,
   updateTenantTable,
+  listTenantTableOptions,
 } from '../controllers/tenantTablesController.js';
 
 const router = express.Router();
@@ -11,5 +12,6 @@ const router = express.Router();
 router.get('/', requireAuth, listTenantTables);
 router.post('/', requireAuth, createTenantTable);
 router.put('/:table_name', requireAuth, updateTenantTable);
+router.get('/options', requireAuth, listTenantTableOptions);
 
 export default router;

--- a/db/index.js
+++ b/db/index.js
@@ -931,6 +931,22 @@ export async function listTenantTables() {
   }));
 }
 
+export async function listAllTenantTableOptions() {
+  const [tables, tenantFlags] = await Promise.all([
+    listDatabaseTables(),
+    listTenantTables(),
+  ]);
+  const flagMap = new Map(tenantFlags.map((t) => [t.tableName, t]));
+  return tables.map((tableName) => {
+    const info = flagMap.get(tableName) || {};
+    return {
+      tableName,
+      isShared: info.isShared ?? false,
+      seedOnCreate: info.seedOnCreate ?? false,
+    };
+  });
+}
+
 export async function upsertTenantTable(
   tableName,
   isShared = 0,

--- a/docs/tenant-table-scoping.md
+++ b/docs/tenant-table-scoping.md
@@ -6,3 +6,15 @@ Data-access helpers that accept `company_id` filters now consult the `tenant_tab
 - **Global tables** not present in `tenant_tables` skip `company_id` scoping entirely.
 
 This ensures queries return tenant-specific data while still honoring shared or global records.
+
+## Listing tenant table options
+
+Administrators can fetch a full list of database tables and their `tenant_tables`
+settings via:
+
+```
+GET /api/tenant_tables/options
+```
+
+The response is an array with each table's `tableName`, `isShared`, and
+`seedOnCreate` flags (defaulting to `false` when not configured).


### PR DESCRIPTION
## Summary
- expose `listAllTenantTableOptions` helper merging tenant flags with DB tables
- add admin-protected controller and route to fetch tenant table options
- document new `/api/tenant_tables/options` endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aff3bd1d348331ac86e3255199a854