### PR TITLE
feat: add multi-language module labels

### DIFF
--- a/config/generalConfig.json
+++ b/config/generalConfig.json
@@ -26,7 +26,13 @@
     "showReportParams": false,
     "requestPollingEnabled": false,
     "requestPollingIntervalSeconds": 30,
-    "procLabels": {},
+    "procLabels": {
+      "sales": {
+        "mn": "Борлуулалтын самбар",
+        "en": "Sales Dashboard",
+        "ru": "Панель продаж"
+      }
+    },
     "procFieldLabels": {},
     "reportProcPrefix": "",
     "reportViewPrefix": "",

--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -78,7 +78,7 @@ function AuthedApp() {
   const moduleMap = {};
   modules.forEach((m) => {
     const label =
-      generalConfig.general?.procLabels?.[m.module_key] ||
+      generalConfig.general?.procLabels?.[m.module_key]?.mn ||
       headerMap[m.module_key] ||
       m.label;
     moduleMap[m.module_key] = { ...m, label, children: [] };

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -74,7 +74,7 @@ export default function ERPLayout() {
     );
     if (!mod) return 'ERP';
     return (
-      generalConfig.general?.procLabels?.[mod.module_key] ||
+      generalConfig.general?.procLabels?.[mod.module_key]?.mn ||
       headerMap[mod.module_key] ||
       mod.label
     );
@@ -220,7 +220,7 @@ function Sidebar({ onOpen, open, isMobile }) {
   const allMap = {};
   modules.forEach((m) => {
     const label =
-      generalConfig.general?.procLabels?.[m.module_key] ||
+      generalConfig.general?.procLabels?.[m.module_key]?.mn ||
       headerMap[m.module_key] ||
       m.label;
     allMap[m.module_key] = { ...m, label };
@@ -243,7 +243,7 @@ function Sidebar({ onOpen, open, isMobile }) {
     if (!m.show_in_sidebar) return;
     if (!isTxn && !perms[m.module_key]) return;
     const label =
-      generalConfig.general?.procLabels?.[m.module_key] ||
+      generalConfig.general?.procLabels?.[m.module_key]?.mn ||
       headerMap[m.module_key] ||
       m.label;
     map[m.module_key] = { ...m, label, children: [] };

--- a/src/erp.mgt.mn/components/HeaderMenu.jsx
+++ b/src/erp.mgt.mn/components/HeaderMenu.jsx
@@ -38,7 +38,7 @@ export default function HeaderMenu({ onOpen }) {
     <nav style={styles.menu}>
       {items.map((m) => {
         const label =
-          generalConfig.general?.procLabels?.[m.module_key] ||
+          generalConfig.general?.procLabels?.[m.module_key]?.mn ||
           headerMap[m.module_key] ||
           m.label;
 

--- a/src/erp.mgt.mn/components/ReportTable.jsx
+++ b/src/erp.mgt.mn/components/ReportTable.jsx
@@ -442,11 +442,18 @@ export default function ReportTable({ procedure = '', params = {}, rows = [], bu
   }
 
   function handleEditProcLabel() {
-    const current = procLabels[procedure] || '';
+    const current = procLabels[procedure]?.mn || '';
     const next = window.prompt('Enter label', current);
     if (next === null) return;
     const existing = generalConfig.general?.procLabels || {};
-    const payload = { general: { procLabels: { ...existing, [procedure]: next } } };
+    const payload = {
+      general: {
+        procLabels: {
+          ...existing,
+          [procedure]: { ...(existing[procedure] || {}), mn: next },
+        },
+      },
+    };
     fetch('/api/general_config', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
@@ -457,7 +464,7 @@ export default function ReportTable({ procedure = '', params = {}, rows = [], bu
       .then((data) => data && updateCache(data));
   }
 
-  const procLabel = procLabels[procedure] || headerMap[procedure] || procedure;
+  const procLabel = procLabels[procedure]?.mn || headerMap[procedure] || procedure;
   const paramText =
     generalConfig.general?.showReportParams &&
     params &&

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -86,7 +86,7 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
 
   function getProcLabel(name) {
     return (
-      generalConfig.general?.procLabels?.[name] || procMap[name] || name
+      generalConfig.general?.procLabels?.[name]?.mn || procMap[name] || name
     );
   }
 

--- a/src/erp.mgt.mn/pages/FormsIndex.jsx
+++ b/src/erp.mgt.mn/pages/FormsIndex.jsx
@@ -19,7 +19,7 @@ export default function FormsIndex() {
   const moduleMap = {};
   modules.forEach((m) => {
     const label =
-      generalConfig.general?.procLabels?.[m.module_key] ||
+      generalConfig.general?.procLabels?.[m.module_key]?.mn ||
       headerMap[m.module_key] ||
       m.label;
     moduleMap[m.module_key] = { ...m, label };
@@ -87,7 +87,7 @@ export default function FormsIndex() {
         groups.map(([key]) => {
           const mod = modules.find((m) => m.module_key === key);
           const label = mod
-            ? generalConfig.general?.procLabels?.[mod.module_key] ||
+            ? generalConfig.general?.procLabels?.[mod.module_key]?.mn ||
               headerMap[mod.module_key] ||
               mod.label
             : key;

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -23,7 +23,9 @@ export default function FormsManagement() {
   const modules = useModules();
   const procMap = useHeaderMappings(procedureOptions);
   function getProcLabel(name) {
-    return generalConfig.general?.procLabels?.[name] || procMap[name] || name;
+    return (
+      generalConfig.general?.procLabels?.[name]?.mn || procMap[name] || name
+    );
   }
   useEffect(() => {
     debugLog('Component mounted: FormsManagement');

--- a/src/erp.mgt.mn/pages/Reports.jsx
+++ b/src/erp.mgt.mn/pages/Reports.jsx
@@ -34,7 +34,7 @@ export default function Reports() {
 
   function getLabel(name) {
     return (
-      generalConfig.general?.procLabels?.[name] || procMap[name] || name
+      generalConfig.general?.procLabels?.[name]?.mn || procMap[name] || name
     );
   }
 


### PR DESCRIPTION
## Summary
- store module labels by language codes
- read Mongolian labels from new mapping in app components
- support editing language-specific labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1cbcc28dc83319b9aaad8666d8465