### PR TITLE
chore: instruct translation API to output JSON

### DIFF
--- a/scripts/generateTranslations.js
+++ b/scripts/generateTranslations.js
@@ -113,14 +113,17 @@ async function translateWithOpenAI(text, from, to) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
   try {
-    const prompt =
-      `Translate this ${from}-language ERP system term into ${to}. Use ERP terminology. ` +
-      'Respond with `{ "translation": "...", "tooltip": "..." }`.\n\n' +
-      text;
+    const systemPrompt =
+      'You are a translation assistant. Respond with a JSON object { "translation": "...", "tooltip": "..." }.';
+    const userPrompt =
+      `Translate the following ${from}-language ERP system term into ${to}. Use ERP terminology.\n\n${text}`;
     const completion = await openai.chat.completions.create(
       {
         model: 'gpt-4o-mini',
-        messages: [{ role: 'user', content: prompt }],
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userPrompt },
+        ],
         response_format: { type: 'json_object' },
       },
       { signal: controller.signal }


### PR DESCRIPTION
## Summary
- ensure translateWithOpenAI uses a system message to instruct the model to reply with `{ "translation": "...", "tooltip": "..." }`

## Testing
- `npm test`
- `npm run generate:translations` *(fails: Cannot find package 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68b2cdc4583883318731dd2e484d5eb3