### PR TITLE
Skip translation for already translated keys

### DIFF
--- a/scripts/generateTranslations.js
+++ b/scripts/generateTranslations.js
@@ -269,6 +269,12 @@ async function main() {
 
       const existing = locales[lang][key];
 
+      if (lang !== sourceLang && existing && existing.trim()) {
+        const prefix = `[gen-i18n]${origin ? `[${origin}]` : ''}`;
+        console.log(`${prefix} Skipping ${lang}.${key}, already translated`);
+        continue;
+      }
+
       if (lang === 'mn' && sourceLang === 'en') {
         const prefix = `[gen-i18n]${origin ? `[${origin}]` : ''}`;
         console.log(`${prefix} Translating "${sourceText}" (en -> mn)`);


### PR DESCRIPTION
## Summary
- Avoid re-translating keys that already have a translation and log when skipping
- Only call translation providers when no translation exists for a key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2ec965f1c8331a2655941a84efabc