### PR TITLE
chore: remove user companies references

### DIFF
--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -101,7 +101,6 @@ function AuthedApp() {
     settings: <SettingsPage />,
     users: <UsersPage />,
     companies: <CompaniesPage />,
-    user_companies: <CompaniesPage />,
     role_permissions: <RolePermissionsPage />,
     user_level_actions: <UserLevelActionsPage />,
     modules: <ModulesPage />,

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -62,10 +62,6 @@ export default function ERPLayout() {
     "/reports": t("reports", "Reports"),
     "/settings": t("settings", "Settings"),
     "/settings/users": t("settings_users", "Users"),
-    "/settings/user-companies": t(
-      "settings_user_companies",
-      "User Companies",
-    ),
     "/settings/role-permissions": t(
       "settings_role_permissions",
       "Role Permissions",

--- a/src/erp.mgt.mn/locales/de.json
+++ b/src/erp.mgt.mn/locales/de.json
@@ -8,7 +8,6 @@
   "reports": "Berichte",
   "settings": "Einstellungen",
   "settings_users": "Benutzer",
-  "settings_user_companies": "Benutzerfirmen",
   "settings_role_permissions": "Rollenberechtigungen",
   "settings_modules": "Module",
   "settings_company_licenses": "Unternehmenslizenzen",

--- a/src/erp.mgt.mn/locales/en.json
+++ b/src/erp.mgt.mn/locales/en.json
@@ -12,7 +12,6 @@
   "reports": "Reports",
   "settings": "Settings",
   "settings_users": "Users",
-  "settings_user_companies": "User Companies",
   "settings_role_permissions": "Role Permissions",
   "settings_modules": "Modules",
   "settings_company_licenses": "Company Licenses",

--- a/src/erp.mgt.mn/locales/es.json
+++ b/src/erp.mgt.mn/locales/es.json
@@ -8,7 +8,6 @@
   "reports": "Informes",
   "settings": "Configuración",
   "settings_users": "Usuarios",
-  "settings_user_companies": "Empresas de usuarios",
   "settings_role_permissions": "Permisos de rol",
   "settings_modules": "Módulos",
   "settings_company_licenses": "Licencias de empresa",

--- a/src/erp.mgt.mn/locales/fr.json
+++ b/src/erp.mgt.mn/locales/fr.json
@@ -8,7 +8,6 @@
   "reports": "Rapports",
   "settings": "Paramètres",
   "settings_users": "Utilisateurs",
-  "settings_user_companies": "Sociétés d'utilisateurs",
   "settings_role_permissions": "Autorisations de rôle",
   "settings_modules": "Modules",
   "settings_company_licenses": "Licences d'entreprise",

--- a/src/erp.mgt.mn/locales/ja.json
+++ b/src/erp.mgt.mn/locales/ja.json
@@ -8,7 +8,6 @@
   "reports": "レポート",
   "settings": "設定",
   "settings_users": "ユーザー",
-  "settings_user_companies": "ユーザー会社",
   "settings_role_permissions": "ロール権限",
   "settings_modules": "モジュール",
   "settings_company_licenses": "会社ライセンス",

--- a/src/erp.mgt.mn/locales/ko.json
+++ b/src/erp.mgt.mn/locales/ko.json
@@ -8,7 +8,6 @@
   "reports": "보고서",
   "settings": "설정",
   "settings_users": "사용자",
-  "settings_user_companies": "사용자 회사",
   "settings_role_permissions": "권한 설정",
   "settings_modules": "모듈",
   "settings_company_licenses": "회사 라이선스",

--- a/src/erp.mgt.mn/locales/mn.json
+++ b/src/erp.mgt.mn/locales/mn.json
@@ -12,7 +12,6 @@
    "reports": "Тайлан",
    "settings": "Тохиргоо",
    "settings_users": "Хэрэглэгчид",
-   "settings_user_companies": "Хэрэглэгчийн компаниуд",
    "settings_role_permissions": "Эрхийн тохиргоо",
    "settings_modules": "Модулууд",
    "settings_company_licenses": "Компанийн лицензүүд",

--- a/src/erp.mgt.mn/locales/ru.json
+++ b/src/erp.mgt.mn/locales/ru.json
@@ -8,7 +8,6 @@
   "reports": "Отчеты",
   "settings": "Настройки",
   "settings_users": "Пользователи",
-  "settings_user_companies": "Компании пользователей",
   "settings_role_permissions": "Права ролей",
   "settings_modules": "Модули",
   "settings_company_licenses": "Лицензии компании",

--- a/src/erp.mgt.mn/locales/zh.json
+++ b/src/erp.mgt.mn/locales/zh.json
@@ -8,7 +8,6 @@
   "reports": "报表",
   "settings": "设置",
   "settings_users": "用户",
-  "settings_user_companies": "用户公司",
   "settings_role_permissions": "角色权限",
   "settings_modules": "模块",
   "settings_company_licenses": "公司许可证",


### PR DESCRIPTION
## Summary
- remove obsolete user_companies route mapping
- drop user companies title/menu entries from layout
- purge settings_user_companies translation keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2de20eca883318fddb6dbba183a60