### PR TITLE
Handle server-sent errors in translation generator

### DIFF
--- a/src/erp.mgt.mn/pages/GenerateTranslationsTab.jsx
+++ b/src/erp.mgt.mn/pages/GenerateTranslationsTab.jsx
@@ -27,21 +27,17 @@ export default function GenerateTranslationsTab() {
         setLogs((prev) => [...prev, e.data]);
       }
     };
-    const handleError = (e) => {
-      es.close();
-      setSource(null);
-      setStatus(
-        t('generationFailed', 'Generation failed') + ': ' + (e.data || 'Unknown error')
-      );
-    };
-    es.addEventListener('error', (e) => {
-      if ('data' in e) handleError(e);
-    });
     es.onerror = () => {
       es.close();
       setSource(null);
       setStatus(t('generationFailed', 'Generation failed'));
     };
+    es.addEventListener('error', (e) => {
+      es.onerror();
+      setStatus(
+        t('generationFailed', 'Generation failed') + ': ' + (e.data || 'Unknown error')
+      );
+    });
     setSource(es);
   }
 


### PR DESCRIPTION
## Summary
- React component now listens for server-sent `error` events and reuses the network `onerror` handler for cleanup while displaying the server-provided message.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3045622908331b7398770b93ed243