### PR TITLE
feat: select seed tables during company setup

### DIFF
--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -108,6 +108,11 @@ export async function addRow(req, res, next) {
   try {
     const columns = await listTableColumns(req.params.table);
     const row = { ...req.body };
+    let seedTables;
+    if (req.params.table === 'companies') {
+      seedTables = Array.isArray(row.seedTables) ? row.seedTables : [];
+      delete row.seedTables;
+    }
     if (columns.includes('created_by')) row.created_by = req.user?.empid;
     if (columns.includes('created_at')) {
       row.created_at = formatDateForDb(new Date());
@@ -118,7 +123,7 @@ export async function addRow(req, res, next) {
     if (columns.includes('g_burtgel_id') && row.g_burtgel_id == null) {
       row.g_burtgel_id = row.g_id ?? 0;
     }
-    const result = await insertTableRow(req.params.table, row);
+    const result = await insertTableRow(req.params.table, row, seedTables);
     res.locals.insertId = result?.id;
     res.status(201).json(result);
   } catch (err) {


### PR DESCRIPTION
## Summary
- fetch available seed tables when creating a company and let admins choose which to copy
- copy only selected tables during seeding with validation against `tenant_tables`
- allow table insert API to accept selected seed tables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b00aa5479083318897d112b80b6127