### PR TITLE
feat: support configurable UI tooltips

### DIFF
--- a/config/tableDisplayFields.json
+++ b/config/tableDisplayFields.json
@@ -4,7 +4,11 @@
     "displayFields": [
       "emp_fname",
       "emp_lname"
-    ]
+    ],
+    "tooltips": {
+      "emp_fname": "tooltip.firstName",
+      "emp_lname": "tooltip.lastName"
+    }
   },
   "code_department": {
     "idField": "department_id",

--- a/config/transactionForms.json
+++ b/config/transactionForms.json
@@ -47,6 +47,10 @@
         "or_o_barimt": "0",
         "company_id": ""
       },
+      "tooltips": {
+        "or_g_id": "tooltip.organization",
+        "or_date": "tooltip.date"
+      },
       "editableDefaultFields": [
         "or_av_now",
         "or_g_id",

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -3,6 +3,8 @@ import AsyncSearchSelect from './AsyncSearchSelect.jsx';
 import Modal from './Modal.jsx';
 import InlineTransactionTable from './InlineTransactionTable.jsx';
 import RowDetailModal from './RowDetailModal.jsx';
+import TooltipWrapper from './TooltipWrapper.jsx';
+import { useTranslation } from 'react-i18next';
 import { AuthContext } from '../context/AuthContext.jsx';
 import formatTimestamp from '../utils/formatTimestamp.js';
 import callProcedure from '../utils/callProcedure.js';
@@ -55,6 +57,7 @@ const RowFormModal = function RowFormModal({
   viewColumns = {},
   procTriggers = {},
   autoFillSession = true,
+  tooltips = {},
 }) {
   const mounted = useRef(false);
   const renderCount = useRef(0);
@@ -63,6 +66,7 @@ const RowFormModal = function RowFormModal({
   const generalConfig = useGeneralConfig();
   const cfg = generalConfig[scope] || {};
   const general = generalConfig.general || {};
+  const { t } = useTranslation();
   labelFontSize = labelFontSize ?? cfg.labelFontSize ?? 14;
   boxWidth = boxWidth ?? cfg.boxWidth ?? 60;
   boxHeight = boxHeight ?? cfg.boxHeight ?? 30;
@@ -908,6 +912,7 @@ const RowFormModal = function RowFormModal({
     const inputClass = `w-full border rounded ${err ? 'border-red-500' : 'border-gray-300'}`;
     const isColumn = columns.includes(c);
     const disabled = disabledSet.has(c.toLowerCase()) || !isColumn;
+    const tip = tooltips[c] ? t(tooltips[c]) : labels[c] || c;
 
     if (disabled) {
       const raw = isColumn ? formVals[c] : extraVals[c];
@@ -944,7 +949,7 @@ const RowFormModal = function RowFormModal({
         maxWidth: `${boxMaxWidth}px`,
       };
       const content = (
-        <div className="flex items-center space-x-1" title={display}>
+        <div className="flex items-center space-x-1">
           <div
             className="border rounded bg-gray-100 px-2 py-1"
             style={readonlyStyle}
@@ -954,22 +959,25 @@ const RowFormModal = function RowFormModal({
           </div>
         </div>
       );
-      if (!withLabel) return content;
+      const wrapped = <TooltipWrapper title={tip}>{content}</TooltipWrapper>;
+      if (!withLabel) return wrapped;
       return (
-        <div key={c} className={fitted ? 'mb-1' : 'mb-3'}>
-          <div className="flex items-center space-x-1">
-            <label className="font-medium" style={labelStyle}>
-              {labels[c] || c}
-            </label>
-            {content}
+        <TooltipWrapper key={c} title={tip}>
+          <div className={fitted ? 'mb-1' : 'mb-3'}>
+            <div className="flex items-center space-x-1">
+              <label className="font-medium" style={labelStyle}>
+                {labels[c] || c}
+              </label>
+              {content}
+            </div>
           </div>
-        </div>
+        </TooltipWrapper>
       );
     }
 
     const control = relationConfigs[c] ? (
       <AsyncSearchSelect
-        title={labels[c] || c}
+        title={tip}
         table={relationConfigs[c].table}
         searchColumn={relationConfigs[c].idField || relationConfigs[c].column}
         searchColumns={[
@@ -1005,7 +1013,7 @@ const RowFormModal = function RowFormModal({
       />
     ) : viewSource[c] && !Array.isArray(relations[c]) ? (
       <AsyncSearchSelect
-        title={labels[c] || c}
+        title={tip}
         table={viewSource[c]}
         searchColumn={viewDisplays[viewSource[c]]?.idField || c}
         searchColumns={[
@@ -1042,7 +1050,7 @@ const RowFormModal = function RowFormModal({
       />
     ) : Array.isArray(relations[c]) ? (
       <select
-        title={formVals[c]}
+        title={tip}
         ref={(el) => (inputRefs.current[c] = el)}
         value={formVals[c]}
         onFocus={() => handleFocusField(c)}
@@ -1070,7 +1078,7 @@ const RowFormModal = function RowFormModal({
       </select>
     ) : (
       <input
-        title={formVals[c]}
+        title={tip}
         ref={(el) => (inputRefs.current[c] = el)}
         type={(() => {
           if (placeholders[c] === 'YYYY-MM-DD') return 'date';
@@ -1116,19 +1124,21 @@ const RowFormModal = function RowFormModal({
       />
     );
 
-    if (!withLabel) return <>{control}</>;
+    if (!withLabel) return <TooltipWrapper title={tip}>{control}</TooltipWrapper>;
 
     return (
-      <div key={c} className={fitted ? 'mb-1' : 'mb-3'}>
-        <label className="block mb-1 font-medium" style={labelStyle}>
-          {labels[c] || c}
-          {requiredFields.includes(c) && (
-            <span className="text-red-500">*</span>
-          )}
-        </label>
-        {control}
-        {err && <div className="text-red-500 text-sm">{err}</div>}
-      </div>
+      <TooltipWrapper key={c} title={tip}>
+        <div className={fitted ? 'mb-1' : 'mb-3'}>
+          <label className="block mb-1 font-medium" style={labelStyle}>
+            {labels[c] || c}
+            {requiredFields.includes(c) && (
+              <span className="text-red-500">*</span>
+            )}
+          </label>
+          {control}
+          {err && <div className="text-red-500 text-sm">{err}</div>}
+        </div>
+      </TooltipWrapper>
     );
   }
 

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -2437,6 +2437,7 @@ const TableManager = forwardRef(function TableManager({
         relationData={refRows}
         disabledFields={disabledFields}
         labels={labels}
+        tooltips={formConfig?.tooltips || {}}
         requiredFields={formConfig?.requiredFields || []}
         defaultValues={rowDefaults}
         dateField={formConfig?.dateField || []}

--- a/src/erp.mgt.mn/components/TooltipWrapper.jsx
+++ b/src/erp.mgt.mn/components/TooltipWrapper.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default function TooltipWrapper({ title, children }) {
+  const [enabled, setEnabled] = React.useState(true);
+  React.useEffect(() => {
+    const val = localStorage.getItem('tooltipsEnabled');
+    setEnabled(val !== 'false');
+  }, []);
+  if (!title) {
+    return children;
+  }
+  const child = React.isValidElement(children)
+    ? React.cloneElement(children, { title })
+    : children;
+  return (
+    <span className="tooltip-wrapper" title={title} data-tooltip={enabled ? title : undefined}>
+      {child}
+    </span>
+  );
+}

--- a/src/erp.mgt.mn/index.css
+++ b/src/erp.mgt.mn/index.css
@@ -308,3 +308,23 @@ th {
     font-size: 0.75rem;
   }
 }
+
+/* Tooltip styles */
+.tooltip-wrapper[data-tooltip] {
+  position: relative;
+}
+
+.tooltip-wrapper[data-tooltip]:hover::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  background: #333;
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  z-index: 50;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+}

--- a/src/erp.mgt.mn/locales/en.json
+++ b/src/erp.mgt.mn/locales/en.json
@@ -29,5 +29,12 @@
   "low_stock": "Low Stock",
   "new_orders": "New Orders",
   "no_activity": "No activity to display.",
-  "plans_coming_soon": "Plans content coming soon."
+  "plans_coming_soon": "Plans content coming soon.",
+  "settings_enable_tooltips": "Enable tooltips",
+  "tooltip": {
+    "organization": "Select organization",
+    "date": "Transaction date",
+    "firstName": "First name",
+    "lastName": "Last name"
+  }
 }

--- a/src/erp.mgt.mn/locales/mn.json
+++ b/src/erp.mgt.mn/locales/mn.json
@@ -29,5 +29,12 @@
   "low_stock": "Бараа дуусаж байна",
   "new_orders": "Шинэ захиалга",
   "no_activity": "Үйл ажиллагаа байхгүй.",
-  "plans_coming_soon": "Төлөвлөгөө тун удахгүй."
+  "plans_coming_soon": "Төлөвлөгөө тун удахгүй.",
+  "settings_enable_tooltips": "Тайлбарыг идэвхжүүлэх",
+  "tooltip": {
+    "organization": "Байгууллага сонгох",
+    "date": "Огноо",
+    "firstName": "Нэр",
+    "lastName": "Овог"
+  }
 }

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -997,6 +997,7 @@ export default function PosTransactionsPage() {
                       disabledFields={disabled}
                       requiredFields={fc.requiredFields || []}
                       labels={labels}
+                      tooltips={fc.tooltips || {}}
                       row={values[t.table]}
                       rows={t.type === 'multi' ? values[t.table] : undefined}
                       headerFields={headerFields}

--- a/src/erp.mgt.mn/pages/Settings.jsx
+++ b/src/erp.mgt.mn/pages/Settings.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { Outlet, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
 export default function SettingsPage() {
   // Just render the nested route content. The left sidebar already
@@ -22,6 +23,11 @@ export function GeneralSettings() {
     return <p>Хандалт хориглолоо.</p>;
   }
   const [settings, setSettings] = useState(null);
+  const { t } = useTranslation();
+  const [tooltipsEnabled, setTooltipsEnabled] = useState(() => {
+    const val = localStorage.getItem('tooltipsEnabled');
+    return val !== 'false';
+  });
 
   useEffect(() => {
     fetch('/api/settings', { credentials: 'include' })
@@ -41,6 +47,20 @@ export function GeneralSettings() {
       ) : (
         <p>Тохиргоо ачааллаж байна…</p>
       )}
+      <div style={{ marginTop: '1rem' }}>
+        <label>
+          <input
+            type="checkbox"
+            checked={tooltipsEnabled}
+            onChange={(e) => {
+              const v = e.target.checked;
+              setTooltipsEnabled(v);
+              localStorage.setItem('tooltipsEnabled', String(v));
+            }}
+          />{' '}
+          {t('settings_enable_tooltips')}
+        </label>
+      </div>
       <p style={{ marginTop: '1rem' }}>
         <Link to="/settings/role-permissions">Эрхийн тохиргоо засах</Link>
       </p>


### PR DESCRIPTION
## Summary
- add TooltipWrapper component that respects user preferences
- enrich transaction and table configs with tooltip metadata and translations
- enable tooltip toggle in Settings and apply tooltips in form renderer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b20a0adaf4833197181d7cccfcff48