### PR TITLE
Add company scoping to user level permissions

### DIFF
--- a/db/migrations/2025-10-28_user_level_permissions_company_id.sql
+++ b/db/migrations/2025-10-28_user_level_permissions_company_id.sql
@@ -1,0 +1,17 @@
+-- Add company_id to user_level_permissions
+ALTER TABLE user_level_permissions
+  ADD COLUMN company_id INT NOT NULL DEFAULT 0 AFTER id;
+
+-- Index for company_id
+ALTER TABLE user_level_permissions
+  ADD INDEX idx_user_level_permissions_company_id (company_id);
+
+-- Update existing records with default company_id
+UPDATE user_level_permissions SET company_id = 0 WHERE company_id IS NULL;
+
+-- Include company_id in keys and add foreign key
+ALTER TABLE user_level_permissions
+  DROP PRIMARY KEY,
+  ADD PRIMARY KEY (id, company_id),
+  ADD UNIQUE KEY uq_user_level_permissions (company_id, userlevel_id, action, action_key),
+  ADD CONSTRAINT fk_user_level_permissions_company FOREIGN KEY (company_id) REFERENCES companies(id);

--- a/db/scripts/migrate_user_level_permissions.sql
+++ b/db/scripts/migrate_user_level_permissions.sql
@@ -1,6 +1,6 @@
 -- Populate action entries in user_level_permissions based on existing settings
-INSERT INTO user_level_permissions (userlevel_id, action, action_key)
-SELECT DISTINCT p.userlevel_id, s.action,
+INSERT INTO user_level_permissions (company_id, userlevel_id, action, action_key)
+SELECT DISTINCT 0, p.userlevel_id, s.action,
        COALESCE(s.ul_module_key, s.function_name) AS action_key
 FROM code_userlevel_settings s
 JOIN user_level_permissions p ON (
@@ -20,8 +20,8 @@ JOIN user_level_permissions p ON (
   (s.license_settings = 1 AND p.action = 'permission' AND p.action_key = 'license_settings') OR
   (s.ai = 1 AND p.action = 'permission' AND p.action_key = 'ai') OR
   (s.dashboard = 1 AND p.action = 'permission' AND p.action_key = 'dashboard') OR
-  (s.ai_dashboard = 1 AND p.action = 'permission' AND p.action_key = 'ai_dashboard')
-);
+   (s.ai_dashboard = 1 AND p.action = 'permission' AND p.action_key = 'ai_dashboard')
+ ) AND p.company_id = 0;
 
 -- Remove legacy settings table
 DROP TABLE code_userlevel_settings;

--- a/db/scripts/populate_user_level_module_permissions.sql
+++ b/db/scripts/populate_user_level_module_permissions.sql
@@ -1,6 +1,6 @@
 -- Backfill module_key permissions for all user levels
-INSERT INTO user_level_permissions (userlevel_id, action, action_key)
-SELECT ul.userlevel_id, 'module_key', m.module_key
+INSERT INTO user_level_permissions (company_id, userlevel_id, action, action_key)
+SELECT 0, ul.userlevel_id, 'module_key', m.module_key
   FROM user_levels ul
   CROSS JOIN modules m
   WHERE ul.userlevel_id <> 1
@@ -10,4 +10,5 @@ SELECT ul.userlevel_id, 'module_key', m.module_key
        WHERE up.userlevel_id = ul.userlevel_id
          AND up.action = 'module_key'
          AND up.action_key = m.module_key
+         AND up.company_id = 0
     );

--- a/db/scripts/populate_user_level_permissions.sql
+++ b/db/scripts/populate_user_level_permissions.sql
@@ -2,13 +2,13 @@ SET collation_connection = 'utf8mb4_unicode_ci';
 SET @json = LOAD_FILE('configs/permissionActions.json');
 
 -- Ensure system admin remains unrestricted
-DELETE FROM user_level_permissions WHERE userlevel_id = 1;
+DELETE FROM user_level_permissions WHERE userlevel_id = 1 AND company_id = 0;
 
-INSERT INTO user_level_permissions (userlevel_id, action, action_key)
-VALUES (1, 'permission', 'system_settings');
+INSERT INTO user_level_permissions (company_id, userlevel_id, action, action_key)
+VALUES (0, 1, 'permission', 'system_settings');
 
-INSERT INTO user_level_permissions (userlevel_id, action, action_key)
-SELECT ul.userlevel_id, a.action, a.action_key
+INSERT INTO user_level_permissions (company_id, userlevel_id, action, action_key)
+SELECT 0, ul.userlevel_id, a.action, a.action_key
   FROM user_levels ul
   JOIN (
     SELECT 'module_key' AS action, m.module_key AS action_key
@@ -27,5 +27,6 @@ SELECT ul.userlevel_id, a.action, a.action_key
     ON up.userlevel_id = ul.userlevel_id
    AND up.action = a.action
    AND up.action_key = a.action_key
+   AND up.company_id = 0
  WHERE up.userlevel_id IS NULL
    AND ul.userlevel_id <> 1;

--- a/scripts/seed-user-level-actions.cjs
+++ b/scripts/seed-user-level-actions.cjs
@@ -21,14 +21,15 @@ const mysql = require('mysql2/promise');
     async function insert(type, keys) {
       for (const key of keys) {
         await pool.query(
-          `INSERT INTO user_level_permissions (userlevel_id, action, action_key)
-           SELECT ul.userlevel_id, ?, ?
+          `INSERT INTO user_level_permissions (company_id, userlevel_id, action, action_key)
+           SELECT 0, ul.userlevel_id, ?, ?
              FROM user_levels ul
              WHERE NOT EXISTS (
                SELECT 1 FROM user_level_permissions up
                 WHERE up.userlevel_id = ul.userlevel_id
                   AND up.action = ?
                   AND up.action_key = ?
+                  AND up.company_id = 0
              )`,
           [type, key, type, key]
         );


### PR DESCRIPTION
## Summary
- extend `user_level_permissions` with a `company_id` column indexed and tied to `companies`
- seed and populate user level permissions using `company_id = 0` for global defaults
- scope permission queries by company

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0166acc1c833196900bb864e9e5c2