### PR TITLE
Use i18n for RowFormModal action buttons

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -1459,27 +1459,27 @@ const RowFormModal = function RowFormModal({
             onClick={() => handlePrint('emp')}
             className="px-3 py-1 bg-gray-200 rounded"
           >
-            Print Emp
+            {t('printEmp', 'Print Emp')}
           </button>
           <button
             type="button"
             onClick={() => handlePrint('cust')}
             className="px-3 py-1 bg-gray-200 rounded"
           >
-            Print Cust
+            {t('printCust', 'Print Cust')}
           </button>
           <button
             type="button"
             onClick={onCancel}
             className="px-3 py-1 bg-gray-200 rounded"
           >
-            Cancel
+            {t('cancel', 'Cancel')}
           </button>
           <button
             type="submit"
             className="px-3 py-1 bg-blue-600 text-white rounded"
           >
-            Post
+            {t('post', 'Post')}
           </button>
         </div>
         <div className="text-sm text-gray-600">


### PR DESCRIPTION
## Summary
- use `t()` for Print Emp, Print Cust, Cancel, and Post buttons in RowFormModal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b65aee9ae88331a3144e58e73267b3