### PR TITLE
feat: filter AsyncSearchSelect results by company

### DIFF
--- a/src/erp.mgt.mn/components/AsyncSearchSelect.jsx
+++ b/src/erp.mgt.mn/components/AsyncSearchSelect.jsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useContext } from 'react';
+import { AuthContext } from '../context/AuthContext.jsx';
 
 export default function AsyncSearchSelect({
   table,
@@ -14,8 +15,11 @@ export default function AsyncSearchSelect({
   inputRef,
   onFocus,
   inputStyle = {},
+  companyId,
   ...rest
 }) {
+  const { company } = useContext(AuthContext);
+  const effectiveCompanyId = companyId ?? company;
   const initialVal =
     typeof value === 'object' && value !== null ? value.value : value || '';
   const initialLabel =
@@ -46,6 +50,7 @@ export default function AsyncSearchSelect({
     setLoading(true);
     try {
       const params = new URLSearchParams({ page: p, perPage: 50 });
+      if (effectiveCompanyId != null) params.set('company_id', effectiveCompanyId);
       if (q) {
         params.set('search', q);
         params.set('searchColumns', cols.join(','));
@@ -101,7 +106,7 @@ export default function AsyncSearchSelect({
     fetchPage(1, '', false, controller.signal);
     setPage(1);
     return () => controller.abort();
-  }, [table]);
+  }, [table, effectiveCompanyId]);
 
   useEffect(() => {
     if (disabled || !show) return;
@@ -110,7 +115,17 @@ export default function AsyncSearchSelect({
     setPage(1);
     fetchPage(1, q, false, controller.signal);
     return () => controller.abort();
-  }, [show, input, disabled, table, searchColumn, searchColumns, labelFields, idField]);
+  }, [
+    show,
+    input,
+    disabled,
+    table,
+    searchColumn,
+    searchColumns,
+    labelFields,
+    idField,
+    effectiveCompanyId,
+  ]);
 
   function handleSelectKeyDown(e) {
     if (e.key === 'ArrowDown') {

--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -1027,6 +1027,7 @@ export default forwardRef(function InlineTransactionTable({
             onFocus={() => handleFocusField(f)}
             className={invalid ? 'border-red-500 bg-red-100' : ''}
             inputStyle={inputStyle}
+            companyId={company}
           />
         );
       }
@@ -1076,6 +1077,7 @@ export default forwardRef(function InlineTransactionTable({
             onFocus={() => handleFocusField(f)}
             className={invalid ? 'border-red-500 bg-red-100' : ''}
             inputStyle={inputStyle}
+            companyId={company}
           />
       );
     }

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -881,6 +881,7 @@ const RowFormModal = function RowFormModal({
         }}
         inputRef={(el) => (inputRefs.current[c] = el)}
         inputStyle={inputStyle}
+        companyId={company}
       />
     ) : viewSource[c] && !Array.isArray(relations[c]) ? (
       <AsyncSearchSelect
@@ -917,6 +918,7 @@ const RowFormModal = function RowFormModal({
         }}
         inputRef={(el) => (inputRefs.current[c] = el)}
         inputStyle={inputStyle}
+        companyId={company}
       />
     ) : Array.isArray(relations[c]) ? (
       <select


### PR DESCRIPTION
## Summary
- support optional `companyId` prop in `AsyncSearchSelect` that defaults to context
- include `company_id` in search requests
- propagate current company id to `AsyncSearchSelect` consumers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b022dbb13c8331b43c16e35d9af54a