### PR TITLE
Add cascading module group toggle and unit test

### DIFF
--- a/src/erp.mgt.mn/pages/UserLevelActions.jsx
+++ b/src/erp.mgt.mn/pages/UserLevelActions.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useToast } from "../context/ToastContext.jsx";
+import { collectModuleKeys, toggleModuleGroupSelection } from "./moduleTreeHelpers.js";
 
 export default function UserLevelActions() {
   const [groups, setGroups] = useState({ modules: [], forms: {}, permissions: [] });
@@ -202,6 +203,13 @@ export default function UserLevelActions() {
     });
   }
 
+  function toggleModuleGroup(keys, checked) {
+    setSelected((prev) => ({
+      ...prev,
+      modules: toggleModuleGroupSelection(prev.modules, keys, checked),
+    }));
+  }
+
   function renderTree(node, type, depth = 0, path = []) {
     const elements = [];
     const currentPath = node.name ? [...path, node.name] : path;
@@ -257,19 +265,23 @@ export default function UserLevelActions() {
   }
 
   function renderModuleTree(items, depth = 0) {
-    return items.map((m) => (
-      <div key={m.key} style={{ marginLeft: depth * 20 }}>
-        <label>
-          <input
-            type="checkbox"
-            checked={selected.modules.includes(m.key)}
-            onChange={(e) => toggle("modules", m.key, e.target.checked)}
-          />
-          {m.name}
-        </label>
-        {m.children?.length ? renderModuleTree(m.children, depth + 1) : null}
-      </div>
-    ));
+    return items.map((m) => {
+      const keys = collectModuleKeys(m);
+      const groupChecked = keys.every((k) => selected.modules.includes(k));
+      return (
+        <div key={m.key} style={{ marginLeft: depth * 20 }}>
+          <label>
+            <input
+              type="checkbox"
+              checked={groupChecked}
+              onChange={(e) => toggleModuleGroup(keys, e.target.checked)}
+            />
+            {m.name}
+          </label>
+          {m.children?.length ? renderModuleTree(m.children, depth + 1) : null}
+        </div>
+      );
+    });
   }
 
   async function handlePopulate() {

--- a/src/erp.mgt.mn/pages/moduleTreeHelpers.js
+++ b/src/erp.mgt.mn/pages/moduleTreeHelpers.js
@@ -1,0 +1,16 @@
+export function collectModuleKeys(mod) {
+  const keys = [mod.key];
+  if (mod.children?.length) {
+    for (const child of mod.children) {
+      keys.push(...collectModuleKeys(child));
+    }
+  }
+  return keys;
+}
+
+export function toggleModuleGroupSelection(current, keys, checked) {
+  const set = new Set(current);
+  if (checked) keys.forEach((k) => set.add(k));
+  else keys.forEach((k) => set.delete(k));
+  return Array.from(set);
+}

--- a/tests/components/moduleGroupToggle.test.js
+++ b/tests/components/moduleGroupToggle.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('toggleModuleGroupSelection selects and deselects descendants', async () => {
+  const { collectModuleKeys, toggleModuleGroupSelection } = await import(
+    '../../src/erp.mgt.mn/pages/moduleTreeHelpers.js'
+  );
+  const tree = {
+    key: 'parent',
+    children: [
+      { key: 'child1' },
+      { key: 'child2', children: [{ key: 'grandchild' }] },
+    ],
+  };
+  const keys = collectModuleKeys(tree);
+  let selected = [];
+  selected = toggleModuleGroupSelection(selected, keys, true);
+  assert.deepEqual(new Set(selected), new Set(keys));
+  selected = toggleModuleGroupSelection(selected, keys, false);
+  assert.deepEqual(selected, []);
+});


### PR DESCRIPTION
## Summary
- add helpers to collect module tree keys and update selection sets
- cascade module selection when parent group checkbox toggled
- test module group toggling for both select and deselect scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b031dc18dc833190d180357f19d60c