### PR TITLE
Add audit metadata to seed permissions

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -1124,12 +1124,12 @@ export async function seedTenantTables(
   }
 
   await pool.query(
-    `INSERT INTO user_level_permissions (company_id, userlevel_id, action, action_key)
-     SELECT ?, userlevel_id, action, action_key
+    `INSERT INTO user_level_permissions (company_id, userlevel_id, action, action_key, created_by, created_at)
+     SELECT ?, userlevel_id, action, action_key, ?, NOW()
        FROM user_level_permissions
        WHERE company_id = ${GLOBAL_COMPANY_ID}
      ON DUPLICATE KEY UPDATE action = VALUES(action)`,
-    [companyId],
+    [companyId, createdBy],
   );
 }
 
@@ -1152,13 +1152,13 @@ export async function seedDefaultsForSeedTables(userId) {
   }
 }
 
-export async function seedSeedTablesForCompanies() {
+export async function seedSeedTablesForCompanies(userId = null) {
   const [companies] = await pool.query(
     `SELECT id FROM companies WHERE id > ?`,
     [GLOBAL_COMPANY_ID],
   );
   for (const { id } of companies) {
-    await seedTenantTables(id);
+    await seedTenantTables(id, null, {}, false, userId);
   }
 }
 


### PR DESCRIPTION
## Summary
- stamp seeded user level permissions with creator and timestamp
- allow seedSeedTablesForCompanies to pass acting user ID
- adjust tests for new audit fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1de676830833198e80baab020493d