### PR TITLE
Filter module license population by creator

### DIFF
--- a/api-server/controllers/moduleController.js
+++ b/api-server/controllers/moduleController.js
@@ -78,7 +78,7 @@ export async function populatePermissions(req, res, next) {
       };
     if (!(await hasAction(session, "system_settings"))) return res.sendStatus(403);
     await populateDefaultModules();
-    await populateCompanyModuleLicenses();
+    await populateCompanyModuleLicenses(req.user.empid);
     await populateUserLevelModulePermissions(req.user.empid);
     res.sendStatus(204);
   } catch (err) {

--- a/db/index.js
+++ b/db/index.js
@@ -844,12 +844,14 @@ export async function populateDefaultModules() {
 }
 
 
-export async function populateCompanyModuleLicenses() {
+export async function populateCompanyModuleLicenses(createdBy) {
   await pool.query(
     `INSERT IGNORE INTO company_module_licenses (company_id, module_key, licensed, created_by)
-     SELECT c.id AS company_id, m.module_key, 1, NULL
+     SELECT c.id AS company_id, m.module_key, 1, ?
        FROM companies c
-       CROSS JOIN modules m`,
+       CROSS JOIN modules m
+       WHERE c.created_by = ?`,
+    [createdBy, createdBy],
   );
 }
 


### PR DESCRIPTION
## Summary
- Track admin when populating company module licenses and scope to their created companies
- Pass current admin empid to permission population

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2b705c1508331b75a1559218b4cbe