### PR TITLE
feat: add translation generation tab

### DIFF
--- a/src/erp.mgt.mn/pages/GenerateTranslationsTab.jsx
+++ b/src/erp.mgt.mn/pages/GenerateTranslationsTab.jsx
@@ -1,0 +1,71 @@
+import React, { useContext, useEffect, useState } from 'react';
+import I18nContext from '../context/I18nContext.jsx';
+
+export default function GenerateTranslationsTab() {
+  const { t } = useContext(I18nContext);
+  const [logs, setLogs] = useState([]);
+  const [status, setStatus] = useState('');
+  const [source, setSource] = useState(null);
+
+  useEffect(() => {
+    return () => {
+      if (source) source.close();
+    };
+  }, [source]);
+
+  function start() {
+    if (source) return;
+    setLogs([]);
+    setStatus(t('generationStarted', 'Generation started'));
+    const es = new EventSource('/api/generate-translations');
+    es.onmessage = (e) => {
+      if (e.data === '[DONE]') {
+        setStatus(t('generationCompleted', 'Generation completed'));
+        es.close();
+        setSource(null);
+      } else {
+        setLogs((prev) => [...prev, e.data]);
+      }
+    };
+    es.onerror = () => {
+      es.close();
+      setSource(null);
+      setStatus(t('generationFailed', 'Generation failed'));
+    };
+    setSource(es);
+  }
+
+  async function cancel() {
+    if (!source) return;
+    try {
+      await fetch('/api/generate-translations/stop', { method: 'POST' });
+    } catch {}
+    source.close();
+    setSource(null);
+    setStatus(t('generationCancelled', 'Generation cancelled'));
+  }
+
+  return (
+    <div>
+      <div style={{ marginBottom: '0.5rem' }}>
+        <button onClick={start} disabled={!!source}>
+          {t('start', 'Start')}
+        </button>
+        <button onClick={cancel} disabled={!source} style={{ marginLeft: '0.5rem' }}>
+          {t('cancel', 'Cancel')}
+        </button>
+      </div>
+      <pre
+        style={{
+          maxHeight: '300px',
+          overflow: 'auto',
+          background: '#f5f5f5',
+          padding: '0.5rem',
+        }}
+      >
+        {logs.join('\n')}
+      </pre>
+      {status && <div style={{ marginTop: '0.5rem' }}>{status}</div>}
+    </div>
+  );
+}

--- a/src/erp.mgt.mn/pages/TranslationEditor.jsx
+++ b/src/erp.mgt.mn/pages/TranslationEditor.jsx
@@ -1,11 +1,13 @@
 import React, { useState, useContext } from 'react';
 import I18nContext from '../context/I18nContext.jsx';
 import { clearHeaderMappingsCache } from '../hooks/useHeaderMappings.js';
+import GenerateTranslationsTab from './GenerateTranslationsTab.jsx';
 
 const LANGS = ['en', 'mn', 'ja', 'ko', 'zh', 'es', 'de', 'fr', 'ru'];
 
 export default function TranslationEditorPage() {
   const { t } = useContext(I18nContext);
+  const [activeTab, setActiveTab] = useState('manual');
   const [header, setHeader] = useState('');
   const [values, setValues] = useState({});
   const [message, setMessage] = useState('');
@@ -55,33 +57,63 @@ export default function TranslationEditorPage() {
     <div>
       <h2>{t('editTranslations', 'Edit Translations')}</h2>
       <div style={{ marginBottom: '1rem' }}>
-        <label>
-          Header key:{' '}
-          <input value={header} onChange={(e) => setHeader(e.target.value)} />
-        </label>
-        <button onClick={loadExisting} style={{ marginLeft: '0.5rem' }}>
-          Load
+        <button
+          onClick={() => setActiveTab('manual')}
+          disabled={activeTab === 'manual'}
+          style={{ marginRight: '0.5rem' }}
+        >
+          {t('manualTranslations', 'Manual')}
+        </button>
+        <button
+          onClick={() => setActiveTab('generate')}
+          disabled={activeTab === 'generate'}
+        >
+          {t('generateTranslations', 'Generate')}
         </button>
       </div>
-      {header && (
+
+      {activeTab === 'manual' && (
         <div>
-          {LANGS.map((l) => (
-            <div key={l} style={{ marginBottom: '0.25rem' }}>
-              <label>
-                {l}:{' '}
-                <input
-                  value={values[l] || ''}
-                  onChange={(e) => handleChange(l, e.target.value)}
-                />
-              </label>
+          <div style={{ marginBottom: '1rem' }}>
+            <label>
+              Header key:{' '}
+              <input
+                value={header}
+                onChange={(e) => setHeader(e.target.value)}
+              />
+            </label>
+            <button
+              onClick={loadExisting}
+              style={{ marginLeft: '0.5rem' }}
+            >
+              Load
+            </button>
+          </div>
+          {header && (
+            <div>
+              {LANGS.map((l) => (
+                <div key={l} style={{ marginBottom: '0.25rem' }}>
+                  <label>
+                    {l}:{' '}
+                    <input
+                      value={values[l] || ''}
+                      onChange={(e) => handleChange(l, e.target.value)}
+                    />
+                  </label>
+                </div>
+              ))}
+              <button onClick={handleSave} style={{ marginTop: '0.5rem' }}>
+                Save
+              </button>
+              {message && (
+                <span style={{ marginLeft: '0.5rem' }}>{message}</span>
+              )}
             </div>
-          ))}
-          <button onClick={handleSave} style={{ marginTop: '0.5rem' }}>
-            Save
-          </button>
-          {message && <span style={{ marginLeft: '0.5rem' }}>{message}</span>}
+          )}
         </div>
       )}
+
+      {activeTab === 'generate' && <GenerateTranslationsTab />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- refactor translation editor with manual and generation tabs
- stream logs via SSE with start/stop controls and final status handling
- drop manual locale updates so labels come from generate translations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2fad77774833190980c4392df7c0e