### PR TITLE
Use tooltip namespace for tooltip translations

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -66,7 +66,7 @@ const RowFormModal = function RowFormModal({
   const generalConfig = useGeneralConfig();
   const cfg = generalConfig[scope] || {};
   const general = generalConfig.general || {};
-  const { t } = useTranslation();
+  const { t } = useTranslation(['translation', 'tooltip']);
   labelFontSize = labelFontSize ?? cfg.labelFontSize ?? 14;
   boxWidth = boxWidth ?? cfg.boxWidth ?? 60;
   boxHeight = boxHeight ?? cfg.boxHeight ?? 30;
@@ -912,7 +912,7 @@ const RowFormModal = function RowFormModal({
     const inputClass = `w-full border rounded ${err ? 'border-red-500' : 'border-gray-300'}`;
     const isColumn = columns.includes(c);
     const disabled = disabledSet.has(c.toLowerCase()) || !isColumn;
-    const tip = t(`tooltip.${c}`, { defaultValue: labels[c] || c });
+    const tip = t(c, { ns: 'tooltip', defaultValue: labels[c] || c });
 
     if (disabled) {
       const raw = isColumn ? formVals[c] : extraVals[c];

--- a/src/erp.mgt.mn/pages/FormRenderer.jsx
+++ b/src/erp.mgt.mn/pages/FormRenderer.jsx
@@ -4,11 +4,11 @@ import TooltipWrapper from '../components/TooltipWrapper.jsx';
 import { useTranslation } from 'react-i18next';
 
 export default function FormRenderer({ schema, uiSchema = {}, formData, onSubmit }) {
-  const { t } = useTranslation();
+  const { t } = useTranslation('tooltip');
 
   const FieldTemplate = (props) => {
     const { id, label, required, children, errors, help, description, name } = props;
-    const title = t(`tooltip.${name}`, { defaultValue: label });
+    const title = t(name, { ns: 'tooltip', defaultValue: label });
     return (
       <TooltipWrapper title={title}>
         <div className="mb-3">

--- a/src/erp.mgt.mn/pages/UserSettings.jsx
+++ b/src/erp.mgt.mn/pages/UserSettings.jsx
@@ -47,12 +47,12 @@ export default function UserSettingsPage() {
 }
 
 function GeneralSettingsTab() {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['translation', 'tooltip']);
   const { userSettings, updateUserSettings } = useAuth();
   const tooltipsEnabled = userSettings.tooltipsEnabled ?? true;
   return (
     <div>
-      <TooltipWrapper title={t('tooltip.enable_tooltips')}>
+      <TooltipWrapper title={t('enable_tooltips', { ns: 'tooltip' })}>
         <label>
           <input
             type="checkbox"


### PR DESCRIPTION
## Summary
- reference tooltip strings via `ns: 'tooltip'`
- load `translation` and `tooltip` namespaces where needed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b34ef4ac3c8331b42dc28a09a8a142