### PR TITLE
feat: extend translation loop for english phrases

### DIFF
--- a/scripts/generateTranslations.js
+++ b/scripts/generateTranslations.js
@@ -263,6 +263,9 @@ async function main() {
     let counter = 0;
 
     for (const { key, sourceText, sourceLang } of entries) {
+      if (sourceLang === 'mn' && !/[\u0400-\u04FF]/.test(sourceText)) continue;
+      if (sourceLang === 'en' && !/[A-Za-z]/.test(sourceText)) continue;
+
       const existing = locales[lang][key];
       const existingTooltip = locales[lang].tooltip[key];
 


### PR DESCRIPTION
## Summary
- allow translation loop to handle English phrases by adding language-aware guard

## Testing
- `npm test` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d77bf8988331b6c3717401e14deb