### PR TITLE
feat: add guided tours with joyride

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "socket.io": "^4.7.5",
     "socket.io-client": "^4.7.5",
     "xlsx": "^0.18.5",
-    "jspdf": "^2.5.2"
+    "jspdf": "^2.5.2",
+    "react-joyride": "^2.9.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -17,6 +17,10 @@ import Spinner from "./Spinner.jsx";
 import useHeaderMappings from "../hooks/useHeaderMappings.js";
 import useRequestNotificationCounts from "../hooks/useRequestNotificationCounts.js";
 import { PendingRequestContext } from "../context/PendingRequestContext.jsx";
+import Joyride, { STATUS } from "react-joyride";
+import "react-joyride/lib/styles.css";
+import { guideSteps as dashboardSteps } from "../pages/DashboardPage.jsx";
+import { guideSteps as formsSteps } from "../pages/Forms.jsx";
 
 /**
  * A desktop‐style “ERPLayout” with:
@@ -43,6 +47,8 @@ export default function ERPLayout() {
 
   const [isMobile, setIsMobile] = useState(() => window.innerWidth < 768);
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [tourSteps, setTourSteps] = useState([]);
+  const [runTour, setRunTour] = useState(false);
   useEffect(() => {
     const handler = () => setIsMobile(window.innerWidth < 768);
     window.addEventListener('resize', handler);
@@ -112,6 +118,35 @@ export default function ERPLayout() {
 
   const windowTitle = titleForPath(location.pathname);
 
+  useEffect(() => {
+    const path = location.pathname;
+    let pageKey = "dashboard";
+    if (path.startsWith("/forms")) pageKey = "forms";
+    const stepsMap = { dashboard: dashboardSteps, forms: formsSteps };
+    const steps = stepsMap[pageKey] || [];
+    setTourSteps(steps);
+    const seenKey = `erpGuideSeen-${pageKey}`;
+    setRunTour(!localStorage.getItem(seenKey) && steps.length > 0);
+  }, [location.pathname]);
+
+  const handleTourCallback = ({ status }) => {
+    if ([STATUS.FINISHED, STATUS.SKIPPED].includes(status)) {
+      const path = location.pathname;
+      let pageKey = "dashboard";
+      if (path.startsWith("/forms")) pageKey = "forms";
+      localStorage.setItem(`erpGuideSeen-${pageKey}`, "1");
+      setRunTour(false);
+    }
+  };
+
+  const resetGuide = () => {
+    const path = location.pathname;
+    let pageKey = "dashboard";
+    if (path.startsWith("/forms")) pageKey = "forms";
+    localStorage.removeItem(`erpGuideSeen-${pageKey}`);
+    setRunTour(tourSteps.length > 0);
+  };
+
   const {
     tabs,
     activeKey,
@@ -163,6 +198,15 @@ export default function ERPLayout() {
   return (
     <PendingRequestContext.Provider value={requestNotifications}>
       <div style={styles.container}>
+        <Joyride
+          steps={tourSteps}
+          run={runTour && tourSteps.length > 0}
+          continuous
+          showSkipButton
+          disableOverlayClose
+          disableKeyboardNavigation={false}
+          callback={handleTourCallback}
+        />
         <Header
           user={user}
           onLogout={handleLogout}
@@ -170,6 +214,7 @@ export default function ERPLayout() {
           isMobile={isMobile}
           onToggleSidebar={() => setSidebarOpen((o) => !o)}
           onOpen={handleOpen}
+          onResetGuide={tourSteps.length > 0 ? resetGuide : undefined}
         />
         <div style={styles.body(isMobile)}>
           {isMobile && sidebarOpen && (
@@ -192,7 +237,7 @@ export default function ERPLayout() {
 }
 
 /** Top header bar **/
-function Header({ user, onLogout, onHome, isMobile, onToggleSidebar, onOpen }) {
+function Header({ user, onLogout, onHome, isMobile, onToggleSidebar, onOpen, onResetGuide }) {
   const { session } = useContext(AuthContext);
   const { lang, setLang, t } = useContext(LangContext);
 
@@ -252,7 +297,7 @@ function Header({ user, onLogout, onHome, isMobile, onToggleSidebar, onOpen }) {
           <option value="fr">fr</option>
           <option value="ru">ru</option>
         </select>
-        <UserMenu user={user} onLogout={onLogout} />
+        <UserMenu user={user} onLogout={onLogout} onResetGuide={onResetGuide} />
       </div>
     </header>
   );

--- a/src/erp.mgt.mn/components/UserMenu.jsx
+++ b/src/erp.mgt.mn/components/UserMenu.jsx
@@ -1,11 +1,13 @@
 import React, { useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext.jsx';
+import LangContext from '../context/I18nContext.jsx';
 
-export default function UserMenu({ user, onLogout }) {
+export default function UserMenu({ user, onLogout, onResetGuide }) {
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
   const { session } = useContext(AuthContext);
+  const { t } = useContext(LangContext);
 
   if (!user) return null;
 
@@ -33,6 +35,17 @@ export default function UserMenu({ user, onLogout }) {
           <button style={styles.menuItem} onClick={handleChangePassword}>
             Нууц үг солих
           </button>
+          {onResetGuide && (
+            <button
+              style={styles.menuItem}
+              onClick={() => {
+                setOpen(false);
+                onResetGuide();
+              }}
+            >
+              {t('show_page_guide', 'Show page guide')}
+            </button>
+          )}
           <button style={styles.menuItem} onClick={handleLogout}>Гарах</button>
         </div>
       )}

--- a/src/erp.mgt.mn/pages/DashboardPage.jsx
+++ b/src/erp.mgt.mn/pages/DashboardPage.jsx
@@ -4,6 +4,7 @@ import PendingRequestWidget from '../components/PendingRequestWidget.jsx';
 import OutgoingRequestWidget from '../components/OutgoingRequestWidget.jsx';
 import { usePendingRequests } from '../context/PendingRequestContext.jsx';
 import LangContext from '../context/I18nContext.jsx';
+import i18next from 'i18next';
 
 export default function DashboardPage() {
   const { user, session } = useContext(AuthContext);
@@ -140,4 +141,11 @@ export default function DashboardPage() {
     </div>
   );
 }
+
+export const guideSteps = [
+  {
+    target: 'body',
+    content: i18next.t('guide.newTransaction'),
+  },
+];
 

--- a/src/erp.mgt.mn/pages/Forms.jsx
+++ b/src/erp.mgt.mn/pages/Forms.jsx
@@ -2,8 +2,16 @@
 import React from 'react';
 import { useOutlet } from 'react-router-dom';
 import FormsIndex from './FormsIndex.jsx';
+import i18next from 'i18next';
 
 export default function FormsPage() {
   const outlet = useOutlet();
   return outlet || <FormsIndex />;
 }
+
+export const guideSteps = [
+  {
+    target: 'body',
+    content: i18next.t('guide.newTransaction'),
+  },
+];


### PR DESCRIPTION
## Summary
- add `react-joyride` dependency
- integrate onboarding tour into ERPLayout
- allow users to replay guides from user menu
- ensure tours run on first visit and import joyride styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b208ebb5ec833186155356849be917