### PR TITLE
feat: record actor on tenant seed data

### DIFF
--- a/api-server/controllers/companyController.js
+++ b/api-server/controllers/companyController.js
@@ -41,6 +41,7 @@ export async function createCompanyHandler(req, res, next) {
       seedTables,
       seedRecords,
       overwrite,
+      req.user.empid,
     );
     res.locals.insertId = result?.id;
     res.status(201).json(result);

--- a/api-server/controllers/tenantTablesController.js
+++ b/api-server/controllers/tenantTablesController.js
@@ -108,7 +108,7 @@ export async function seedExistingCompanies(req, res, next) {
     const companies = await listCompanies();
     for (const { id } of companies) {
       if (id === GLOBAL_COMPANY_ID) continue;
-      await seedTenantTables(id, tables, recordMap, overwrite);
+      await seedTenantTables(id, tables, recordMap, overwrite, req.user.empid);
     }
     res.sendStatus(204);
   } catch (err) {
@@ -140,7 +140,7 @@ export async function seedCompany(req, res, next) {
         recordMap[rec.table] = rec.ids;
       }
     }
-    await seedTenantTables(companyId, tables, recordMap, overwrite);
+    await seedTenantTables(companyId, tables, recordMap, overwrite, req.user.empid);
     res.sendStatus(204);
   } catch (err) {
     next(err);


### PR DESCRIPTION
## Summary
- allow seedTenantTables to set created_by/updated_by timestamps and user IDs
- pass user ID through company creation and seeding APIs
- test seedTenantTables audit field overrides

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1d962045883319dfca89b0771fc11