### PR TITLE
feat: add Joyride tour provider and settings toggle

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -1,5 +1,5 @@
 // src/erp.mgt.mn/components/ERPLayout.jsx
-import React, { useContext, useState, useEffect, useRef, useMemo } from "react";
+import React, { useContext, useState, useEffect, useRef, useMemo, useCallback } from "react";
 import HeaderMenu from "./HeaderMenu.jsx";
 import UserMenu from "./UserMenu.jsx";
 import { useOutlet, useNavigate, useLocation } from "react-router-dom";
@@ -18,10 +18,16 @@ import useHeaderMappings from "../hooks/useHeaderMappings.js";
 import useRequestNotificationCounts from "../hooks/useRequestNotificationCounts.js";
 import { PendingRequestContext } from "../context/PendingRequestContext.jsx";
 import Joyride, { STATUS } from "react-joyride";
-import { getGuideSteps as getDashboardGuideSteps } from "../pages/DashboardPage.jsx";
-import { getGuideSteps as getFormsGuideSteps } from "../pages/Forms.jsx";
 import ErrorBoundary from "../components/ErrorBoundary.jsx";
 import { useToast } from "../context/ToastContext.jsx";
+
+const TourContext = React.createContext(() => {});
+export const useTour = (pageKey, steps) => {
+  const startTour = useContext(TourContext);
+  useEffect(() => {
+    startTour(pageKey, steps);
+  }, [startTour, pageKey, steps]);
+};
 
 /**
  * A desktop‐style “ERPLayout” with:
@@ -50,10 +56,22 @@ export default function ERPLayout() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [tourSteps, setTourSteps] = useState([]);
   const [runTour, setRunTour] = useState(false);
+  const [currentTourPage, setCurrentTourPage] = useState('');
   useEffect(() => {
     const handler = () => setIsMobile(window.innerWidth < 768);
     window.addEventListener('resize', handler);
     return () => window.removeEventListener('resize', handler);
+  }, []);
+
+  const startTour = useCallback((pageKey, steps) => {
+    const enabled = localStorage.getItem('settings_enable_tours') === 'true';
+    if (!enabled) return;
+    const seenKey = `erpGuideSeen-${pageKey}`;
+    if (!localStorage.getItem(seenKey) && steps && steps.length) {
+      setTourSteps(steps);
+      setCurrentTourPage(pageKey);
+      setRunTour(true);
+    }
   }, []);
 
   const modules = useModules();
@@ -149,40 +167,18 @@ export default function ERPLayout() {
     }
   }, [modules, validPaths, location.pathname, navigate, addToast, t]);
 
-  useEffect(() => {
-    const path = location.pathname;
-    let pageKey = "dashboard";
-    if (path.startsWith("/forms")) pageKey = "forms";
-    const stepsMap = {
-      dashboard: getDashboardGuideSteps,
-      forms: getFormsGuideSteps,
-    };
-    const stepsFn = stepsMap[pageKey];
-    const steps = stepsFn ? stepsFn(t) : [];
-    setTourSteps(steps);
-    const seenKey = `erpGuideSeen-${pageKey}`;
-    if (!localStorage.getItem(seenKey) && steps.length) {
-      setRunTour(true);
-    } else {
-      setRunTour(false);
-    }
-  }, [location.pathname, t]);
-
   const handleTourCallback = ({ status }) => {
     if ([STATUS.FINISHED, STATUS.SKIPPED].includes(status)) {
-      const path = location.pathname;
-      let pageKey = "dashboard";
-      if (path.startsWith("/forms")) pageKey = "forms";
-      localStorage.setItem(`erpGuideSeen-${pageKey}`, "1");
+      if (currentTourPage) {
+        localStorage.setItem(`erpGuideSeen-${currentTourPage}`, "1");
+      }
       setRunTour(false);
     }
   };
 
   const resetGuide = () => {
-    const path = location.pathname;
-    let pageKey = "dashboard";
-    if (path.startsWith("/forms")) pageKey = "forms";
-    localStorage.removeItem(`erpGuideSeen-${pageKey}`);
+    const key = currentTourPage || location.pathname.split('/').filter(Boolean)[0] || 'dashboard';
+    localStorage.removeItem(`erpGuideSeen-${key}`);
     setRunTour(true);
   };
 
@@ -235,43 +231,45 @@ export default function ERPLayout() {
   }
 
   return (
-    <PendingRequestContext.Provider value={requestNotifications}>
-      <div style={styles.container}>
-        <Joyride
-          steps={tourSteps}
-          run={runTour}
-          continuous
-          showSkipButton
-          disableOverlayClose
-          disableKeyboardNavigation={false}
-          callback={handleTourCallback}
-        />
-        <Header
-          user={user}
-          onLogout={handleLogout}
-          onHome={handleHome}
-          isMobile={isMobile}
-          onToggleSidebar={() => setSidebarOpen((o) => !o)}
-          onOpen={handleOpen}
-          onResetGuide={resetGuide}
-        />
-        <div style={styles.body(isMobile)}>
-          {isMobile && sidebarOpen && (
-            <div
-              className="sidebar-overlay"
-              onClick={() => setSidebarOpen(false)}
-            />
-          )}
-          <Sidebar
-            open={isMobile ? sidebarOpen : true}
-            onOpen={handleOpen}
-            isMobile={isMobile}
+    <TourContext.Provider value={startTour}>
+      <PendingRequestContext.Provider value={requestNotifications}>
+        <div style={styles.container}>
+          <Joyride
+            steps={tourSteps}
+            run={runTour}
+            continuous
+            showSkipButton
+            disableOverlayClose
+            disableKeyboardNavigation={false}
+            callback={handleTourCallback}
           />
-          <MainWindow title={windowTitle} />
+          <Header
+            user={user}
+            onLogout={handleLogout}
+            onHome={handleHome}
+            isMobile={isMobile}
+            onToggleSidebar={() => setSidebarOpen((o) => !o)}
+            onOpen={handleOpen}
+            onResetGuide={resetGuide}
+          />
+          <div style={styles.body(isMobile)}>
+            {isMobile && sidebarOpen && (
+              <div
+                className="sidebar-overlay"
+                onClick={() => setSidebarOpen(false)}
+              />
+            )}
+            <Sidebar
+              open={isMobile ? sidebarOpen : true}
+              onOpen={handleOpen}
+              isMobile={isMobile}
+            />
+            <MainWindow title={windowTitle} />
+          </div>
+          {generalConfig.general?.aiApiEnabled && <AskAIFloat />}
         </div>
-        {generalConfig.general?.aiApiEnabled && <AskAIFloat />}
-      </div>
-    </PendingRequestContext.Provider>
+      </PendingRequestContext.Provider>
+    </TourContext.Provider>
   );
 }
 

--- a/src/erp.mgt.mn/pages/DashboardPage.jsx
+++ b/src/erp.mgt.mn/pages/DashboardPage.jsx
@@ -1,15 +1,19 @@
-import React, { useContext, useState, useEffect, useRef } from 'react';
+import React, { useContext, useState, useEffect, useRef, useMemo } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
 import PendingRequestWidget from '../components/PendingRequestWidget.jsx';
 import OutgoingRequestWidget from '../components/OutgoingRequestWidget.jsx';
 import { usePendingRequests } from '../context/PendingRequestContext.jsx';
 import LangContext from '../context/I18nContext.jsx';
+import { useTour } from '../components/ERPLayout.jsx';
+import dashboardSteps from '../tours/DashboardPage.js';
 
 export default function DashboardPage() {
   const { user, session } = useContext(AuthContext);
   const { hasNew, markSeen, outgoing } = usePendingRequests();
   const { t } = useContext(LangContext);
   const [active, setActive] = useState('general');
+  const steps = useMemo(() => dashboardSteps(t), [t]);
+  useTour('dashboard', steps);
 
   const prevTab = useRef('general');
   useEffect(() => {
@@ -140,11 +144,4 @@ export default function DashboardPage() {
     </div>
   );
 }
-
-export const getGuideSteps = (t) => [
-  {
-    target: '#new-transaction-button',
-    content: t('guide.newTransaction'),
-  },
-];
 

--- a/src/erp.mgt.mn/pages/Forms.jsx
+++ b/src/erp.mgt.mn/pages/Forms.jsx
@@ -1,16 +1,16 @@
 // src/erp.mgt.mn/pages/Forms.jsx
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useOutlet } from 'react-router-dom';
 import FormsIndex from './FormsIndex.jsx';
+import { useTour } from '../components/ERPLayout.jsx';
+import formsSteps from '../tours/Forms.js';
+import { useTranslation } from 'react-i18next';
 
 export default function FormsPage() {
   const outlet = useOutlet();
+  const { t } = useTranslation();
+  const steps = useMemo(() => formsSteps(t), [t]);
+  useTour('forms', steps);
   return outlet || <FormsIndex />;
 }
 
-export const getGuideSteps = (t) => [
-  {
-    target: '#new-transaction-button',
-    content: t('guide.newTransaction'),
-  },
-];

--- a/src/erp.mgt.mn/pages/Settings.jsx
+++ b/src/erp.mgt.mn/pages/Settings.jsx
@@ -29,6 +29,9 @@ export function GeneralSettings() {
     const val = localStorage.getItem('tooltipsEnabled');
     return val !== 'false';
   });
+  const [toursEnabled, setToursEnabled] = useState(() => {
+    return localStorage.getItem('settings_enable_tours') === 'true';
+  });
 
   useEffect(() => {
     fetch('/api/settings', { credentials: 'include' })
@@ -68,6 +71,20 @@ export function GeneralSettings() {
             }}
           />{' '}
           {t('settings_enable_tooltips', 'Enable tooltips')}
+        </label>
+      </div>
+      <div style={{ marginTop: '0.5rem' }}>
+        <label>
+          <input
+            type="checkbox"
+            checked={toursEnabled}
+            onChange={(e) => {
+              const v = e.target.checked;
+              setToursEnabled(v);
+              localStorage.setItem('settings_enable_tours', String(v));
+            }}
+          />{' '}
+          {t('settings_enable_tours', 'Show page guide')}
         </label>
       </div>
       <p style={{ marginTop: '1rem' }}>

--- a/src/erp.mgt.mn/tours/DashboardPage.js
+++ b/src/erp.mgt.mn/tours/DashboardPage.js
@@ -1,0 +1,6 @@
+export default (t) => [
+  {
+    selector: '#new-transaction-button',
+    content: t('guide.newTransaction'),
+  },
+];

--- a/src/erp.mgt.mn/tours/Forms.js
+++ b/src/erp.mgt.mn/tours/Forms.js
@@ -1,0 +1,6 @@
+export default (t) => [
+  {
+    selector: '#new-transaction-button',
+    content: t('guide.newTransaction'),
+  },
+];


### PR DESCRIPTION
## Summary
- introduce TourContext and useTour hook to run Joyride tours based on localStorage flags
- add example tours for Dashboard and Forms pages
- expose "Show page guide" toggle in settings to enable tours

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b30cc993cc8331bd425670a4190f79