### PR TITLE
allow system admin general configuration toggles

### DIFF
--- a/tests/controllers/generalConfigController.test.js
+++ b/tests/controllers/generalConfigController.test.js
@@ -72,3 +72,26 @@ test('saveGeneralConfig allows update with user-level permission', async () => {
   await saveGeneralConfig(req, res, () => {});
   assert.deepEqual(res.body, { general: { aiApiEnabled: true } });
 });
+
+test('fetchGeneralConfig allows system admin', async () => {
+  const req = {
+    user: { empid: 1, companyId: 0 },
+    session: { permissions: { system_settings: 1 }, company_id: 0 },
+    getGeneralConfig: async () => ({ general: { aiApiEnabled: true } }),
+  };
+  const res = createRes();
+  await fetchGeneralConfig(req, res, () => {});
+  assert.deepEqual(res.body, { general: { aiApiEnabled: true } });
+});
+
+test('saveGeneralConfig allows system admin', async () => {
+  const req = {
+    user: { empid: 1, companyId: 0 },
+    body: { general: { aiApiEnabled: true } },
+    session: { permissions: { system_settings: 1 }, company_id: 0 },
+    updateGeneralConfig: async (body) => body,
+  };
+  const res = createRes();
+  await saveGeneralConfig(req, res, () => {});
+  assert.deepEqual(res.body, { general: { aiApiEnabled: true } });
+});


### PR DESCRIPTION
## Summary
- allow system admins to fetch and update general configuration settings
- show General Configuration page to system admins
- update tests to cover system admin access

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2195a43b08331aecbb6ef95d091ec