### PR TITLE
fix: use options signal for openai translation

### DIFF
--- a/scripts/generateTranslations.js
+++ b/scripts/generateTranslations.js
@@ -114,11 +114,13 @@ async function translateWithOpenAI(text, from, to) {
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
   try {
     const prompt = `Translate this ${from}-language ERP system term into ${to}. Use ERP terminology.\n\n${text}`;
-    const completion = await openai.chat.completions.create({
-      model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: prompt }],
-      signal: controller.signal,
-    });
+    const completion = await openai.chat.completions.create(
+      {
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: prompt }],
+      },
+      { signal: controller.signal }
+    );
     clearTimeout(timer);
 
     const translation = completion.choices?.[0]?.message?.content?.trim();


### PR DESCRIPTION
## Summary
- pass abort signal to `openai.chat.completions.create` via options instead of payload

## Testing
- `npm run generate:translations` *(fails: Cannot find package 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68b2c00c613883319d421603c3916a3a