### PR TITLE
Load React Joyride styles for ERP tour tooltips

### DIFF
--- a/src/erp.mgt.mn/main.jsx
+++ b/src/erp.mgt.mn/main.jsx
@@ -5,6 +5,7 @@ import './utils/csrfFetch.js';
 import './utils/debug.js';
 import { setupDebugHooks } from './utils/debugHooks.js';
 import './index.css';
+import 'react-joyride/lib/react-joyride.css';
 import './legacyModals.js';
 
 setupDebugHooks();


### PR DESCRIPTION
## Summary
- Import React Joyride CSS in ERP client entry to ensure tour tooltips render fully

## Testing
- `npm test`
- `npm run build:erp` *(fails: Cannot find package '@babel/parser')*


------
https://chatgpt.com/codex/tasks/task_e_68b32d934b008331864bc73af6517280