### PR TITLE
Default role_module_permissions company_id to 0

### DIFF
--- a/db/migrations/2025-06-14_role_module_permissions_company_id.sql
+++ b/db/migrations/2025-06-14_role_module_permissions_company_id.sql
@@ -1,8 +1,8 @@
 -- Add company_id to role_module_permissions for per-company defaults
 ALTER TABLE role_module_permissions
-  ADD COLUMN company_id INT NOT NULL DEFAULT 1;
+  ADD COLUMN company_id INT NOT NULL DEFAULT 0;
 
-UPDATE role_module_permissions SET company_id = 1 WHERE company_id IS NULL;
+UPDATE role_module_permissions SET company_id = 0 WHERE company_id IS NULL;
 
 ALTER TABLE role_module_permissions
   DROP PRIMARY KEY,

--- a/db/migrations/2025-06-16_role_module_permissions_company_id_fix.sql
+++ b/db/migrations/2025-06-16_role_module_permissions_company_id_fix.sql
@@ -1,0 +1,7 @@
+-- Correct company_id default for existing deployments
+ALTER TABLE role_module_permissions
+  ALTER COLUMN company_id SET DEFAULT 0;
+
+UPDATE role_module_permissions
+SET company_id = 0
+WHERE company_id = 1;


### PR DESCRIPTION
## Summary
- default role_module_permissions.company_id to 0 and seed existing rows accordingly
- add migration to update environments that used the old default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b007d3e388833186d00323bc8587e6