### PR TITLE
Scope transactions by company ID

### DIFF
--- a/api-server/controllers/transactionController.js
+++ b/api-server/controllers/transactionController.js
@@ -21,6 +21,7 @@ export async function getTransactions(req, res, next) {
       perPage: Number(perPage) || 50,
       refCol,
       refVal,
+      company_id: req.user.companyId,
     });
     res.json(result);
   } catch (err) {

--- a/db/index.js
+++ b/db/index.js
@@ -1482,12 +1482,17 @@ export async function listTransactions({
   perPage = 50,
   refCol,
   refVal,
+  company_id,
 } = {}) {
   if (!table || !/^[a-zA-Z0-9_]+$/.test(table)) {
     throw new Error('Invalid table');
   }
   const clauses = [];
   const params = [];
+  if (company_id !== undefined && company_id !== '') {
+    clauses.push('company_id = ?');
+    params.push(company_id);
+  }
   if (branchId !== undefined && branchId !== '') {
     clauses.push('branch_id = ?');
     params.push(branchId);

--- a/src/erp.mgt.mn/components/ReportTable.jsx
+++ b/src/erp.mgt.mn/components/ReportTable.jsx
@@ -65,7 +65,7 @@ function isCountColumn(name) {
 }
 
 export default function ReportTable({ procedure = '', params = {}, rows = [], buttonPerms = {} }) {
-  const { user, company, branch, department } = useContext(AuthContext);
+  const { user, branch, department } = useContext(AuthContext);
   const generalConfig = useGeneralConfig();
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
@@ -339,7 +339,6 @@ export default function ReportTable({ procedure = '', params = {}, rows = [], bu
       extraConditions,
       session: {
         empid: user?.empid,
-        company_id: company,
         branch_id: branch,
         department_id: department,
       },


### PR DESCRIPTION
## Summary
- Pass authenticated `company_id` to transaction queries
- Filter transactions by company in database layer
- Stop sending `company_id` from frontend `ReportTable`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b01fbe4d548331a6563e029c032f9e