### PR TITLE
Add company scoping to forms table

### DIFF
--- a/db/migrations/2025-06-18_forms_table.sql
+++ b/db/migrations/2025-06-18_forms_table.sql
@@ -3,5 +3,8 @@ CREATE TABLE IF NOT EXISTS forms (
   id INT AUTO_INCREMENT PRIMARY KEY,
   name VARCHAR(100) NOT NULL,
   schema_json JSON NOT NULL,
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  company_id INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  KEY idx_forms_company_id (company_id),
+  CONSTRAINT fk_forms_company FOREIGN KEY (company_id) REFERENCES companies(id)
 );

--- a/db/scripts/populate_company_records.sql
+++ b/db/scripts/populate_company_records.sql
@@ -26,5 +26,8 @@ SELECT c.id, s.z_num, s.z_barimt, s.z_tosov_code, s.z_tosov_zuil,
   s.userid
 FROM SZardal s CROSS JOIN companies c;
 
+-- Ensure existing forms are scoped to the global company
+UPDATE forms SET company_id = 0 WHERE company_id IS NULL;
+
 -- Repeat similar INSERT ... SELECT for tusuv, BMBurtgel, MMorder, SGereeJ, form_submissions
 -- ensuring company_id is included


### PR DESCRIPTION
## Summary
- add `company_id` column with FK to companies on forms table
- default existing forms to global company in population script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0127bd41c8331847f1ffe16cbc6e8