### PR TITLE
Expose user settings API route

### DIFF
--- a/api-server/server.js
+++ b/api-server/server.js
@@ -46,6 +46,7 @@ import featureToggle from "./middlewares/featureToggle.js";
 import reportBuilderRoutes from "./routes/report_builder.js";
 import pendingRequestRoutes from "./routes/pending_request.js";
 import activityLogRoutes from "./routes/user_activity_log.js";
+import userSettingsRoutes from "./routes/user_settings.js";
 
 // Polyfill for __dirname in ES modules
 const __filename = fileURLToPath(import.meta.url);
@@ -141,6 +142,7 @@ app.use("/api/general_config", requireAuth, generalConfigRoutes);
 app.use("/api/tenant_tables", tenantTablesRoutes);
 app.use("/api/permissions", permissionsRoutes);
 app.use("/api/pending_request", pendingRequestRoutes);
+app.use("/api/user/settings", userSettingsRoutes);
 app.use("/api/user_activity_log", activityLogRoutes);
 
 // Serve static React build and fallback to index.html


### PR DESCRIPTION
## Summary
- import user settings routes
- mount `/api/user/settings` route

## Testing
- `npm test`
- ⚠️ `JWT_SECRET=testsecret node api-server/server.js` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68b32aaeff348331a67f3e51865eb205