### PR TITLE
feat: filter user manual by user level

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "socket.io-client": "^4.7.5",
     "xlsx": "^0.18.5",
     "jspdf": "^2.5.2",
-    "react-joyride": "^2.9.0"
+    "react-joyride": "^2.9.0",
+    "pdfkit": "^0.15.0",
+    "blob-stream": "^0.1.3"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",


### PR DESCRIPTION
## Summary
- allow admins to pick a user level and generate manuals scoped to its permissions
- merge pre-generated manual sections and export to PDF using pdfkit
- add translations fallback and new dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b31b0bdc7c8331a42d8adc9c3d2937