### PR TITLE
Assign creator to new company and link user automatically

### DIFF
--- a/api-server/controllers/companyController.js
+++ b/api-server/controllers/companyController.js
@@ -1,6 +1,7 @@
 import {
   listCompanies,
   insertTableRow,
+  assignCompanyToUser,
   getEmploymentSession,
   getEmploymentSessions,
 } from '../../db/index.js';
@@ -23,6 +24,7 @@ export async function createCompanyHandler(req, res, next) {
       overwrite = false,
       ...company
     } = req.body || {};
+    company.created_by = req.user.empid;
     const session =
       req.session ||
       (await getEmploymentSession(req.user.empid, req.user.companyId));
@@ -44,6 +46,9 @@ export async function createCompanyHandler(req, res, next) {
       req.user.empid,
     );
     res.locals.insertId = result?.id;
+    if (result?.id) {
+      await assignCompanyToUser(req.user.empid, result.id, null, null, req.user.empid);
+    }
     res.status(201).json(result);
   } catch (err) {
     next(err);

--- a/tests/api/companyController.test.js
+++ b/tests/api/companyController.test.js
@@ -69,8 +69,9 @@ test('allows POST /api/companies when any session has system_settings', async ()
         permission_list: 'system_settings',
       },
     ]],
-    [[{ COLUMN_NAME: 'name' }]],
+    [[{ COLUMN_NAME: 'name' }, { COLUMN_NAME: 'created_by' }]],
     [{ insertId: 1 }],
+    [{ affectedRows: 1 }],
   ]);
   const req = {
     body: { name: 'NewCo', seedTables: [] },

--- a/tests/controllers/companyController.test.js
+++ b/tests/controllers/companyController.test.js
@@ -48,9 +48,11 @@ test('createCompanyHandler allows system admin with companyId=0', async () => {
       permission_list: 'system_settings',
       }]];
     },
-    [[{ COLUMN_NAME: 'name' }]],
+    [[{ COLUMN_NAME: 'name' }, { COLUMN_NAME: 'created_by' }]],
     [{ insertId: 5 }],
     [[]],
+    [[]],
+    [{ affectedRows: 1 }],
   ]);
   const req = { body: { name: 'NewCo' }, user: { empid: 1, companyId: 0 } };
   const res = createRes();
@@ -67,7 +69,7 @@ test('createCompanyHandler forwards seedRecords and overwrite', async () => {
   let deleteCalled = false;
   db.pool.query = async (sql, params) => {
     if (/information_schema\.COLUMNS/.test(sql) && params[0] === 'companies') {
-      return [[{ COLUMN_NAME: 'name' }]];
+      return [[{ COLUMN_NAME: 'name' }, { COLUMN_NAME: 'created_by' }]];
     }
     if (sql.startsWith('INSERT INTO ??') && params[0] === 'companies') {
       return [{ insertId: 9 }];
@@ -94,6 +96,9 @@ test('createCompanyHandler forwards seedRecords and overwrite', async () => {
     }
     if (/INSERT INTO user_level_permissions/.test(sql)) {
       return [[]];
+    }
+    if (/INSERT INTO user_companies/.test(sql)) {
+      return [{ affectedRows: 1 }];
     }
     return [[]];
   };


### PR DESCRIPTION
## Summary
- Set `created_by` on new companies based on the requesting user's empid
- Automatically assign newly created companies to the creator
- Update tests for new company assignment behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2b17e469c83318cf4dc9fe91fea4e