### PR TITLE
refactor translation generator into function

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:erp": "vite build --config vite.config.js",
     "serve": "node api-server/server.js",
     "test": "node --test",
-    "generate:translations": "node scripts/generateTranslations.js"
+    "generate:translations": "node scripts/generateTranslations.cli.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/scripts/generateTranslations.cli.js
+++ b/scripts/generateTranslations.cli.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import { generateTranslations } from './generateTranslations.js';
+
+const controller = new AbortController();
+process.on('SIGINT', () => controller.abort());
+
+process.on('unhandledRejection', (err) => {
+  console.error('[gen-i18n] UNHANDLED REJECTION', err);
+  process.exit(2);
+});
+process.on('uncaughtException', (err) => {
+  console.error('[gen-i18n] UNCAUGHT EXCEPTION', err);
+  process.exit(3);
+});
+
+generateTranslations({ onLog: console.log, signal: controller.signal }).catch((err) => {
+  console.error('[gen-i18n] FATAL', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- refactor translation generator into exported `generateTranslations` with log callback and abort signal checks
- add CLI wrapper that passes `console.log` and an `AbortController` signal
- update npm script to use new CLI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b30086d80883318065513b26f77849