### PR TITLE
feat: handle extended company fields dynamically

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -690,10 +690,10 @@ export async function listAllUserCompanies(companyId, createdBy = null) {
  * List all companies
  */
 export async function listCompanies(createdBy = null) {
-  let sql = "SELECT id, name, created_at, created_by FROM companies";
+  let sql = 'SELECT * FROM companies';
   const params = [];
   if (createdBy) {
-    sql += " WHERE created_by = ?";
+    sql += ' WHERE created_by = ?';
     params.push(createdBy);
   }
   const [rows] = await pool.query(sql, params);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -360,7 +360,16 @@ CREATE TABLE `code_workplace_other` (
 CREATE TABLE `companies` (
   `id` int NOT NULL,
   `name` varchar(100) NOT NULL,
-  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP
+  `company_id` int NOT NULL DEFAULT '0',
+  `Gov_Registration_number` varchar(50) NOT NULL,
+  `Address` varchar(255) NOT NULL,
+  `Telephone` varchar(50) NOT NULL,
+  `website` varchar(255) DEFAULT NULL,
+  `email` varchar(255) DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `created_by` varchar(50) DEFAULT NULL,
+  `updated_by` varchar(50) DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 CREATE TABLE `company_licenses` (
   `id` int NOT NULL,

--- a/db/seed_default.sql
+++ b/db/seed_default.sql
@@ -1,6 +1,13 @@
 -- Global company for shared defaults
-INSERT INTO companies (id, name)
-VALUES (0, 'Global Defaults')
+INSERT INTO companies (
+  id,
+  name,
+  company_id,
+  Gov_Registration_number,
+  Address,
+  Telephone
+)
+VALUES (0, 'Global Defaults', 0, '0', '', '')
 ON DUPLICATE KEY UPDATE name = VALUES(name);
 
 -- Shared code tables

--- a/src/erp.mgt.mn/pages/Companies.jsx
+++ b/src/erp.mgt.mn/pages/Companies.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 export default function CompaniesPage() {
   const [companies, setCompanies] = useState([]);
@@ -21,12 +21,23 @@ export default function CompaniesPage() {
   async function handleAdd() {
     const name = prompt('Company name?');
     if (!name) return;
+    const reg = prompt('Gov registration number?');
+    if (reg == null) return;
+    const addr = prompt('Address?');
+    if (addr == null) return;
+    const tel = prompt('Telephone?');
+    if (tel == null) return;
     const res = await fetch('/api/companies', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       skipErrorToast: true,
-      body: JSON.stringify({ name })
+      body: JSON.stringify({
+        name,
+        Gov_Registration_number: reg,
+        Address: addr,
+        Telephone: tel
+      })
     });
     if (res.status === 403) {
       window.dispatchEvent(
@@ -54,8 +65,16 @@ export default function CompaniesPage() {
   }
 
   const visibleCompanies = companies.filter((c) =>
-    c.name.toLowerCase().includes(filter.toLowerCase())
+    (c.name || '').toLowerCase().includes(filter.toLowerCase())
   );
+
+  const columns = useMemo(() => {
+    const set = new Set(['id', 'name']);
+    companies.forEach((c) => {
+      Object.keys(c).forEach((k) => set.add(k));
+    });
+    return Array.from(set);
+  }, [companies]);
 
   return (
     <div>
@@ -87,19 +106,30 @@ export default function CompaniesPage() {
           >
             <thead>
               <tr style={{ backgroundColor: '#e5e7eb' }}>
-                <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>ID</th>
-                <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Нэр</th>
+                {columns.map((col) => (
+                  <th
+                    key={col}
+                    style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}
+                  >
+                    {col}
+                  </th>
+                ))}
               </tr>
             </thead>
             <tbody>
-              {visibleCompanies.map((c) => (
-                <tr key={c.id}>
-                  <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
-                    {c.id != null ? c.id : ''}
-                  </td>
-                  <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
-                    {c.name != null ? c.name : ''}
-                  </td>
+              {visibleCompanies.map((c, i) => (
+                <tr key={c.id ?? i}>
+                  {columns.map((col) => (
+                    <td
+                      key={col}
+                      style={{
+                        padding: '0.5rem',
+                        border: '1px solid #d1d5db'
+                      }}
+                    >
+                      {c[col] != null ? c[col] : ''}
+                    </td>
+                  ))}
                 </tr>
               ))}
             </tbody>

--- a/tests/api/companyController.test.js
+++ b/tests/api/companyController.test.js
@@ -41,7 +41,13 @@ test('allows POST /api/companies when user level has system_settings', async () 
   let assignArgs;
   const restore = mockPoolSequential([
     [[{ action: 'permission', action_key: 'system_settings' }]],
-    [[{ COLUMN_NAME: 'name' }, { COLUMN_NAME: 'created_by' }]],
+    [[
+      { COLUMN_NAME: 'name' },
+      { COLUMN_NAME: 'Gov_Registration_number' },
+      { COLUMN_NAME: 'Address' },
+      { COLUMN_NAME: 'Telephone' },
+      { COLUMN_NAME: 'created_by' }
+    ]],
     (sql, params) => {
       insertArgs = [sql, params];
       return [{ insertId: 1 }];
@@ -52,7 +58,13 @@ test('allows POST /api/companies when user level has system_settings', async () 
     },
   ]);
   const req = {
-    body: { name: 'NewCo', seedTables: [] },
+    body: {
+      name: 'NewCo',
+      Gov_Registration_number: '123',
+      Address: 'Addr',
+      Telephone: '555',
+      seedTables: []
+    },
     user: { empid: 1, companyId: 1, userLevel: 2 },
     session: { permissions: { system_settings: false } },
   };
@@ -62,7 +74,10 @@ test('allows POST /api/companies when user level has system_settings', async () 
   assert.equal(res.code, 201);
   assert.deepEqual(res.body, { id: 1 });
   assert.ok(insertArgs[0].includes('`created_by`'));
-  assert.deepEqual(insertArgs[1], ['companies', 'NewCo', 1]);
+  assert.ok(insertArgs[0].includes('`Gov_Registration_number`'));
+  assert.ok(insertArgs[0].includes('`Address`'));
+  assert.ok(insertArgs[0].includes('`Telephone`'));
+  assert.deepEqual(insertArgs[1], ['companies', 'NewCo', '123', 'Addr', '555', 1]);
   assert.ok(assignArgs[0].startsWith('INSERT INTO user_companies'));
   assert.deepEqual(assignArgs[1], [1, 1, null, null, 1]);
 });
@@ -71,7 +86,13 @@ test('allows POST /api/companies when user level has system_settings', async () 
 test('returns 403 for POST /api/companies when user level lacks system_settings', async () => {
   const restore = mockPoolSequential([[[]]]);
   const req = {
-    body: { name: 'NewCo', seedTables: [] },
+    body: {
+      name: 'NewCo',
+      Gov_Registration_number: '123',
+      Address: 'Addr',
+      Telephone: '555',
+      seedTables: []
+    },
     user: { empid: 1, companyId: 1, userLevel: 2 },
     session: { permissions: { system_settings: false } },
   };

--- a/tests/controllers/companyController.test.js
+++ b/tests/controllers/companyController.test.js
@@ -48,13 +48,27 @@ test('createCompanyHandler allows system admin with companyId=0', async () => {
       permission_list: 'system_settings',
       }]];
     },
-    [[{ COLUMN_NAME: 'name' }, { COLUMN_NAME: 'created_by' }]],
+    [[
+      { COLUMN_NAME: 'name' },
+      { COLUMN_NAME: 'Gov_Registration_number' },
+      { COLUMN_NAME: 'Address' },
+      { COLUMN_NAME: 'Telephone' },
+      { COLUMN_NAME: 'created_by' }
+    ]],
     [{ insertId: 5 }],
     [[]],
     [[]],
     [{ affectedRows: 1 }],
   ]);
-  const req = { body: { name: 'NewCo' }, user: { empid: 1, companyId: 0 } };
+  const req = {
+    body: {
+      name: 'NewCo',
+      Gov_Registration_number: '123',
+      Address: 'Addr',
+      Telephone: '555'
+    },
+    user: { empid: 1, companyId: 0 }
+  };
   const res = createRes();
   await createCompanyHandler(req, res, () => {});
   restore();
@@ -69,7 +83,13 @@ test('createCompanyHandler forwards seedRecords and overwrite', async () => {
   let deleteCalled = false;
   db.pool.query = async (sql, params) => {
     if (/information_schema\.COLUMNS/.test(sql) && params[0] === 'companies') {
-      return [[{ COLUMN_NAME: 'name' }, { COLUMN_NAME: 'created_by' }]];
+      return [[
+        { COLUMN_NAME: 'name' },
+        { COLUMN_NAME: 'Gov_Registration_number' },
+        { COLUMN_NAME: 'Address' },
+        { COLUMN_NAME: 'Telephone' },
+        { COLUMN_NAME: 'created_by' }
+      ]];
     }
     if (sql.startsWith('INSERT INTO ??') && params[0] === 'companies') {
       return [{ insertId: 9 }];
@@ -105,6 +125,9 @@ test('createCompanyHandler forwards seedRecords and overwrite', async () => {
   const req = {
     body: {
       name: 'SeedCo',
+      Gov_Registration_number: '123',
+      Address: 'Addr',
+      Telephone: '555',
       seedTables: ['posts'],
       seedRecords: { posts: [{ id: 1 }, { id: 2 }] },
       overwrite: true,


### PR DESCRIPTION
## Summary
- expand `companies` schema with registration, address, contact and audit columns
- return all company columns and seed defaults for new fields
- dynamically prompt/render new company fields in UI and extend controller tests

## Testing
- `npm test tests/api/companyController.test.js tests/controllers/companyController.test.js tests/pages/UserCompanies.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b1bc334a8c833188a84dbb99edb16d