### PR TITLE
feat: add OpenAI fallback for translation generator

### DIFF
--- a/scripts/generateTranslations.js
+++ b/scripts/generateTranslations.js
@@ -1,20 +1,84 @@
+import 'dotenv/config';
 import fs from 'fs';
 import path from 'path';
+import OpenAI from 'openai';
 
-const languages = ['mn','en','ja','ko','zh','es','de','fr','ru'];
+const languages = ['mn', 'en', 'ja', 'ko', 'zh', 'es', 'de', 'fr', 'ru'];
 const headerMappingsPath = path.resolve('config/headerMappings.json');
 const localesDir = path.resolve('src/erp.mgt.mn/locales');
 
-async function translate(text, to, from = 'mn') {
-  const url = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=${from}&tl=${to}&dt=t&q=${encodeURIComponent(text)}`;
+const openai = process.env.OPENAI_API_KEY
+  ? new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+  : null;
+
+async function translateWithGoogle(text, to, from) {
+  const params = new URLSearchParams({
+    client: 'gtx',
+    sl: from,
+    tl: to,
+    dt: 't',
+    q: text,
+  });
+  const url = `https://translate.googleapis.com/translate_a/single?${params.toString()}`;
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        const data = await res.json();
+        return data[0].map((t) => t[0]).join('');
+      }
+      const status = res.status;
+      if (attempt === 0 && (status === 400 || status === 429 || status >= 500)) {
+        console.warn(`Google HTTP ${status}; retrying`);
+        continue;
+      }
+      throw new Error(`HTTP ${status}`);
+    } catch (err) {
+      if (attempt === 0) {
+        console.warn(`Google request failed; retrying (${err.message})`);
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw new Error('Google Translate failed');
+}
+
+async function translateWithOpenAI(text, to, from) {
+  if (!openai) throw new Error('Missing OpenAI API key');
+
+  const completion = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    messages: [
+      {
+        role: 'system',
+        content: `You are a translation engine. Translate the user text from ${from} to ${to}. Return only the translation.`,
+      },
+      { role: 'user', content: text },
+    ],
+  });
+
+  const translation = completion.choices?.[0]?.message?.content?.trim();
+  if (!translation) throw new Error('Empty translation from OpenAI');
+  return translation;
+}
+
+async function translate(text, to, from) {
   try {
-    const res = await fetch(url);
-    if (!res.ok) throw new Error(`Failed to translate to ${to}`);
-    const data = await res.json();
-    return data[0].map((t) => t[0]).join('');
-  } catch (e) {
-    console.warn(`Translation service unavailable for ${to}, using source text`);
-    return text;
+    const translated = await translateWithGoogle(text, to, from);
+    console.log('    using Google');
+    return translated;
+  } catch (err) {
+    console.warn(`Google translation failed (${from} -> ${to}) for "${text}": ${err.message}`);
+    try {
+      const translated = await translateWithOpenAI(text, to, from);
+      console.log('    using OpenAI');
+      return translated;
+    } catch (err2) {
+      console.warn(`OpenAI translation failed (${from} -> ${to}) for "${text}": ${err2.message}`);
+      return text;
+    }
   }
 }
 
@@ -38,12 +102,12 @@ async function main() {
       sourceLang = value.mn ? 'mn' : 'en';
     } else {
       sourceText = value;
-      sourceLang = 'mn';
+      sourceLang = /[\u0400-\u04FF]/.test(sourceText) ? 'mn' : 'en';
     }
 
     if (
       typeof sourceText !== 'string' ||
-      !/[\u0400-\u04FF]/.test(sourceText) ||
+      (!/[\u0400-\u04FF]/.test(sourceText) && !/[A-Za-z]/.test(sourceText)) ||
       sourceText.trim().toLowerCase() === key.toLowerCase()
     ) {
       continue;
@@ -57,25 +121,24 @@ async function main() {
         if (lang === baseLang) {
           locales[lang][key] = baseText;
         } else {
+          console.log(`Translating "${baseText}" (${baseLang} -> ${lang})`);
           const translation = await translate(baseText, lang, baseLang);
           locales[lang][key] = translation;
           if (translation === baseText) untranslated[lang].push(key);
-          console.log(`Translated ${key}: "${baseText}" -> ${lang}`);
         }
       }
     }
   }
 
   for (const lang of languages) {
-    const ordered = Object.keys(locales[lang]).sort().reduce((acc, k) => {
-      acc[k] = locales[lang][k];
-      return acc;
-    }, {});
+    const ordered = Object.keys(locales[lang])
+      .sort()
+      .reduce((acc, k) => {
+        acc[k] = locales[lang][k];
+        return acc;
+      }, {});
     const file = path.join(localesDir, `${lang}.json`);
     fs.writeFileSync(file, JSON.stringify(ordered, null, 2));
-  }
-
-  for (const lang of languages) {
     if (untranslated[lang].length) {
       console.log(`Untranslated keys for ${lang}: ${untranslated[lang].join(', ')}`);
     }
@@ -86,3 +149,4 @@ main().catch((e) => {
   console.error(e);
   process.exit(1);
 });
+


### PR DESCRIPTION
## Summary
- wrap Google Translate requests with proper encoding and retry logic
- fall back to OpenAI's gpt-4o-mini when Google fails
- log translation provider and phrase details

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1cadfde008331b8d62428da183876