### PR TITLE
Handle company ID 0 in log record IDs

### DIFF
--- a/api-server/routes/company_modules.js
+++ b/api-server/routes/company_modules.js
@@ -1,20 +1,9 @@
 import express from 'express';
 import { listLicenses, updateLicense } from '../controllers/companyModuleController.js';
 import { requireAuth } from '../middlewares/auth.js';
+import { setCompanyModuleLogId } from './logRecordId.js';
 
 const router = express.Router();
 router.get('/', requireAuth, listLicenses);
-router.put(
-  '/',
-  requireAuth,
-  (req, res, next) => {
-    res.locals.logTable = 'company_module_licenses';
-    const { companyId, moduleKey } = req.body || {};
-    if (companyId && moduleKey) {
-      res.locals.logRecordId = `${companyId}-${moduleKey}`;
-    }
-    next();
-  },
-  updateLicense,
-);
+router.put('/', requireAuth, setCompanyModuleLogId, updateLicense);
 export default router;

--- a/api-server/routes/logRecordId.js
+++ b/api-server/routes/logRecordId.js
@@ -1,0 +1,17 @@
+export function setCompanyModuleLogId(req, res, next) {
+  res.locals.logTable = 'company_module_licenses';
+  const { companyId, moduleKey } = req.body || {};
+  if (companyId != null && moduleKey) {
+    res.locals.logRecordId = `${companyId}-${moduleKey}`;
+  }
+  next();
+}
+
+export function setUserCompanyLogId(req, res, next) {
+  res.locals.logTable = 'user_companies';
+  const { empid, companyId } = req.body || {};
+  if (empid != null && companyId != null) {
+    res.locals.logRecordId = `${empid}-${companyId}`;
+  }
+  next();
+}

--- a/api-server/routes/user_companies.js
+++ b/api-server/routes/user_companies.js
@@ -6,46 +6,11 @@ import {
   updateAssignment
 } from '../controllers/userCompanyController.js';
 import { requireAuth } from '../middlewares/auth.js';
+import { setUserCompanyLogId } from './logRecordId.js';
 
 const router = express.Router();
 router.get('/', requireAuth, listAssignments);
-router.post(
-  '/',
-  requireAuth,
-  (req, res, next) => {
-    res.locals.logTable = 'user_companies';
-    const { empid, companyId } = req.body || {};
-    if (empid && companyId) {
-      res.locals.logRecordId = `${empid}-${companyId}`;
-    }
-    next();
-  },
-  assignCompany,
-);
-router.delete(
-  '/',
-  requireAuth,
-  (req, res, next) => {
-    res.locals.logTable = 'user_companies';
-    const { empid, companyId } = req.body || {};
-    if (empid && companyId) {
-      res.locals.logRecordId = `${empid}-${companyId}`;
-    }
-    next();
-  },
-  removeAssignment,
-);
-router.put(
-  '/',
-  requireAuth,
-  (req, res, next) => {
-    res.locals.logTable = 'user_companies';
-    const { empid, companyId } = req.body || {};
-    if (empid && companyId) {
-      res.locals.logRecordId = `${empid}-${companyId}`;
-    }
-    next();
-  },
-  updateAssignment,
-);
+router.post('/', requireAuth, setUserCompanyLogId, assignCompany);
+router.delete('/', requireAuth, setUserCompanyLogId, removeAssignment);
+router.put('/', requireAuth, setUserCompanyLogId, updateAssignment);
 export default router;

--- a/tests/routes/logRecordId.test.js
+++ b/tests/routes/logRecordId.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  setCompanyModuleLogId,
+  setUserCompanyLogId,
+} from '../../api-server/routes/logRecordId.js';
+
+function createRes() {
+  return { locals: {} };
+}
+
+test('company_modules sets logRecordId when companyId is 0', () => {
+  const req = { body: { companyId: 0, moduleKey: 'm' } };
+  const res = createRes();
+  setCompanyModuleLogId(req, res, () => {});
+  assert.equal(res.locals.logRecordId, '0-m');
+});
+
+test('user_companies routes set logRecordId when companyId is 0', () => {
+  const req = { body: { empid: 0, companyId: 0 } };
+  const res = createRes();
+  setUserCompanyLogId(req, res, () => {});
+  assert.equal(res.locals.logRecordId, '0-0');
+});


### PR DESCRIPTION
## Summary
- ensure company_modules and user_companies routes set logRecordId when companyId or empid is 0
- factor log-id middleware into reusable module
- add unit tests for companyId 0 cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1b1fb8ac48331882a071bdab441a7