### PR TITLE
Handle missing permissions when adding companies

### DIFF
--- a/src/erp.mgt.mn/pages/Companies.jsx
+++ b/src/erp.mgt.mn/pages/Companies.jsx
@@ -25,13 +25,29 @@ export default function CompaniesPage() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
+      skipErrorToast: true,
       body: JSON.stringify({ name })
     });
+    if (res.status === 403) {
+      window.dispatchEvent(
+        new CustomEvent('toast', {
+          detail: {
+            message: 'You need System Settings permission to add a company.',
+            type: 'error'
+          }
+        })
+      );
+      return;
+    }
     if (!res.ok) {
       const { message } = await res
         .json()
         .catch(() => ({ message: 'Failed to add company' }));
-      alert(message || 'Failed to add company');
+      window.dispatchEvent(
+        new CustomEvent('toast', {
+          detail: { message: message || 'Failed to add company', type: 'error' }
+        })
+      );
       return;
     }
     loadCompanies();

--- a/src/erp.mgt.mn/utils/csrfFetch.js
+++ b/src/erp.mgt.mn/utils/csrfFetch.js
@@ -26,7 +26,7 @@ async function getToken() {
 
 const originalFetch = window.fetch.bind(window);
 window.fetch = async (url, options = {}, _retry) => {
-  const { skipLoader, ...opts } = options || {};
+  const { skipLoader, skipErrorToast, ...opts } = options || {};
   const key = skipLoader ? null : currentKey();
   if (key) dispatchStart(key);
   const method = (opts.method || 'GET').toUpperCase();
@@ -65,7 +65,7 @@ window.fetch = async (url, options = {}, _retry) => {
     }
     return res;
   }
-  if (!res.ok) {
+  if (!res.ok && !skipErrorToast) {
     let errorMsg = res.statusText;
     try {
       const data = await res.clone().json();


### PR DESCRIPTION
## Summary
- Show explicit toast when company creation returns 403
- Allow fetch wrapper to skip generic error toasts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2bfe72b8883319337fd2aa35e47d2