### PR TITLE
style: contrast language selector in header

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -207,7 +207,12 @@ function Header({ user, onLogout, onHome, isMobile, onToggleSidebar, onOpen }) {
         <select
           value={lang}
           onChange={(e) => setLang(e.target.value)}
-          style={{ marginRight: '0.5rem' }}
+          style={{
+            marginRight: '0.5rem',
+            color: '#fff',
+            backgroundColor: '#1f2937',
+            border: '1px solid #fff',
+          }}
         >
           <option value="en">en</option>
           <option value="mn">mn</option>


### PR DESCRIPTION
## Summary
- style: ensure header language dropdown is legible against dark background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1e5045c0c833181f07a0d7add26cc