### PR TITLE
Filter modules by license and permissions

### DIFF
--- a/api-server/controllers/moduleController.js
+++ b/api-server/controllers/moduleController.js
@@ -11,7 +11,10 @@ import { hasAction } from "../utils/hasAction.js";
 
 export async function listModules(req, res, next) {
   try {
-    const modules = await dbListModules();
+    const modules = await dbListModules(
+      req.user.userLevel,
+      req.user.companyId,
+    );
     res.json(modules);
   } catch (err) {
     next(err);

--- a/src/erp.mgt.mn/hooks/useModules.js
+++ b/src/erp.mgt.mn/hooks/useModules.js
@@ -9,7 +9,6 @@ const cache = {
   branchId: undefined,
   departmentId: undefined,
   prefix: undefined,
-  txnKeyCount: undefined,
 };
 const emitter = new EventTarget();
 
@@ -26,6 +25,7 @@ export function useModules() {
 
   async function fetchModules() {
     try {
+      // Server returns modules already filtered by license and permission.
       const res = await fetch('/api/modules', { credentials: 'include' });
       const rows = res.ok ? await res.json() : [];
       // Ensure dynamic transaction modules exist in the module list so users
@@ -77,7 +77,6 @@ export function useModules() {
       cache.branchId = branch;
       cache.departmentId = department;
       cache.prefix = generalConfig?.general?.reportProcPrefix;
-      cache.txnKeyCount = txnModules.keys.size;
       setModules(rows);
     } catch (err) {
       console.error('Failed to load modules', err);
@@ -87,17 +86,16 @@ export function useModules() {
 
   useEffect(() => {
     debugLog('useModules effect: initial fetch');
-    const prefix = generalConfig?.general?.reportProcPrefix;
-    if (
-      !cache.data ||
-      cache.branchId !== branch ||
-      cache.departmentId !== department ||
-      cache.prefix !== prefix ||
-      cache.txnKeyCount !== txnModules.keys.size
-    ) {
-      fetchModules();
-    }
-  }, [branch, department, generalConfig?.general?.reportProcPrefix, txnModules]);
+      const prefix = generalConfig?.general?.reportProcPrefix;
+      if (
+        !cache.data ||
+        cache.branchId !== branch ||
+        cache.departmentId !== department ||
+        cache.prefix !== prefix
+      ) {
+        fetchModules();
+      }
+    }, [branch, department, generalConfig?.general?.reportProcPrefix, txnModules]);
 
   useEffect(() => {
     debugLog('useModules effect: refresh listener');

--- a/tests/controllers/listModulesPermissions.test.js
+++ b/tests/controllers/listModulesPermissions.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as db from '../../db/index.js';
+
+await test('listModules filters by license and permission', async () => {
+  const controller = await import('../../api-server/controllers/moduleController.js?test=listModulesPerm');
+  const origQuery = db.pool.query;
+  const queries = [];
+  db.pool.query = async (sql, params) => {
+    queries.push({ sql, params });
+    const modules = [
+      { module_key: 'sales', label: 'Sales', parent_key: null, show_in_sidebar: 1, show_in_header: 0 },
+      { module_key: 'hr', label: 'HR', parent_key: null, show_in_sidebar: 1, show_in_header: 0 },
+    ];
+    // Only "sales" is both licensed and permitted
+    const licensed = new Set(['sales', 'hr']);
+    const permitted = new Set(['sales']);
+    const rows = modules.filter(
+      (m) => licensed.has(m.module_key) && permitted.has(m.module_key),
+    );
+    return [rows];
+  };
+
+  const req = { user: { userLevel: 2, companyId: 1 } };
+  const res = { body: undefined, json(data) { this.body = data; } };
+  await controller.listModules(req, res, () => {});
+  db.pool.query = origQuery;
+
+  assert.deepEqual(res.body.map((m) => m.module_key), ['sales']);
+  assert.deepEqual(queries[0].params, [1, 2, 1]);
+  assert.ok(/company_module_licenses/.test(queries[0].sql));
+  assert.ok(/user_level_permissions/.test(queries[0].sql));
+});


### PR DESCRIPTION
## Summary
- restrict `db.listModules` to modules licensed for the company and permitted for the user level
- pass authenticated user context into module listing controller
- simplify `useModules` to rely on server-side filtering while still appending dynamic transaction modules
- test that `/api/modules` returns only licensed and permitted modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b03042cffc8331a0275e691213d767