### PR TITLE
Handle loading state for seed table modal

### DIFF
--- a/src/erp.mgt.mn/pages/TenantTablesRegistry.jsx
+++ b/src/erp.mgt.mn/pages/TenantTablesRegistry.jsx
@@ -521,12 +521,14 @@ export default function TenantTablesRegistry() {
             ))}
           </select>
         </div>
-        {tables && tables.filter((t) => t.seedOnCreate).length === 0 ? (
+        {tables === null ? (
+          <p>{t('loading', 'Loading...')}</p>
+        ) : (tables ?? []).filter((t) => t.seedOnCreate).length === 0 ? (
           <p>{t('noSeedOnCreateTables', 'No seed_on_create tables.')}</p>
         ) : (
           <div style={{ maxHeight: '60vh', overflowY: 'auto' }}>
-            {tables
-              ?.filter((t) => t.seedOnCreate)
+            {(tables ?? [])
+              .filter((t) => t.seedOnCreate)
               .map((table) => (
                 <div key={table.tableName} style={{ marginBottom: '0.5rem' }}>
                   <label>


### PR DESCRIPTION
## Summary
- show a loading message in the seed-on-create modal until tables are available
- guard table list rendering with null-safe access

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b300b1e21483318fa391e41a781014