### PR TITLE
feat: localize forms index messages

### DIFF
--- a/src/erp.mgt.mn/locales/en.json
+++ b/src/erp.mgt.mn/locales/en.json
@@ -9,6 +9,7 @@
   "serviceUnavailable": "Service unavailable",
   "dashboard": "Dashboard",
   "forms": "Forms",
+  "formsNone": "No forms found.",
   "reports": "Reports",
   "settings": "Settings",
   "settings_users": "Users",

--- a/src/erp.mgt.mn/locales/mn.json
+++ b/src/erp.mgt.mn/locales/mn.json
@@ -9,6 +9,7 @@
    "serviceUnavailable": "Үйлчилгээ боломжгүй",
    "dashboard": "Дашбоард",
    "forms": "Маягтууд",
+   "formsNone": "Маягт олдсонгүй.",
    "reports": "Тайлан",
    "settings": "Тохиргоо",
    "settings_users": "Хэрэглэгчид",

--- a/src/erp.mgt.mn/pages/FormsIndex.jsx
+++ b/src/erp.mgt.mn/pages/FormsIndex.jsx
@@ -6,6 +6,7 @@ import { useCompanyModules } from '../hooks/useCompanyModules.js';
 import { useTxnModules } from '../hooks/useTxnModules.js';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import useHeaderMappings from '../hooks/useHeaderMappings.js';
+import I18nContext from '../context/I18nContext.jsx';
 
 export default function FormsIndex() {
   const [transactions, setTransactions] = useState({});
@@ -14,6 +15,7 @@ export default function FormsIndex() {
   const licensed = useCompanyModules(company);
   const txnModules = useTxnModules();
   const generalConfig = useGeneralConfig();
+  const { t } = useContext(I18nContext);
 
   const headerMap = useHeaderMappings(modules.map((m) => m.module_key));
   const moduleMap = {};
@@ -80,9 +82,9 @@ export default function FormsIndex() {
 
   return (
     <div>
-      <h2>Маягтууд</h2>
+      <h2>{t('forms', 'Forms')}</h2>
       {groups.length === 0 ? (
-        <p>Маягт олдсонгүй.</p>
+        <p>{t('formsNone', 'No forms found.')}</p>
       ) : (
         groups.map(([key]) => {
           const mod = modules.find((m) => m.module_key === key);


### PR DESCRIPTION
## Summary
- localize FormsIndex header and empty message using I18nContext
- add `formsNone` translation string for English and Mongolian

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2f48164e48331a4eac0ab10f86d92