### PR TITLE
feat: seed tenant tables for company

### DIFF
--- a/src/erp.mgt.mn/pages/TenantTablesRegistry.jsx
+++ b/src/erp.mgt.mn/pages/TenantTablesRegistry.jsx
@@ -21,15 +21,34 @@ export default function TenantTablesRegistry() {
   const [saving, setSaving] = useState({});
   const [resetting, setResetting] = useState(false);
   const [seedingDefaults, setSeedingDefaults] = useState(false);
-  const [seedingCompanies, setSeedingCompanies] = useState(false);
+  const [seedingCompany, setSeedingCompany] = useState(false);
   const [seedModalOpen, setSeedModalOpen] = useState(false);
   const [selectedTables, setSelectedTables] = useState({});
   const [tableRecords, setTableRecords] = useState({});
+  const [companies, setCompanies] = useState([]);
+  const [companyId, setCompanyId] = useState('');
   const { addToast } = useToast();
 
   useEffect(() => {
     loadTables();
+    loadCompanies();
   }, []);
+
+  async function loadCompanies() {
+    try {
+      const res = await fetch('/api/companies', { credentials: 'include' });
+      const ct = res.headers.get('content-type') || '';
+      if (!res.ok) {
+        const msg = await parseErrorBody(res);
+        throw new Error(msg || `${res.status} ${res.statusText}`);
+      } else if (!ct.includes('application/json')) {
+        throw new Error(`Unexpected response: ${ct || 'unknown content-type'}`);
+      }
+      setCompanies(await res.json());
+    } catch (err) {
+      addToast(`Failed to load companies: ${err.message}`, 'error');
+    }
+  }
 
   async function loadTables() {
     let options = [];
@@ -123,7 +142,7 @@ export default function TenantTablesRegistry() {
     }
   }
 
-  function openSeedCompaniesModal() {
+  function openSeedCompanyModal() {
     setSelectedTables({});
     setTableRecords({});
     setSeedModalOpen(true);
@@ -189,34 +208,42 @@ export default function TenantTablesRegistry() {
     }
   }
 
-  async function handleSeedCompaniesSubmit() {
+  async function handleSeedCompanySubmit(overwrite) {
     const tables = Object.keys(selectedTables).filter((t) => selectedTables[t]);
-    if (tables.length === 0) {
+    if (!companyId || tables.length === 0) {
       setSeedModalOpen(false);
       return;
     }
-    setSeedingCompanies(true);
+    setSeedingCompany(true);
     try {
       const records = tables
         .map((t) => ({ table: t, ids: Array.from(tableRecords[t]?.selected || []) }))
         .filter((r) => r.ids.length > 0);
-      const res = await fetch('/api/tenant_tables/seed-companies', {
+      const res = await fetch('/api/tenant_tables/seed-company', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ tables, records }),
+        body: JSON.stringify({
+          companyId,
+          tables,
+          records,
+          overwrite,
+        }),
       });
       if (!res.ok) {
         const msg = await parseErrorBody(res);
-        throw new Error(msg || 'Failed to seed companies');
+        throw new Error(msg || 'Failed to seed company');
       }
-      addToast('Populated defaults for existing companies', 'success');
+      addToast(
+        overwrite ? 'Repopulated company defaults' : 'Populated company defaults',
+        'success',
+      );
       setSeedModalOpen(false);
       await loadTables();
     } catch (err) {
-      addToast(`Failed to seed companies: ${err.message}`, 'error');
+      addToast(`Failed to seed company: ${err.message}`, 'error');
     } finally {
-      setSeedingCompanies(false);
+      setSeedingCompany(false);
     }
   }
 
@@ -281,8 +308,8 @@ export default function TenantTablesRegistry() {
         <button onClick={handleSeedDefaults} disabled={seedingDefaults}>
           Populate defaults (tenant key 0)
         </button>
-        <button onClick={openSeedCompaniesModal} disabled={seedingCompanies}>
-          Populate defaults for existing companies
+        <button onClick={openSeedCompanyModal} disabled={seedingCompany}>
+          Populate defaults for company
         </button>
         <button onClick={handleResetTenantKeys} disabled={resetting}>
           Reset Shared Table Tenant Keys
@@ -333,10 +360,24 @@ export default function TenantTablesRegistry() {
       )}
       <Modal
         visible={seedModalOpen}
-        title="Populate defaults for existing companies"
+        title="Populate defaults for company"
         onClose={() => setSeedModalOpen(false)}
         width="500px"
       >
+        <div style={{ marginBottom: '0.5rem' }}>
+          <select
+            value={companyId}
+            onChange={(e) => setCompanyId(e.target.value)}
+            style={{ width: '100%' }}
+          >
+            <option value="">Select company</option>
+            {companies.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
         {tables && tables.filter((t) => t.seedOnCreate).length === 0 ? (
           <p>No seed_on_create tables.</p>
         ) : (
@@ -381,13 +422,25 @@ export default function TenantTablesRegistry() {
         )}
         <div style={{ marginTop: '1rem', textAlign: 'right' }}>
           <button
-            onClick={handleSeedCompaniesSubmit}
+            onClick={() => handleSeedCompanySubmit(false)}
             disabled={
-              seedingCompanies ||
+              seedingCompany ||
+              !companyId ||
+              Object.keys(selectedTables).filter((t) => selectedTables[t]).length === 0
+            }
+            style={{ marginRight: '0.5rem' }}
+          >
+            Populate
+          </button>
+          <button
+            onClick={() => handleSeedCompanySubmit(true)}
+            disabled={
+              seedingCompany ||
+              !companyId ||
               Object.keys(selectedTables).filter((t) => selectedTables[t]).length === 0
             }
           >
-            Submit
+            Repopulate
           </button>
         </div>
       </Modal>


### PR DESCRIPTION
## Summary
- add company dropdown in Tenant Tables Registry
- seed selected company via /api/tenant_tables/seed-company with populate and repopulate options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b16dc91a2083319a3b9dbce41f0548