### PR TITLE
feat: bypass button perms with system settings

### DIFF
--- a/src/erp.mgt.mn/hooks/useButtonPerms.js
+++ b/src/erp.mgt.mn/hooks/useButtonPerms.js
@@ -1,0 +1,19 @@
+import { useContext, useMemo } from 'react';
+import { AuthContext } from '../context/AuthContext.jsx';
+
+const ALL_BUTTONS = new Proxy(
+  {},
+  {
+    get: () => true,
+    has: () => true,
+  },
+);
+
+export default function useButtonPerms() {
+  const { session, permissions } = useContext(AuthContext);
+  return useMemo(() => {
+    if (session?.permissions?.system_settings) return ALL_BUTTONS;
+    return permissions?.buttons || {};
+  }, [session?.permissions?.system_settings, permissions?.buttons]);
+}
+

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -16,6 +16,7 @@ import formatTimestamp from '../utils/formatTimestamp.js';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import useHeaderMappings from '../hooks/useHeaderMappings.js';
 import CustomDatePicker from '../components/CustomDatePicker.jsx';
+import useButtonPerms from '../hooks/useButtonPerms.js';
 
 function normalizeDateInput(value, format) {
   if (typeof value !== 'string') return value;
@@ -66,6 +67,7 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
   const [reportResult, setReportResult] = useState(null);
   const [manualParams, setManualParams] = useState({});
   const { company, branch, department, user, permissions: perms } = useContext(AuthContext);
+  const buttonPerms = useButtonPerms();
   const generalConfig = useGeneralConfig();
   const licensed = useCompanyModules(company);
   const tableRef = useRef(null);
@@ -594,7 +596,7 @@ useEffect(() => {
       {table && config && (
         <>
           <div style={{ marginBottom: '0.5rem' }}>
-            {perms?.buttons?.['New transaction'] && (
+            {buttonPerms['New transaction'] && (
               <button
                 onClick={() => tableRef.current?.openAdd()}
                 style={{ marginRight: '0.5rem' }}
@@ -616,7 +618,7 @@ useEffect(() => {
             initialPerPage={10}
             addLabel="Гүйлгээ нэмэх"
             showTable={showTable}
-            buttonPerms={perms?.buttons || {}}
+            buttonPerms={buttonPerms}
           />
         </>
       )}
@@ -625,7 +627,7 @@ useEffect(() => {
           procedure={reportResult.name}
           params={reportResult.params}
           rows={reportResult.rows}
-          buttonPerms={perms?.buttons || {}}
+          buttonPerms={buttonPerms}
         />
       )}
       {transactionNames.length === 0 && (

--- a/src/erp.mgt.mn/pages/Reports.jsx
+++ b/src/erp.mgt.mn/pages/Reports.jsx
@@ -7,6 +7,7 @@ import ReportTable from '../components/ReportTable.jsx';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import useHeaderMappings from '../hooks/useHeaderMappings.js';
 import CustomDatePicker from '../components/CustomDatePicker.jsx';
+import useButtonPerms from '../hooks/useButtonPerms.js';
 
 function normalizeDateInput(value, format) {
   if (typeof value !== 'string') return value;
@@ -19,7 +20,8 @@ function normalizeDateInput(value, format) {
 }
 
 export default function Reports() {
-  const { company, branch, user, permissions: perms } = useContext(AuthContext);
+  const { company, branch, user } = useContext(AuthContext);
+  const buttonPerms = useButtonPerms();
   const { addToast } = useToast();
   const generalConfig = useGeneralConfig();
   const [procedures, setProcedures] = useState([]);
@@ -283,7 +285,7 @@ export default function Reports() {
           procedure={result.name}
           params={result.params}
           rows={result.rows}
-          buttonPerms={perms?.buttons || {}}
+          buttonPerms={buttonPerms}
         />
       )}
     </div>

--- a/src/erp.mgt.mn/pages/TablesManagement.jsx
+++ b/src/erp.mgt.mn/pages/TablesManagement.jsx
@@ -1,12 +1,12 @@
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useEffect, useState } from 'react';
 import TableManager from '../components/TableManager.jsx';
-import { AuthContext } from '../context/AuthContext.jsx';
+import useButtonPerms from '../hooks/useButtonPerms.js';
 
 export default function TablesManagement() {
   const [tables, setTables] = useState([]);
   const [selectedTable, setSelectedTable] = useState('');
   const [refreshId, setRefreshId] = useState(0);
-  const { permissions: perms } = useContext(AuthContext);
+  const buttonPerms = useButtonPerms();
 
   const loadTables = async () => {
     try {
@@ -46,7 +46,7 @@ export default function TablesManagement() {
         <TableManager
           table={selectedTable}
           refreshId={refreshId}
-          buttonPerms={perms?.buttons || {}}
+          buttonPerms={buttonPerms}
           autoFillSession={false}
         />
       )}


### PR DESCRIPTION
## Summary
- add `useButtonPerms` hook to allow system settings users to bypass button permission checks
- update pages to use new hook for consistent overrides

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b653b370f883318d6928a2edcd4317