### PR TITLE
feat: add tooltip translations

### DIFF
--- a/src/erp.mgt.mn/locales/de.json
+++ b/src/erp.mgt.mn/locales/de.json
@@ -29,5 +29,12 @@
   "low_stock": "Niedriger Bestand",
   "new_orders": "Neue Bestellungen",
   "no_activity": "Keine Aktivitäten verfügbar.",
-  "plans_coming_soon": "Planinhalte folgen bald."
+  "plans_coming_soon": "Planinhalte folgen bald.",
+  "settings_enable_tooltips": "Tooltips aktivieren",
+  "tooltip": {
+    "organization": "Organisation auswählen",
+    "date": "Transaktionsdatum",
+    "firstName": "Vorname",
+    "lastName": "Nachname"
+  }
 }

--- a/src/erp.mgt.mn/locales/es.json
+++ b/src/erp.mgt.mn/locales/es.json
@@ -29,5 +29,12 @@
   "low_stock": "Bajo inventario",
   "new_orders": "Nuevos pedidos",
   "no_activity": "No hay actividad para mostrar.",
-  "plans_coming_soon": "Contenido de planes próximamente."
+  "plans_coming_soon": "Contenido de planes próximamente.",
+  "settings_enable_tooltips": "Habilitar tooltips",
+  "tooltip": {
+    "organization": "Seleccionar organización",
+    "date": "Fecha de transacción",
+    "firstName": "Nombre",
+    "lastName": "Apellido"
+  }
 }

--- a/src/erp.mgt.mn/locales/fr.json
+++ b/src/erp.mgt.mn/locales/fr.json
@@ -29,5 +29,12 @@
   "low_stock": "Stock faible",
   "new_orders": "Nouvelles commandes",
   "no_activity": "Aucune activité à afficher.",
-  "plans_coming_soon": "Contenu des plans à venir."
+  "plans_coming_soon": "Contenu des plans à venir.",
+  "settings_enable_tooltips": "Activer les info-bulles",
+  "tooltip": {
+    "organization": "Sélectionner l'organisation",
+    "date": "Date de transaction",
+    "firstName": "Prénom",
+    "lastName": "Nom de famille"
+  }
 }

--- a/src/erp.mgt.mn/locales/ja.json
+++ b/src/erp.mgt.mn/locales/ja.json
@@ -29,5 +29,12 @@
   "low_stock": "在庫不足",
   "new_orders": "新規注文",
   "no_activity": "表示する活動がありません。",
-  "plans_coming_soon": "計画の内容は近日公開予定です。"
+  "plans_coming_soon": "計画の内容は近日公開予定です。",
+  "settings_enable_tooltips": "ツールチップを有効にする",
+  "tooltip": {
+    "organization": "組織を選択",
+    "date": "取引日",
+    "firstName": "名",
+    "lastName": "姓"
+  }
 }

--- a/src/erp.mgt.mn/locales/ko.json
+++ b/src/erp.mgt.mn/locales/ko.json
@@ -29,5 +29,12 @@
   "low_stock": "재고 부족",
   "new_orders": "신규 주문",
   "no_activity": "표시할 활동이 없습니다.",
-  "plans_coming_soon": "계획 콘텐츠는 곧 제공됩니다."
+  "plans_coming_soon": "계획 콘텐츠는 곧 제공됩니다.",
+  "settings_enable_tooltips": "툴팁 활성화",
+  "tooltip": {
+    "organization": "조직 선택",
+    "date": "거래 날짜",
+    "firstName": "이름",
+    "lastName": "성"
+  }
 }

--- a/src/erp.mgt.mn/locales/ru.json
+++ b/src/erp.mgt.mn/locales/ru.json
@@ -29,5 +29,12 @@
   "low_stock": "Мало на складе",
   "new_orders": "Новые заказы",
   "no_activity": "Нет активности для отображения.",
-  "plans_coming_soon": "Содержание планов скоро появится."
+  "plans_coming_soon": "Содержание планов скоро появится.",
+  "settings_enable_tooltips": "Включить подсказки",
+  "tooltip": {
+    "organization": "Выберите организацию",
+    "date": "Дата операции",
+    "firstName": "Имя",
+    "lastName": "Фамилия"
+  }
 }

--- a/src/erp.mgt.mn/locales/zh.json
+++ b/src/erp.mgt.mn/locales/zh.json
@@ -29,5 +29,12 @@
   "low_stock": "库存不足",
   "new_orders": "新订单",
   "no_activity": "没有可显示的活动。",
-  "plans_coming_soon": "计划内容即将推出。"
+  "plans_coming_soon": "计划内容即将推出。",
+  "settings_enable_tooltips": "启用提示",
+  "tooltip": {
+    "organization": "选择组织",
+    "date": "交易日期",
+    "firstName": "名",
+    "lastName": "姓"
+  }
 }


### PR DESCRIPTION
## Summary
- add tooltip strings and translations for all locales

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2c98fbad483318e43a0b0ddb8c370