### PR TITLE
Support language-specific header mappings

### DIFF
--- a/api-server/routes/header_mappings.js
+++ b/api-server/routes/header_mappings.js
@@ -8,7 +8,7 @@ const router = express.Router();
 router.get('/', requireAuth, async (req, res, next) => {
   try {
     const headers = req.query.headers ? req.query.headers.split(',') : [];
-    const map = await getMappings(headers);
+    const map = await getMappings(headers, req.query.lang);
     res.json(map);
   } catch (err) {
     next(err);


### PR DESCRIPTION
## Summary
- Extend header mapping service to fetch language-specific strings
- Deep merge mapping language objects instead of overwriting
- Ensure header mappings JSON writes are formatted

## Testing
- `npm test` *(fails: detectIncompleteImages finds and fixes files)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d5fa69cc833187fb3734d14d34b7