### PR TITLE
feat: allow custom tenant table seeding with overwrite

### DIFF
--- a/api-server/controllers/companyController.js
+++ b/api-server/controllers/companyController.js
@@ -16,7 +16,12 @@ export async function listCompaniesHandler(req, res, next) {
 export async function createCompanyHandler(req, res, next) {
   try {
     res.locals.logTable = 'companies';
-    const { seedTables = null, seedRecords = null, ...company } = req.body || {};
+    const {
+      seedTables = null,
+      seedRecords = null,
+      overwrite = false,
+      ...company
+    } = req.body || {};
     const session =
       req.session ||
       (await getEmploymentSession(req.user.empid, req.user.companyId));
@@ -26,6 +31,7 @@ export async function createCompanyHandler(req, res, next) {
       company,
       seedTables,
       seedRecords,
+      overwrite,
     );
     res.locals.insertId = result?.id;
     res.status(201).json(result);

--- a/api-server/controllers/tenantTablesController.js
+++ b/api-server/controllers/tenantTablesController.js
@@ -101,3 +101,34 @@ export async function seedExistingCompanies(req, res, next) {
     next(err);
   }
 }
+
+export async function seedCompany(req, res, next) {
+  try {
+    if (!(await ensureAdmin(req))) return res.sendStatus(403);
+    const { companyId, tables = null, records = [], overwrite = false } =
+      req.body || {};
+    if (!companyId) {
+      return res.status(400).json({ message: 'companyId is required' });
+    }
+    const recordMap = {};
+    for (const rec of records || []) {
+      if (
+        rec?.table &&
+        Array.isArray(rec.rows) &&
+        rec.rows.length > 0
+      ) {
+        recordMap[rec.table] = rec.rows;
+      } else if (
+        rec?.table &&
+        Array.isArray(rec.ids) &&
+        rec.ids.length > 0
+      ) {
+        recordMap[rec.table] = rec.ids;
+      }
+    }
+    await seedTenantTables(companyId, tables, recordMap, overwrite);
+    res.sendStatus(204);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/api-server/routes/tenant_tables.js
+++ b/api-server/routes/tenant_tables.js
@@ -8,6 +8,7 @@ import {
   resetSharedTenantKeys,
   seedDefaults,
   seedExistingCompanies,
+  seedCompany,
 } from '../controllers/tenantTablesController.js';
 
 const router = express.Router();
@@ -19,5 +20,6 @@ router.get('/options', requireAuth, listTenantTableOptions);
 router.post('/zero-keys', requireAuth, resetSharedTenantKeys);
 router.post('/seed-defaults', requireAuth, seedDefaults);
 router.post('/seed-companies', requireAuth, seedExistingCompanies);
+router.post('/seed-company', requireAuth, seedCompany);
 
 export default router;


### PR DESCRIPTION
## Summary
- allow `seedTenantTables` to accept explicit record data and optional overwrite
- forward `seedRecords` and `overwrite` flags when creating a company
- add route to seed tenant tables for a specific company

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b16ab1853c8331a0f9befa56e8d7c7