### PR TITLE
feat: add i18n helper and apply translations

### DIFF
--- a/src/erp.mgt.mn/components/Layout.jsx
+++ b/src/erp.mgt.mn/components/Layout.jsx
@@ -13,6 +13,7 @@ import { LangContext } from '../context/LangContext.jsx';
  */
 export default function ERPLayout() {
   const { user, session, setUser } = useContext(AuthContext);
+  const { t } = useContext(LangContext);
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -21,16 +22,16 @@ export default function ERPLayout() {
   }, []);
 
   const titleMap = {
-    '/': 'Dashboard',
-    '/forms': 'Forms',
-    '/reports': 'Reports',
-    '/settings': 'Settings',
-    '/settings/users': 'Users',
-    '/settings/user-companies': 'User Companies',
-    '/settings/role-permissions': 'Role Permissions',
-    '/settings/change-password': 'Change Password',
+    '/': t('dashboard', 'Dashboard'),
+    '/forms': t('forms', 'Forms'),
+    '/reports': t('reports', 'Reports'),
+    '/settings': t('settings', 'Settings'),
+    '/settings/users': t('users', 'Users'),
+    '/settings/user-companies': t('userCompanies', 'User Companies'),
+    '/settings/role-permissions': t('rolePermissions', 'Role Permissions'),
+    '/settings/change-password': t('changePassword', 'Change Password'),
   };
-  const windowTitle = titleMap[location.pathname] || 'ERP';
+  const windowTitle = titleMap[location.pathname] || t('erp', 'ERP');
 
   async function handleLogout() {
     await logout(user?.empid);
@@ -66,9 +67,9 @@ function Header({ user, onLogout }) {
         <span style={styles.logoText}>MyERP</span>
       </div>
       <nav style={styles.headerNav}>
-        <button style={styles.iconBtn}>🗔 {t('home')}</button>
-        <button style={styles.iconBtn}>🗗 {t('windows')}</button>
-        <button style={styles.iconBtn}>❔ {t('help')}</button>
+        <button style={styles.iconBtn}>🗔 {t('home', 'Home')}</button>
+        <button style={styles.iconBtn}>🗗 {t('windows', 'Windows')}</button>
+        <button style={styles.iconBtn}>❔ {t('help', 'Help')}</button>
       </nav>
       <div style={styles.userSection}>
         <select
@@ -87,11 +88,11 @@ function Header({ user, onLogout }) {
           <option value="ru">ru</option>
         </select>
         <span style={{ marginRight: '0.5rem' }}>
-          {user ? `${t('welcome')}, ${user.empid}` : ''}
+          {user ? `${t('welcome', 'Welcome')}, ${user.empid}` : ''}
         </span>
         {user && (
           <button style={styles.logoutBtn} onClick={onLogout}>
-            {t('logout')}
+            {t('logout', 'Logout')}
           </button>
         )}
       </div>
@@ -111,43 +112,43 @@ function Sidebar() {
   return (
     <aside className="sidebar menu-container" style={styles.sidebar}>
       <div className="menu-group" style={styles.menuGroup}>
-        <div style={styles.groupTitle}>📌 {t('pinned')}</div>
+        <div style={styles.groupTitle}>📌 {t('pinned', 'Pinned')}</div>
         <NavLink to="/" className="menu-item" style={styles.menuItem}>
-          {t('dashboard')}
+          {t('dashboard', 'Dashboard')}
         </NavLink>
         <NavLink to="/forms" className="menu-item" style={styles.menuItem}>
-          {t('forms')}
+          {t('forms', 'Forms')}
         </NavLink>
         <NavLink to="/reports" className="menu-item" style={styles.menuItem}>
-          {t('reports')}
+          {t('reports', 'Reports')}
         </NavLink>
       </div>
 
       <hr style={styles.divider} />
 
       <div className="menu-group" style={styles.menuGroup}>
-        <div style={styles.groupTitle}>⚙ {t('settings')}</div>
+        <div style={styles.groupTitle}>⚙ {t('settings', 'Settings')}</div>
         <NavLink to="/settings" className="menu-item" style={styles.menuItem} end>
-          {t('general')}
+          {t('general', 'General')}
         </NavLink>
         {hasAdmin && (
           <>
             <NavLink to="/settings/users" className="menu-item" style={styles.menuItem}>
-              {t('users')}
+              {t('users', 'Users')}
             </NavLink>
             <NavLink to="/settings/user-companies" className="menu-item" style={styles.menuItem}>
-              {t('userCompanies')}
+              {t('userCompanies', 'User Companies')}
             </NavLink>
             <NavLink to="/settings/role-permissions" className="menu-item" style={styles.menuItem}>
-              {t('rolePermissions')}
+              {t('rolePermissions', 'Role Permissions')}
             </NavLink>
             <NavLink to="/settings/modules" className="menu-item" style={styles.menuItem}>
-              {t('modules')}
+              {t('modules', 'Modules')}
             </NavLink>
           </>
         )}
         <NavLink to="/settings/change-password" className="menu-item" style={styles.menuItem}>
-          {t('changePassword')}
+          {t('changePassword', 'Change Password')}
         </NavLink>
       </div>
     </aside>

--- a/src/erp.mgt.mn/components/LoginForm.jsx
+++ b/src/erp.mgt.mn/components/LoginForm.jsx
@@ -6,6 +6,7 @@ import { refreshCompanyModules } from '../hooks/useCompanyModules.js';
 import { refreshModules } from '../hooks/useModules.js';
 import { refreshTxnModules } from '../hooks/useTxnModules.js';
 import { useNavigate } from 'react-router-dom';
+import LangContext from '../context/LangContext.jsx';
 
 export default function LoginForm() {
   // login using employee ID only
@@ -25,6 +26,7 @@ export default function LoginForm() {
     setPosition,
     setPermissions,
   } = useContext(AuthContext);
+  const { t } = useContext(LangContext);
   const navigate = useNavigate();
 
   async function handleSubmit(e) {
@@ -36,7 +38,7 @@ export default function LoginForm() {
       const payload = isCompanyStep
         ? { ...storedCreds, companyId: Number(companyId) }
         : { empid, password };
-      const loggedIn = await login(payload);
+      const loggedIn = await login(payload, t);
 
       if (loggedIn.needsCompany) {
         setStoredCreds({ empid, password });
@@ -63,18 +65,18 @@ export default function LoginForm() {
       navigate('/');
     } catch (err) {
       console.error('Login failed:', err);
-      setError(err.message || 'Login error');
+      setError(err.message || t('loginError', 'Login error'));
     }
   }
 
   if (isCompanyStep) {
     return (
       <div style={{ maxWidth: '320px' }}>
-        <h1>Компани сонгох</h1>
+        <h1>{t('selectCompany', 'Компани сонгох')}</h1>
         <form onSubmit={handleSubmit}>
           <div style={{ marginBottom: '0.75rem' }}>
             <label htmlFor="company" style={{ display: 'block', marginBottom: '0.25rem' }}>
-              Компани
+              {t('company', 'Компани')}
             </label>
             <select
               id="company"
@@ -83,7 +85,7 @@ export default function LoginForm() {
               required
               style={{ width: '100%', padding: '0.5rem', borderRadius: '3px', border: '1px solid #ccc' }}
             >
-              <option value="">Компани сонгох</option>
+              <option value="">{t('selectCompany', 'Компани сонгох')}</option>
               {companyOptions.map((c) => (
                 <option key={c.company_id} value={c.company_id}>
                   {c.company_name}
@@ -107,7 +109,7 @@ export default function LoginForm() {
               cursor: 'pointer',
             }}
           >
-            Сонгох
+            {t('choose', 'Сонгох')}
           </button>
         </form>
       </div>
@@ -115,13 +117,13 @@ export default function LoginForm() {
   }
 
   return (
-    <div style={{ maxWidth: '320px' }}>
-      <h1>Нэвтрэх</h1>
-      <form onSubmit={handleSubmit}>
-        <div style={{ marginBottom: '0.75rem' }}>
-          <label htmlFor="empid" style={{ display: 'block', marginBottom: '0.25rem' }}>
-            Ажилтны ID
-          </label>
+      <div style={{ maxWidth: '320px' }}>
+        <h1>{t('login', 'Нэвтрэх')}</h1>
+        <form onSubmit={handleSubmit}>
+          <div style={{ marginBottom: '0.75rem' }}>
+            <label htmlFor="empid" style={{ display: 'block', marginBottom: '0.25rem' }}>
+              {t('employeeId', 'Ажилтны ID')}
+            </label>
           <input
             id="empid"
             type="text"
@@ -132,10 +134,10 @@ export default function LoginForm() {
           />
         </div>
 
-        <div style={{ marginBottom: '0.75rem' }}>
-          <label htmlFor="password" style={{ display: 'block', marginBottom: '0.25rem' }}>
-            Нууц үг
-          </label>
+          <div style={{ marginBottom: '0.75rem' }}>
+            <label htmlFor="password" style={{ display: 'block', marginBottom: '0.25rem' }}>
+              {t('password', 'Нууц үг')}
+            </label>
           <input
             id="password"
             type="password"
@@ -150,20 +152,20 @@ export default function LoginForm() {
           <p style={{ color: 'red', marginBottom: '0.75rem' }}>{error}</p>
         )}
 
-        <button
-          type="submit"
-          style={{
-            backgroundColor: '#2563eb',
+          <button
+            type="submit"
+            style={{
+              backgroundColor: '#2563eb',
             color: '#fff',
             padding: '0.5rem 1rem',
             border: '1px solid #2563eb',
             borderRadius: '3px',
             cursor: 'pointer',
           }}
-        >
-          Нэвтрэх
-        </button>
-      </form>
-    </div>
+          >
+            {t('login', 'Нэвтрэх')}
+          </button>
+        </form>
+      </div>
   );
 }

--- a/src/erp.mgt.mn/context/LangContext.jsx
+++ b/src/erp.mgt.mn/context/LangContext.jsx
@@ -5,7 +5,7 @@ import translations from './translations.json';
 export const LangContext = createContext({
   lang: 'en',
   setLang: () => {},
-  t: (key) => key,
+  t: (key, fallback) => fallback || key,
 });
 
 export function LangProvider({ children }) {
@@ -16,10 +16,10 @@ export function LangProvider({ children }) {
   }, [lang]);
 
   const t = useMemo(() => {
-    return (key) => {
+    return (key, fallback = key) => {
       const entry = translations[key];
-      if (!entry) return key;
-      return entry[lang] || entry.en || key;
+      if (!entry) return fallback;
+      return entry[lang] || entry.en || fallback;
     };
   }, [lang]);
 

--- a/src/erp.mgt.mn/hooks/useAuth.jsx
+++ b/src/erp.mgt.mn/hooks/useAuth.jsx
@@ -1,6 +1,4 @@
 // src/erp.mgt.mn/hooks/useAuth.jsx
-import { useContext } from 'react';
-import { AuthContext } from '../context/AuthContext.jsx';
 import { API_BASE } from '../utils/apiBase.js';
 
 // src/erp.mgt.mn/hooks/useAuth.jsx
@@ -12,7 +10,7 @@ import { API_BASE } from '../utils/apiBase.js';
  * @param {{empid: string, password: string, companyId?: number}} credentials
  * @returns {Promise<any>}
 */
-export async function login({ empid, password, companyId }) {
+export async function login({ empid, password, companyId }, t = (key, fallback) => fallback || key) {
   let res;
   try {
     res = await fetch(`${API_BASE}/auth/login`, {
@@ -23,17 +21,17 @@ export async function login({ empid, password, companyId }) {
     });
   } catch (err) {
     // Network errors (e.g. server unreachable)
-    throw new Error('Login request failed');
+    throw new Error(t('loginRequestFailed', 'Login request failed'));
   }
 
   if (!res.ok) {
     const contentType = res.headers.get('content-type') || '';
-    let message = 'Login failed';
+    let message = t('loginFailed', 'Login failed');
     if (contentType.includes('application/json')) {
       const data = await res.json().catch(() => ({}));
       if (data && data.message) message = data.message;
     } else if (res.status === 503) {
-      message = 'Service unavailable';
+      message = t('serviceUnavailable', 'Service unavailable');
     } else {
       message = res.statusText || message;
     }
@@ -80,9 +78,9 @@ export async function logout(empid) {
  * Fetches current user profile if authenticated.
  * @returns {Promise<{id: number, empid: string, position: string}>}
 */
-export async function fetchProfile() {
+export async function fetchProfile(t = (key, fallback) => fallback || key) {
   const res = await fetch(`${API_BASE}/auth/me`, { credentials: 'include' });
-  if (!res.ok) throw new Error('Not authenticated');
+  if (!res.ok) throw new Error(t('notAuthenticated', 'Not authenticated'));
   const data = await res.json();
   if (data?.session) {
     try {

--- a/src/erp.mgt.mn/pages/UserLevelActions.jsx
+++ b/src/erp.mgt.mn/pages/UserLevelActions.jsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { useToast } from "../context/ToastContext.jsx";
 import { collectModuleKeys, toggleModuleGroupSelection } from "./moduleTreeHelpers.js";
+import LangContext from "../context/LangContext.jsx";
 
 export default function UserLevelActions() {
   const [groups, setGroups] = useState({ modules: [], forms: {}, permissions: [] });
@@ -20,13 +21,14 @@ export default function UserLevelActions() {
   const [userLevelId, setUserLevelId] = useState("");
   const [userLevels, setUserLevels] = useState([]);
   const { addToast } = useToast();
+  const { t } = useContext(LangContext);
 
   const loadGroups = async () => {
     try {
       const res = await fetch("/api/permissions/actions", { credentials: "include" });
       if (!res.ok) {
         const msg = await res.text();
-        throw new Error(msg || "Failed to load action groups");
+        throw new Error(msg || t("failedLoadActionGroups", "Failed to load action groups"));
       }
       const data = await res.json();
       const forms = data.forms || {};
@@ -55,10 +57,10 @@ export default function UserLevelActions() {
           typeof p === "string" ? p : p.key,
         ),
       });
-      addToast("Action groups loaded", "success");
+      addToast(t("actionGroupsLoaded", "Action groups loaded"), "success");
     } catch (err) {
-      console.error("Failed to load action groups", err);
-      addToast(`Failed to load action groups: ${err.message}`, "error");
+      console.error(t("failedLoadActionGroups", "Failed to load action groups"), err);
+      addToast(`${t("failedLoadActionGroups", "Failed to load action groups")}: ${err.message}`, "error");
     }
   };
 
@@ -67,7 +69,7 @@ export default function UserLevelActions() {
     fetch("/api/permissions/user-levels", { credentials: "include" })
       .then((res) => res.json())
       .then(setUserLevels)
-      .catch(() => addToast("Failed to load user levels", "error"));
+      .catch(() => addToast(t("failedLoadUserLevels", "Failed to load user levels"), "error"));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -84,12 +86,12 @@ export default function UserLevelActions() {
 
   function loadCurrent() {
     if (!userLevelId) {
-      addToast("User Level ID required", "error");
+      addToast(t("userLevelIdRequired", "User Level ID required"), "error");
       return;
     }
     fetch(`/api/permissions/actions/${userLevelId}`, { credentials: "include" })
       .then((res) => {
-        if (!res.ok) throw new Error("Failed to load current actions");
+        if (!res.ok) throw new Error(t("failedLoadCurrentActions", "Failed to load current actions"));
         return res.json();
       })
       .then((data) => {
@@ -116,11 +118,11 @@ export default function UserLevelActions() {
           validPermissions.has(p),
         );
         setSelected(sel);
-        addToast("Current actions loaded", "success");
+        addToast(t("currentActionsLoaded", "Current actions loaded"), "success");
       })
       .catch((err) => {
-        console.error("Failed to load current actions", err);
-        addToast("Failed to load current actions", "error");
+        console.error(t("failedLoadCurrentActions", "Failed to load current actions"), err);
+        addToast(t("failedLoadCurrentActions", "Failed to load current actions"), "error");
       });
   }
 
@@ -135,7 +137,7 @@ export default function UserLevelActions() {
 
   async function handleSave() {
     if (!userLevelId) {
-      addToast("User Level ID required", "error");
+      addToast(t("userLevelIdRequired", "User Level ID required"), "error");
       return;
     }
     try {
@@ -146,13 +148,13 @@ export default function UserLevelActions() {
         body: JSON.stringify(selected),
       });
       if (res.ok) {
-        addToast("Actions updated", "success");
+        addToast(t("actionsUpdated", "Actions updated"), "success");
       } else {
-        addToast("Failed to save actions", "error");
+        addToast(t("failedSaveActions", "Failed to save actions"), "error");
       }
     } catch (err) {
-      console.error("Failed to save actions", err);
-      addToast("Failed to save actions", "error");
+      console.error(t("failedSaveActions", "Failed to save actions"), err);
+      addToast(t("failedSaveActions", "Failed to save actions"), "error");
     }
   }
 
@@ -286,7 +288,10 @@ export default function UserLevelActions() {
 
   async function handlePopulate() {
     const allow = window.confirm(
-      "Allow all new operations by default? Click Cancel to disallow.",
+      t(
+        "allowAllNewOperations",
+        "Allow all new operations by default? Click Cancel to disallow.",
+      ),
     );
     try {
       const res = await fetch("/api/permissions/actions/populate", {
@@ -296,26 +301,26 @@ export default function UserLevelActions() {
         body: JSON.stringify({ allow }),
       });
       if (res.ok) {
-        addToast("Permissions populated", "success");
+        addToast(t("permissionsPopulated", "Permissions populated"), "success");
         loadGroups();
       } else {
-        addToast("Failed to populate permissions", "error");
+        addToast(t("failedPopulatePermissions", "Failed to populate permissions"), "error");
       }
     } catch (err) {
-      console.error("Failed to populate permissions", err);
-      addToast("Failed to populate permissions", "error");
+      console.error(t("failedPopulatePermissions", "Failed to populate permissions"), err);
+      addToast(t("failedPopulatePermissions", "Failed to populate permissions"), "error");
     }
   }
 
   return (
     <div>
-      <h2>User Level Actions</h2>
+      <h2>{t("userLevelActions", "User Level Actions")}</h2>
       <select
         value={userLevelId}
         onChange={(e) => setUserLevelId(e.target.value)}
         style={{ marginRight: "0.5rem" }}
       >
-        <option value="">Select user level</option>
+        <option value="">{t("selectUserLevel", "Select user level")}</option>
         {userLevels.map((ul) => (
           <option key={ul.id} value={ul.id}>
             {ul.name || ul.id}
@@ -323,27 +328,27 @@ export default function UserLevelActions() {
         ))}
       </select>
       <button onClick={loadCurrent} style={{ marginRight: "0.5rem" }}>
-        Load
+        {t("load", "Load")}
       </button>
       <button
         onClick={handleSave}
         disabled={!userLevelId}
         style={{ marginRight: "0.5rem" }}
       >
-        Save
+        {t("save", "Save")}
       </button>
       <button onClick={loadGroups} style={{ marginRight: "0.5rem" }}>
-        Refresh
+        {t("refresh", "Refresh")}
       </button>
-      <button onClick={handlePopulate}>Batch Populate</button>
+      <button onClick={handlePopulate}>{t("batchPopulate", "Batch Populate")}</button>
       <div style={{ display: "flex", gap: "1rem", marginTop: "1rem" }}>
         <div>
-          <h3>Modules</h3>
+          <h3>{t("modules", "Modules")}</h3>
           {renderModuleTree(groups.modules)}
         </div>
         {groups.permissions?.length ? (
           <div>
-            <h3>Permissions</h3>
+            <h3>{t("permissions", "Permissions")}</h3>
             {renderActionTree("permissions", groups.permissions)}
           </div>
         ) : null}
@@ -354,19 +359,19 @@ export default function UserLevelActions() {
             <h3>{form.name || describe(formKey)}</h3>
             {form.buttons?.length ? (
               <div>
-                <h4>Buttons</h4>
+                <h4>{t("buttons", "Buttons")}</h4>
                 {renderActionTree("buttons", form.buttons)}
               </div>
             ) : null}
             {form.functions?.length ? (
               <div>
-                <h4>Functions</h4>
+                <h4>{t("functions", "Functions")}</h4>
                 {renderActionTree("functions", form.functions)}
               </div>
             ) : null}
             {form.api?.length ? (
               <div>
-                <h4>APIs</h4>
+                <h4>{t("apis", "APIs")}</h4>
                 {renderActionTree("api", form.api)}
               </div>
             ) : null}


### PR DESCRIPTION
## Summary
- add `t(key, fallback)` translation helper via LangContext
- replace hardcoded strings in layout, login, permissions pages with `t()` calls
- internationalize auth hook error messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1d8f6789c8331a605d3e5e4c72a5b