### PR TITLE
Scope user-level permissions to tenant company

### DIFF
--- a/tests/controllers/listModulesPermissions.test.js
+++ b/tests/controllers/listModulesPermissions.test.js
@@ -30,4 +30,5 @@ await test('listModules filters by license and permission', async () => {
   assert.deepEqual(queries[0].params, [1, 2, 1]);
   assert.ok(/company_module_licenses/.test(queries[0].sql));
   assert.ok(/user_level_permissions/.test(queries[0].sql));
+  assert.ok(/up.company_id = \?/.test(queries[0].sql));
 });

--- a/tests/db/seedTenantTables.test.js
+++ b/tests/db/seedTenantTables.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as db from '../../db/index.js';
+
+await test('seedTenantTables copies user level permissions', async () => {
+  const orig = db.pool.query;
+  const calls = [];
+  db.pool.query = async (sql, params) => {
+    calls.push({ sql, params });
+    if (sql.startsWith('SELECT table_name, is_shared FROM tenant_tables')) {
+      return [[]];
+    }
+    return [[], []];
+  };
+  await db.seedTenantTables(7);
+  db.pool.query = orig;
+  const insertCall = calls.find((c) => /INSERT INTO user_level_permissions/.test(c.sql));
+  assert.ok(insertCall);
+  assert.deepEqual(insertCall.params, [7]);
+  assert.match(
+    insertCall.sql,
+    /SELECT \?,\s*userlevel_id, action, action_key\s+FROM user_level_permissions\s+WHERE company_id = 0/,
+  );
+});

--- a/tests/db/userLevelActions.test.js
+++ b/tests/db/userLevelActions.test.js
@@ -14,8 +14,8 @@ test('getUserLevelActions includes company-specific permissions', async () => {
   const perms = await db.getUserLevelActions(2, 5);
   db.pool.query = orig;
   assert.equal(perms.m1, true);
-  assert.match(capturedSql, /company_id IN \(0, \?\)/);
-  assert.deepEqual(capturedParams, [2, 5]);
+  assert.match(capturedSql, /company_id = \? AND userlevel_id = \?/);
+  assert.deepEqual(capturedParams, [5, 2]);
 });
 
 test('setUserLevelActions uses provided company id', async () => {


### PR DESCRIPTION
## Summary
- Query user permissions by specific company and module
- Limit module listing to tenant-level permissions
- Seed default user_level_permissions when creating a company

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b039305ed8833193caf1abd1b601a9