### PR TITLE
feat: add modal to seed defaults for companies

### DIFF
--- a/src/erp.mgt.mn/pages/TenantTablesRegistry.jsx
+++ b/src/erp.mgt.mn/pages/TenantTablesRegistry.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import Modal from '../components/Modal.jsx';
 import { useToast } from '../context/ToastContext.jsx';
 
 async function parseErrorBody(res) {
@@ -21,6 +22,9 @@ export default function TenantTablesRegistry() {
   const [resetting, setResetting] = useState(false);
   const [seedingDefaults, setSeedingDefaults] = useState(false);
   const [seedingCompanies, setSeedingCompanies] = useState(false);
+  const [seedModalOpen, setSeedModalOpen] = useState(false);
+  const [selectedTables, setSelectedTables] = useState({});
+  const [tableRecords, setTableRecords] = useState({});
   const { addToast } = useToast();
 
   useEffect(() => {
@@ -119,18 +123,95 @@ export default function TenantTablesRegistry() {
     }
   }
 
-  async function handleSeedCompanies() {
+  function openSeedCompaniesModal() {
+    setSelectedTables({});
+    setTableRecords({});
+    setSeedModalOpen(true);
+  }
+
+  function handleTableSelect(table, checked) {
+    setSelectedTables((prev) => ({ ...prev, [table]: checked }));
+    if (checked && !tableRecords[table]) {
+      loadTableRecords(table);
+    }
+  }
+
+  function handleRecordSelect(table, id, checked) {
+    setTableRecords((prev) => {
+      const info = prev[table];
+      if (!info) return prev;
+      const selected = new Set(info.selected);
+      if (checked) selected.add(id);
+      else selected.delete(id);
+      return { ...prev, [table]: { ...info, selected } };
+    });
+  }
+
+  async function loadTableRecords(table) {
+    setTableRecords((prev) => ({
+      ...prev,
+      [table]: { loading: true, rows: [], selected: new Set() },
+    }));
+    try {
+      const [rowsRes, colsRes] = await Promise.all([
+        fetch(`/api/tables/${encodeURIComponent(table)}?company_id=0&perPage=500`, {
+          credentials: 'include',
+        }),
+        fetch(`/api/tables/${encodeURIComponent(table)}/columns`, {
+          credentials: 'include',
+        }),
+      ]);
+      if (!rowsRes.ok) {
+        const msg = await parseErrorBody(rowsRes);
+        throw new Error(msg || 'Failed to load records');
+      }
+      if (!colsRes.ok) {
+        const msg = await parseErrorBody(colsRes);
+        throw new Error(msg || 'Failed to load columns');
+      }
+      const rowsData = await rowsRes.json();
+      const cols = await colsRes.json();
+      const pk = cols.find((c) => c.key === 'PRI')?.name;
+      const recs = (rowsData.rows || [])
+        .filter((r) => pk && r[pk] !== undefined)
+        .map((r) => ({ id: r[pk] }));
+      const selected = new Set(recs.map((r) => r.id));
+      setTableRecords((prev) => ({
+        ...prev,
+        [table]: { loading: false, rows: recs, selected },
+      }));
+    } catch (err) {
+      setTableRecords((prev) => ({
+        ...prev,
+        [table]: { loading: false, rows: [], selected: new Set() },
+      }));
+      addToast(`Failed to load records for ${table}: ${err.message}`, 'error');
+    }
+  }
+
+  async function handleSeedCompaniesSubmit() {
+    const tables = Object.keys(selectedTables).filter((t) => selectedTables[t]);
+    if (tables.length === 0) {
+      setSeedModalOpen(false);
+      return;
+    }
     setSeedingCompanies(true);
     try {
+      const records = tables
+        .map((t) => ({ table: t, ids: Array.from(tableRecords[t]?.selected || []) }))
+        .filter((r) => r.ids.length > 0);
       const res = await fetch('/api/tenant_tables/seed-companies', {
         method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
+        body: JSON.stringify({ tables, records }),
       });
       if (!res.ok) {
         const msg = await parseErrorBody(res);
         throw new Error(msg || 'Failed to seed companies');
       }
       addToast('Populated defaults for existing companies', 'success');
+      setSeedModalOpen(false);
       await loadTables();
     } catch (err) {
       addToast(`Failed to seed companies: ${err.message}`, 'error');
@@ -200,7 +281,7 @@ export default function TenantTablesRegistry() {
         <button onClick={handleSeedDefaults} disabled={seedingDefaults}>
           Populate defaults (tenant key 0)
         </button>
-        <button onClick={handleSeedCompanies} disabled={seedingCompanies}>
+        <button onClick={openSeedCompaniesModal} disabled={seedingCompanies}>
           Populate defaults for existing companies
         </button>
         <button onClick={handleResetTenantKeys} disabled={resetting}>
@@ -250,6 +331,66 @@ export default function TenantTablesRegistry() {
           </tbody>
         </table>
       )}
+      <Modal
+        visible={seedModalOpen}
+        title="Populate defaults for existing companies"
+        onClose={() => setSeedModalOpen(false)}
+        width="500px"
+      >
+        {tables && tables.filter((t) => t.seedOnCreate).length === 0 ? (
+          <p>No seed_on_create tables.</p>
+        ) : (
+          <div style={{ maxHeight: '60vh', overflowY: 'auto' }}>
+            {tables
+              ?.filter((t) => t.seedOnCreate)
+              .map((t) => (
+                <div key={t.tableName} style={{ marginBottom: '0.5rem' }}>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={!!selectedTables[t.tableName]}
+                      onChange={(e) => handleTableSelect(t.tableName, e.target.checked)}
+                    />{' '}
+                    {t.tableName}
+                  </label>
+                  {selectedTables[t.tableName] && (
+                    <div style={{ marginLeft: '1rem', marginTop: '0.25rem' }}>
+                      {tableRecords[t.tableName]?.loading ? (
+                        <p>Loading...</p>
+                      ) : tableRecords[t.tableName]?.rows.length ? (
+                        tableRecords[t.tableName].rows.map((r) => (
+                          <label key={r.id} style={{ display: 'block' }}>
+                            <input
+                              type="checkbox"
+                              checked={tableRecords[t.tableName].selected.has(r.id)}
+                              onChange={(e) =>
+                                handleRecordSelect(t.tableName, r.id, e.target.checked)
+                              }
+                            />{' '}
+                            {String(r.id)}
+                          </label>
+                        ))
+                      ) : (
+                        <p>No records</p>
+                      )}
+                    </div>
+                  )}
+                </div>
+              ))}
+          </div>
+        )}
+        <div style={{ marginTop: '1rem', textAlign: 'right' }}>
+          <button
+            onClick={handleSeedCompaniesSubmit}
+            disabled={
+              seedingCompanies ||
+              Object.keys(selectedTables).filter((t) => selectedTables[t]).length === 0
+            }
+          >
+            Submit
+          </button>
+        </div>
+      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add modal to select seed_on_create tables and records
- post selected tables/records to /api/tenant_tables/seed-companies
- refresh registry and disable buttons during requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b15d647dd08331bccd20393b9e3ab5