### PR TITLE
feat: translation editor and fallback language order

### DIFF
--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -42,6 +42,7 @@ import { useTxnModules } from './hooks/useTxnModules.js';
 import useGeneralConfig from './hooks/useGeneralConfig.js';
 import TabbedWindows from './components/TabbedWindows.jsx';
 import TenantTablesRegistryPage from './pages/TenantTablesRegistry.jsx';
+import TranslationEditorPage from './pages/TranslationEditor.jsx';
 
 export default function App() {
   useEffect(() => {
@@ -164,6 +165,7 @@ function AuthedApp() {
       <Route path="/" element={<ERPLayout />}>
         <Route path="requests" element={<RequestsPage />} />
         {roots.map(renderRoute)}
+        <Route path="settings/translations" element={<TranslationEditorPage />} />
       </Route>
       <Route
         path="inventory-demo"

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -64,6 +64,7 @@ export default function ERPLayout() {
     "/settings/report-management": "Тайлангийн удирдлага",
     "/settings/change-password": "Нууц үг солих",
     "/settings/tenant-tables-registry": "Tenant Tables Registry",
+    "/settings/translations": "Edit Translations",
   };
 
   function titleForPath(path) {

--- a/src/erp.mgt.mn/context/I18nContext.jsx
+++ b/src/erp.mgt.mn/context/I18nContext.jsx
@@ -5,11 +5,15 @@ import { initReactI18next } from 'react-i18next';
 export const I18nContext = createContext({
   lang: 'en',
   setLang: () => {},
+  fallbackLangs: ['en'],
   t: (key, fallback) => fallback || key,
 });
 
 export function I18nProvider({ children }) {
   const [lang, setLang] = useState(() => localStorage.getItem('lang') || 'en');
+  // Define a fallback order for languages. If a translation is missing in the
+  // active language, we will try these in order.
+  const fallbackLangs = ['mn', 'en'];
 
   useEffect(() => {
     localStorage.setItem('lang', lang);
@@ -24,12 +28,13 @@ export function I18nProvider({ children }) {
             [lang]: { translation: translations.default },
           },
           lng: lang,
-          fallbackLng: 'en',
+          fallbackLng: fallbackLangs,
           interpolation: { escapeValue: false },
         });
       } else {
         i18n.addResourceBundle(lang, 'translation', translations.default, true, true);
         i18n.changeLanguage(lang);
+        i18n.options.fallbackLng = fallbackLangs;
       }
     }
     load();
@@ -39,6 +44,7 @@ export function I18nProvider({ children }) {
     () => ({
       lang,
       setLang,
+      fallbackLangs,
       t: (key, fallback) => i18n.t(key, { defaultValue: fallback ?? key }),
     }),
     [lang]

--- a/src/erp.mgt.mn/hooks/useHeaderMappings.js
+++ b/src/erp.mgt.mn/hooks/useHeaderMappings.js
@@ -1,13 +1,34 @@
 import { useContext, useEffect, useState } from 'react';
 import I18nContext from '../context/I18nContext.jsx';
 
-// Cache translations by "locale|header" so different locales don't collide
+// Cache translations by "locale|header" so different locales don't collide.
 const cache = {};
+const listeners = new Set();
+
+// Allow external callers to clear the cache and trigger a refresh.
+export function clearHeaderMappingsCache(headers) {
+  if (!headers) {
+    Object.keys(cache).forEach((k) => delete cache[k]);
+  } else {
+    Object.keys(cache).forEach((k) => {
+      if (headers.some((h) => k.endsWith(`|${h}`))) delete cache[k];
+    });
+  }
+  listeners.forEach((fn) => fn());
+}
 
 export default function useHeaderMappings(headers = [], locale) {
-  const { lang } = useContext(I18nContext);
+  const { lang, fallbackLangs } = useContext(I18nContext);
   const currentLang = locale || lang;
   const [map, setMap] = useState({});
+  const [tick, setTick] = useState(0);
+
+  // Re-fetch when the cache is cleared elsewhere.
+  useEffect(() => {
+    const fn = () => setTick((t) => t + 1);
+    listeners.add(fn);
+    return () => listeners.delete(fn);
+  }, []);
 
   useEffect(() => {
     const unique = Array.from(new Set(headers.filter(Boolean)));
@@ -16,42 +37,50 @@ export default function useHeaderMappings(headers = [], locale) {
       return;
     }
 
-    const keyFor = (h) => `${currentLang}|${h}`;
-    const missing = unique.filter((h) => cache[keyFor(h)] === undefined);
-    if (missing.length > 0) {
-      const params = new URLSearchParams();
-      params.set('headers', missing.join(','));
-      if (currentLang) params.set('lang', currentLang);
-      fetch(`/api/header_mappings?${params.toString()}`, { credentials: 'include' })
-        .then((res) => (res.ok ? res.json() : {}))
-        .then((data) => {
-          Object.entries(data).forEach(([k, v]) => {
-            cache[keyFor(k)] = v;
-          });
-          const result = {};
-          unique.forEach((h) => {
-            const val = cache[keyFor(h)];
-            if (val !== undefined) result[h] = val;
-          });
-          setMap(result);
-        })
-        .catch(() => {
-          const result = {};
-          unique.forEach((h) => {
-            const val = cache[keyFor(h)];
-            if (val !== undefined) result[h] = val;
-          });
-          setMap(result);
+    const langsToTry = [
+      currentLang,
+      ...((fallbackLangs || []).filter((l) => l !== currentLang)),
+    ];
+
+    const result = {};
+
+    async function load() {
+      for (const lng of langsToTry) {
+        const keyFor = (h) => `${lng}|${h}`;
+        const missing = unique.filter((h) => cache[keyFor(h)] === undefined);
+        if (missing.length > 0) {
+          const params = new URLSearchParams();
+          params.set('headers', missing.join(','));
+          if (lng) params.set('lang', lng);
+          try {
+            const res = await fetch(`/api/header_mappings?${params.toString()}`, {
+              credentials: 'include',
+            });
+            const data = res.ok ? await res.json() : {};
+            Object.entries(data).forEach(([k, v]) => {
+              cache[keyFor(k)] = v;
+            });
+          } catch {
+            // ignore network errors
+          }
+        }
+        unique.forEach((h) => {
+          const val = cache[keyFor(h)];
+          if (val !== undefined && result[h] === undefined) result[h] = val;
         });
-    } else {
-      const result = {};
-      unique.forEach((h) => {
-        const val = cache[keyFor(h)];
-        if (val !== undefined) result[h] = val;
-      });
+        const unresolved = unique.filter((h) => result[h] === undefined);
+        if (unresolved.length === 0) break;
+      }
       setMap(result);
     }
-  }, [headers.join(','), currentLang]);
+
+    load();
+  }, [
+    headers.join(','),
+    currentLang,
+    (fallbackLangs || []).join(','),
+    tick,
+  ]);
 
   return map;
 }

--- a/src/erp.mgt.mn/pages/Settings.jsx
+++ b/src/erp.mgt.mn/pages/Settings.jsx
@@ -47,6 +47,9 @@ export function GeneralSettings() {
       <p style={{ marginTop: '0.5rem' }}>
         <Link to="/settings/tenant-tables-registry">Tenant Tables Registry</Link>
       </p>
+      <p style={{ marginTop: '0.5rem' }}>
+        <Link to="/settings/translations">Edit Translations</Link>
+      </p>
     </div>
   );
 }

--- a/src/erp.mgt.mn/pages/TranslationEditor.jsx
+++ b/src/erp.mgt.mn/pages/TranslationEditor.jsx
@@ -1,0 +1,88 @@
+import React, { useState, useContext } from 'react';
+import I18nContext from '../context/I18nContext.jsx';
+import { clearHeaderMappingsCache } from '../hooks/useHeaderMappings.js';
+
+const LANGS = ['en', 'mn', 'ja', 'ko', 'zh', 'es', 'de', 'fr', 'ru'];
+
+export default function TranslationEditorPage() {
+  const { t } = useContext(I18nContext);
+  const [header, setHeader] = useState('');
+  const [values, setValues] = useState({});
+  const [message, setMessage] = useState('');
+
+  async function loadExisting() {
+    if (!header) return;
+    const newVals = {};
+    for (const lang of LANGS) {
+      const params = new URLSearchParams();
+      params.set('headers', header);
+      params.set('lang', lang);
+      try {
+        const res = await fetch(`/api/header_mappings?${params.toString()}`, {
+          credentials: 'include',
+        });
+        const data = res.ok ? await res.json() : {};
+        newVals[lang] = data[header] || '';
+      } catch {
+        newVals[lang] = '';
+      }
+    }
+    setValues(newVals);
+  }
+
+  function handleChange(lang, val) {
+    setValues((v) => ({ ...v, [lang]: val }));
+  }
+
+  async function handleSave() {
+    const body = {
+      [header]: Object.fromEntries(
+        LANGS.filter((l) => values[l]).map((l) => [l, values[l]])
+      ),
+    };
+    await fetch('/api/header_mappings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(body),
+    });
+    clearHeaderMappingsCache([header]);
+    setMessage('Saved');
+    await loadExisting();
+  }
+
+  return (
+    <div>
+      <h2>{t('editTranslations', 'Edit Translations')}</h2>
+      <div style={{ marginBottom: '1rem' }}>
+        <label>
+          Header key:{' '}
+          <input value={header} onChange={(e) => setHeader(e.target.value)} />
+        </label>
+        <button onClick={loadExisting} style={{ marginLeft: '0.5rem' }}>
+          Load
+        </button>
+      </div>
+      {header && (
+        <div>
+          {LANGS.map((l) => (
+            <div key={l} style={{ marginBottom: '0.25rem' }}>
+              <label>
+                {l}:{' '}
+                <input
+                  value={values[l] || ''}
+                  onChange={(e) => handleChange(l, e.target.value)}
+                />
+              </label>
+            </div>
+          ))}
+          <button onClick={handleSave} style={{ marginTop: '0.5rem' }}>
+            Save
+          </button>
+          {message && <span style={{ marginLeft: '0.5rem' }}>{message}</span>}
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add i18n fallback language order and expose to hooks
- implement fallback-aware header mapping hook with cache refresh
- add settings page to edit header translations across languages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1dbc1366083318f02a1f76cb00ab5