### PR TITLE
chore: auto resolve tooltips

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -58,7 +58,6 @@ const RowFormModal = function RowFormModal({
   viewColumns = {},
   procTriggers = {},
   autoFillSession = true,
-  tooltips = {},
 }) {
   const mounted = useRef(false);
   const renderCount = useRef(0);
@@ -913,7 +912,7 @@ const RowFormModal = function RowFormModal({
     const inputClass = `w-full border rounded ${err ? 'border-red-500' : 'border-gray-300'}`;
     const isColumn = columns.includes(c);
     const disabled = disabledSet.has(c.toLowerCase()) || !isColumn;
-    const tip = tooltips[c] ? t(tooltips[c]) : labels[c] || c;
+    const tip = t(`tooltip.${c}`, { defaultValue: labels[c] || c });
 
     if (disabled) {
       const raw = isColumn ? formVals[c] : extraVals[c];

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -2604,7 +2604,6 @@ const TableManager = forwardRef(function TableManager({
         relationData={refRows}
         disabledFields={disabledFields}
         labels={labels}
-        tooltips={formConfig?.tooltips || {}}
         requiredFields={formConfig?.requiredFields || []}
         defaultValues={rowDefaults}
         dateField={formConfig?.dateField || []}

--- a/src/erp.mgt.mn/pages/FormRenderer.jsx
+++ b/src/erp.mgt.mn/pages/FormRenderer.jsx
@@ -3,13 +3,12 @@ import Form from '@rjsf/core';
 import TooltipWrapper from '../components/TooltipWrapper.jsx';
 import { useTranslation } from 'react-i18next';
 
-export default function FormRenderer({ schema, uiSchema = {}, formData, onSubmit, tooltips = {} }) {
+export default function FormRenderer({ schema, uiSchema = {}, formData, onSubmit }) {
   const { t } = useTranslation();
 
   const FieldTemplate = (props) => {
     const { id, label, required, children, errors, help, description, name } = props;
-    const tipKey = tooltips[name];
-    const title = tipKey ? t(tipKey) : label;
+    const title = t(`tooltip.${name}`, { defaultValue: label });
     return (
       <TooltipWrapper title={title}>
         <div className="mb-3">

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -1091,7 +1091,6 @@ export default function PosTransactionsPage() {
                       disabledFields={disabled}
                       requiredFields={fc.requiredFields || []}
                       labels={labels}
-                      tooltips={fc.tooltips || {}}
                       row={values[t.table]}
                       rows={t.type === 'multi' ? values[t.table] : undefined}
                       headerFields={headerFields}


### PR DESCRIPTION
## Summary
- simplify tooltip translation lookup in RowFormModal
- auto-translate tooltips in FormRenderer
- drop legacy tooltip mappings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b342c3aab883319b0cc3a3408d5409