### PR TITLE
Add AI translation fallback for user manuals

### DIFF
--- a/docs/openai-usage.md
+++ b/docs/openai-usage.md
@@ -25,6 +25,12 @@ The file [`docs/openai-floating-bar.html`](./openai-floating-bar.html) demonstra
 
 The bar adapts to smaller screens and can be reopened via the "AI" button when collapsed.
 
+## Automatic Translation
+
+The front-end utility [`translateWithAI`](../src/erp.mgt.mn/utils/translateWithAI.js) loads strings from the locale files under `src/erp.mgt.mn/locales/`. When a key is missing, it posts the source text to `/api/openai` to request a translation into the desired language. Responses are cached in the browser's `localStorage` using keys of the form `ai-translations-<lang>`. Remove those entries to clear cached translations.
+
+The API route uses the `OPENAI_API_KEY` environment variable shown above; ensure it is set before starting the server so translation requests succeed. If the feature is disabled or the server returns a 404, the helper silently falls back to the source text without showing error toasts.
+
 ## Benchmark Image Lookup
 
 Server code also exposes `findBenchmarkCode` for resolving a transaction type code from an uploaded image name. See [Benchmark Image Verification](./benchmark-image-verification.md) for details.

--- a/src/erp.mgt.mn/utils/translateWithAI.js
+++ b/src/erp.mgt.mn/utils/translateWithAI.js
@@ -1,0 +1,65 @@
+const localeCache = {};
+const aiCache = {};
+let aiDisabled = false;
+
+async function loadLocale(lang) {
+  if (!localeCache[lang]) {
+    try {
+      localeCache[lang] = (await import(`../locales/${lang}.json`)).default;
+    } catch (err) {
+      console.error('Failed to load locale', lang, err);
+      localeCache[lang] = {};
+    }
+  }
+  return localeCache[lang];
+}
+
+function getCache(lang) {
+  if (!aiCache[lang]) {
+    try {
+      aiCache[lang] = JSON.parse(localStorage.getItem(`ai-translations-${lang}`) || '{}');
+    } catch {
+      aiCache[lang] = {};
+    }
+  }
+  return aiCache[lang];
+}
+
+function saveCache(lang) {
+  localStorage.setItem(`ai-translations-${lang}`, JSON.stringify(aiCache[lang]));
+}
+
+async function requestAI(text, lang) {
+  if (aiDisabled) return text;
+  try {
+    const res = await fetch('/api/openai', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: `Translate the following text to ${lang}: ${text}` }),
+      skipErrorToast: true,
+      skipLoader: true,
+    });
+    if (res.status === 404) {
+      aiDisabled = true;
+      return text;
+    }
+    if (!res.ok) throw new Error('AI request failed');
+    const data = await res.json();
+    return data.response?.trim() || text;
+  } catch (err) {
+    console.error('AI translation failed', err);
+    return text;
+  }
+}
+
+export default async function translateWithAI(lang, key, fallback) {
+  const locales = await loadLocale(lang);
+  if (locales[key]) return locales[key];
+  const cache = getCache(lang);
+  if (cache[key]) return cache[key];
+  const text = fallback ?? key;
+  const translated = await requestAI(text, lang);
+  cache[key] = translated;
+  saveCache(lang);
+  return translated;
+}


### PR DESCRIPTION
## Summary
- allow selecting manual export language and translate strings using OpenAI
- add `translateWithAI` helper with localStorage caching and ignore errors when AI feature is disabled
- document API key setup, clearing translation cache, and silent fallback when AI translation is unavailable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7a4890d188331a0009f8a33bc8692