### PR TITLE
feat(api): add translation generator SSE endpoint

### DIFF
--- a/api-server/app.js
+++ b/api-server/app.js
@@ -22,6 +22,7 @@ import generatedSqlRoutes from "./routes/generated_sql.js";
 import generalConfigRoutes from "./routes/general_config.js";
 import permissionsRoutes from "./routes/permissions.js";
 import tenantTablesRoutes from "./routes/tenant_tables.js";
+import translationGeneratorRoutes from "./routes/translation_generator.js";
 import { getGeneralConfig } from "./services/generalConfig.js";
 
 // Polyfill for __dirname in ES modules
@@ -82,6 +83,7 @@ app.use("/api/generated_sql", generatedSqlRoutes);
 app.use("/api/general_config", generalConfigRoutes);
 app.use("/api/permissions", permissionsRoutes);
 app.use("/api/tenant_tables", tenantTablesRoutes);
+app.use("/api/translations/generate", translationGeneratorRoutes);
 
 // Serve static React build and fallback to index.html
 // NOTE: adjust this path to where your SPA build actually lives.

--- a/api-server/routes/translation_generator.js
+++ b/api-server/routes/translation_generator.js
@@ -1,0 +1,77 @@
+import express from 'express';
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { requireAuth } from '../middlewares/auth.js';
+import { getEmploymentSession } from '../../db/index.js';
+import { hasAction } from '../utils/hasAction.js';
+
+const router = express.Router();
+let currentController = null;
+
+async function checkPermission(req) {
+  const session =
+    req.session ||
+    (await getEmploymentSession(req.user.empid, req.user.companyId));
+  return hasAction(session, 'system_settings');
+}
+
+router.get('/', requireAuth, async (req, res, next) => {
+  try {
+    if (!(await checkPermission(req))) return res.sendStatus(403);
+
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.flushHeaders && res.flushHeaders();
+
+    const controller = new AbortController();
+    currentController = controller;
+
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = path.dirname(__filename);
+    const scriptPath = path.resolve(__dirname, '../../scripts/generateTranslations.js');
+
+    const child = spawn(process.execPath, [scriptPath], {
+      signal: controller.signal,
+    });
+
+    const send = (chunk) => {
+      const lines = chunk.toString().split(/\r?\n/);
+      for (const line of lines) {
+        if (line) res.write(`data: ${line}\n\n`);
+      }
+    };
+
+    child.stdout.on('data', send);
+    child.stderr.on('data', send);
+
+    child.on('close', () => {
+      res.write('data: [DONE]\n\n');
+      res.end();
+      if (currentController === controller) currentController = null;
+    });
+
+    req.on('close', () => {
+      controller.abort();
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/stop', requireAuth, async (req, res, next) => {
+  try {
+    if (!(await checkPermission(req))) return res.sendStatus(403);
+    if (currentController) {
+      currentController.abort();
+      currentController = null;
+    }
+    res.json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;
+

--- a/src/erp.mgt.mn/pages/GenerateTranslationsTab.jsx
+++ b/src/erp.mgt.mn/pages/GenerateTranslationsTab.jsx
@@ -17,7 +17,7 @@ export default function GenerateTranslationsTab() {
     if (source) return;
     setLogs([]);
     setStatus(t('generationStarted', 'Generation started'));
-    const es = new EventSource('/api/generate-translations');
+    const es = new EventSource('/api/translations/generate');
     es.onmessage = (e) => {
       if (e.data === '[DONE]') {
         setStatus(t('generationCompleted', 'Generation completed'));
@@ -38,7 +38,7 @@ export default function GenerateTranslationsTab() {
   async function cancel() {
     if (!source) return;
     try {
-      await fetch('/api/generate-translations/stop', { method: 'POST' });
+      await fetch('/api/translations/generate/stop', { method: 'POST' });
     } catch {}
     source.close();
     setSource(null);


### PR DESCRIPTION
## Summary
- add `/api/translations/generate` SSE endpoint to run translation script and stream output
- allow stopping the generator via POST or disconnect
- update frontend translation generator tab to use new endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2fedd9294833182648cbd956eeebe