### PR TITLE
Enforce tenant scoping for user company assignments

### DIFF
--- a/api-server/controllers/userCompanyController.js
+++ b/api-server/controllers/userCompanyController.js
@@ -11,14 +11,26 @@ import { hasAction } from '../utils/hasAction.js';
 export async function listAssignments(req, res, next) {
   try {
     const empid = req.query.empid;
-    const companyId = req.query.companyId;
+    const companyId = req.query.companyId || req.user.companyId;
+
+    if (
+      req.query.companyId &&
+      Number(req.query.companyId) !== Number(req.user.companyId)
+    ) {
+      const session = await getEmploymentSession(
+        req.user.empid,
+        req.user.companyId,
+      );
+      if (!(await hasAction(session, 'system_settings'))) {
+        return res.sendStatus(403);
+      }
+    }
+
     let assignments;
     if (empid) {
       assignments = await listUserCompanies(empid);
-    } else if (companyId) {
-      assignments = await listAllUserCompanies(companyId);
     } else {
-      assignments = await listAllUserCompanies();
+      assignments = await listAllUserCompanies(companyId);
     }
     res.json(assignments);
   } catch (err) {

--- a/tests/controllers/userCompanyController.test.js
+++ b/tests/controllers/userCompanyController.test.js
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as db from '../../db/index.js';
+import { listAssignments } from '../../api-server/controllers/userCompanyController.js';
+
+function createRes() {
+  return {
+    code: undefined,
+    body: undefined,
+    status(c) { this.code = c; return this; },
+    json(b) { this.body = b; },
+    sendStatus(c) { this.code = c; },
+  };
+}
+
+test('listAssignments defaults companyId to req.user.companyId', async (t) => {
+  const req = { query: {}, user: { empid: 1, companyId: 2 } };
+  const res = createRes();
+  let captured;
+  const mock = t.mock.method(db.pool, 'query', async (sql, params) => {
+    captured = params[0];
+    return [[{ id: 1 }]];
+  });
+  await listAssignments(req, res, () => {});
+  assert.equal(captured, 2);
+  assert.deepEqual(res.body, [{ id: 1 }]);
+  mock.mock.restore();
+});
+
+test('listAssignments rejects cross-tenant requests without permission', async (t) => {
+  const req = { query: { companyId: 3 }, user: { empid: 1, companyId: 2 } };
+  const res = createRes();
+  let calls = 0;
+  const mock = t.mock.method(db.pool, 'query', async () => {
+    calls += 1;
+    return [[]];
+  });
+  await listAssignments(req, res, () => {});
+  assert.equal(res.code, 403);
+  assert.equal(calls, 1);
+  mock.mock.restore();
+});


### PR DESCRIPTION
## Summary
- Default company scope for listing assignments to the requester’s company
- Block cross-tenant assignment listings unless the user has system_settings rights
- Add tests covering company scoping and unauthorized cross-tenant access

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b01e7fc2388331aede059a7171878d