### PR TITLE
Handle translation generator errors with custom SSE event

### DIFF
--- a/api-server/routes/translation_generator.js
+++ b/api-server/routes/translation_generator.js
@@ -33,7 +33,7 @@ router.get('/', requireAuth, async (req, res, next) => {
     const scriptPath = path.resolve(__dirname, '../../scripts/generateTranslations.js');
 
     const sendError = (err) => {
-      res.write(`event: error\ndata: ${err.message}\n\n`);
+      res.write(`event: generator_error\ndata: ${err.message}\n\n`);
       res.write('data: [DONE]\n\n');
       res.end();
       if (currentController === controller) currentController = null;

--- a/src/erp.mgt.mn/pages/GenerateTranslationsTab.jsx
+++ b/src/erp.mgt.mn/pages/GenerateTranslationsTab.jsx
@@ -32,8 +32,9 @@ export default function GenerateTranslationsTab() {
       setSource(null);
       setStatus(t('generationFailed', 'Generation failed'));
     };
-    es.addEventListener('error', (e) => {
-      es.onerror();
+    es.addEventListener('generator_error', (e) => {
+      es.close();
+      setSource(null);
       setStatus(
         t('generationFailed', 'Generation failed') + ': ' + (e.data || 'Unknown error')
       );


### PR DESCRIPTION
## Summary
- Emit `generator_error` server-sent event from translation generator API
- Listen for `generator_error` on client to close stream and show failure details

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3062d15c08331983834260c966f41