### PR TITLE
chore: remove User Companies settings link

### DIFF
--- a/src/erp.mgt.mn/components/Layout.jsx
+++ b/src/erp.mgt.mn/components/Layout.jsx
@@ -27,7 +27,6 @@ export default function ERPLayout() {
     '/reports': t('reports', 'Reports'),
     '/settings': t('settings', 'Settings'),
     '/settings/users': t('users', 'Users'),
-    '/settings/user-companies': t('userCompanies', 'User Companies'),
     '/settings/role-permissions': t('rolePermissions', 'Role Permissions'),
     '/settings/change-password': t('changePassword', 'Change Password'),
   };
@@ -135,9 +134,6 @@ function Sidebar() {
           <>
             <NavLink to="/settings/users" className="menu-item" style={styles.menuItem}>
               {t('users', 'Users')}
-            </NavLink>
-            <NavLink to="/settings/user-companies" className="menu-item" style={styles.menuItem}>
-              {t('userCompanies', 'User Companies')}
             </NavLink>
             <NavLink to="/settings/role-permissions" className="menu-item" style={styles.menuItem}>
               {t('rolePermissions', 'Role Permissions')}


### PR DESCRIPTION
## Summary
- remove unused User Companies page from title map
- drop User Companies link from settings sidebar

## Testing
- `npm test`
- `npm run build:erp` *(fails: sh: 1: vite: not found)*
- `npm install vite@6.3.5 @vitejs/plugin-react@4` *(fails: npm ERR! 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ef01afa8833183b8ce3cf046176e