### PR TITLE
Track acting user when changing passwords

### DIFF
--- a/api-server/controllers/authController.js
+++ b/api-server/controllers/authController.js
@@ -141,7 +141,7 @@ export async function changePassword(req, res, next) {
       return res.status(400).json({ message: 'Password required' });
     }
     const hashed = await hash(password);
-    await updateUserPassword(req.user.id, hashed);
+    await updateUserPassword(req.user.id, hashed, req.user.id);
     res.sendStatus(204);
   } catch (err) {
     next(err);

--- a/db/index.js
+++ b/db/index.js
@@ -586,11 +586,11 @@ export async function updateUser(id) {
   return { id };
 }
 
-export async function updateUserPassword(id, hashedPassword) {
-  await pool.query("UPDATE users SET password = ? WHERE id = ?", [
-    hashedPassword,
-    id,
-  ]);
+export async function updateUserPassword(id, hashedPassword, updatedBy) {
+  await pool.query(
+    "UPDATE users SET password = ?, updated_by = ?, updated_at = NOW() WHERE id = ?",
+    [hashedPassword, updatedBy, id],
+  );
   return { id };
 }
 


### PR DESCRIPTION
## Summary
- record updater and timestamp in `updateUserPassword`
- include acting user's ID when changing password

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1cb5055908331b6e6cde384a314f5