### PR TITLE
feat: support custom tooltips in form components

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -58,6 +58,7 @@ const RowFormModal = function RowFormModal({
   viewColumns = {},
   procTriggers = {},
   autoFillSession = true,
+  tooltips = {},
 }) {
   const mounted = useRef(false);
   const renderCount = useRef(0);
@@ -912,7 +913,8 @@ const RowFormModal = function RowFormModal({
     const inputClass = `w-full border rounded ${err ? 'border-red-500' : 'border-gray-300'}`;
     const isColumn = columns.includes(c);
     const disabled = disabledSet.has(c.toLowerCase()) || !isColumn;
-    const tip = t(`tooltip.${c}`, { defaultValue: labels[c] || c });
+    const key = tooltips[c] || `tooltip.${c}`;
+    const tip = t(key, { defaultValue: labels[c] || c });
 
     if (disabled) {
       const raw = isColumn ? formVals[c] : extraVals[c];

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -2626,6 +2626,7 @@ const TableManager = forwardRef(function TableManager({
         viewSource={viewSourceMap}
         viewDisplays={viewDisplayMap}
         viewColumns={viewColumns}
+        tooltips={formConfig?.tooltips || {}}
         onRowsChange={setGridRows}
         autoFillSession={autoFillSession}
         scope="forms"

--- a/src/erp.mgt.mn/pages/FormRenderer.jsx
+++ b/src/erp.mgt.mn/pages/FormRenderer.jsx
@@ -3,12 +3,19 @@ import Form from '@rjsf/core';
 import TooltipWrapper from '../components/TooltipWrapper.jsx';
 import { useTranslation } from 'react-i18next';
 
-export default function FormRenderer({ schema, uiSchema = {}, formData, onSubmit }) {
+export default function FormRenderer({
+  schema,
+  uiSchema = {},
+  formData,
+  onSubmit,
+  tooltips = {},
+}) {
   const { t } = useTranslation();
 
   const FieldTemplate = (props) => {
     const { id, label, required, children, errors, help, description, name } = props;
-    const title = t(`tooltip.${name}`, { defaultValue: label });
+    const key = tooltips[name] || `tooltip.${name}`;
+    const title = t(key, { defaultValue: label });
     return (
       <TooltipWrapper title={title}>
         <div className="mb-3">

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -1107,11 +1107,12 @@ export default function PosTransactionsPage() {
                       relations={relationsMap[t.table] || {}}
                       relationConfigs={relationConfigs[t.table] || {}}
                       relationData={relationData[t.table] || {}}
-                    procTriggers={procTriggersMap[t.table] || {}}
-                    viewSource={fc.viewSource || {}}
-                    viewDisplays={viewDisplaysMap[t.table] || {}}
-                    viewColumns={viewColumnsMap[t.table] || {}}
-                    user={user}
+                      tooltips={fc.tooltips || {}}
+                      procTriggers={procTriggersMap[t.table] || {}}
+                      viewSource={fc.viewSource || {}}
+                      viewDisplays={viewDisplaysMap[t.table] || {}}
+                      viewColumns={viewColumnsMap[t.table] || {}}
+                      user={user}
                     
                     columnCaseMap={(columnMeta[t.table] || []).reduce((m,c)=>{m[c.name.toLowerCase()] = c.name;return m;}, {})}
                     onChange={(changes) => handleChange(t.table, changes)}


### PR DESCRIPTION
## Summary
- allow RowFormModal and FormRenderer to accept custom tooltip mappings
- resolve tooltip keys using provided mapping or fallback
- wire up tooltips mapping from form config in TableManager and POS transactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b34815bf6c8331bee80093f00fac43