### PR TITLE
Restrict company assignment actions to company creators

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -662,13 +662,18 @@ export async function updateCompanyAssignment(empid, companyId, position_id, bra
 /**
  * List all user-company assignments
  */
-export async function listAllUserCompanies(companyId) {
+export async function listAllUserCompanies(companyId, createdBy = null) {
   const params = [];
-  let where = '';
+  const clauses = [];
   if (companyId) {
-    where = 'WHERE uc.company_id = ?';
+    clauses.push('uc.company_id = ?');
     params.push(companyId);
   }
+  if (createdBy) {
+    clauses.push('c.created_by = ?');
+    params.push(createdBy);
+  }
+  const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
   const [rows] = await pool.query(
     `SELECT uc.empid, uc.company_id, c.name AS company_name, uc.position_id,
             uc.branch_id, b.name AS branch_name

--- a/tests/db/userCompanies.test.js
+++ b/tests/db/userCompanies.test.js
@@ -31,3 +31,18 @@ test('listAllUserCompanies joins branch with company scope', async () => {
     /LEFT JOIN code_branches b ON uc\.branch_id = b\.id AND b\.company_id = uc\.company_id/
   );
 });
+
+test('listAllUserCompanies filters by created_by when provided', async () => {
+  const orig = db.pool.query;
+  let capturedSql = '';
+  let capturedParams;
+  db.pool.query = async (sql, params) => {
+    capturedSql = sql;
+    capturedParams = params;
+    return [[]];
+  };
+  await db.listAllUserCompanies(null, 5);
+  db.pool.query = orig;
+  assert.match(capturedSql, /WHERE c\.created_by = \?/);
+  assert.equal(capturedParams[0], 5);
+});


### PR DESCRIPTION
## Summary
- add optional `createdBy` filter to `listAllUserCompanies`
- enforce company `created_by` ownership on listing and assignment actions
- update tests for new filtering and authorization logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2b5080a008331a8d5abaddf562131