### PR TITLE
Add locale-aware header mappings with fallback

### DIFF
--- a/api-server/services/headerMappings.js
+++ b/api-server/services/headerMappings.js
@@ -20,12 +20,24 @@ export async function getMappings(headers = [], lang) {
   const map = await readMappings();
   const result = {};
   headers.forEach((h) => {
-    if (map[h]) {
-      if (lang && typeof map[h] === 'object') {
-        result[h] = map[h][lang] ?? map[h];
+    const entry = map[h];
+    if (entry == null) {
+      // No mapping found; fall back to the original key
+      result[h] = h;
+      return;
+    }
+    if (typeof entry === 'object' && entry !== null) {
+      // Prefer the requested language, then English, then the key itself
+      if (lang && entry[lang]) {
+        result[h] = entry[lang];
+      } else if (entry.en) {
+        result[h] = entry.en;
       } else {
-        result[h] = map[h];
+        result[h] = h;
       }
+    } else {
+      // Primitive mapping string
+      result[h] = entry;
     }
   });
   return result;

--- a/src/erp.mgt.mn/hooks/useHeaderMappings.js
+++ b/src/erp.mgt.mn/hooks/useHeaderMappings.js
@@ -1,8 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
+import LangContext from '../context/LangContext.jsx';
 
+// Cache translations by "locale|header" so different locales don't collide
 const cache = {};
 
-export default function useHeaderMappings(headers = []) {
+export default function useHeaderMappings(headers = [], locale) {
+  const { lang } = useContext(LangContext);
+  const currentLang = locale || lang;
   const [map, setMap] = useState({});
 
   useEffect(() => {
@@ -11,35 +15,43 @@ export default function useHeaderMappings(headers = []) {
       setMap({});
       return;
     }
-    const missing = unique.filter((h) => cache[h] === undefined);
+
+    const keyFor = (h) => `${currentLang}|${h}`;
+    const missing = unique.filter((h) => cache[keyFor(h)] === undefined);
     if (missing.length > 0) {
       const params = new URLSearchParams();
       params.set('headers', missing.join(','));
+      if (currentLang) params.set('lang', currentLang);
       fetch(`/api/header_mappings?${params.toString()}`, { credentials: 'include' })
         .then((res) => (res.ok ? res.json() : {}))
         .then((data) => {
-          Object.assign(cache, data);
+          Object.entries(data).forEach(([k, v]) => {
+            cache[keyFor(k)] = v;
+          });
           const result = {};
           unique.forEach((h) => {
-            if (cache[h] !== undefined) result[h] = cache[h];
+            const val = cache[keyFor(h)];
+            if (val !== undefined) result[h] = val;
           });
           setMap(result);
         })
         .catch(() => {
           const result = {};
           unique.forEach((h) => {
-            if (cache[h] !== undefined) result[h] = cache[h];
+            const val = cache[keyFor(h)];
+            if (val !== undefined) result[h] = val;
           });
           setMap(result);
         });
     } else {
       const result = {};
       unique.forEach((h) => {
-        if (cache[h] !== undefined) result[h] = cache[h];
+        const val = cache[keyFor(h)];
+        if (val !== undefined) result[h] = val;
       });
       setMap(result);
     }
-  }, [headers.join(',')]);
+  }, [headers.join(','), currentLang]);
 
   return map;
 }


### PR DESCRIPTION
## Summary
- Allow header mapping fetches to request a specific locale
- Cache header translations per locale and include lang in API queries
- Provide server-side fallback from locale to English to header key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1d7b21a848331bfc3aa305188351a