### PR TITLE
Fix company module license filtering for global tenant

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -855,7 +855,7 @@ export async function populateUserLevelModulePermissions() {
 export async function listCompanyModuleLicenses(companyId) {
   const params = [];
   let where = '';
-  if (companyId) {
+  if (companyId != null) {
     where = 'WHERE c.id = ?';
     params.push(companyId);
   }

--- a/tests/api/companyModules.test.js
+++ b/tests/api/companyModules.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { listLicenses } from '../../api-server/controllers/companyModuleController.js';
+import * as db from '../../db/index.js';
+
+function createRes() {
+  return {
+    body: undefined,
+    status() { return this; },
+    json(b) { this.body = b; },
+    sendStatus() {},
+  };
+}
+
+function mockPool() {
+  const orig = db.pool.query;
+  db.pool.query = async (sql, params) => {
+    if (/WHERE c.id = \?/.test(sql)) {
+      assert.deepEqual(params, [0]);
+      return [[{ company_id: 0, company_name: 'Global', module_key: 'mod', label: 'Mod', licensed: 1 }]];
+    }
+    return [[
+      { company_id: 0, company_name: 'Global', module_key: 'mod', label: 'Mod', licensed: 1 },
+      { company_id: 1, company_name: 'Other', module_key: 'mod', label: 'Mod', licensed: 1 },
+    ]];
+  };
+  return () => { db.pool.query = orig; };
+}
+
+test('GET /api/company_modules?companyId=0 returns only global tenant licenses', async () => {
+  const restore = mockPool();
+  const req = { query: { companyId: 0 } };
+  const res = createRes();
+  await listLicenses(req, res, () => {});
+  restore();
+  assert.deepEqual(res.body, [
+    { company_id: 0, company_name: 'Global', module_key: 'mod', label: 'Mod', licensed: 1 },
+  ]);
+});


### PR DESCRIPTION
## Summary
- handle companyId 0 in listCompanyModuleLicenses to filter by selected company
- add test covering companyId=0 fetch of module licenses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1ac01a3548331ba266a3f2e4aa732