### PR TITLE
Use OpenAI client for translations with Google fallback

### DIFF
--- a/api-server/utils/openaiClient.js
+++ b/api-server/utils/openaiClient.js
@@ -3,10 +3,15 @@ import OpenAI from 'openai';
 
 dotenv.config();
 
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const client = process.env.OPENAI_API_KEY
+  ? new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+  : null;
+
+export default client;
 
 export async function getResponse(prompt) {
   if (!prompt) throw new Error('Prompt is required');
+  if (!client) throw new Error('OpenAI client not configured');
   const completion = await client.chat.completions.create({
     model: 'gpt-3.5-turbo',
     messages: [{ role: 'user', content: prompt }],
@@ -16,6 +21,7 @@ export async function getResponse(prompt) {
 
 export async function getResponseWithFile(prompt, fileBuffer, mimeType) {
   if (!prompt) throw new Error('Prompt is required');
+  if (!client) throw new Error('OpenAI client not configured');
 
   const messages = [
     {


### PR DESCRIPTION
## Summary
- Expose the shared OpenAI client and guard when the API key is missing
- Add translateWithOpenAI using the shared client and a prompt that specifies source and target languages
- Prefer OpenAI for translations with Google fallback when errors occur

## Testing
- `npm test` *(fails: listAssignments defaults companyId to req.user.companyId; listAssignments rejects when company not created by acting admin)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d928be9c83319def63f7bfc272a7