### PR TITLE
allow system admin general configuration toggles

### DIFF
--- a/api-server/routes/general_config.js
+++ b/api-server/routes/general_config.js
@@ -1,30 +1,13 @@
 import express from 'express';
 import { requireAuth } from '../middlewares/auth.js';
-import { getGeneralConfig, updateGeneralConfig } from '../services/generalConfig.js';
-import { getEmploymentSession } from '../../db/index.js';
+import {
+  fetchGeneralConfig,
+  saveGeneralConfig,
+} from '../controllers/generalConfigController.js';
 
 const router = express.Router();
 
-router.get('/', requireAuth, async (req, res, next) => {
-  try {
-    const cfg = await getGeneralConfig();
-    res.json(cfg);
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.put('/', requireAuth, async (req, res, next) => {
-  try {
-    const session =
-      req.session ||
-      (await getEmploymentSession(req.user.empid, req.user.companyId));
-    if (!session?.permissions?.system_settings) return res.sendStatus(403);
-    const cfg = await updateGeneralConfig(req.body || {});
-    res.json(cfg);
-  } catch (err) {
-    next(err);
-  }
-});
+router.get('/', requireAuth, fetchGeneralConfig);
+router.put('/', requireAuth, saveGeneralConfig);
 
 export default router;

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -761,12 +761,13 @@ const RowFormModal = function RowFormModal({
     if (submitLocked) return;
     setSubmitLocked(true);
     if (useGrid && tableRef.current) {
-      if (tableRef.current.hasInvalid && tableRef.current.hasInvalid()) {
+      const grid = tableRef.current;
+      if (grid.hasInvalid && grid.hasInvalid()) {
         alert('Тэмдэглэсэн талбаруудыг засна уу.');
         setSubmitLocked(false);
         return;
       }
-      const rows = tableRef.current.getRows();
+      const rows = grid.getRows();
       const cleanedRows = [];
       const rowIndices = [];
       let hasMissing = false;
@@ -854,9 +855,9 @@ const RowFormModal = function RowFormModal({
           window.dispatchEvent(new Event('pending-request-refresh'));
         }
         if (failedRows.length === 0) {
-          tableRef.current.clearRows();
-        } else if (tableRef.current.replaceRows) {
-          tableRef.current.replaceRows(failedRows);
+          grid?.clearRows?.();
+        } else if (grid?.replaceRows) {
+          grid.replaceRows(failedRows);
         }
       }
       procCache.current = {};

--- a/tests/controllers/generalConfigController.test.js
+++ b/tests/controllers/generalConfigController.test.js
@@ -72,3 +72,36 @@ test('saveGeneralConfig allows update with user-level permission', async () => {
   await saveGeneralConfig(req, res, () => {});
   assert.deepEqual(res.body, { general: { aiApiEnabled: true } });
 });
+
+test('fetchGeneralConfig allows system admin', async () => {
+  const req = {
+    user: { empid: 1, companyId: 0 },
+    session: {
+      permissions: { system_settings: 0 },
+      company_id: 0,
+      user_level: 1,
+      __userLevelActions: { permissions: { system_settings: true } },
+    },
+    getGeneralConfig: async () => ({ general: { aiApiEnabled: true } }),
+  };
+  const res = createRes();
+  await fetchGeneralConfig(req, res, () => {});
+  assert.deepEqual(res.body, { general: { aiApiEnabled: true } });
+});
+
+test('saveGeneralConfig allows system admin', async () => {
+  const req = {
+    user: { empid: 1, companyId: 0 },
+    body: { general: { aiApiEnabled: true } },
+    session: {
+      permissions: { system_settings: 0 },
+      company_id: 0,
+      user_level: 1,
+      __userLevelActions: { permissions: { system_settings: true } },
+    },
+    updateGeneralConfig: async (body) => body,
+  };
+  const res = createRes();
+  await saveGeneralConfig(req, res, () => {});
+  assert.deepEqual(res.body, { general: { aiApiEnabled: true } });
+});


### PR DESCRIPTION
## Summary
- allow system admins to fetch and update general configuration settings
- show General Configuration page to system admins
- wire general configuration API route to shared permission checks so admins aren't blocked
- update tests to cover system admin access
- fix request edit form submission when modal closes during posting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2195a43b08331aecbb6ef95d091ec