### PR TITLE
track soft delete metadata

### DIFF
--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -177,7 +177,7 @@ export async function deleteRow(req, res, next) {
     if (req.query.cascade === 'true') {
       await deleteTableRowCascade(table, id);
     } else {
-      await deleteTableRow(table, id);
+      await deleteTableRow(table, id, undefined, req.user?.empid);
     }
     if (row) {
       try {

--- a/db/migrations/2025-08-31_add_deleted_fields.sql
+++ b/db/migrations/2025-08-31_add_deleted_fields.sql
@@ -1,0 +1,30 @@
+-- Add deleted_by and deleted_at columns to all soft-deletable tables
+-- Soft-deletable tables are identified by presence of typical soft delete columns
+-- such as is_deleted or deleted flag.
+DELIMITER $$
+CREATE PROCEDURE add_deleted_audit_fields()
+BEGIN
+  DECLARE done INT DEFAULT FALSE;
+  DECLARE t VARCHAR(191);
+  DECLARE cur CURSOR FOR
+    SELECT DISTINCT table_name
+      FROM information_schema.columns
+     WHERE table_schema = DATABASE()
+       AND column_name IN ('is_deleted','deleted','deleted_at','isDeleted','deletedAt');
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+  OPEN cur;
+  read_loop: LOOP
+    FETCH cur INTO t;
+    IF done THEN LEAVE read_loop; END IF;
+    SET @stmt = CONCAT('ALTER TABLE `', t, '` '
+      , 'ADD COLUMN IF NOT EXISTS `deleted_by` VARCHAR(50) NULL, '
+      , 'ADD COLUMN IF NOT EXISTS `deleted_at` TIMESTAMP NULL');
+    PREPARE s FROM @stmt;
+    EXECUTE s;
+    DEALLOCATE PREPARE s;
+  END LOOP;
+  CLOSE cur;
+END$$
+DELIMITER ;
+CALL add_deleted_audit_fields();
+DROP PROCEDURE add_deleted_audit_fields;

--- a/tests/db/validation.test.js
+++ b/tests/db/validation.test.js
@@ -73,11 +73,17 @@ test('deleteTableRow uses soft delete column when configured', async () => {
       return [[{ COLUMN_NAME: 'id' }, { COLUMN_NAME: 'is_deleted' }]];
     }
     called = true;
-    assert.equal(sql, 'UPDATE ?? SET `is_deleted` = 1 WHERE id = ?');
-    assert.deepEqual(params, ['softdelete', '5']);
+    assert.equal(
+      sql,
+      'UPDATE ?? SET `is_deleted` = 1, `deleted_by` = ?, `deleted_at` = ? WHERE id = ?',
+    );
+    assert.equal(params[0], 'softdelete');
+    assert.equal(params[1], 'EMP1');
+    assert.match(params[2], /^\d{4}-\d{2}-\d{2} /);
+    assert.equal(params[3], '5');
     return [{}];
   };
-  await db.deleteTableRow('softdelete', '5');
+  await db.deleteTableRow('softdelete', '5', undefined, 'EMP1');
   db.pool.query = original;
   assert.ok(called);
 });


### PR DESCRIPTION
## Summary
- add migration for deleted_by/deleted_at on soft-delete tables
- store deleting user and timestamp in deleteTableRow
- pass user ID through tableController and verify via tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1c123dfe483319667447c88017322