### PR TITLE
feat: add Joyride tour provider and user settings page

### DIFF
--- a/src/erp.mgt.mn/App.jsx
+++ b/src/erp.mgt.mn/App.jsx
@@ -45,6 +45,7 @@ import TenantTablesRegistryPage from './pages/TenantTablesRegistry.jsx';
 import TranslationEditorPage from './pages/TranslationEditor.jsx';
 import UserManualExportPage from './pages/UserManualExport.jsx';
 import ErrorBoundary from './components/ErrorBoundary.jsx';
+import UserSettingsPage from './pages/UserSettings.jsx';
 
 export default function App() {
   useEffect(() => {
@@ -106,6 +107,7 @@ function AuthedApp() {
     companies: <CompaniesPage />,
     role_permissions: <RolePermissionsPage />,
     user_level_actions: <UserLevelActionsPage />,
+    user_settings: <UserSettingsPage />,
     modules: <ModulesPage />,
     company_licenses: <CompanyLicensesPage />,
     tables_management: <TablesManagementPage />,

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -1,5 +1,5 @@
 // src/erp.mgt.mn/components/ERPLayout.jsx
-import React, { useContext, useState, useEffect, useRef, useMemo } from "react";
+import React, { useContext, useState, useEffect, useRef, useMemo, useCallback } from "react";
 import HeaderMenu from "./HeaderMenu.jsx";
 import UserMenu from "./UserMenu.jsx";
 import { useOutlet, useNavigate, useLocation } from "react-router-dom";
@@ -18,10 +18,16 @@ import useHeaderMappings from "../hooks/useHeaderMappings.js";
 import useRequestNotificationCounts from "../hooks/useRequestNotificationCounts.js";
 import { PendingRequestContext } from "../context/PendingRequestContext.jsx";
 import Joyride, { STATUS } from "react-joyride";
-import { getGuideSteps as getDashboardGuideSteps } from "../pages/DashboardPage.jsx";
-import { getGuideSteps as getFormsGuideSteps } from "../pages/Forms.jsx";
 import ErrorBoundary from "../components/ErrorBoundary.jsx";
 import { useToast } from "../context/ToastContext.jsx";
+
+const TourContext = React.createContext(() => {});
+export const useTour = (pageKey, steps) => {
+  const startTour = useContext(TourContext);
+  useEffect(() => {
+    startTour(pageKey, steps);
+  }, [startTour, pageKey, steps]);
+};
 
 /**
  * A desktop‐style “ERPLayout” with:
@@ -50,10 +56,22 @@ export default function ERPLayout() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [tourSteps, setTourSteps] = useState([]);
   const [runTour, setRunTour] = useState(false);
+  const [currentTourPage, setCurrentTourPage] = useState('');
   useEffect(() => {
     const handler = () => setIsMobile(window.innerWidth < 768);
     window.addEventListener('resize', handler);
     return () => window.removeEventListener('resize', handler);
+  }, []);
+
+  const startTour = useCallback((pageKey, steps) => {
+    const enabled = localStorage.getItem('settings_enable_tours') === 'true';
+    if (!enabled) return;
+    const seenKey = `erpGuideSeen-${pageKey}`;
+    if (!localStorage.getItem(seenKey) && steps && steps.length) {
+      setTourSteps(steps);
+      setCurrentTourPage(pageKey);
+      setRunTour(true);
+    }
   }, []);
 
   const modules = useModules();
@@ -73,6 +91,11 @@ export default function ERPLayout() {
       map[modulePath(moduleMap.settings, moduleMap)] = t("settings", "Settings");
     if (moduleMap.users)
       map[modulePath(moduleMap.users, moduleMap)] = t("settings_users", "Users");
+    if (moduleMap.user_settings)
+      map[modulePath(moduleMap.user_settings, moduleMap)] = t(
+        "settings_user_settings",
+        "User Settings",
+      );
     if (moduleMap.role_permissions)
       map[modulePath(moduleMap.role_permissions, moduleMap)] = t(
         "settings_role_permissions",
@@ -149,40 +172,18 @@ export default function ERPLayout() {
     }
   }, [modules, validPaths, location.pathname, navigate, addToast, t]);
 
-  useEffect(() => {
-    const path = location.pathname;
-    let pageKey = "dashboard";
-    if (path.startsWith("/forms")) pageKey = "forms";
-    const stepsMap = {
-      dashboard: getDashboardGuideSteps,
-      forms: getFormsGuideSteps,
-    };
-    const stepsFn = stepsMap[pageKey];
-    const steps = stepsFn ? stepsFn(t) : [];
-    setTourSteps(steps);
-    const seenKey = `erpGuideSeen-${pageKey}`;
-    if (!localStorage.getItem(seenKey) && steps.length) {
-      setRunTour(true);
-    } else {
-      setRunTour(false);
-    }
-  }, [location.pathname, t]);
-
   const handleTourCallback = ({ status }) => {
     if ([STATUS.FINISHED, STATUS.SKIPPED].includes(status)) {
-      const path = location.pathname;
-      let pageKey = "dashboard";
-      if (path.startsWith("/forms")) pageKey = "forms";
-      localStorage.setItem(`erpGuideSeen-${pageKey}`, "1");
+      if (currentTourPage) {
+        localStorage.setItem(`erpGuideSeen-${currentTourPage}`, "1");
+      }
       setRunTour(false);
     }
   };
 
   const resetGuide = () => {
-    const path = location.pathname;
-    let pageKey = "dashboard";
-    if (path.startsWith("/forms")) pageKey = "forms";
-    localStorage.removeItem(`erpGuideSeen-${pageKey}`);
+    const key = currentTourPage || location.pathname.split('/').filter(Boolean)[0] || 'dashboard';
+    localStorage.removeItem(`erpGuideSeen-${key}`);
     setRunTour(true);
   };
 
@@ -235,43 +236,45 @@ export default function ERPLayout() {
   }
 
   return (
-    <PendingRequestContext.Provider value={requestNotifications}>
-      <div style={styles.container}>
-        <Joyride
-          steps={tourSteps}
-          run={runTour}
-          continuous
-          showSkipButton
-          disableOverlayClose
-          disableKeyboardNavigation={false}
-          callback={handleTourCallback}
-        />
-        <Header
-          user={user}
-          onLogout={handleLogout}
-          onHome={handleHome}
-          isMobile={isMobile}
-          onToggleSidebar={() => setSidebarOpen((o) => !o)}
-          onOpen={handleOpen}
-          onResetGuide={resetGuide}
-        />
-        <div style={styles.body(isMobile)}>
-          {isMobile && sidebarOpen && (
-            <div
-              className="sidebar-overlay"
-              onClick={() => setSidebarOpen(false)}
-            />
-          )}
-          <Sidebar
-            open={isMobile ? sidebarOpen : true}
-            onOpen={handleOpen}
-            isMobile={isMobile}
+    <TourContext.Provider value={startTour}>
+      <PendingRequestContext.Provider value={requestNotifications}>
+        <div style={styles.container}>
+          <Joyride
+            steps={tourSteps}
+            run={runTour}
+            continuous
+            showSkipButton
+            disableOverlayClose
+            disableKeyboardNavigation={false}
+            callback={handleTourCallback}
           />
-          <MainWindow title={windowTitle} />
+          <Header
+            user={user}
+            onLogout={handleLogout}
+            onHome={handleHome}
+            isMobile={isMobile}
+            onToggleSidebar={() => setSidebarOpen((o) => !o)}
+            onOpen={handleOpen}
+            onResetGuide={resetGuide}
+          />
+          <div style={styles.body(isMobile)}>
+            {isMobile && sidebarOpen && (
+              <div
+                className="sidebar-overlay"
+                onClick={() => setSidebarOpen(false)}
+              />
+            )}
+            <Sidebar
+              open={isMobile ? sidebarOpen : true}
+              onOpen={handleOpen}
+              isMobile={isMobile}
+            />
+            <MainWindow title={windowTitle} />
+          </div>
+          {generalConfig.general?.aiApiEnabled && <AskAIFloat />}
         </div>
-        {generalConfig.general?.aiApiEnabled && <AskAIFloat />}
-      </div>
-    </PendingRequestContext.Provider>
+      </PendingRequestContext.Provider>
+    </TourContext.Provider>
   );
 }
 

--- a/src/erp.mgt.mn/pages/DashboardPage.jsx
+++ b/src/erp.mgt.mn/pages/DashboardPage.jsx
@@ -1,15 +1,19 @@
-import React, { useContext, useState, useEffect, useRef } from 'react';
+import React, { useContext, useState, useEffect, useRef, useMemo } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
 import PendingRequestWidget from '../components/PendingRequestWidget.jsx';
 import OutgoingRequestWidget from '../components/OutgoingRequestWidget.jsx';
 import { usePendingRequests } from '../context/PendingRequestContext.jsx';
 import LangContext from '../context/I18nContext.jsx';
+import { useTour } from '../components/ERPLayout.jsx';
+import dashboardSteps from '../tours/DashboardPage.js';
 
 export default function DashboardPage() {
   const { user, session } = useContext(AuthContext);
   const { hasNew, markSeen, outgoing } = usePendingRequests();
   const { t } = useContext(LangContext);
   const [active, setActive] = useState('general');
+  const steps = useMemo(() => dashboardSteps(t), [t]);
+  useTour('dashboard', steps);
 
   const prevTab = useRef('general');
   useEffect(() => {
@@ -140,11 +144,4 @@ export default function DashboardPage() {
     </div>
   );
 }
-
-export const getGuideSteps = (t) => [
-  {
-    target: '#new-transaction-button',
-    content: t('guide.newTransaction'),
-  },
-];
 

--- a/src/erp.mgt.mn/pages/Forms.jsx
+++ b/src/erp.mgt.mn/pages/Forms.jsx
@@ -1,16 +1,16 @@
 // src/erp.mgt.mn/pages/Forms.jsx
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useOutlet } from 'react-router-dom';
 import FormsIndex from './FormsIndex.jsx';
+import { useTour } from '../components/ERPLayout.jsx';
+import formsSteps from '../tours/Forms.js';
+import { useTranslation } from 'react-i18next';
 
 export default function FormsPage() {
   const outlet = useOutlet();
+  const { t } = useTranslation();
+  const steps = useMemo(() => formsSteps(t), [t]);
+  useTour('forms', steps);
   return outlet || <FormsIndex />;
 }
 
-export const getGuideSteps = (t) => [
-  {
-    target: '#new-transaction-button',
-    content: t('guide.newTransaction'),
-  },
-];

--- a/src/erp.mgt.mn/pages/Settings.jsx
+++ b/src/erp.mgt.mn/pages/Settings.jsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState, useContext } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { Outlet, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import TooltipWrapper from '../components/TooltipWrapper.jsx';
 
 export default function SettingsPage() {
   // Just render the nested route content. The left sidebar already

--- a/src/erp.mgt.mn/pages/UserSettings.jsx
+++ b/src/erp.mgt.mn/pages/UserSettings.jsx
@@ -1,0 +1,65 @@
+import React, { useState, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useTour } from '../components/ERPLayout.jsx';
+import userSettingsSteps from '../tours/UserSettings.js';
+
+export default function UserSettingsPage() {
+  const { t } = useTranslation();
+  const steps = useMemo(() => userSettingsSteps(t), [t]);
+  useTour('user-settings', steps);
+  const tabs = [
+    { key: 'profile', label: t('profile', 'Profile') },
+    { key: 'manual', label: t('user_manual', 'User manual') },
+  ];
+  const [active, setActive] = useState('manual');
+  return (
+    <div style={{ padding: '1rem' }}>
+      <div style={{ display: 'flex', borderBottom: '1px solid #ddd', marginBottom: '1rem' }}>
+        {tabs.map((tab) => (
+          <button
+            key={tab.key}
+            onClick={() => setActive(tab.key)}
+            style={{
+              padding: '0.5rem 1rem',
+              border: 'none',
+              borderBottom:
+                active === tab.key ? '2px solid #2563eb' : '2px solid transparent',
+              background: 'none',
+              cursor: 'pointer',
+            }}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      {active === 'manual' && <UserManualTab />}
+      {active === 'profile' && (
+        <div>{t('profile_settings_placeholder', 'Profile settings coming soon.')}</div>
+      )}
+    </div>
+  );
+}
+
+function UserManualTab() {
+  const { t } = useTranslation();
+  const [toursEnabled, setToursEnabled] = useState(() =>
+    localStorage.getItem('settings_enable_tours') === 'true',
+  );
+  return (
+    <div>
+      <label>
+        <input
+          id="show-page-guide-toggle"
+          type="checkbox"
+          checked={toursEnabled}
+          onChange={(e) => {
+            const v = e.target.checked;
+            setToursEnabled(v);
+            localStorage.setItem('settings_enable_tours', String(v));
+          }}
+        />{' '}
+        {t('settings_enable_tours', 'Show page guide')}
+      </label>
+    </div>
+  );
+}

--- a/src/erp.mgt.mn/tours/DashboardPage.js
+++ b/src/erp.mgt.mn/tours/DashboardPage.js
@@ -1,0 +1,6 @@
+export default (t) => [
+  {
+    selector: '#new-transaction-button',
+    content: t('guide.newTransaction'),
+  },
+];

--- a/src/erp.mgt.mn/tours/Forms.js
+++ b/src/erp.mgt.mn/tours/Forms.js
@@ -1,0 +1,6 @@
+export default (t) => [
+  {
+    selector: '#new-transaction-button',
+    content: t('guide.newTransaction'),
+  },
+];

--- a/src/erp.mgt.mn/tours/UserSettings.js
+++ b/src/erp.mgt.mn/tours/UserSettings.js
@@ -1,0 +1,6 @@
+export default (t) => [
+  {
+    selector: '#show-page-guide-toggle',
+    content: t('guide.showPageGuide'),
+  },
+];


### PR DESCRIPTION
## Summary
- introduce TourContext and useTour hook to run Joyride tours based on localStorage flags
- add example tours for Dashboard and Forms pages
- move "Show page guide" toggle to new User Settings page under User manual tab

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b30cc993cc8331bd425670a4190f79