### PR TITLE
Handle SSE translation errors

### DIFF
--- a/src/erp.mgt.mn/pages/GenerateTranslationsTab.jsx
+++ b/src/erp.mgt.mn/pages/GenerateTranslationsTab.jsx
@@ -27,6 +27,16 @@ export default function GenerateTranslationsTab() {
         setLogs((prev) => [...prev, e.data]);
       }
     };
+    const handleError = (e) => {
+      es.close();
+      setSource(null);
+      setStatus(
+        t('generationFailed', 'Generation failed') + ': ' + (e.data || 'Unknown error')
+      );
+    };
+    es.addEventListener('error', (e) => {
+      if ('data' in e) handleError(e);
+    });
     es.onerror = () => {
       es.close();
       setSource(null);


### PR DESCRIPTION
## Summary
- Send server-sent `error` events with details when translation generator fails
- Surface server error messages on client via EventSource listener

## Testing
- `npm test` *(fails: 1, pass: 161)*

------
https://chatgpt.com/codex/tasks/task_e_68b301dc8e188331a82025b31f81cd76