### PR TITLE
feat: seed tenant tables with record filters

### DIFF
--- a/api-server/controllers/companyController.js
+++ b/api-server/controllers/companyController.js
@@ -16,12 +16,17 @@ export async function listCompaniesHandler(req, res, next) {
 export async function createCompanyHandler(req, res, next) {
   try {
     res.locals.logTable = 'companies';
-    const { seedTables = null, ...company } = req.body || {};
+    const { seedTables = null, seedRecords = null, ...company } = req.body || {};
     const session =
       req.session ||
       (await getEmploymentSession(req.user.empid, req.user.companyId));
     if (!session?.permissions?.system_settings) return res.sendStatus(403);
-    const result = await insertTableRow('companies', company, seedTables);
+    const result = await insertTableRow(
+      'companies',
+      company,
+      seedTables,
+      seedRecords,
+    );
     res.locals.insertId = result?.id;
     res.status(201).json(result);
   } catch (err) {


### PR DESCRIPTION
## Summary
- allow seedTenantTables to copy only specified record IDs per table
- forward seedRecords through insertTableRow and createCompanyHandler
- add admin endpoint to seed selected tables for existing companies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b15a3c27f08331a0562fe9a257313d