### PR TITLE
fix: terminate license population query

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -839,6 +839,7 @@ export async function populateCompanyModuleLicenses() {
      SELECT c.id AS company_id, m.module_key, 0, NULL
        FROM companies c
        CROSS JOIN modules m
+       WHERE 1
      ON DUPLICATE KEY UPDATE licensed = VALUES(licensed), updated_by = VALUES(created_by), updated_at = NOW()`,
   );
 }


### PR DESCRIPTION
## Summary
- ensure populateCompanyModuleLicenses query properly terminates before `ON DUPLICATE KEY`

## Testing
- `npm test`
- `node -e "import { populatePermissions } from './api-server/controllers/moduleController.js'; import { pool } from './db/index.js'; pool.query = async (...args)=>{ if(args[0].includes('company_module_licenses')) console.log('QUERY', args[0].split('\n').join(' ')); return [[]]; }; const req={user:{empid:1, companyId:1}, session:{user_level:1, company_id:1, permissions:{system_settings:true}}}; const res={sendStatus:(c)=>console.log('STATUS', c)}; await populatePermissions(req,res,(e)=>console.error('ERROR',e));" >/tmp/pop.log && tail -n 3 /tmp/pop.log`

------
https://chatgpt.com/codex/tasks/task_e_68b1e6281c0083319b312b4110ea0bef