### PR TITLE
Populate company ids for existing records

### DIFF
--- a/db/migrations/2025-10-24_company_id_defaults.sql
+++ b/db/migrations/2025-10-24_company_id_defaults.sql
@@ -1,43 +1,97 @@
 -- Ensure company_id columns are non-null with default and indexed
 
 -- SOrlogo
-UPDATE SOrlogo SET company_id = 0 WHERE company_id IS NULL;
+SELECT COUNT(*) AS total_before, SUM(company_id IS NULL) AS null_before FROM SOrlogo;
+UPDATE SOrlogo so
+LEFT JOIN user_companies uc ON uc.empid = so.userid
+SET so.company_id = COALESCE(uc.company_id, 0)
+WHERE so.company_id IS NULL;
+SELECT COUNT(*) AS total_after,
+       SUM(company_id = 0) AS global_rows,
+       SUM(company_id > 0) AS company_rows
+  FROM SOrlogo;
 ALTER TABLE SOrlogo
   MODIFY COLUMN company_id INT NOT NULL DEFAULT 0;
 CREATE INDEX idx_SOrlogo_company_id ON SOrlogo(company_id);
 
 -- SZardal
-UPDATE SZardal SET company_id = 0 WHERE company_id IS NULL;
+SELECT COUNT(*) AS total_before, SUM(company_id IS NULL) AS null_before FROM SZardal;
+UPDATE SZardal sz
+LEFT JOIN user_companies uc ON uc.empid = sz.userid
+SET sz.company_id = COALESCE(uc.company_id, 0)
+WHERE sz.company_id IS NULL;
+SELECT COUNT(*) AS total_after,
+       SUM(company_id = 0) AS global_rows,
+       SUM(company_id > 0) AS company_rows
+  FROM SZardal;
 ALTER TABLE SZardal
   MODIFY COLUMN company_id INT NOT NULL DEFAULT 0;
 CREATE INDEX idx_SZardal_company_id ON SZardal(company_id);
 
 -- tusuv
-UPDATE tusuv SET company_id = 0 WHERE company_id IS NULL;
+SELECT COUNT(*) AS total_before, SUM(company_id IS NULL) AS null_before FROM tusuv;
+UPDATE tusuv t
+LEFT JOIN user_companies uc ON uc.empid = t.userid
+SET t.company_id = COALESCE(uc.company_id, 0)
+WHERE t.company_id IS NULL;
+SELECT COUNT(*) AS total_after,
+       SUM(company_id = 0) AS global_rows,
+       SUM(company_id > 0) AS company_rows
+  FROM tusuv;
 ALTER TABLE tusuv
   MODIFY COLUMN company_id INT NOT NULL DEFAULT 0;
 CREATE INDEX idx_tusuv_company_id ON tusuv(company_id);
 
 -- BMBurtgel
-UPDATE BMBurtgel SET company_id = 0 WHERE company_id IS NULL;
+SELECT COUNT(*) AS total_before, SUM(company_id IS NULL) AS null_before FROM BMBurtgel;
+UPDATE BMBurtgel b
+LEFT JOIN user_companies uc ON uc.empid = b.userid
+SET b.company_id = COALESCE(uc.company_id, 0)
+WHERE b.company_id IS NULL;
+SELECT COUNT(*) AS total_after,
+       SUM(company_id = 0) AS global_rows,
+       SUM(company_id > 0) AS company_rows
+  FROM BMBurtgel;
 ALTER TABLE BMBurtgel
   MODIFY COLUMN company_id INT NOT NULL DEFAULT 0;
 CREATE INDEX idx_BMBurtgel_company_id ON BMBurtgel(company_id);
 
 -- MMorder
-UPDATE MMorder SET company_id = 0 WHERE company_id IS NULL;
+SELECT COUNT(*) AS total_before, SUM(company_id IS NULL) AS null_before FROM MMorder;
+UPDATE MMorder m
+LEFT JOIN user_companies uc ON uc.empid = m.userid
+SET m.company_id = COALESCE(uc.company_id, 0)
+WHERE m.company_id IS NULL;
+SELECT COUNT(*) AS total_after,
+       SUM(company_id = 0) AS global_rows,
+       SUM(company_id > 0) AS company_rows
+  FROM MMorder;
 ALTER TABLE MMorder
   MODIFY COLUMN company_id INT NOT NULL DEFAULT 0;
 CREATE INDEX idx_MMorder_company_id ON MMorder(company_id);
 
 -- SGereeJ
-UPDATE SGereeJ SET company_id = 0 WHERE company_id IS NULL;
+SELECT COUNT(*) AS total_before, SUM(company_id IS NULL) AS null_before FROM SGereeJ;
+UPDATE SGereeJ s
+LEFT JOIN user_companies uc ON uc.empid = s.userid
+SET s.company_id = COALESCE(uc.company_id, 0)
+WHERE s.company_id IS NULL;
+SELECT COUNT(*) AS total_after,
+       SUM(company_id = 0) AS global_rows,
+       SUM(company_id > 0) AS company_rows
+  FROM SGereeJ;
 ALTER TABLE SGereeJ
   MODIFY COLUMN company_id INT NOT NULL DEFAULT 0;
 CREATE INDEX idx_SGereeJ_company_id ON SGereeJ(company_id);
 
 -- form_submissions
-UPDATE form_submissions SET company_id = 0 WHERE company_id IS NULL;
+SELECT COUNT(*) AS total_before, SUM(company_id IS NULL) AS null_before FROM form_submissions;
+UPDATE form_submissions
+SET company_id = 0
+WHERE company_id IS NULL;
+SELECT COUNT(*) AS total_after,
+       SUM(company_id = 0) AS global_rows
+  FROM form_submissions;
 ALTER TABLE form_submissions
   MODIFY COLUMN company_id INT NOT NULL DEFAULT 0;
 CREATE INDEX idx_form_submissions_company_id ON form_submissions(company_id);


### PR DESCRIPTION
## Summary
- Populate `company_id` for existing records via `user_companies` joins
- Default unmatched rows to global `company_id` 0 and log row counts before/after
- Enforce non-null `company_id` with indexes for key tables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b00f0a2594833186046e271258e94b