### PR TITLE
Clarify self-created company lists

### DIFF
--- a/src/erp.mgt.mn/pages/Companies.jsx
+++ b/src/erp.mgt.mn/pages/Companies.jsx
@@ -44,6 +44,9 @@ export default function CompaniesPage() {
   return (
     <div>
       <h2>Компаниуд</h2>
+      <p style={{ fontSize: '0.875rem', color: '#4b5563' }}>
+        Зөвхөн таны үүсгэсэн компаниудыг харуулна.
+      </p>
       <input
         type="text"
         placeholder="Компанийн нэр шүүх"
@@ -53,7 +56,10 @@ export default function CompaniesPage() {
       />
       <button onClick={handleAdd}>Компани нэмэх</button>
       {visibleCompanies.length === 0 ? (
-        <p>Компани олдсонгүй.</p>
+        <p>
+          Таны үүсгэсэн компани олдсонгүй. Компани нэмэх товчийг ашиглан шинэ
+          компани үүсгэнэ үү.
+        </p>
       ) : (
         <div className="table-container overflow-x-auto" style={{ maxHeight: '70vh' }}>
           <table

--- a/src/erp.mgt.mn/pages/CompanyLicenses.jsx
+++ b/src/erp.mgt.mn/pages/CompanyLicenses.jsx
@@ -47,6 +47,9 @@ export default function CompanyLicenses() {
   return (
     <div>
       <h2>Лиценз</h2>
+      <p style={{ fontSize: '0.875rem', color: '#4b5563' }}>
+        Зөвхөн таны үүсгэсэн компаниудын лицензүүдийг харуулна.
+      </p>
       <input
         type="text"
         placeholder="Компанийн ID-р шүүх"
@@ -56,7 +59,10 @@ export default function CompanyLicenses() {
       />
       <button onClick={handleFilter}>Шүүх</button>
       {licenses.length === 0 ? (
-        <p>Лиценз алга.</p>
+        <p>
+          Лиценз олдсонгүй. Таны үүсгэсэн компаниудад лиценз тохируулаагүй
+          байна.
+        </p>
       ) : (
         <div className="table-container overflow-x-auto" style={{ maxHeight: '70vh' }}>
         <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '0.5rem' }}>

--- a/src/erp.mgt.mn/pages/UserCompanies.jsx
+++ b/src/erp.mgt.mn/pages/UserCompanies.jsx
@@ -109,6 +109,9 @@ export default function UserCompanies() {
   return (
     <div>
       <h2>Хэрэглэгчийн компаниуд</h2>
+      <p style={{ fontSize: '0.875rem', color: '#4b5563' }}>
+        Зөвхөн таны үүсгэсэн компаниудад хийсэн хуваарилалтыг харуулна.
+      </p>
       <input
         type="text"
         placeholder="EmpID-р шүүх"
@@ -121,7 +124,10 @@ export default function UserCompanies() {
       </button>
       <button onClick={handleAdd}>Хуваарилалт нэмэх</button>
       {assignments.length === 0 ? (
-        <p>Хуваарилалт алга.</p>
+        <p>
+          Хуваарилалт олдсонгүй. Өөрийн үүсгэсэн компанид хэрэглэгч
+          хуваарилагдаагүй байна.
+        </p>
       ) : (
         <div className="table-container overflow-x-auto" style={{ maxHeight: '70vh' }}>
         <table


### PR DESCRIPTION
## Summary
- Add guidance that company-related pages only show companies you created
- Improve empty-list messages for companies, licenses, and user-company assignments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2b7ae9afc8331a818003f4558ae38