### PR TITLE
Track audit info for tenant table upserts

### DIFF
--- a/api-server/controllers/tenantTablesController.js
+++ b/api-server/controllers/tenantTablesController.js
@@ -42,7 +42,14 @@ export async function createTenantTable(req, res, next) {
     if (!tableName) {
       return res.status(400).json({ message: 'tableName is required' });
     }
-    const result = await upsertTenantTable(tableName, isShared, seedOnCreate);
+    const userId = req.user?.empid;
+    const result = await upsertTenantTable(
+      tableName,
+      isShared,
+      seedOnCreate,
+      userId,
+      userId,
+    );
     res.status(201).json(result);
   } catch (err) {
     next(err);
@@ -54,7 +61,14 @@ export async function updateTenantTable(req, res, next) {
     if (!(await ensureAdmin(req))) return res.sendStatus(403);
     const tableName = req.params.table_name;
     const { isShared, seedOnCreate } = req.body || {};
-    const result = await upsertTenantTable(tableName, isShared, seedOnCreate);
+    const userId = req.user?.empid;
+    const result = await upsertTenantTable(
+      tableName,
+      isShared,
+      seedOnCreate,
+      null,
+      userId,
+    );
     res.json(result);
   } catch (err) {
     next(err);

--- a/db/index.js
+++ b/db/index.js
@@ -982,14 +982,19 @@ export async function upsertTenantTable(
   tableName,
   isShared = 0,
   seedOnCreate = 0,
+  createdBy = null,
+  updatedBy = null,
 ) {
+  const userId = createdBy ?? updatedBy;
   await pool.query(
-    `INSERT INTO tenant_tables (table_name, is_shared, seed_on_create)
-     VALUES (?, ?, ?)
+    `INSERT INTO tenant_tables (table_name, is_shared, seed_on_create, created_by, created_at)
+     VALUES (?, ?, ?, ?, NOW())
      ON DUPLICATE KEY UPDATE
        is_shared = VALUES(is_shared),
-       seed_on_create = VALUES(seed_on_create)`,
-    [tableName, isShared ? 1 : 0, seedOnCreate ? 1 : 0],
+       seed_on_create = VALUES(seed_on_create),
+       updated_by = VALUES(created_by),
+       updated_at = NOW()`,
+    [tableName, isShared ? 1 : 0, seedOnCreate ? 1 : 0, userId],
   );
   return { tableName, isShared: !!isShared, seedOnCreate: !!seedOnCreate };
 }


### PR DESCRIPTION
## Summary
- capture created_by and created_at when registering tenant tables
- update existing rows with is_shared, seed_on_create and audit fields
- pass user IDs from controllers to support creation and update auditing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1d5769a888331ba97406f37e5f78c