### PR TITLE
Scope table queries by company

### DIFF
--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -51,7 +51,13 @@ export async function getTableRows(req, res, next) {
     const result = await listTableRows(req.params.table, {
       page: Number(page) || 1,
       perPage: rowsPerPage,
-      filters: { ...filters, company_id: req.user?.companyId },
+      filters: {
+        ...filters,
+        company_id:
+          company_id !== undefined && company_id !== ''
+            ? company_id
+            : req.user?.companyId,
+      },
       search: search || '',
       searchColumns: typeof searchColumns === 'string' ? searchColumns.split(',') : [],
       sort: { column: sort, dir },

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -622,6 +622,7 @@ const TableManager = forwardRef(function TableManager({
             }
             while (true) {
               const params = new URLSearchParams({ page, perPage });
+              if (company != null) params.set('company_id', company);
               const refRes = await fetch(
                 `/api/tables/${encodeURIComponent(rel.table)}?${params.toString()}`,
                 { credentials: 'include' },
@@ -721,6 +722,7 @@ const TableManager = forwardRef(function TableManager({
     if (!table || columnMeta.length === 0) return;
     let canceled = false;
     const params = new URLSearchParams({ page, perPage });
+    if (company != null) params.set('company_id', company);
     if (sort.column && validCols.has(sort.column)) {
       params.set('sort', sort.column);
       params.set('dir', sort.dir);
@@ -1060,6 +1062,7 @@ const TableManager = forwardRef(function TableManager({
       const view = viewSourceMap[field];
       if (!view || val === '') return;
       const params = new URLSearchParams({ perPage: 1, debug: 1 });
+      if (company != null) params.set('company_id', company);
       const cols = viewColumns[view] || [];
       Object.entries(viewSourceMap).forEach(([f, v]) => {
         if (v !== view) return;
@@ -1226,6 +1229,7 @@ const TableManager = forwardRef(function TableManager({
       const savedRow = res.ok ? await res.json().catch(() => ({})) : {};
       if (res.ok) {
         const params = new URLSearchParams({ page, perPage });
+        if (company != null) params.set('company_id', company);
         if (sort.column) {
           params.set('sort', sort.column);
           params.set('dir', sort.dir);
@@ -1316,6 +1320,7 @@ const TableManager = forwardRef(function TableManager({
     );
     if (res.ok) {
       const params = new URLSearchParams({ page, perPage });
+      if (company != null) params.set('company_id', company);
       if (sort.column) {
         params.set('sort', sort.column);
         params.set('dir', sort.dir);
@@ -1483,6 +1488,7 @@ const TableManager = forwardRef(function TableManager({
       }
     }
     const params = new URLSearchParams({ page, perPage });
+    if (company != null) params.set('company_id', company);
     if (sort.column) {
       params.set('sort', sort.column);
       params.set('dir', sort.dir);

--- a/tests/db/listRows.test.js
+++ b/tests/db/listRows.test.js
@@ -75,6 +75,16 @@ test('listTableRows scopes company_id with shared tables', async () => {
   assert.ok(/`company_id`\s+IN\s*\(0,\s*\?\)/i.test(count.sql));
 });
 
+test('listTableRows scopes company_id with tenant tables', async () => {
+  const restore = mockPool({ tenant: { is_shared: 0, seed_on_create: 0 } });
+  await db.listTableRows('tenant', {
+    filters: { company_id: 9 },
+  });
+  const calls = restore();
+  const count = calls.find((c) => c.sql.includes('COUNT(*)'));
+  assert.ok(/`company_id`\s*=\s*\?/i.test(count.sql));
+});
+
 test('listTableRows skips company_id for global tables', async () => {
   const restore = mockPool({});
   await db.listTableRows('global', {


### PR DESCRIPTION
## Summary
- Always attach current company_id to TableManager fetch params
- Respect provided company_id in tableController
- Add tests ensuring company scoping for shared and tenant tables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b021723cd88331af7e768005f06362