### PR TITLE
Seed global tenant row and document usage

### DIFF
--- a/db/migrations/2025-10-29_global_defaults_company.sql
+++ b/db/migrations/2025-10-29_global_defaults_company.sql
@@ -1,0 +1,4 @@
+-- Ensure a global tenant row exists for shared defaults
+INSERT INTO companies (id, name)
+VALUES (0, 'Global Defaults')
+ON DUPLICATE KEY UPDATE name = VALUES(name);

--- a/db/migrations/README.md
+++ b/db/migrations/README.md
@@ -1,0 +1,5 @@
+# Database Migrations
+
+Migrations are plain SQL files executed in filename order. Use the `YYYY-MM-DD_description.sql` naming convention and append new files at the end.
+
+A special global tenant exists in the `companies` table with `id=0` and name `Global Defaults`. Migration `2025-10-29_global_defaults_company.sql` seeds this row. Future migrations may assume it exists and should use `company_id=0` when inserting shared records.

--- a/docs/tenant-table-scoping.md
+++ b/docs/tenant-table-scoping.md
@@ -7,6 +7,10 @@ Data-access helpers that accept `company_id` filters now consult the `tenant_tab
 
 This ensures queries return tenant-specific data while still honoring shared or global records.
 
+## Global tenant row
+
+The `companies` table reserves `id=0` for a `Global Defaults` tenant. Migration `2025-10-29_global_defaults_company.sql` seeds this row and future migrations may assume it exists. Use `company_id=0` when inserting records intended to be shared across all tenants.
+
 ## Listing tenant table options
 
 Administrators can fetch a full list of database tables and their `tenant_tables`


### PR DESCRIPTION
## Summary
- seed `companies` table with a `Global Defaults` row using an idempotent migration
- document the global tenant row and reference migration expectations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b02bf688408331a32805a019936081