### PR TITLE
Guard tooltip attributes behind setting

### DIFF
--- a/src/erp.mgt.mn/components/TooltipWrapper.jsx
+++ b/src/erp.mgt.mn/components/TooltipWrapper.jsx
@@ -7,12 +7,14 @@ export default function TooltipWrapper({ title, children }) {
   if (!title) {
     return children;
   }
-  const child = React.isValidElement(children)
-    ? React.cloneElement(children, { title })
-    : children;
   return (
-    <span className="tooltip-wrapper" title={title} data-tooltip={enabled ? title : undefined}>
-      {child}
+    <span
+      className="tooltip-wrapper"
+      title={enabled ? title : undefined}
+      aria-label={enabled ? title : undefined}
+      data-tooltip={enabled ? title : undefined}
+    >
+      {children}
     </span>
   );
 }


### PR DESCRIPTION
## Summary
- prevent native tooltips on wrapped elements
- add `title`, `aria-label`, and `data-tooltip` only when tooltips are enabled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3301a1de083319586fcd26b640c93