### PR TITLE
feat: generate tour steps from page markup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ config/*.json
 !config/headerMappings.json
 !config/userLevelActions.json
 !config/softDeleteTables.json
+!config/tourOrder.json
 config/generated.sql
 .ico
 uploads/*

--- a/config/tourOrder.json
+++ b/config/tourOrder.json
@@ -1,0 +1,5 @@
+{
+  "DashboardPage": ["#new-transaction-button"],
+  "Forms": ["#new-transaction-button"],
+  "UserSettings": ["#show-page-guide-toggle"]
+}

--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
   "scripts": {
     "dev": "vite",
     "build:homepage": "vite build --config vite.home.config.js",
-    "build:erp": "vite build --config vite.config.js",
+    "build:erp": "node scripts/extractTourOrder.js && vite build --config vite.config.js",
     "serve": "node api-server/server.js",
     "test": "node --test",
     "generate:translations": "node scripts/generateTranslations.cli.js",
-    "generate:manuals": "node scripts/generateManuals.js"
+    "generate:manuals": "node scripts/extractTourOrder.js && node scripts/generateManuals.js",
+    "generate:tours": "node scripts/extractTourOrder.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
@@ -38,6 +39,8 @@
     "react-joyride": "^2.9.0"
   },
   "devDependencies": {
+    "@babel/parser": "^7.26.2",
+    "@babel/traverse": "^7.26.0",
     "@vitejs/plugin-react": "^4.0.0",
     "html2canvas": "^1.4.1",
     "puppeteer": "^23.5.0",

--- a/scripts/extractTourOrder.js
+++ b/scripts/extractTourOrder.js
@@ -1,0 +1,73 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import parser from '@babel/parser';
+import traverse from '@babel/traverse';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+const pagesDir = path.join(rootDir, 'src', 'erp.mgt.mn', 'pages');
+const toursDir = path.join(rootDir, 'src', 'erp.mgt.mn', 'tours');
+const configFile = path.join(rootDir, 'config', 'tourOrder.json');
+
+async function readJSON(file) {
+  try {
+    const data = await fs.readFile(file, 'utf8');
+    return JSON.parse(data);
+  } catch {
+    return {};
+  }
+}
+
+function sanitizeKey(sel) {
+  return sel.replace(/^[#.]/, '').replace(/[^\w]/g, '_');
+}
+
+function parseSelectors(code) {
+  const ast = parser.parse(code, {
+    sourceType: 'module',
+    plugins: ['jsx'],
+  });
+  const selectors = [];
+  traverse(ast, {
+    JSXAttribute({ node }) {
+      const { name, value } = node;
+      if (!value || value.type !== 'StringLiteral') return;
+      if (name.name === 'id') {
+        selectors.push(`#${value.value}`);
+      } else if (name.name === 'data-tour' || name.name === 'data-tour-id') {
+        selectors.push(`[${name.name}="${value.value}"]`);
+      }
+    },
+  });
+  return selectors;
+}
+
+async function generate() {
+  const overrides = await readJSON(configFile);
+  const files = await fs.readdir(pagesDir);
+  await fs.mkdir(toursDir, { recursive: true });
+  for (const file of files) {
+    if (!file.endsWith('.jsx') && !file.endsWith('.js')) continue;
+    const pageName = path.basename(file, path.extname(file));
+    const code = await fs.readFile(path.join(pagesDir, file), 'utf8');
+    const defaultSelectors = parseSelectors(code);
+    const selectors = overrides[pageName] || defaultSelectors;
+    if (!selectors.length) continue;
+    const steps = selectors
+      .map((sel) => {
+        const key = sanitizeKey(sel);
+        return `  { selector: '${sel}', content: t('guide.${key}', '${key}') },`;
+      })
+      .join('\n');
+    const content = `export default (t) => [\n${steps}\n];\n`;
+    await fs.writeFile(path.join(toursDir, `${pageName}.js`), content);
+  }
+}
+
+generate().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+

--- a/src/erp.mgt.mn/tours/ChangePassword.js
+++ b/src/erp.mgt.mn/tours/ChangePassword.js
@@ -1,0 +1,4 @@
+export default (t) => [
+  { selector: '#newpwd', content: t('guide.newpwd', 'newpwd') },
+  { selector: '#confirm', content: t('guide.confirm', 'confirm') },
+];

--- a/src/erp.mgt.mn/tours/DashboardPage.js
+++ b/src/erp.mgt.mn/tours/DashboardPage.js
@@ -1,6 +1,3 @@
 export default (t) => [
-  {
-    selector: '#new-transaction-button',
-    content: t('guide.newTransaction'),
-  },
+  { selector: '#new-transaction-button', content: t('guide.new_transaction_button', 'new_transaction_button') },
 ];

--- a/src/erp.mgt.mn/tours/Forms.js
+++ b/src/erp.mgt.mn/tours/Forms.js
@@ -1,6 +1,3 @@
 export default (t) => [
-  {
-    selector: '#new-transaction-button',
-    content: t('guide.newTransaction'),
-  },
+  { selector: '#new-transaction-button', content: t('guide.new_transaction_button', 'new_transaction_button') },
 ];

--- a/src/erp.mgt.mn/tours/UserSettings.js
+++ b/src/erp.mgt.mn/tours/UserSettings.js
@@ -1,6 +1,3 @@
 export default (t) => [
-  {
-    selector: '#show-page-guide-toggle',
-    content: t('guide.showPageGuide'),
-  },
+  { selector: '#show-page-guide-toggle', content: t('guide.show_page_guide_toggle', 'show_page_guide_toggle') },
 ];


### PR DESCRIPTION
## Summary
- parse `src/erp.mgt.mn/pages` with Babel to collect DOM element order
- allow custom tour sequences via `config/tourOrder.json`
- generate tour files during build and manual generation

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden for @babel/parser)*
- `node scripts/extractTourOrder.js` *(fails: Cannot find package '@babel/parser')*

------
https://chatgpt.com/codex/tasks/task_e_68b3228b5b908331b34cc404d1a27864