### PR TITLE
fix: allow tooltip pseudo-element to render fully

### DIFF
--- a/src/erp.mgt.mn/index.css
+++ b/src/erp.mgt.mn/index.css
@@ -312,6 +312,8 @@ th {
 /* Tooltip styles */
 .tooltip-wrapper[data-tooltip] {
   position: relative;
+  display: inline-block;
+  overflow: visible;
 }
 
 .tooltip-wrapper[data-tooltip]:hover::after {


### PR DESCRIPTION
## Summary
- ensure `.tooltip-wrapper[data-tooltip]` displays inline-block with visible overflow for proper tooltip rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b330ee2ec08331baeca3fee707eb55