### PR TITLE
feat: track updater metadata on table updates

### DIFF
--- a/api-server/controllers/moduleController.js
+++ b/api-server/controllers/moduleController.js
@@ -58,6 +58,7 @@ export async function saveModule(req, res, next) {
       parentKey,
       showInSidebar,
       showInHeader,
+      req.user.empid,
     );
     await setCompanyModuleLicense(GLOBAL_COMPANY_ID, moduleKey, true);
     await setCompanyModuleLicense(req.user.companyId, moduleKey, true);

--- a/api-server/controllers/settingsController.js
+++ b/api-server/controllers/settingsController.js
@@ -39,7 +39,11 @@ export async function getTenantFlagsHandler(req, res, next) {
 export async function setTenantFlagsHandler(req, res, next) {
   try {
     const companyId = req.user.company_id || req.body.companyId;
-    const updatedFlags = await setTenantFlags(companyId, req.body.flags);
+    const updatedFlags = await setTenantFlags(
+      companyId,
+      req.body.flags,
+      req.user.empid,
+    );
     res.json(updatedFlags);
   } catch (err) {
     next(err);

--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -107,6 +107,11 @@ export async function updateRow(req, res, next) {
     const updates = { ...req.body };
     delete updates.created_by;
     delete updates.created_at;
+    const columns = await listTableColumns(req.params.table);
+    if (columns.includes('updated_by')) updates.updated_by = req.user.empid;
+    if (columns.includes('updated_at')) {
+      updates.updated_at = formatDateForDb(new Date());
+    }
     if (req.params.table === 'users' && updates.password) {
       updates.password = await bcrypt.hash(updates.password, 10);
     }

--- a/tests/db/setTenantFlags.test.js
+++ b/tests/db/setTenantFlags.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as db from '../../db/index.js';
+
+test('setTenantFlags includes updated_by and updated_at', async () => {
+  const calls = [];
+  const orig = db.pool.query;
+  db.pool.query = async (sql, params) => {
+    calls.push({ sql, params });
+    if (sql.startsWith('INSERT INTO tenant_feature_flags')) return [{}];
+    if (sql.startsWith('SELECT flag_key')) return [[{ flag_key: 'a', flag_value: 1 }]];
+    return [{}];
+  };
+  const result = await db.setTenantFlags(1, { a: true }, 'E1');
+  db.pool.query = orig;
+  assert.ok(calls[0].sql.includes('updated_by'));
+  assert.ok(calls[0].sql.includes('updated_at'));
+  assert.deepEqual(calls[0].params.slice(0, 4), [1, 'a', 1, 'E1']);
+  assert.match(calls[0].params[4], /\d{4}-\d{2}-\d{2}/);
+  assert.deepEqual(result, { a: true });
+});

--- a/tests/db/upsertModule.test.js
+++ b/tests/db/upsertModule.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as db from '../../db/index.js';
+
+test('upsertModule includes updated_by and updated_at', async () => {
+  const calls = [];
+  const orig = db.pool.query;
+  db.pool.query = async (sql, params) => {
+    calls.push({ sql, params });
+    return [{}];
+  };
+  await db.upsertModule('t', 'T', null, true, false, 'E1');
+  db.pool.query = orig;
+  assert.ok(calls[0].sql.includes('updated_by'));
+  assert.ok(calls[0].sql.includes('updated_at'));
+  assert.deepEqual(calls[0].params.slice(0, 6), ['t', 'T', null, 1, 0, 'E1']);
+  assert.match(calls[0].params[6], /\d{4}-\d{2}-\d{2}/);
+});


### PR DESCRIPTION
## Summary
- populate `updated_by` and `updated_at` when updating table rows
- forward user info to tenant flag and module upsert helpers
- cover update helpers with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1bfd34cac8331b99eda2e7ba0f0ff