### PR TITLE
Remove user company assignment on creation

### DIFF
--- a/api-server/controllers/companyController.js
+++ b/api-server/controllers/companyController.js
@@ -1,7 +1,6 @@
 import {
   listCompanies,
   insertTableRow,
-  assignCompanyToUser,
   getEmploymentSession,
   getUserLevelActions,
 } from '../../db/index.js';
@@ -44,9 +43,6 @@ export async function createCompanyHandler(req, res, next) {
       req.user.empid,
     );
     res.locals.insertId = result?.id;
-    if (result?.id) {
-      await assignCompanyToUser(req.user.empid, result.id, null, null, req.user.empid);
-    }
     res.status(201).json(result);
   } catch (err) {
     next(err);

--- a/tests/api/companyController.test.js
+++ b/tests/api/companyController.test.js
@@ -38,7 +38,6 @@ function createRes() {
 // Allow company creation when the user's level grants `system_settings`.
 test('allows POST /api/companies when user level has system_settings', async () => {
   let insertArgs;
-  let assignArgs;
   const restore = mockPoolSequential([
     [[{ action: 'permission', action_key: 'system_settings' }]],
     [[
@@ -51,10 +50,6 @@ test('allows POST /api/companies when user level has system_settings', async () 
     (sql, params) => {
       insertArgs = [sql, params];
       return [{ insertId: 1 }];
-    },
-    (sql, params) => {
-      assignArgs = [sql, params];
-      return [{ affectedRows: 1 }];
     },
   ]);
   const req = {
@@ -78,8 +73,6 @@ test('allows POST /api/companies when user level has system_settings', async () 
   assert.ok(insertArgs[0].includes('`Address`'));
   assert.ok(insertArgs[0].includes('`Telephone`'));
   assert.deepEqual(insertArgs[1], ['companies', 'NewCo', '123', 'Addr', '555', 1]);
-  assert.ok(assignArgs[0].startsWith('INSERT INTO user_companies'));
-  assert.deepEqual(assignArgs[1], [1, 1, null, null, 1]);
 });
 
 // Deny creation when the user's level lacks `system_settings`.

--- a/tests/controllers/companyController.test.js
+++ b/tests/controllers/companyController.test.js
@@ -58,7 +58,6 @@ test('createCompanyHandler allows system admin with companyId=0', async () => {
     [{ insertId: 5 }],
     [[]],
     [[]],
-    [{ affectedRows: 1 }],
   ]);
   const req = {
     body: {
@@ -116,9 +115,6 @@ test('createCompanyHandler forwards seedRecords and overwrite', async () => {
     }
     if (/INSERT INTO user_level_permissions/.test(sql)) {
       return [[]];
-    }
-    if (/INSERT INTO user_companies/.test(sql)) {
-      return [{ affectedRows: 1 }];
     }
     return [[]];
   };


### PR DESCRIPTION
## Summary
- avoid assigning newly created companies to users
- drop user company insert assertions in company controller tests

## Testing
- `npm test` *(fails: listAssignments tests)*
- `node --test tests/api/companyController.test.js tests/controllers/companyController.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2d88ab30083319eec6ad47ed6a0d5