### PR TITLE
feat: share code reference tables

### DIFF
--- a/db/migrations/2025-10-23_tenant_tables_code_defaults.sql
+++ b/db/migrations/2025-10-23_tenant_tables_code_defaults.sql
@@ -1,0 +1,9 @@
+-- Mark code tables as shared so global rows are visible to all tenants
+INSERT INTO tenant_tables (table_name, is_shared, seed_on_create)
+VALUES
+  ('code_position', 1, 0),
+  ('code_branches', 1, 0),
+  ('code_department', 1, 0)
+ON DUPLICATE KEY UPDATE
+  is_shared = VALUES(is_shared),
+  seed_on_create = VALUES(seed_on_create);

--- a/docs/tenant-table-scoping.md
+++ b/docs/tenant-table-scoping.md
@@ -18,3 +18,14 @@ GET /api/tenant_tables/options
 
 The response is an array with each table's `tableName`, `isShared`, and
 `seedOnCreate` flags (defaulting to `false` when not configured).
+
+## Default shared tables
+
+The following tables are preconfigured as shared (`is_shared=1`) so that global rows
+(company_id 0) are visible to every tenant. They do not seed tenant-specific copies
+when a new company is created (`seed_on_create=0`):
+
+- `code_position`
+- `code_branches`
+- `code_department`
+


### PR DESCRIPTION
## Summary
- mark code_position, code_branches and code_department as shared
- document default shared code tables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b009c7b78c8331b5f2594676c743d6