### PR TITLE
Support lang query for header mappings route

### DIFF
--- a/api-server/routes/header_mappings.js
+++ b/api-server/routes/header_mappings.js
@@ -5,10 +5,13 @@ import rateLimit from 'express-rate-limit';
 
 const router = express.Router();
 
+// GET /api/header_mappings?headers=a,b&lang=en
+// "lang" selects a localized value when available.
 router.get('/', requireAuth, async (req, res, next) => {
   try {
-    const headers = req.query.headers ? req.query.headers.split(',') : [];
-    const map = await getMappings(headers, req.query.lang);
+    const { headers: headersParam, lang } = req.query;
+    const headers = headersParam ? headersParam.split(',') : [];
+    const map = await getMappings(headers, lang);
     res.json(map);
   } catch (err) {
     next(err);
@@ -21,10 +24,11 @@ const postRateLimiter = rateLimit({
   message: 'Too many requests, please try again later.',
 });
 
+// POST /api/header_mappings
+// Body: { "sales": { "en": "Sales Dashboard" } }
 router.post('/', requireAuth, postRateLimiter, async (req, res, next) => {
   try {
-    const mappings = req.body.mappings || {};
-    await addMappings(mappings);
+    await addMappings(req.body || {});
     res.sendStatus(204);
   } catch (err) {
     next(err);


### PR DESCRIPTION
## Summary
- Accept `lang` query parameter when retrieving header mappings and document usage
- Allow POST route to accept direct mapping objects, e.g. `{ "sales": { "en": "Sales Dashboard" } }`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1d6bcdabc83319ff04b2ff3f8a997