### PR TITLE
Scope branch and department joins by company

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -252,8 +252,8 @@ export async function getEmploymentSessions(empid) {
         GROUP_CONCAT(DISTINCT up.action_key) AS permission_list
      FROM tbl_employment e
      LEFT JOIN companies c ON e.employment_company_id = c.id
-     LEFT JOIN code_branches b ON e.employment_branch_id = b.id
-     LEFT JOIN code_department d ON e.employment_department_id = d.${deptIdCol}
+     LEFT JOIN code_branches b ON e.employment_branch_id = b.id AND b.company_id = e.employment_company_id
+     LEFT JOIN code_department d ON e.employment_department_id = d.${deptIdCol} AND d.company_id IN (0, e.employment_company_id)
      LEFT JOIN tbl_employee emp ON e.employment_emp_id = emp.emp_id
      LEFT JOIN user_levels ul ON e.employment_user_level = ul.userlevel_id
      LEFT JOIN user_level_permissions up ON up.userlevel_id = ul.userlevel_id AND up.action = 'permission'
@@ -309,8 +309,8 @@ export async function getEmploymentSession(empid, companyId) {
           GROUP_CONCAT(DISTINCT up.action_key) AS permission_list
        FROM tbl_employment e
        LEFT JOIN companies c ON e.employment_company_id = c.id
-       LEFT JOIN code_branches b ON e.employment_branch_id = b.id
-       LEFT JOIN code_department d ON e.employment_department_id = d.${deptIdCol}
+       LEFT JOIN code_branches b ON e.employment_branch_id = b.id AND b.company_id = e.employment_company_id
+       LEFT JOIN code_department d ON e.employment_department_id = d.${deptIdCol} AND d.company_id IN (0, e.employment_company_id)
        LEFT JOIN tbl_employee emp ON e.employment_emp_id = emp.emp_id
        LEFT JOIN user_levels ul ON e.employment_user_level = ul.userlevel_id
        LEFT JOIN user_level_permissions up ON up.userlevel_id = ul.userlevel_id AND up.action = 'permission'
@@ -624,7 +624,7 @@ export async function listUserCompanies(empid) {
             uc.branch_id, b.name AS branch_name
      FROM user_companies uc
      JOIN companies c ON uc.company_id = c.id
-     LEFT JOIN code_branches b ON uc.branch_id = b.id
+     LEFT JOIN code_branches b ON uc.branch_id = b.id AND b.company_id = uc.company_id
      WHERE uc.empid = ?`,
     [empid],
   );
@@ -668,7 +668,7 @@ export async function listAllUserCompanies(companyId) {
             uc.branch_id, b.name AS branch_name
      FROM user_companies uc
      JOIN companies c ON uc.company_id = c.id
-     LEFT JOIN code_branches b ON uc.branch_id = b.id
+     LEFT JOIN code_branches b ON uc.branch_id = b.id AND b.company_id = uc.company_id
      ${where}`,
     params,
   );

--- a/tests/db/getEmploymentSession.test.js
+++ b/tests/db/getEmploymentSession.test.js
@@ -23,3 +23,35 @@ test('getEmploymentSession populates system_settings permission', async () => {
   assert.equal(session.permissions.system_settings, true);
 });
 
+test('getEmploymentSession joins branch and department with company scope', async () => {
+  const orig = db.pool.query;
+  let capturedSql = '';
+  db.pool.query = async (sql) => {
+    capturedSql = sql;
+    return [[{
+      company_id: 1,
+      company_name: 'Comp',
+      branch_id: 1,
+      branch_name: 'Branch',
+      department_id: 1,
+      department_name: 'Dept',
+      position_id: 1,
+      senior_empid: null,
+      employee_name: 'Emp',
+      user_level: 1,
+      user_level_name: 'Admin',
+      permission_list: 'system_settings',
+    }]];
+  };
+  await db.getEmploymentSession(1, 1);
+  db.pool.query = orig;
+  assert.match(
+    capturedSql,
+    /LEFT JOIN code_branches b ON e\.employment_branch_id = b\.id AND b\.company_id = e\.employment_company_id/,
+  );
+  assert.match(
+    capturedSql,
+    /LEFT JOIN code_department d ON e\.employment_department_id = d\.\w+ AND d\.company_id IN \(0, e\.employment_company_id\)/,
+  );
+});
+

--- a/tests/db/userCompanies.test.js
+++ b/tests/db/userCompanies.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as db from '../../db/index.js';
+
+test('listUserCompanies joins branch with company scope', async () => {
+  const orig = db.pool.query;
+  let capturedSql = '';
+  db.pool.query = async (sql) => {
+    capturedSql = sql;
+    return [[]];
+  };
+  await db.listUserCompanies(1);
+  db.pool.query = orig;
+  assert.match(
+    capturedSql,
+    /LEFT JOIN code_branches b ON uc\.branch_id = b\.id AND b\.company_id = uc\.company_id/
+  );
+});
+
+test('listAllUserCompanies joins branch with company scope', async () => {
+  const orig = db.pool.query;
+  let capturedSql = '';
+  db.pool.query = async (sql) => {
+    capturedSql = sql;
+    return [[]];
+  };
+  await db.listAllUserCompanies();
+  db.pool.query = orig;
+  assert.match(
+    capturedSql,
+    /LEFT JOIN code_branches b ON uc\.branch_id = b\.id AND b\.company_id = uc\.company_id/
+  );
+});


### PR DESCRIPTION
## Summary
- ensure employment session queries scope branch and department joins by company
- constrain user company branch lookups to current company
- cover tenant vs shared table joins in tests

## Testing
- `npm test`
- `node -e "import('./db/index.js').then(async (db)=>{try{const [rows]=await db.pool.query('SHOW INDEX FROM code_branches');console.log(rows);}catch(err){console.error('ERROR',err.message)} finally{db.pool.end();}});"`
- `node -e "import('./db/index.js').then(async (db)=>{try{const [rows]=await db.pool.query('SHOW INDEX FROM code_department');console.log(rows);}catch(err){console.error('ERROR',err.message)} finally{db.pool.end();}});"`


------
https://chatgpt.com/codex/tasks/task_e_68b008925364833183be3d7be952b8d3