### PR TITLE
forbid system admin general config

### DIFF
--- a/api-server/controllers/generalConfigController.js
+++ b/api-server/controllers/generalConfigController.js
@@ -7,6 +7,7 @@ export async function fetchGeneralConfig(req, res, next) {
     const session =
       req.session ||
       (await getEmploymentSession(req.user.empid, req.user.companyId));
+    if (session?.company_id === 0) return res.sendStatus(403);
     if (!(await hasAction(session, 'system_settings'))) return res.sendStatus(403);
     const getter = req.getGeneralConfig || cfgSvc.getGeneralConfig;
     const cfg = await getter();
@@ -21,6 +22,7 @@ export async function saveGeneralConfig(req, res, next) {
     const session =
       req.session ||
       (await getEmploymentSession(req.user.empid, req.user.companyId));
+    if (session?.company_id === 0) return res.sendStatus(403);
     if (!(await hasAction(session, 'system_settings'))) return res.sendStatus(403);
     const updater = req.updateGeneralConfig || cfgSvc.updateGeneralConfig;
     const cfg = await updater(req.body || {});

--- a/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
+++ b/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
@@ -12,8 +12,9 @@ export default function GeneralConfiguration() {
   const { addToast } = useToast();
   const { session, permissions } = useContext(AuthContext);
   const hasAdmin =
-    permissions?.permissions?.system_settings ||
-    session?.permissions?.system_settings;
+    (permissions?.permissions?.system_settings ||
+      session?.permissions?.system_settings) &&
+    session?.company_id !== 0;
   if (!hasAdmin) {
     return <Navigate to="/" replace />;
   }

--- a/tests/controllers/generalConfigController.test.js
+++ b/tests/controllers/generalConfigController.test.js
@@ -72,3 +72,30 @@ test('saveGeneralConfig allows update with user-level permission', async () => {
   await saveGeneralConfig(req, res, () => {});
   assert.deepEqual(res.body, { general: { aiApiEnabled: true } });
 });
+
+test('fetchGeneralConfig forbids system admin', async () => {
+  const req = {
+    user: { empid: 1, companyId: 0 },
+    session: { permissions: { system_settings: 1 }, company_id: 0 },
+    getGeneralConfig: async () => {
+      throw new Error('should not fetch');
+    },
+  };
+  const res = createRes();
+  await fetchGeneralConfig(req, res, () => {});
+  assert.equal(res.code, 403);
+});
+
+test('saveGeneralConfig forbids system admin', async () => {
+  const req = {
+    user: { empid: 1, companyId: 0 },
+    body: { general: { aiApiEnabled: true } },
+    session: { permissions: { system_settings: 1 }, company_id: 0 },
+    updateGeneralConfig: async () => {
+      throw new Error('should not update');
+    },
+  };
+  const res = createRes();
+  await saveGeneralConfig(req, res, () => {});
+  assert.equal(res.code, 403);
+});


### PR DESCRIPTION
## Summary
- block system admins from fetching or updating general configuration
- hide General Configuration UI for system admins
- add tests ensuring system admins cannot access general configuration endpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2195a43b08331aecbb6ef95d091ec