### PR TITLE
Handle company 0 in user management pages

### DIFF
--- a/src/erp.mgt.mn/pages/RolePermissions.jsx
+++ b/src/erp.mgt.mn/pages/RolePermissions.jsx
@@ -10,7 +10,7 @@ export default function RolePermissions() {
   function loadPerms(positionId) {
     const params = [];
     if (positionId) params.push(`positionId=${encodeURIComponent(positionId)}`);
-    if (company) params.push(`companyId=${encodeURIComponent(company)}`);
+    if (company != null) params.push(`companyId=${encodeURIComponent(company)}`);
     const url = params.length ? `/api/role_permissions?${params.join("&")}` : "/api/role_permissions";
     fetch(url, { credentials: "include" })
       .then((res) => {

--- a/src/erp.mgt.mn/pages/UserCompanies.jsx
+++ b/src/erp.mgt.mn/pages/UserCompanies.jsx
@@ -20,7 +20,7 @@ export default function UserCompanies() {
   function loadAssignments(empid) {
     const params = [];
     if (empid) params.push(`empid=${encodeURIComponent(empid)}`);
-    if (company) params.push(`companyId=${encodeURIComponent(company)}`);
+    if (company != null) params.push(`companyId=${encodeURIComponent(company)}`);
     const url = params.length ? `/api/user_companies?${params.join('&')}` : '/api/user_companies';
     fetch(url, { credentials: 'include' })
       .then(res => {

--- a/src/erp.mgt.mn/pages/Users.jsx
+++ b/src/erp.mgt.mn/pages/Users.jsx
@@ -13,7 +13,7 @@ export default function Users() {
   }, []);
 
   function loadUsers() {
-    const params = company ? `?companyId=${encodeURIComponent(company)}` : '';
+    const params = company != null ? `?companyId=${encodeURIComponent(company)}` : '';
     fetch(`/api/users${params}`, { credentials: 'include' })
       .then((res) => {
         if (!res.ok) throw new Error('Failed to fetch users');

--- a/tests/pages/RolePermissions.test.js
+++ b/tests/pages/RolePermissions.test.js
@@ -1,0 +1,53 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+if (typeof mock.import !== 'function') {
+  test('RolePermissions page loads permissions when company is 0', { skip: true }, () => {});
+} else {
+  test('RolePermissions page loads permissions when company is 0', async () => {
+    const states = [];
+    let fetchUrl;
+    const reactMock = {
+      useState(initial) {
+        const idx = states.length;
+        states.push(initial);
+        return [states[idx], (v) => (states[idx] = v)];
+      },
+      useEffect(fn) { fn(); },
+      useContext() {
+        return { company: 0 };
+      },
+      createElement() { return null; },
+    };
+
+    const data = [
+      { position_id: 1, module_key: 'mod', role: 'Role', label: 'Module', allowed: 1 },
+    ];
+    global.fetch = async (url) => {
+      fetchUrl = url;
+      return { ok: true, json: async () => data };
+    };
+
+    const { default: RolePermissions } = await mock.import(
+      '../../src/erp.mgt.mn/pages/RolePermissions.jsx',
+      {
+        react: {
+          default: reactMock,
+          useState: reactMock.useState,
+          useEffect: reactMock.useEffect,
+          useContext: reactMock.useContext,
+        },
+        '../context/AuthContext.jsx': { AuthContext: {} },
+      },
+    );
+
+    RolePermissions();
+    await Promise.resolve();
+
+    assert.equal(fetchUrl, '/api/role_permissions?companyId=0');
+    assert.deepEqual(states[0], data);
+
+    delete global.fetch;
+  });
+}
+

--- a/tests/pages/UserCompanies.test.js
+++ b/tests/pages/UserCompanies.test.js
@@ -1,0 +1,66 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+if (typeof mock.import !== 'function') {
+  test('UserCompanies page loads assignments when company is 0', { skip: true }, () => {});
+} else {
+  test('UserCompanies page loads assignments when company is 0', async () => {
+    const states = [];
+    const fetchUrls = [];
+    const reactMock = {
+      useState(initial) {
+        const idx = states.length;
+        states.push(initial);
+        return [states[idx], (v) => (states[idx] = v)];
+      },
+      useEffect(fn) { fn(); },
+      useContext() {
+        return { company: 0 };
+      },
+      createElement() { return null; },
+    };
+
+    const assignmentData = [
+      {
+        empid: 'e1',
+        company_id: 0,
+        company_name: 'Comp',
+        branch_name: 'Branch',
+        position: 'Pos',
+      },
+    ];
+    const responses = {
+      '/api/user_companies?companyId=0': assignmentData,
+      '/api/users': [],
+      '/api/companies': [],
+      '/api/tables/code_branches?perPage=500': { rows: [] },
+    };
+    global.fetch = async (url) => {
+      fetchUrls.push(url);
+      return { ok: true, json: async () => responses[url] };
+    };
+
+    const { default: UserCompanies } = await mock.import(
+      '../../src/erp.mgt.mn/pages/UserCompanies.jsx',
+      {
+        react: {
+          default: reactMock,
+          useState: reactMock.useState,
+          useEffect: reactMock.useEffect,
+          useContext: reactMock.useContext,
+        },
+        '../context/AuthContext.jsx': { AuthContext: {} },
+        '../utils/debug.js': { debugLog: () => {} },
+      },
+    );
+
+    UserCompanies();
+    await Promise.resolve();
+
+    assert.ok(fetchUrls.includes('/api/user_companies?companyId=0'));
+    assert.deepEqual(states[0], assignmentData);
+
+    delete global.fetch;
+  });
+}
+

--- a/tests/pages/Users.test.js
+++ b/tests/pages/Users.test.js
@@ -1,0 +1,52 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+if (typeof mock.import !== 'function') {
+  test('Users page loads data when company is 0', { skip: true }, () => {});
+} else {
+  test('Users page loads data when company is 0', async () => {
+    const states = [];
+    let fetchUrl;
+    const reactMock = {
+      useState(initial) {
+        const idx = states.length;
+        states.push(initial);
+        return [states[idx], (v) => (states[idx] = v)];
+      },
+      useEffect(fn) { fn(); },
+      useContext() {
+        return { company: 0 };
+      },
+      createElement() { return null; },
+    };
+
+    const data = [{ id: 1, empid: 'john', position: 'boss' }];
+    global.fetch = async (url) => {
+      fetchUrl = url;
+      return { ok: true, json: async () => data };
+    };
+
+    const { default: Users } = await mock.import(
+      '../../src/erp.mgt.mn/pages/Users.jsx',
+      {
+        react: {
+          default: reactMock,
+          useState: reactMock.useState,
+          useEffect: reactMock.useEffect,
+          useContext: reactMock.useContext,
+        },
+        '../context/AuthContext.jsx': { AuthContext: {} },
+        '../utils/debug.js': { debugLog: () => {} },
+      },
+    );
+
+    Users();
+    await Promise.resolve();
+
+    assert.equal(fetchUrl, '/api/users?companyId=0');
+    assert.deepEqual(states[0], data);
+
+    delete global.fetch;
+  });
+}
+


### PR DESCRIPTION
## Summary
- Ensure user management pages pass companyId=0 by using explicit null checks
- Add tests confirming pages load data when AuthContext.company is 0

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1afb43b748331b986cc95fbc64f0a