### PR TITLE
Support company-specific user level permissions

### DIFF
--- a/api-server/controllers/authController.js
+++ b/api-server/controllers/authController.js
@@ -36,7 +36,10 @@ export async function login(req, res, next) {
       }
     }
 
-    const permissions = await getUserLevelActions(session.user_level);
+    const permissions = await getUserLevelActions(
+      session.user_level,
+      session.company_id,
+    );
     const {
       company_id: company,
       branch_id: branch,
@@ -103,7 +106,7 @@ export async function logout(req, res) {
 export async function getProfile(req, res) {
   const session = await getEmploymentSession(req.user.empid, req.user.companyId);
   const permissions = session?.user_level
-    ? await getUserLevelActions(session.user_level)
+    ? await getUserLevelActions(session.user_level, session.company_id)
     : {};
   const {
     company_id: company,
@@ -156,7 +159,7 @@ export async function refresh(req, res) {
     if (!user) throw new Error('User not found');
     const session = await getEmploymentSession(user.empid, payload.companyId);
     const permissions = session?.user_level
-      ? await getUserLevelActions(session.user_level)
+      ? await getUserLevelActions(session.user_level, session.company_id)
       : {};
     const {
       company_id: company,

--- a/api-server/controllers/permissionsController.js
+++ b/api-server/controllers/permissionsController.js
@@ -63,7 +63,7 @@ export async function listGroups(req, res, next) {
 export async function getActions(req, res, next) {
   try {
     const id = req.params.userLevelId;
-    const actions = await getUserLevelActions(id);
+    const actions = await getUserLevelActions(id, req.user.companyId);
     res.json(actions);
   } catch (err) {
     next(err);
@@ -80,7 +80,7 @@ export async function updateActions(req, res, next) {
       functions,
       api,
       permissions,
-    });
+    }, req.user.companyId);
     res.sendStatus(200);
   } catch (err) {
     next(err);

--- a/api-server/controllers/userActionController.js
+++ b/api-server/controllers/userActionController.js
@@ -4,7 +4,7 @@ export async function getUserActions(req, res, next) {
   try {
     const session = await getEmploymentSession(req.user.empid, req.user.companyId);
     const permissions = session?.user_level
-      ? await getUserLevelActions(session.user_level)
+      ? await getUserLevelActions(session.user_level, req.user.companyId)
       : {};
     res.json(permissions);
   } catch (err) {

--- a/api-server/utils/hasAction.js
+++ b/api-server/utils/hasAction.js
@@ -4,7 +4,10 @@ export async function hasAction(session, action) {
   if (session?.permissions?.[action]) return true;
   if (!session?.user_level) return false;
   if (!session.__userLevelActions) {
-    session.__userLevelActions = await getUserLevelActions(session.user_level);
+    session.__userLevelActions = await getUserLevelActions(
+      session.user_level,
+      session.company_id,
+    );
   }
   return !!session.__userLevelActions?.permissions?.[action];
 }

--- a/db/index.js
+++ b/db/index.js
@@ -339,13 +339,16 @@ export async function listUserLevels() {
   return rows;
 }
 
-export async function getUserLevelActions(userLevelId) {
+export async function getUserLevelActions(
+  userLevelId,
+  companyId = GLOBAL_COMPANY_ID,
+) {
   const id = Number(userLevelId);
   const [rows] = await pool.query(
     `SELECT action, action_key
        FROM user_level_permissions
-       WHERE userlevel_id = ? AND action IS NOT NULL AND company_id = ${GLOBAL_COMPANY_ID}`,
-    [userLevelId],
+       WHERE userlevel_id = ? AND action IS NOT NULL AND company_id IN (${GLOBAL_COMPANY_ID}, ?)`,
+    [userLevelId, companyId],
   );
   if (id === 1) {
     const perms = {};
@@ -439,31 +442,32 @@ export async function listActionGroups() {
 export async function setUserLevelActions(
   userLevelId,
   { modules = [], buttons = [], functions = [], api = [], permissions = [] },
+  companyId = GLOBAL_COMPANY_ID,
 ) {
   await pool.query(
-    `DELETE FROM user_level_permissions WHERE userlevel_id = ? AND action IS NOT NULL AND company_id = ${GLOBAL_COMPANY_ID}`,
+    `DELETE FROM user_level_permissions WHERE userlevel_id = ? AND action IS NOT NULL AND company_id = ${companyId}`,
     [userLevelId],
   );
   const values = [];
   const params = [];
   for (const m of modules) {
-    values.push(`(${GLOBAL_COMPANY_ID}, ?,'module_key',?)`);
+    values.push(`(${companyId}, ?,'module_key',?)`);
     params.push(userLevelId, m);
   }
   for (const b of buttons) {
-    values.push(`(${GLOBAL_COMPANY_ID}, ?,'button',?)`);
+    values.push(`(${companyId}, ?,'button',?)`);
     params.push(userLevelId, b);
   }
   for (const f of functions) {
-    values.push(`(${GLOBAL_COMPANY_ID}, ?,'function',?)`);
+    values.push(`(${companyId}, ?,'function',?)`);
     params.push(userLevelId, f);
   }
   for (const a of api) {
-    values.push(`(${GLOBAL_COMPANY_ID}, ?,'API',?)`);
+    values.push(`(${companyId}, ?,'API',?)`);
     params.push(userLevelId, a);
   }
   for (const p of permissions) {
-    values.push(`(${GLOBAL_COMPANY_ID}, ?,'permission',?)`);
+    values.push(`(${companyId}, ?,'permission',?)`);
     params.push(userLevelId, p);
   }
   if (values.length) {

--- a/tests/controllers/permissionsController.test.js
+++ b/tests/controllers/permissionsController.test.js
@@ -25,6 +25,7 @@ test('updateActions allows modifying level 1', async () => {
   const req = {
     params: { userLevelId: '1' },
     body: { modules: ['m1'], buttons: [], functions: [], api: [], permissions: [] },
+    user: { companyId: 0 },
   };
   const res = createRes();
   const original = db.pool.query;

--- a/tests/db/userLevelActions.test.js
+++ b/tests/db/userLevelActions.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as db from '../../db/index.js';
+
+test('getUserLevelActions includes company-specific permissions', async () => {
+  const orig = db.pool.query;
+  let capturedSql = '';
+  let capturedParams = [];
+  db.pool.query = async (sql, params) => {
+    capturedSql = sql;
+    capturedParams = params;
+    return [[{ action: 'module_key', action_key: 'm1' }]];
+  };
+  const perms = await db.getUserLevelActions(2, 5);
+  db.pool.query = orig;
+  assert.equal(perms.m1, true);
+  assert.match(capturedSql, /company_id IN \(0, \?\)/);
+  assert.deepEqual(capturedParams, [2, 5]);
+});
+
+test('setUserLevelActions uses provided company id', async () => {
+  const orig = db.pool.query;
+  const calls = [];
+  db.pool.query = async (sql, params) => {
+    calls.push({ sql, params });
+    return [[], []];
+  };
+  await db.setUserLevelActions(
+    2,
+    { modules: ['m1'], buttons: [], functions: [], api: [], permissions: [] },
+    5,
+  );
+  db.pool.query = orig;
+  assert.match(calls[0].sql, /company_id = 5/);
+  assert.deepEqual(calls[0].params, [2]);
+  assert.match(calls[1].sql, /\(5, \?,'module_key',\?\)/);
+});


### PR DESCRIPTION
## Summary
- load user-level permissions for both global and specific companies
- persist user-level permissions against a chosen company id
- add tests covering company-scoped permission load/save

## Testing
- `npm test` *(fails: deleteImageMovesFile.test.js, detectIncompleteImages.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b02ad51a408331953a88fc821a3671