### PR TITLE
feat: link company to foreign keys

### DIFF
--- a/api-server/controllers/activityLogController.js
+++ b/api-server/controllers/activityLogController.js
@@ -41,8 +41,8 @@ export async function restoreLogEntry(req, res, next) {
     if (!entry) return res.sendStatus(404);
 
     const [rows] = await pool.query(
-      'SELECT employment_senior_empid FROM tbl_employment WHERE employment_emp_id = ? LIMIT 1',
-      [entry.emp_id],
+      'SELECT employment_senior_empid FROM tbl_employment WHERE employment_emp_id = ? AND employment_company_id = ? LIMIT 1',
+      [entry.emp_id, entry.company_id],
     );
     const senior = rows[0]?.employment_senior_empid;
     if (senior !== req.user.empid) return res.sendStatus(403);

--- a/db/index.js
+++ b/db/index.js
@@ -529,14 +529,16 @@ export async function listUsers() {
     `SELECT u.id, u.empid, e.employment_position_id AS position_id, u.created_at
        FROM users u
        LEFT JOIN (
-         SELECT t1.employment_emp_id, t1.employment_position_id
+         SELECT t1.employment_company_id, t1.employment_emp_id, t1.employment_position_id
            FROM tbl_employment t1
            JOIN (
-             SELECT employment_emp_id, MAX(id) AS max_id
+             SELECT employment_company_id, employment_emp_id, MAX(id) AS max_id
                FROM tbl_employment
-               GROUP BY employment_emp_id
-           ) t2 ON t1.employment_emp_id = t2.employment_emp_id AND t1.id = t2.max_id
-       ) e ON u.empid = e.employment_emp_id`,
+               GROUP BY employment_company_id, employment_emp_id
+           ) t2 ON t1.employment_company_id = t2.employment_company_id
+                AND t1.employment_emp_id = t2.employment_emp_id
+                AND t1.id = t2.max_id
+       ) e ON u.company_id = e.employment_company_id AND u.empid = e.employment_emp_id`,
   );
   return rows;
 }

--- a/db/mgtmn_erp_db.sql
+++ b/db/mgtmn_erp_db.sql
@@ -23632,37 +23632,37 @@ CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW 
 -- Constraints for table `code_abhuvaari`
 --
 ALTER TABLE `code_abhuvaari`
-  ADD CONSTRAINT `code_abhuvaari_ibfk_1` FOREIGN KEY (`HBChig_id2`) REFERENCES `code_chiglel` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `code_abhuvaari_ibfk_2` FOREIGN KEY (`HBTorol_id2`) REFERENCES `code_torol` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `code_abhuvaari_ibfk_3` FOREIGN KEY (`Hbaitsaagch_id2`) REFERENCES `code_huvaari` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `code_abhuvaari_ibfk_1` FOREIGN KEY (`company_id`, `HBChig_id2`) REFERENCES `code_chiglel` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `code_abhuvaari_ibfk_2` FOREIGN KEY (`company_id`, `HBTorol_id2`) REFERENCES `code_torol` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `code_abhuvaari_ibfk_3` FOREIGN KEY (`company_id`, `Hbaitsaagch_id2`) REFERENCES `code_huvaari` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 --
 -- Constraints for table `code_bkodprim`
 --
 ALTER TABLE `code_bkodprim`
-  ADD CONSTRAINT `code_bkodprim_ibfk_1` FOREIGN KEY (`bkod_Tk_muid`) REFERENCES `code_unit` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `code_bkodprim_ibfk_1` FOREIGN KEY (`company_id`, `bkod_Tk_muid`) REFERENCES `code_unit` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 --
 -- Constraints for table `code_expensebaltype`
 --
 ALTER TABLE `code_expensebaltype`
-  ADD CONSTRAINT `code_expensebaltype_ibfk_2` FOREIGN KEY (`k2`) REFERENCES `code_expenseangilal` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `code_expensebaltype_ibfk_3` FOREIGN KEY (`k3`) REFERENCES `code_expensetype` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `code_expensebaltype_ibfk_4` FOREIGN KEY (`k4`) REFERENCES `code_expenseutga` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `code_expensebaltype_ibfk_5` FOREIGN KEY (`k5`) REFERENCES `code_expensebalancetype` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `code_expensebaltype_ibfk_6` FOREIGN KEY (`k6_`) REFERENCES `code_expensebalancetype` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `code_expensebaltype_ibfk_2` FOREIGN KEY (`company_id`, `k2`) REFERENCES `code_expenseangilal` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `code_expensebaltype_ibfk_3` FOREIGN KEY (`company_id`, `k3`) REFERENCES `code_expensetype` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `code_expensebaltype_ibfk_4` FOREIGN KEY (`company_id`, `k4`) REFERENCES `code_expenseutga` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `code_expensebaltype_ibfk_5` FOREIGN KEY (`company_id`, `k5`) REFERENCES `code_expensebalancetype` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `code_expensebaltype_ibfk_6` FOREIGN KEY (`company_id`, `k6_`) REFERENCES `code_expensebalancetype` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 --
 -- Constraints for table `code_materialprim`
 --
 ALTER TABLE `code_materialprim`
-  ADD CONSTRAINT `code_materialprim_ibfk_1` FOREIGN KEY (`xmkodtk_muid`) REFERENCES `code_unit` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `code_materialprim_ibfk_1` FOREIGN KEY (`company_id`, `xmkodtk_muid`) REFERENCES `code_unit` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 --
 -- Constraints for table `code_workplace`
 --
 ALTER TABLE `code_workplace`
-  ADD CONSTRAINT `code_workplace_ibfk_1` FOREIGN KEY (`workplace_position_id`) REFERENCES `code_position` (`position_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `code_workplace_ibfk_1` FOREIGN KEY (`company_id`, `workplace_position_id`) REFERENCES `code_position` (`company_id`, `position_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 --
 -- Constraints for table `company_module_licenses`
@@ -23681,7 +23681,7 @@ ALTER TABLE `modules`
 -- Constraints for table `request_seen_counts`
 --
 ALTER TABLE `request_seen_counts`
-  ADD CONSTRAINT `fk_seen_emp` FOREIGN KEY (`emp_id`) REFERENCES `tbl_employment` (`employment_emp_id`);
+  ADD CONSTRAINT `fk_seen_emp` FOREIGN KEY (`company_id`, `emp_id`) REFERENCES `tbl_employment` (`employment_company_id`, `employment_emp_id`);
 
 --
 -- Constraints for table `role_default_modules`
@@ -23700,42 +23700,42 @@ ALTER TABLE `role_module_permissions`
 -- Constraints for table `tbl_beltgenniiluulegch`
 --
 ALTER TABLE `tbl_beltgenniiluulegch`
-  ADD CONSTRAINT `tbl_beltgenniiluulegch_ibfk_1` FOREIGN KEY (`manuf_id`) REFERENCES `tbl_contracter` (`manuf_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `tbl_beltgenniiluulegch_ibfk_1` FOREIGN KEY (`company_id`, `manuf_id`) REFERENCES `tbl_contracter` (`company_id`, `manuf_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 --
 -- Constraints for table `tbl_currate`
 --
 ALTER TABLE `tbl_currate`
-  ADD CONSTRAINT `tbl_currate_ibfk_1` FOREIGN KEY (`Valutid`) REFERENCES `code_valut` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `tbl_currate_ibfk_1` FOREIGN KEY (`company_id`, `Valutid`) REFERENCES `code_valut` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 --
 -- Constraints for table `tbl_discount`
 --
 ALTER TABLE `tbl_discount`
-  ADD CONSTRAINT `tbl_discount_ibfk_1` FOREIGN KEY (`branchid`) REFERENCES `code_branches` (`branch_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `tbl_discount_ibfk_1` FOREIGN KEY (`company_id`, `branchid`) REFERENCES `code_branches` (`company_id`, `branch_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 --
 -- Constraints for table `tbl_employment`
 --
 ALTER TABLE `tbl_employment`
   ADD CONSTRAINT `tbl_employment_ibfk_1` FOREIGN KEY (`employment_company_id`) REFERENCES `companies` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `tbl_employment_ibfk_2` FOREIGN KEY (`employment_emp_id`) REFERENCES `tbl_employee` (`emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `tbl_employment_ibfk_3` FOREIGN KEY (`employment_branch_id`) REFERENCES `code_branches` (`branch_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `tbl_employment_ibfk_4` FOREIGN KEY (`employment_department_id`) REFERENCES `code_department` (`department_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `tbl_employment_ibfk_2` FOREIGN KEY (`employment_company_id`, `employment_emp_id`) REFERENCES `tbl_employee` (`Company_id`, `emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `tbl_employment_ibfk_3` FOREIGN KEY (`employment_company_id`, `employment_branch_id`) REFERENCES `code_branches` (`company_id`, `branch_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `tbl_employment_ibfk_4` FOREIGN KEY (`employment_company_id`, `employment_department_id`) REFERENCES `code_department` (`company_id`, `department_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
   ADD CONSTRAINT `tbl_employment_ibfk_5` FOREIGN KEY (`employment_user_level`) REFERENCES `user_levels` (`userlevel_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `tbl_employment_ibfk_6` FOREIGN KEY (`employment_senior_empid`) REFERENCES `tbl_employee` (`emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `tbl_employment_ibfk_6` FOREIGN KEY (`employment_company_id`, `employment_senior_empid`) REFERENCES `tbl_employee` (`Company_id`, `emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 --
 -- Constraints for table `tbl_expenseorg`
 --
 ALTER TABLE `tbl_expenseorg`
-  ADD CONSTRAINT `tbl_expenseorg_ibfk_1` FOREIGN KEY (`z_org_id`) REFERENCES `tbl_contracter` (`manuf_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `tbl_expenseorg_ibfk_1` FOREIGN KEY (`company_id`, `z_org_id`) REFERENCES `tbl_contracter` (`company_id`, `manuf_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 --
 -- Constraints for table `tbl_workplace_schedule`
 --
 ALTER TABLE `tbl_workplace_schedule`
-  ADD CONSTRAINT `tbl_workplace_schedule_ibfk_1` FOREIGN KEY (`ws_emp_id`) REFERENCES `tbl_employee` (`emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `tbl_workplace_schedule_ibfk_1` FOREIGN KEY (`company_id`, `ws_emp_id`) REFERENCES `tbl_employee` (`Company_id`, `emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 --
 -- Constraints for table `transactions_contract`
@@ -23747,10 +23747,10 @@ ALTER TABLE `transactions_contract`
 -- Constraints for table `transactions_expense`
 --
 ALTER TABLE `transactions_expense`
-  ADD CONSTRAINT `transactions_expense_ibfk_1` FOREIGN KEY (`branch_id`) REFERENCES `code_branches` (`branch_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `transactions_expense_ibfk_2` FOREIGN KEY (`z_angilal_b`) REFERENCES `code_branches` (`branch_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `transactions_expense_ibfk_1` FOREIGN KEY (`company_id`, `branch_id`) REFERENCES `code_branches` (`company_id`, `branch_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `transactions_expense_ibfk_2` FOREIGN KEY (`company_id`, `z_angilal_b`) REFERENCES `code_branches` (`company_id`, `branch_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
   ADD CONSTRAINT `transactions_expense_ibfk_3` FOREIGN KEY (`company_id`) REFERENCES `companies` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `transactions_expense_ibfk_4` FOREIGN KEY (`z_from`) REFERENCES `code_cashier` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `transactions_expense_ibfk_4` FOREIGN KEY (`company_id`, `z_from`) REFERENCES `code_cashier` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
   ADD CONSTRAINT `transactions_expense_ibfk_5` FOREIGN KEY (`TransType`) REFERENCES `code_transaction` (`UITransType`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 --
@@ -23764,14 +23764,14 @@ ALTER TABLE `transactions_income`
 --
 ALTER TABLE `transactions_inventory`
   ADD CONSTRAINT `transactions_inventory_ibfk_1` FOREIGN KEY (`company_id`) REFERENCES `companies` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `transactions_inventory_ibfk_2` FOREIGN KEY (`sp_pm_unit_id`) REFERENCES `code_unit` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `transactions_inventory_ibfk_2` FOREIGN KEY (`company_id`, `sp_pm_unit_id`) REFERENCES `code_unit` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 --
 -- Constraints for table `transactions_order`
 --
 ALTER TABLE `transactions_order`
   ADD CONSTRAINT `transactions_order_ibfk_1` FOREIGN KEY (`company_id`) REFERENCES `companies` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `transactions_order_ibfk_2` FOREIGN KEY (`sp_pm_unit_id`) REFERENCES `code_unit` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `transactions_order_ibfk_2` FOREIGN KEY (`company_id`, `sp_pm_unit_id`) REFERENCES `code_unit` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 --
 -- Constraints for table `transactions_plan`
@@ -23783,19 +23783,19 @@ ALTER TABLE `transactions_plan`
 -- Constraints for table `transactions_pos`
 --
 ALTER TABLE `transactions_pos`
-  ADD CONSTRAINT `transactions_pos_ibfk_1` FOREIGN KEY (`branch_id`) REFERENCES `code_branches` (`branch_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `transactions_pos_ibfk_1` FOREIGN KEY (`company_id`, `branch_id`) REFERENCES `code_branches` (`company_id`, `branch_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
   ADD CONSTRAINT `transactions_pos_ibfk_2` FOREIGN KEY (`company_id`) REFERENCES `companies` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `transactions_pos_ibfk_3` FOREIGN KEY (`emp_id`) REFERENCES `tbl_employee` (`emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `transactions_pos_ibfk_5` FOREIGN KEY (`status`) REFERENCES `code_status` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `transactions_pos_ibfk_6` FOREIGN KEY (`payment_type`) REFERENCES `code_cashier` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `transactions_pos_ibfk_8` FOREIGN KEY (`cashback_payment_type`) REFERENCES `code_cashier` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `transactions_pos_ibfk_3` FOREIGN KEY (`company_id`, `emp_id`) REFERENCES `tbl_employee` (`Company_id`, `emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `transactions_pos_ibfk_5` FOREIGN KEY (`company_id`, `status`) REFERENCES `code_status` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `transactions_pos_ibfk_6` FOREIGN KEY (`company_id`, `payment_type`) REFERENCES `code_cashier` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `transactions_pos_ibfk_8` FOREIGN KEY (`company_id`, `cashback_payment_type`) REFERENCES `code_cashier` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 --
 -- Constraints for table `users`
 --
 ALTER TABLE `users`
-  ADD CONSTRAINT `users_ibfk_1` FOREIGN KEY (`empid`) REFERENCES `tbl_employment` (`employment_emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `users_ibfk_2` FOREIGN KEY (`empid`) REFERENCES `tbl_employee` (`emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `users_ibfk_1` FOREIGN KEY (`company_id`, `empid`) REFERENCES `tbl_employment` (`employment_company_id`, `employment_emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `users_ibfk_2` FOREIGN KEY (`company_id`, `empid`) REFERENCES `tbl_employee` (`Company_id`, `emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 --
 -- Constraints for table `user_level_permissions`

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -2166,78 +2166,78 @@ ALTER TABLE `user_levels`
 ALTER TABLE `user_level_permissions`
   MODIFY `id` int NOT NULL AUTO_INCREMENT;
 ALTER TABLE `code_abhuvaari`
-  ADD CONSTRAINT `code_abhuvaari_ibfk_1` FOREIGN KEY (`HBChig_id2`) REFERENCES `code_chiglel` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `code_abhuvaari_ibfk_2` FOREIGN KEY (`HBTorol_id2`) REFERENCES `code_torol` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `code_abhuvaari_ibfk_3` FOREIGN KEY (`Hbaitsaagch_id2`) REFERENCES `code_huvaari` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `code_abhuvaari_ibfk_1` FOREIGN KEY (`company_id`, `HBChig_id2`) REFERENCES `code_chiglel` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `code_abhuvaari_ibfk_2` FOREIGN KEY (`company_id`, `HBTorol_id2`) REFERENCES `code_torol` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `code_abhuvaari_ibfk_3` FOREIGN KEY (`company_id`, `Hbaitsaagch_id2`) REFERENCES `code_huvaari` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 ALTER TABLE `code_bkodprim`
-  ADD CONSTRAINT `code_bkodprim_ibfk_1` FOREIGN KEY (`bkod_Tk_muid`) REFERENCES `code_unit` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `code_bkodprim_ibfk_1` FOREIGN KEY (`company_id`, `bkod_Tk_muid`) REFERENCES `code_unit` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 ALTER TABLE `code_expensebaltype`
-  ADD CONSTRAINT `code_expensebaltype_ibfk_2` FOREIGN KEY (`k2`) REFERENCES `code_expenseangilal` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `code_expensebaltype_ibfk_3` FOREIGN KEY (`k3`) REFERENCES `code_expensetype` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `code_expensebaltype_ibfk_4` FOREIGN KEY (`k4`) REFERENCES `code_expenseutga` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `code_expensebaltype_ibfk_5` FOREIGN KEY (`k5`) REFERENCES `code_expensebalancetype` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `code_expensebaltype_ibfk_6` FOREIGN KEY (`k6_`) REFERENCES `code_expensebalancetype` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `code_expensebaltype_ibfk_2` FOREIGN KEY (`company_id`, `k2`) REFERENCES `code_expenseangilal` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `code_expensebaltype_ibfk_3` FOREIGN KEY (`company_id`, `k3`) REFERENCES `code_expensetype` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `code_expensebaltype_ibfk_4` FOREIGN KEY (`company_id`, `k4`) REFERENCES `code_expenseutga` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `code_expensebaltype_ibfk_5` FOREIGN KEY (`company_id`, `k5`) REFERENCES `code_expensebalancetype` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `code_expensebaltype_ibfk_6` FOREIGN KEY (`company_id`, `k6_`) REFERENCES `code_expensebalancetype` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 ALTER TABLE `code_materialprim`
-  ADD CONSTRAINT `code_materialprim_ibfk_1` FOREIGN KEY (`xmkodtk_muid`) REFERENCES `code_unit` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `code_materialprim_ibfk_1` FOREIGN KEY (`company_id`, `xmkodtk_muid`) REFERENCES `code_unit` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 ALTER TABLE `code_workplace`
-  ADD CONSTRAINT `code_workplace_ibfk_1` FOREIGN KEY (`workplace_position_id`) REFERENCES `code_position` (`position_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `code_workplace_ibfk_1` FOREIGN KEY (`company_id`, `workplace_position_id`) REFERENCES `code_position` (`company_id`, `position_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 ALTER TABLE `company_module_licenses`
   ADD CONSTRAINT `company_module_licenses_ibfk_2` FOREIGN KEY (`module_key`) REFERENCES `modules` (`module_key`) ON DELETE RESTRICT ON UPDATE RESTRICT,
   ADD CONSTRAINT `company_module_licenses_ibfk_3` FOREIGN KEY (`company_id`) REFERENCES `companies` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 ALTER TABLE `modules`
   ADD CONSTRAINT `fk_modules_parent` FOREIGN KEY (`parent_key`) REFERENCES `modules` (`module_key`);
 ALTER TABLE `request_seen_counts`
-  ADD CONSTRAINT `fk_seen_emp` FOREIGN KEY (`emp_id`) REFERENCES `tbl_employment` (`employment_emp_id`);
+  ADD CONSTRAINT `fk_seen_emp` FOREIGN KEY (`company_id`, `emp_id`) REFERENCES `tbl_employment` (`employment_company_id`, `employment_emp_id`);
 ALTER TABLE `role_default_modules`
   ADD CONSTRAINT `role_default_modules_ibfk_2` FOREIGN KEY (`module_key`) REFERENCES `modules` (`module_key`);
 ALTER TABLE `role_module_permissions`
   ADD CONSTRAINT `role_module_permissions_ibfk_1` FOREIGN KEY (`company_id`) REFERENCES `companies` (`id`),
   ADD CONSTRAINT `role_module_permissions_ibfk_3` FOREIGN KEY (`module_key`) REFERENCES `modules` (`module_key`);
 ALTER TABLE `tbl_beltgenniiluulegch`
-  ADD CONSTRAINT `tbl_beltgenniiluulegch_ibfk_1` FOREIGN KEY (`manuf_id`) REFERENCES `tbl_contracter` (`manuf_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `tbl_beltgenniiluulegch_ibfk_1` FOREIGN KEY (`company_id`, `manuf_id`) REFERENCES `tbl_contracter` (`company_id`, `manuf_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 ALTER TABLE `tbl_currate`
-  ADD CONSTRAINT `tbl_currate_ibfk_1` FOREIGN KEY (`Valutid`) REFERENCES `code_valut` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `tbl_currate_ibfk_1` FOREIGN KEY (`company_id`, `Valutid`) REFERENCES `code_valut` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 ALTER TABLE `tbl_discount`
-  ADD CONSTRAINT `tbl_discount_ibfk_1` FOREIGN KEY (`branchid`) REFERENCES `code_branches` (`branch_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `tbl_discount_ibfk_1` FOREIGN KEY (`company_id`, `branchid`) REFERENCES `code_branches` (`company_id`, `branch_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 ALTER TABLE `tbl_employment`
   ADD CONSTRAINT `tbl_employment_ibfk_1` FOREIGN KEY (`employment_company_id`) REFERENCES `companies` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `tbl_employment_ibfk_2` FOREIGN KEY (`employment_emp_id`) REFERENCES `tbl_employee` (`emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `tbl_employment_ibfk_3` FOREIGN KEY (`employment_branch_id`) REFERENCES `code_branches` (`branch_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `tbl_employment_ibfk_4` FOREIGN KEY (`employment_department_id`) REFERENCES `code_department` (`department_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `tbl_employment_ibfk_2` FOREIGN KEY (`employment_company_id`, `employment_emp_id`) REFERENCES `tbl_employee` (`Company_id`, `emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `tbl_employment_ibfk_3` FOREIGN KEY (`employment_company_id`, `employment_branch_id`) REFERENCES `code_branches` (`company_id`, `branch_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `tbl_employment_ibfk_4` FOREIGN KEY (`employment_company_id`, `employment_department_id`) REFERENCES `code_department` (`company_id`, `department_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
   ADD CONSTRAINT `tbl_employment_ibfk_5` FOREIGN KEY (`employment_user_level`) REFERENCES `user_levels` (`userlevel_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `tbl_employment_ibfk_6` FOREIGN KEY (`employment_senior_empid`) REFERENCES `tbl_employee` (`emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `tbl_employment_ibfk_6` FOREIGN KEY (`employment_company_id`, `employment_senior_empid`) REFERENCES `tbl_employee` (`Company_id`, `emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 ALTER TABLE `tbl_expenseorg`
-  ADD CONSTRAINT `tbl_expenseorg_ibfk_1` FOREIGN KEY (`z_org_id`) REFERENCES `tbl_contracter` (`manuf_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `tbl_expenseorg_ibfk_1` FOREIGN KEY (`company_id`, `z_org_id`) REFERENCES `tbl_contracter` (`company_id`, `manuf_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 ALTER TABLE `tbl_workplace_schedule`
-  ADD CONSTRAINT `tbl_workplace_schedule_ibfk_1` FOREIGN KEY (`ws_emp_id`) REFERENCES `tbl_employee` (`emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `tbl_workplace_schedule_ibfk_1` FOREIGN KEY (`company_id`, `ws_emp_id`) REFERENCES `tbl_employee` (`Company_id`, `emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 ALTER TABLE `transactions_contract`
   ADD CONSTRAINT `transactions_contract_ibfk_1` FOREIGN KEY (`company_id`) REFERENCES `companies` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 ALTER TABLE `transactions_expense`
-  ADD CONSTRAINT `transactions_expense_ibfk_1` FOREIGN KEY (`branch_id`) REFERENCES `code_branches` (`branch_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `transactions_expense_ibfk_2` FOREIGN KEY (`z_angilal_b`) REFERENCES `code_branches` (`branch_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `transactions_expense_ibfk_1` FOREIGN KEY (`company_id`, `branch_id`) REFERENCES `code_branches` (`company_id`, `branch_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `transactions_expense_ibfk_2` FOREIGN KEY (`company_id`, `z_angilal_b`) REFERENCES `code_branches` (`company_id`, `branch_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
   ADD CONSTRAINT `transactions_expense_ibfk_3` FOREIGN KEY (`company_id`) REFERENCES `companies` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `transactions_expense_ibfk_4` FOREIGN KEY (`z_from`) REFERENCES `code_cashier` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `transactions_expense_ibfk_4` FOREIGN KEY (`company_id`, `z_from`) REFERENCES `code_cashier` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
   ADD CONSTRAINT `transactions_expense_ibfk_5` FOREIGN KEY (`TransType`) REFERENCES `code_transaction` (`UITransType`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 ALTER TABLE `transactions_income`
   ADD CONSTRAINT `transactions_income_ibfk_1` FOREIGN KEY (`company_id`) REFERENCES `companies` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 ALTER TABLE `transactions_inventory`
   ADD CONSTRAINT `transactions_inventory_ibfk_1` FOREIGN KEY (`company_id`) REFERENCES `companies` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `transactions_inventory_ibfk_2` FOREIGN KEY (`sp_pm_unit_id`) REFERENCES `code_unit` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `transactions_inventory_ibfk_2` FOREIGN KEY (`company_id`, `sp_pm_unit_id`) REFERENCES `code_unit` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 ALTER TABLE `transactions_order`
   ADD CONSTRAINT `transactions_order_ibfk_1` FOREIGN KEY (`company_id`) REFERENCES `companies` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `transactions_order_ibfk_2` FOREIGN KEY (`sp_pm_unit_id`) REFERENCES `code_unit` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `transactions_order_ibfk_2` FOREIGN KEY (`company_id`, `sp_pm_unit_id`) REFERENCES `code_unit` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 ALTER TABLE `transactions_plan`
   ADD CONSTRAINT `transactions_plan_ibfk_1` FOREIGN KEY (`company_id`) REFERENCES `companies` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 ALTER TABLE `transactions_pos`
-  ADD CONSTRAINT `transactions_pos_ibfk_1` FOREIGN KEY (`branch_id`) REFERENCES `code_branches` (`branch_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `transactions_pos_ibfk_1` FOREIGN KEY (`company_id`, `branch_id`) REFERENCES `code_branches` (`company_id`, `branch_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
   ADD CONSTRAINT `transactions_pos_ibfk_2` FOREIGN KEY (`company_id`) REFERENCES `companies` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `transactions_pos_ibfk_3` FOREIGN KEY (`emp_id`) REFERENCES `tbl_employee` (`emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `transactions_pos_ibfk_5` FOREIGN KEY (`status`) REFERENCES `code_status` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `transactions_pos_ibfk_6` FOREIGN KEY (`payment_type`) REFERENCES `code_cashier` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `transactions_pos_ibfk_8` FOREIGN KEY (`cashback_payment_type`) REFERENCES `code_cashier` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `transactions_pos_ibfk_3` FOREIGN KEY (`company_id`, `emp_id`) REFERENCES `tbl_employee` (`Company_id`, `emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `transactions_pos_ibfk_5` FOREIGN KEY (`company_id`, `status`) REFERENCES `code_status` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `transactions_pos_ibfk_6` FOREIGN KEY (`company_id`, `payment_type`) REFERENCES `code_cashier` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `transactions_pos_ibfk_8` FOREIGN KEY (`company_id`, `cashback_payment_type`) REFERENCES `code_cashier` (`company_id`, `id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 ALTER TABLE `users`
-  ADD CONSTRAINT `users_ibfk_1` FOREIGN KEY (`empid`) REFERENCES `tbl_employment` (`employment_emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `users_ibfk_2` FOREIGN KEY (`empid`) REFERENCES `tbl_employee` (`emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD CONSTRAINT `users_ibfk_1` FOREIGN KEY (`company_id`, `empid`) REFERENCES `tbl_employment` (`employment_company_id`, `employment_emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  ADD CONSTRAINT `users_ibfk_2` FOREIGN KEY (`company_id`, `empid`) REFERENCES `tbl_employee` (`Company_id`, `emp_id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 ALTER TABLE `user_level_permissions`
   ADD CONSTRAINT `user_level_permissions_ibfk_1` FOREIGN KEY (`userlevel_id`) REFERENCES `user_levels` (`userlevel_id`),
   ADD CONSTRAINT `user_level_permissions_ibfk_2` FOREIGN KEY (`company_id`) REFERENCES `companies` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;


### PR DESCRIPTION
## Summary
- add company_id to cross-table references and redefine FKs to pair company_id with ids
- join users to employment by company and employee
- ensure activity log lookups filter by company

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b67d09e1108331aae8116ff7a1f56a