### PR TITLE
Handle Google translation failures in generateTranslations

### DIFF
--- a/scripts/generateTranslations.js
+++ b/scripts/generateTranslations.js
@@ -448,7 +448,15 @@ export async function generateTranslations({ onLog = console.log, signal } = {})
         }
 
         if (!provider) {
-          const t = await translateWithGoogle(baseText, lang, fromLang, key);
+          let t;
+          try {
+            t = await translateWithGoogle(baseText, lang, fromLang, key);
+          } catch (err) {
+            console.warn(
+              `[gen-i18n] Google failed key="${key}" (${fromLang}->${lang}): ${err.message}`,
+            );
+            t = baseText;
+          }
           if (!existing) {
             locales[lang][key] = t;
           } else if (t.trim() !== existing.trim()) {


### PR DESCRIPTION
## Summary
- Guard Google translation fallback with try/catch
- Warn and fall back to source text when Google translate fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b30c7f014083319a3d3dca709895a9