### PR TITLE
Filter company module licenses in hook and add test

### DIFF
--- a/src/erp.mgt.mn/hooks/useCompanyModules.js
+++ b/src/erp.mgt.mn/hooks/useCompanyModules.js
@@ -19,7 +19,7 @@ export function useCompanyModules(companyId) {
       const rows = res.ok ? await res.json() : [];
       const map = {};
       rows.forEach((r) => {
-        if (r.licensed) {
+        if (Number(r.company_id) === Number(id) && r.licensed) {
           map[r.module_key] = true;
         }
       });

--- a/tests/hooks/useCompanyModules.test.js
+++ b/tests/hooks/useCompanyModules.test.js
@@ -88,5 +88,26 @@ if (!haveReact) {
     assert.equal(container.textContent, 'loaded');
     root.unmount();
   });
-}
 
+  test('useCompanyModules filters licenses by companyId', async () => {
+    global.fetch = async () => ({
+      ok: true,
+      json: async () => [
+        { company_id: 0, module_key: 'finance_transactions', licensed: 1 },
+        { company_id: 1, module_key: 'finance_reports', licensed: 1 },
+      ],
+    });
+
+    function TestComponent() {
+      const licensed = useCompanyModules(0);
+      return React.createElement('p', null, licensed ? JSON.stringify(licensed) : '');
+    }
+
+    const { container, root } = render(React.createElement(TestComponent));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    assert.equal(container.textContent, JSON.stringify({ finance_transactions: true }));
+    root.unmount();
+  });
+}


### PR DESCRIPTION
## Summary
- Ensure `useCompanyModules` only records licenses for the requested company ID
- Add test verifying hook ignores licenses from other companies

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ace293e88331b4bb41541f000744