### PR TITLE
Wrap routes and tab content with ErrorBoundary

### DIFF
--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -44,6 +44,7 @@ import TabbedWindows from './components/TabbedWindows.jsx';
 import TenantTablesRegistryPage from './pages/TenantTablesRegistry.jsx';
 import TranslationEditorPage from './pages/TranslationEditor.jsx';
 import UserManualExportPage from './pages/UserManualExport.jsx';
+import ErrorBoundary from './components/ErrorBoundary.jsx';
 
 export default function App() {
   useEffect(() => {
@@ -58,12 +59,14 @@ export default function App() {
             <LoadingProvider>
               <TabProvider>
                 <HashRouter>
-                  <Routes>
-                    <Route path="/login" element={<LoginPage />} />
-                    <Route element={<RequireAuth />}>
-                      <Route path="/*" element={<AuthedApp />} />
-                    </Route>
-                  </Routes>
+                  <ErrorBoundary>
+                    <Routes>
+                      <Route path="/login" element={<LoginPage />} />
+                      <Route element={<RequireAuth />}>
+                        <Route path="/*" element={<AuthedApp />} />
+                      </Route>
+                    </Routes>
+                  </ErrorBoundary>
                 </HashRouter>
               </TabProvider>
             </LoadingProvider>
@@ -163,19 +166,21 @@ function AuthedApp() {
     .map((m) => moduleMap[m.module_key]);
 
   return (
-    <Routes>
-      <Route path="/" element={<ERPLayout />}>
-        <Route path="requests" element={<RequestsPage />} />
-        {roots.map(renderRoute)}
-      </Route>
-      <Route
-        path="inventory-demo"
-        element={
-          <AppLayout title="Inventory">
-            <InventoryPage />
-          </AppLayout>
-        }
-      />
-    </Routes>
+    <ErrorBoundary>
+      <Routes>
+        <Route path="/" element={<ERPLayout />}>
+          <Route path="requests" element={<RequestsPage />} />
+          {roots.map(renderRoute)}
+        </Route>
+        <Route
+          path="inventory-demo"
+          element={
+            <AppLayout title="Inventory">
+              <InventoryPage />
+            </AppLayout>
+          }
+        />
+      </Routes>
+    </ErrorBoundary>
   );
 }

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -20,6 +20,7 @@ import { PendingRequestContext } from "../context/PendingRequestContext.jsx";
 import Joyride, { STATUS } from "react-joyride";
 import { getGuideSteps as getDashboardGuideSteps } from "../pages/DashboardPage.jsx";
 import { getGuideSteps as getFormsGuideSteps } from "../pages/Forms.jsx";
+import ErrorBoundary from "../components/ErrorBoundary.jsx";
 
 /**
  * A desktop‐style “ERPLayout” with:
@@ -528,7 +529,9 @@ function MainWindow({ title }) {
       <div style={styles.windowContent}>
         {tabs.map((t) => (
           <TabPanel key={t.key} tabKey={t.key} active={t.key === activeKey}>
-            {t.key === location.pathname ? elements[t.key] : cache[t.key]}
+            <ErrorBoundary>
+              {t.key === location.pathname ? elements[t.key] : cache[t.key]}
+            </ErrorBoundary>
           </TabPanel>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- Protect ERP tabs by rendering each tab panel inside ErrorBoundary
- Guard top-level routing with ErrorBoundary to show red error messages instead of blank screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2f42dffcc8331b7ccbcd3c8f622cf