### PR TITLE
feat: generate missing tooltip translations

### DIFF
--- a/scripts/generateTranslations.cli.js
+++ b/scripts/generateTranslations.cli.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
-import { generateTranslations } from './generateTranslations.js';
+import {
+  generateTranslations,
+  generateTooltipTranslations,
+} from './generateTranslations.js';
 
 const controller = new AbortController();
 process.on('SIGINT', () => controller.abort());
@@ -13,7 +16,14 @@ process.on('uncaughtException', (err) => {
   process.exit(3);
 });
 
-generateTranslations({ onLog: console.log, signal: controller.signal }).catch((err) => {
-  console.error('[gen-i18n] FATAL', err);
-  process.exit(1);
-});
+async function main() {
+  try {
+    await generateTranslations({ onLog: console.log, signal: controller.signal });
+    await generateTooltipTranslations({ onLog: console.log, signal: controller.signal });
+  } catch (err) {
+    console.error('[gen-i18n] FATAL', err);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add `generateTooltipTranslations` to fill untranslated tooltip files
- run tooltip generation after standard locale generation in CLI

## Testing
- `npm test` *(fails: detectIncompleteImages finds and fixes files)*

------
https://chatgpt.com/codex/tasks/task_e_68b3411949448331ba11d0de499ade0f