### PR TITLE
chore: remove redundant company id column

### DIFF
--- a/db/mgtmn_erp_db.sql
+++ b/db/mgtmn_erp_db.sql
@@ -1743,8 +1743,7 @@ CREATE TABLE `code_workplace_other` (
 CREATE TABLE `companies` (
   `id` int NOT NULL,
   `name` varchar(100) NOT NULL,
-  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
-  `company_id` int NOT NULL DEFAULT '0'
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- --------------------------------------------------------


### PR DESCRIPTION
## Summary
- drop `company_id` from `companies` table definition in schema dump

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b05fe6a69c8331afe03138f8df5900