### PR TITLE
Wrap settings fields with TooltipWrapper

### DIFF
--- a/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
+++ b/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
@@ -147,251 +147,388 @@ export default function GeneralConfiguration() {
             </TooltipWrapper>
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
-            <label>
-              Box Height{' '}
-              <input
-                name="boxHeight"
-                type="number"
-                inputMode="decimal"
-                value={active.boxHeight ?? ''}
-                onChange={handleChange}
-              />
-            </label>
+            <TooltipWrapper
+              title={t('box_height', { ns: 'tooltip', defaultValue: 'Input box height' })}
+            >
+              <label>
+                Box Height{' '}
+                <input
+                  name="boxHeight"
+                  type="number"
+                  inputMode="decimal"
+                  value={active.boxHeight ?? ''}
+                  onChange={handleChange}
+                />
+              </label>
+            </TooltipWrapper>
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
-            <label>
-              Box Max Width{' '}
-              <input
-                name="boxMaxWidth"
-                type="number"
-                inputMode="decimal"
-                value={active.boxMaxWidth ?? ''}
-                onChange={handleChange}
-              />
-            </label>
+            <TooltipWrapper
+              title={t('box_max_width', {
+                ns: 'tooltip',
+                defaultValue: 'Max input box width',
+              })}
+            >
+              <label>
+                Box Max Width{' '}
+                <input
+                  name="boxMaxWidth"
+                  type="number"
+                  inputMode="decimal"
+                  value={active.boxMaxWidth ?? ''}
+                  onChange={handleChange}
+                />
+              </label>
+            </TooltipWrapper>
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
-            <label>
-              Box Max Height{' '}
-              <input
-                name="boxMaxHeight"
-                type="number"
-                inputMode="decimal"
-                value={active.boxMaxHeight ?? ''}
-                onChange={handleChange}
-              />
-            </label>
+            <TooltipWrapper
+              title={t('box_max_height', {
+                ns: 'tooltip',
+                defaultValue: 'Max input box height',
+              })}
+            >
+              <label>
+                Box Max Height{' '}
+                <input
+                  name="boxMaxHeight"
+                  type="number"
+                  inputMode="decimal"
+                  value={active.boxMaxHeight ?? ''}
+                  onChange={handleChange}
+                />
+              </label>
+            </TooltipWrapper>
           </div>
         </>
       ) : tab === 'images' ? (
         <>
           <div style={{ marginBottom: '0.5rem' }}>
-            <label>
-              Base Path{' '}
-              <input
-                name="basePath"
-                type="text"
-                value={active.basePath ?? ''}
-                onChange={handleChange}
-              />
-            </label>
+            <TooltipWrapper
+              title={t('base_path', {
+                ns: 'tooltip',
+                defaultValue: 'Base path for images',
+              })}
+            >
+              <label>
+                Base Path{' '}
+                <input
+                  name="basePath"
+                  type="text"
+                  value={active.basePath ?? ''}
+                  onChange={handleChange}
+                />
+              </label>
+            </TooltipWrapper>
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
-            <label>
-              Cleanup Days{' '}
-              <input
-                name="cleanupDays"
-                type="number"
-                inputMode="decimal"
-                value={active.cleanupDays ?? ''}
-                onChange={handleChange}
-                style={{ width: '4rem' }}
-              />
-            </label>
+            <TooltipWrapper
+              title={t('cleanup_days', {
+                ns: 'tooltip',
+                defaultValue: 'Days to retain images',
+              })}
+            >
+              <label>
+                Cleanup Days{' '}
+                <input
+                  name="cleanupDays"
+                  type="number"
+                  inputMode="decimal"
+                  value={active.cleanupDays ?? ''}
+                  onChange={handleChange}
+                  style={{ width: '4rem' }}
+                />
+              </label>
+            </TooltipWrapper>
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
-            <label>
-              Ignore on Search
-              <textarea
-                name="ignoreOnSearch"
-                value={(active.ignoreOnSearch || []).join('\n')}
-                onChange={(e) => {
-                  const list = e.target.value
-                    .split('\n')
-                    .map((s) => s.trim())
-                    .filter(Boolean);
-                  setCfg((c) => ({
-                    ...c,
-                    images: { ...(c.images || {}), ignoreOnSearch: list },
-                  }));
-                }}
-                rows={3}
-                style={{ display: 'block', width: '100%', marginTop: '0.25rem' }}
-              />
-            </label>
+            <TooltipWrapper
+              title={t('ignore_on_search', {
+                ns: 'tooltip',
+                defaultValue: 'Images to ignore during search',
+              })}
+            >
+              <label>
+                Ignore on Search
+                <textarea
+                  name="ignoreOnSearch"
+                  value={(active.ignoreOnSearch || []).join('\n')}
+                  onChange={(e) => {
+                    const list = e.target.value
+                      .split('\n')
+                      .map((s) => s.trim())
+                      .filter(Boolean);
+                    setCfg((c) => ({
+                      ...c,
+                      images: { ...(c.images || {}), ignoreOnSearch: list },
+                    }));
+                  }}
+                  rows={3}
+                  style={{ display: 'block', width: '100%', marginTop: '0.25rem' }}
+                />
+              </label>
+            </TooltipWrapper>
           </div>
         </>
       ) : (
         <>
           <div style={{ marginBottom: '0.5rem' }}>
-            <label>
-              Stored Procedure Prefix{' '}
-              <input
-                name="reportProcPrefix"
-                type="text"
-                value={active.reportProcPrefix ?? ''}
-                onChange={handleChange}
-                style={{ width: '8rem' }}
-              />
-            </label>
+            <TooltipWrapper
+              title={t('report_proc_prefix', {
+                ns: 'tooltip',
+                defaultValue: 'Prefix for report stored procedures',
+              })}
+            >
+              <label>
+                Stored Procedure Prefix{' '}
+                <input
+                  name="reportProcPrefix"
+                  type="text"
+                  value={active.reportProcPrefix ?? ''}
+                  onChange={handleChange}
+                  style={{ width: '8rem' }}
+                />
+              </label>
+            </TooltipWrapper>
             <div style={{ fontSize: '0.8rem' }}>Prepended to report stored procedure names</div>
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
-            <label>
-              View Prefix{' '}
-              <input
-                name="reportViewPrefix"
-                type="text"
-                value={active.reportViewPrefix ?? ''}
-                onChange={handleChange}
-                style={{ width: '8rem' }}
-              />
-            </label>
+            <TooltipWrapper
+              title={t('report_view_prefix', {
+                ns: 'tooltip',
+                defaultValue: 'Prefix for report views',
+              })}
+            >
+              <label>
+                View Prefix{' '}
+                <input
+                  name="reportViewPrefix"
+                  type="text"
+                  value={active.reportViewPrefix ?? ''}
+                  onChange={handleChange}
+                  style={{ width: '8rem' }}
+                />
+              </label>
+            </TooltipWrapper>
             <div style={{ fontSize: '0.8rem' }}>Prepended to report view names</div>
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
-            <label>
-              Enable AI API{' '}
-              <input
-                name="aiApiEnabled"
-                type="checkbox"
-                checked={active.aiApiEnabled ?? false}
-                onChange={handleChange}
-              />
-            </label>
+            <TooltipWrapper
+              title={t('ai_api_enabled', {
+                ns: 'tooltip',
+                defaultValue: 'Enable AI API',
+              })}
+            >
+              <label>
+                Enable AI API{' '}
+                <input
+                  name="aiApiEnabled"
+                  type="checkbox"
+                  checked={active.aiApiEnabled ?? false}
+                  onChange={handleChange}
+                />
+              </label>
+            </TooltipWrapper>
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
-            <label>
-              Enable AI Inventory API{' '}
-              <input
-                name="aiInventoryApiEnabled"
-                type="checkbox"
-                checked={active.aiInventoryApiEnabled ?? false}
-                onChange={handleChange}
-              />
-            </label>
+            <TooltipWrapper
+              title={t('ai_inventory_api_enabled', {
+                ns: 'tooltip',
+                defaultValue: 'Enable AI inventory API',
+              })}
+            >
+              <label>
+                Enable AI Inventory API{' '}
+                <input
+                  name="aiInventoryApiEnabled"
+                  type="checkbox"
+                  checked={active.aiInventoryApiEnabled ?? false}
+                  onChange={handleChange}
+                />
+              </label>
+            </TooltipWrapper>
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
-            <label>
-              Show Trigger Toasts{' '}
-              <input
-                name="triggerToastEnabled"
-                type="checkbox"
-                checked={active.triggerToastEnabled ?? false}
-                onChange={handleChange}
-              />
-            </label>
+            <TooltipWrapper
+              title={t('trigger_toast_enabled', {
+                ns: 'tooltip',
+                defaultValue: 'Display trigger messages as toasts',
+              })}
+            >
+              <label>
+                Show Trigger Toasts{' '}
+                <input
+                  name="triggerToastEnabled"
+                  type="checkbox"
+                  checked={active.triggerToastEnabled ?? false}
+                  onChange={handleChange}
+                />
+              </label>
+            </TooltipWrapper>
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
-            <label>
-              Show Procedure Toasts{' '}
-              <input
-                name="procToastEnabled"
-                type="checkbox"
-                checked={active.procToastEnabled ?? false}
-                onChange={handleChange}
-              />
-            </label>
+            <TooltipWrapper
+              title={t('proc_toast_enabled', {
+                ns: 'tooltip',
+                defaultValue: 'Display procedure messages as toasts',
+              })}
+            >
+              <label>
+                Show Procedure Toasts{' '}
+                <input
+                  name="procToastEnabled"
+                  type="checkbox"
+                  checked={active.procToastEnabled ?? false}
+                  onChange={handleChange}
+                />
+              </label>
+            </TooltipWrapper>
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
-            <label>
-              Show View Lookup Toasts{' '}
-              <input
-                name="viewToastEnabled"
-                type="checkbox"
-                checked={active.viewToastEnabled ?? false}
-                onChange={handleChange}
-              />
-            </label>
+            <TooltipWrapper
+              title={t('view_toast_enabled', {
+                ns: 'tooltip',
+                defaultValue: 'Display view lookup toasts',
+              })}
+            >
+              <label>
+                Show View Lookup Toasts{' '}
+                <input
+                  name="viewToastEnabled"
+                  type="checkbox"
+                  checked={active.viewToastEnabled ?? false}
+                  onChange={handleChange}
+                />
+              </label>
+            </TooltipWrapper>
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
-            <label>
-              Show Report Row Toasts{' '}
-              <input
-                name="reportRowToastEnabled"
-                type="checkbox"
-                checked={active.reportRowToastEnabled ?? false}
-                onChange={handleChange}
-              />
-            </label>
+            <TooltipWrapper
+              title={t('report_row_toast_enabled', {
+                ns: 'tooltip',
+                defaultValue: 'Display report row toasts',
+              })}
+            >
+              <label>
+                Show Report Row Toasts{' '}
+                <input
+                  name="reportRowToastEnabled"
+                  type="checkbox"
+                  checked={active.reportRowToastEnabled ?? false}
+                  onChange={handleChange}
+                />
+              </label>
+            </TooltipWrapper>
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
-            <label>
-              Show Image Toasts{' '}
-              <input
-                name="imageToastEnabled"
-                type="checkbox"
-                checked={active.imageToastEnabled ?? false}
-                onChange={handleChange}
-              />
-            </label>
+            <TooltipWrapper
+              title={t('image_toast_enabled', {
+                ns: 'tooltip',
+                defaultValue: 'Display image toasts',
+              })}
+            >
+              <label>
+                Show Image Toasts{' '}
+                <input
+                  name="imageToastEnabled"
+                  type="checkbox"
+                  checked={active.imageToastEnabled ?? false}
+                  onChange={handleChange}
+                />
+              </label>
+            </TooltipWrapper>
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
-            <label>
-              Enable Field Label Editing{' '}
-              <input
-                name="editLabelsEnabled"
-                type="checkbox"
-                checked={active.editLabelsEnabled ?? false}
-                onChange={handleChange}
-              />
-            </label>
+            <TooltipWrapper
+              title={t('edit_labels_enabled', {
+                ns: 'tooltip',
+                defaultValue: 'Allow editing field labels',
+              })}
+            >
+              <label>
+                Enable Field Label Editing{' '}
+                <input
+                  name="editLabelsEnabled"
+                  type="checkbox"
+                  checked={active.editLabelsEnabled ?? false}
+                  onChange={handleChange}
+                />
+              </label>
+            </TooltipWrapper>
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
-            <label>
-              Show Report Parameters{' '}
-              <input
-                name="showReportParams"
-                type="checkbox"
-                checked={active.showReportParams ?? false}
-                onChange={handleChange}
-              />
-            </label>
+            <TooltipWrapper
+              title={t('show_report_params', {
+                ns: 'tooltip',
+                defaultValue: 'Display report parameters',
+              })}
+            >
+              <label>
+                Show Report Parameters{' '}
+                <input
+                  name="showReportParams"
+                  type="checkbox"
+                  checked={active.showReportParams ?? false}
+                  onChange={handleChange}
+                />
+              </label>
+            </TooltipWrapper>
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
-            <label>
-              Enable Debug Logging{' '}
-              <input
-                name="debugLoggingEnabled"
-                type="checkbox"
-                checked={active.debugLoggingEnabled ?? false}
-                onChange={handleChange}
-              />
-            </label>
+            <TooltipWrapper
+              title={t('debug_logging_enabled', {
+                ns: 'tooltip',
+                defaultValue: 'Enable debug logging',
+              })}
+            >
+              <label>
+                Enable Debug Logging{' '}
+                <input
+                  name="debugLoggingEnabled"
+                  type="checkbox"
+                  checked={active.debugLoggingEnabled ?? false}
+                  onChange={handleChange}
+                />
+              </label>
+            </TooltipWrapper>
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
-            <label>
-              Enable Request Polling{' '}
-              <input
-                name="requestPollingEnabled"
-                type="checkbox"
-                checked={active.requestPollingEnabled ?? false}
-                onChange={handleChange}
-              />
-            </label>
+            <TooltipWrapper
+              title={t('request_polling_enabled', {
+                ns: 'tooltip',
+                defaultValue: 'Periodically fetch pending requests',
+              })}
+            >
+              <label>
+                Enable Request Polling{' '}
+                <input
+                  name="requestPollingEnabled"
+                  type="checkbox"
+                  checked={active.requestPollingEnabled ?? false}
+                  onChange={handleChange}
+                />
+              </label>
+            </TooltipWrapper>
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
-            <label>
-              Request Polling Interval (seconds){' '}
-              <input
-                name="requestPollingIntervalSeconds"
-                type="number"
-                min={1}
-                value={active.requestPollingIntervalSeconds ?? 30}
-                onChange={handleChange}
-                style={{ width: '4rem' }}
-              />
-            </label>
+            <TooltipWrapper
+              title={t('request_polling_interval', {
+                ns: 'tooltip',
+                defaultValue: 'Seconds between request polls',
+              })}
+            >
+              <label>
+                Request Polling Interval (seconds){' '}
+                <input
+                  name="requestPollingIntervalSeconds"
+                  type="number"
+                  min={1}
+                  value={active.requestPollingIntervalSeconds ?? 30}
+                  onChange={handleChange}
+                  style={{ width: '4rem' }}
+                />
+              </label>
+            </TooltipWrapper>
           </div>
         </>
       )}

--- a/src/erp.mgt.mn/pages/UserSettings.jsx
+++ b/src/erp.mgt.mn/pages/UserSettings.jsx
@@ -72,15 +72,24 @@ function UserManualTab() {
   const toursEnabled = userSettings.settings_enable_tours ?? false;
   return (
     <div>
-      <label>
-        <input
-          id="show-page-guide-toggle"
-          type="checkbox"
-          checked={toursEnabled}
-          onChange={(e) => updateUserSettings({ settings_enable_tours: e.target.checked })}
-        />{' '}
-        {t('settings_enable_tours', 'Show page guide')}
-      </label>
+      <TooltipWrapper
+        title={t('settings_enable_tours', {
+          ns: 'tooltip',
+          defaultValue: 'Show page guide',
+        })}
+      >
+        <label>
+          <input
+            id="show-page-guide-toggle"
+            type="checkbox"
+            checked={toursEnabled}
+            onChange={(e) =>
+              updateUserSettings({ settings_enable_tours: e.target.checked })
+            }
+          />{' '}
+          {t('settings_enable_tours', 'Show page guide')}
+        </label>
+      </TooltipWrapper>
     </div>
   );
 }
@@ -97,20 +106,27 @@ function PrinterSettingsTab() {
   }, []);
   return (
     <div>
-      <label>
-        {t('printer', 'Printer')}: {' '}
-        <select
-          value={userSettings.printerId || ''}
-          onChange={(e) => updateUserSettings({ printerId: e.target.value })}
-        >
-          <option value="">{t('select_printer', 'Select printer')}</option>
-          {printers.map((p) => (
-            <option key={p.id} value={p.id}>
-              {p.name}
-            </option>
-          ))}
-        </select>
-      </label>
+      <TooltipWrapper
+        title={t('select_printer', {
+          ns: 'tooltip',
+          defaultValue: 'Select printer',
+        })}
+      >
+        <label>
+          {t('printer', 'Printer')}: {' '}
+          <select
+            value={userSettings.printerId || ''}
+            onChange={(e) => updateUserSettings({ printerId: e.target.value })}
+          >
+            <option value="">{t('select_printer', 'Select printer')}</option>
+            {printers.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </TooltipWrapper>
     </div>
   );
 }
@@ -120,20 +136,27 @@ function ProfileSettingsTab() {
   const { lang, setLang } = useContext(LangContext);
   return (
     <div>
-      <label>
-        {t('language', 'Language')}: {' '}
-        <select value={lang} onChange={(e) => setLang(e.target.value)}>
-          <option value="en">English</option>
-          <option value="mn">Mongolian</option>
-          <option value="ja">Japanese</option>
-          <option value="ko">Korean</option>
-          <option value="zh">Chinese</option>
-          <option value="es">Spanish</option>
-          <option value="de">German</option>
-          <option value="fr">French</option>
-          <option value="ru">Russian</option>
-        </select>
-      </label>
+      <TooltipWrapper
+        title={t('language', {
+          ns: 'tooltip',
+          defaultValue: 'Select language',
+        })}
+      >
+        <label>
+          {t('language', 'Language')}: {' '}
+          <select value={lang} onChange={(e) => setLang(e.target.value)}>
+            <option value="en">English</option>
+            <option value="mn">Mongolian</option>
+            <option value="ja">Japanese</option>
+            <option value="ko">Korean</option>
+            <option value="zh">Chinese</option>
+            <option value="es">Spanish</option>
+            <option value="de">German</option>
+            <option value="fr">French</option>
+            <option value="ru">Russian</option>
+          </select>
+        </label>
+      </TooltipWrapper>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- use TooltipWrapper for user settings fields with localized tooltip text
- add tooltip coverage to general configuration inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6899768108331b75763faacd4f328