### PR TITLE
feat: resilient translation fallbacks

### DIFF
--- a/scripts/generateManuals.js
+++ b/scripts/generateManuals.js
@@ -37,14 +37,9 @@ function moduleSlug(key) {
 
 async function loadLabels(lang = 'en') {
   const headerMap = await loadJSON(path.join(configDir, 'headerMappings.json'));
-  const locale = await loadJSON(
-    path.join(rootDir, 'src', 'erp.mgt.mn', 'locales', `${lang}.json`),
-  );
   const translate = async (key) => {
-    const mapped = headerMap[key] || key;
-    if (locale[mapped]) return locale[mapped];
-    if (lang === 'en') return mapped;
-    return translateWithCache(lang, mapped);
+    const fallback = headerMap[key];
+    return translateWithCache(lang, key, fallback);
   };
   return translate;
 }
@@ -97,6 +92,7 @@ async function captureScreenshot(url, requiredFields) {
 }
 
 async function generateManualForModule(module, translate, configs, options) {
+  const { lang } = options;
   const slug = moduleSlug(module.module_key);
   let md = `# ${await translate(module.module_key)}\n\n`;
 
@@ -108,38 +104,39 @@ async function generateManualForModule(module, translate, configs, options) {
 
   const formsCfg = configs.transactionForms[module.module_key] || {};
   for (const [formName, formCfg] of Object.entries(formsCfg)) {
-    md += `## ${formName}\n`;
+    const fTitle = await translate(formName);
+    md += `## ${fTitle}\n`;
     if (formCfg.visibleFields?.length) {
       const vis = await Promise.all(formCfg.visibleFields.map((f) => translate(f)));
-      md += `- Visible: ${vis.join(', ')}\n`;
+      md += `- ${await translateWithCache(lang, 'visible', 'Visible')}: ${vis.join(', ')}\n`;
     }
     if (formCfg.requiredFields?.length) {
       const req = await Promise.all(formCfg.requiredFields.map((f) => translate(f)));
-      md += `- Required: ${req.join(', ')}\n`;
+      md += `- ${await translateWithCache(lang, 'required', 'Required')}: ${req.join(', ')}\n`;
     }
     if (formCfg.defaultValues && Object.keys(formCfg.defaultValues).length) {
       const defsArr = await Promise.all(
         Object.entries(formCfg.defaultValues).map(async ([k, v]) => `${await translate(k)}=${v}`),
       );
-      md += `- Defaults: ${defsArr.join(', ')}\n`;
+      md += `- ${await translateWithCache(lang, 'defaults', 'Defaults')}: ${defsArr.join(', ')}\n`;
     }
     if (formCfg.conditions && Object.keys(formCfg.conditions).length) {
-      md += `- Conditions: ${JSON.stringify(formCfg.conditions)}\n`;
+      md += `- ${await translateWithCache(lang, 'conditions', 'Conditions')}: ${JSON.stringify(formCfg.conditions)}\n`;
     }
     md += '\n';
   }
 
   const tableCfg = configs.tableDisplayFields[module.module_key];
   if (tableCfg) {
-    md += `### Table Display\n`;
-    md += `- ID Field: ${await translate(tableCfg.idField)}\n`;
+    md += `### ${await translateWithCache(lang, 'tableDisplay', 'Table Display')}\n`;
+    md += `- ${await translateWithCache(lang, 'idField', 'ID Field')}: ${await translate(tableCfg.idField)}\n`;
     const display = await Promise.all(tableCfg.displayFields.map((f) => translate(f)));
-    md += `- Display Fields: ${display.join(', ')}\n`;
+    md += `- ${await translateWithCache(lang, 'displayFields', 'Display Fields')}: ${display.join(', ')}\n`;
     if (tableCfg.tooltips) {
       const tipsArr = await Promise.all(
         Object.entries(tableCfg.tooltips).map(async ([k, v]) => `${await translate(k)}: ${await translate(v)}`),
       );
-      md += `- Tooltips: ${tipsArr.join(', ')}\n`;
+      md += `- ${await translateWithCache(lang, 'tooltips', 'Tooltips')}: ${tipsArr.join(', ')}\n`;
     }
     md += '\n';
   }
@@ -162,9 +159,11 @@ async function generateManualForModule(module, translate, configs, options) {
 
 async function main() {
   const baseUrl = process.env.BASE_URL || 'http://localhost:3000';
-  const capture = process.argv.includes('--capture');
+  const args = process.argv.slice(2);
+  const capture = args.includes('--capture');
+  const lang = args.find((a) => !a.startsWith('--')) || 'en';
 
-  const translate = await loadLabels('en');
+  const translate = await loadLabels(lang);
   const configs = await collectConfigs();
   await fs.mkdir(manualsDir, { recursive: true });
 
@@ -175,6 +174,7 @@ async function main() {
     const manual = await generateManualForModule(mod, translate, configs, {
       capture,
       baseUrl,
+      lang,
     });
     const mdFile = path.join(manualsDir, `${mod.module_key}.md`);
     const htmlFile = path.join(manualsDir, `${mod.module_key}.html`);

--- a/src/erp.mgt.mn/pages/UserManualExport.jsx
+++ b/src/erp.mgt.mn/pages/UserManualExport.jsx
@@ -5,7 +5,6 @@ import I18nContext from "../context/I18nContext.jsx";
 import { AuthContext } from "../context/AuthContext.jsx";
 import { useToast } from "../context/ToastContext.jsx";
 import useHeaderMappings from "../hooks/useHeaderMappings.js";
-import translateWithAI from "../utils/translateWithAI.js";
 import translateWithCache from "../utils/translateWithCache.js";
 import transactionForms from "../../../config/transactionForms.json";
 
@@ -156,29 +155,19 @@ export default function UserManualExport() {
     return <p>{t("accessDenied", "Access denied", { lng: lang })}</p>;
   }
 
-  function describe(key) {
-    return key
-      .replace(/_/g, " ")
-      .replace(/\b\w/g, (c) => c.toUpperCase());
-  }
-
   async function translate(key) {
     if (!key) return "";
     if (headerMap[key]) return headerMap[key];
-    const tr = t(key, "", { lng: lang });
-    if (tr && tr !== key) return tr;
-    const desc = describe(key);
-    if (lang === "en") return desc;
-    return translateWithCache(lang, desc);
+    return translateWithCache(lang, key);
   }
 
   async function buildMarkdown() {
-    let md = `# ${await translateWithAI(lang, "userManual", "User Manual")}\n\n`;
-    md += `## ${await translateWithAI(lang, "forms", "Forms")}\n`;
+    let md = `# ${await translateWithCache(lang, "userManual", "User Manual")}\n\n`;
+    md += `## ${await translateWithCache(lang, "forms", "Forms")}\n`;
     for (const [mKey, mod] of Object.entries(manual)) {
       if (!mod.forms.length) continue;
       md += `### ${await translate(mKey)}\n`;
-      md += `| ${await translateWithAI(lang, "formName", "Form Name")} | ${await translateWithAI(lang, "identifier", "Identifier")} | ${await translateWithAI(lang, "description", "Description")} |\n`;
+      md += `| ${await translateWithCache(lang, "formName", "Form Name")} | ${await translateWithCache(lang, "identifier", "Identifier")} | ${await translateWithCache(lang, "description", "Description")} |\n`;
       md += `| --- | --- | --- |\n`;
       for (const form of mod.forms) {
         const formName = await translate(form.key);
@@ -191,12 +180,12 @@ export default function UserManualExport() {
           })();
         if (!formDesc) {
           const intro = `This form enables authorised users to manage records related to ${formName}.`;
-          formDesc = await translateWithAI(lang, "formIntro", intro);
+          formDesc = await translateWithCache(lang, "formIntro", intro);
         }
         md += `| ${formName} | ${form.key} | ${formDesc} |\n`;
         if (form.buttons?.length) {
-          md += `\n#### ${formName} ${await translateWithAI(lang, "buttons", "Buttons")}\n`;
-          md += `| ${await translateWithAI(lang, "buttonName", "Button Name")} | ${await translateWithAI(lang, "identifier", "Identifier")} | ${await translateWithAI(lang, "description", "Description")} |\n`;
+          md += `\n#### ${formName} ${await translateWithCache(lang, "buttons", "Buttons")}\n`;
+          md += `| ${await translateWithCache(lang, "buttonName", "Button Name")} | ${await translateWithCache(lang, "identifier", "Identifier")} | ${await translateWithCache(lang, "description", "Description")} |\n`;
           md += `| --- | --- | --- |\n`;
           for (const btn of form.buttons) {
             const bKey = typeof btn === "string" ? btn : btn.key;
@@ -220,7 +209,7 @@ export default function UserManualExport() {
               sentenceDefault += ` Requires: ${rfNames.join(", ")}.`;
             }
             if (!bDesc) {
-              bDesc = await translateWithAI(lang, "buttonPurposeDetail", sentenceDefault);
+              bDesc = await translateWithCache(lang, "buttonPurposeDetail", sentenceDefault);
             }
             md += `| ${bName} | ${bKey} | ${bDesc} |\n`;
           }
@@ -228,11 +217,11 @@ export default function UserManualExport() {
       }
     }
 
-    md += `\n## ${await translateWithAI(lang, "reports", "Reports")}\n`;
+    md += `\n## ${await translateWithCache(lang, "reports", "Reports")}\n`;
     for (const [mKey, mod] of Object.entries(manual)) {
       if (!mod.reports.length) continue;
       md += `### ${await translate(mKey)}\n`;
-      md += `| ${await translateWithAI(lang, "reportName", "Report Name")} | ${await translateWithAI(lang, "identifier", "Identifier")} | ${await translateWithAI(lang, "description", "Description")} |\n`;
+      md += `| ${await translateWithCache(lang, "reportName", "Report Name")} | ${await translateWithCache(lang, "identifier", "Identifier")} | ${await translateWithCache(lang, "description", "Description")} |\n`;
       md += `| --- | --- | --- |\n`;
       for (const r of mod.reports) {
           const k = typeof r === "string" ? r : r.key;
@@ -246,19 +235,19 @@ export default function UserManualExport() {
             })();
           if (!rDesc) {
             const sentenceDefault = `The ${reportName} report provides a comprehensive overview of the associated data set, presenting information in a structured and readable manner for further analysis.`;
-            rDesc = await translateWithAI(lang, "reportPurposeDetail", sentenceDefault);
+            rDesc = await translateWithCache(lang, "reportPurposeDetail", sentenceDefault);
           }
           md += `| ${reportName} | ${k} | ${rDesc} |\n`;
       }
     }
 
-    md += `\n## ${await translateWithAI(lang, "settings", "Settings")}\n`;
+    md += `\n## ${await translateWithCache(lang, "settings", "Settings")}\n`;
     for (const [mKey, mod] of Object.entries(manual)) {
       if (!mod.buttons.length && !mod.functions.length) continue;
       md += `### ${await translate(mKey)}\n`;
       if (mod.buttons.length) {
-        md += `#### ${await translateWithAI(lang, "buttons", "Buttons")}\n`;
-        md += `| ${await translateWithAI(lang, "buttonName", "Button Name")} | ${await translateWithAI(lang, "identifier", "Identifier")} | ${await translateWithAI(lang, "description", "Description")} |\n`;
+        md += `#### ${await translateWithCache(lang, "buttons", "Buttons")}\n`;
+        md += `| ${await translateWithCache(lang, "buttonName", "Button Name")} | ${await translateWithCache(lang, "identifier", "Identifier")} | ${await translateWithCache(lang, "description", "Description")} |\n`;
         md += `| --- | --- | --- |\n`;
         for (const b of mod.buttons) {
           const bName = await translate(b);
@@ -275,26 +264,26 @@ export default function UserManualExport() {
             sentenceDefault = `The ${bName} button allows administrators to execute the ${bName} operation. Requires: ${rfNames.join(", ")}.`;
           }
           if (!bDesc) {
-            bDesc = await translateWithAI(lang, "settingsButtonDetail", sentenceDefault);
+            bDesc = await translateWithCache(lang, "settingsButtonDetail", sentenceDefault);
           }
           md += `| ${bName} | ${b} | ${bDesc} |\n`;
         }
       }
       if (mod.functions.length) {
-        md += `\n#### ${await translateWithAI(lang, "functions", "Functions")}\n`;
-        md += `| ${await translateWithAI(lang, "functionName", "Function Name")} | ${await translateWithAI(lang, "identifier", "Identifier")} | ${await translateWithAI(lang, "description", "Description")} |\n`;
+        md += `\n#### ${await translateWithCache(lang, "functions", "Functions")}\n`;
+        md += `| ${await translateWithCache(lang, "functionName", "Function Name")} | ${await translateWithCache(lang, "identifier", "Identifier")} | ${await translateWithCache(lang, "description", "Description")} |\n`;
         md += `| --- | --- | --- |\n`;
         for (const fn of mod.functions) {
           const fnName = await translate(fn);
           const sentenceDefault = `The ${fnName} function performs the ${fnName} process, leveraging the active settings to modify how the application operates.`;
-          const sentence = await translateWithAI(lang, "settingsFunctionDetail", sentenceDefault);
+          const sentence = await translateWithCache(lang, "settingsFunctionDetail", sentenceDefault);
           md += `| ${fnName} | ${fn} | ${sentence} |\n`;
         }
       }
     }
 
-    md += `\n## ${await translateWithAI(lang, "quickReference", "Quick Reference")}\n`;
-    md += `| ${await translateWithAI(lang, "userLevel", "User Level")} | ${await translateWithAI(lang, "modules", "Modules")} | ${await translateWithAI(lang, "forms", "Forms")} | ${await translateWithAI(lang, "reports", "Reports")} | ${await translateWithAI(lang, "buttons", "Buttons")} | ${await translateWithAI(lang, "functions", "Functions")} |\n`;
+    md += `\n## ${await translateWithCache(lang, "quickReference", "Quick Reference")}\n`;
+    md += `| ${await translateWithCache(lang, "userLevel", "User Level")} | ${await translateWithCache(lang, "modules", "Modules")} | ${await translateWithCache(lang, "forms", "Forms")} | ${await translateWithCache(lang, "reports", "Reports")} | ${await translateWithCache(lang, "buttons", "Buttons")} | ${await translateWithCache(lang, "functions", "Functions")} |\n`;
     md += `| --- | --- | --- | --- | --- | --- |\n`;
     const moduleCount = Object.keys(manual).length;
     let formsCount = 0;


### PR DESCRIPTION
## Summary
- fall back to locale, English, or heuristic descriptions when OpenAI translation is unavailable
- rely on translateWithCache for UserManualExport translations
- allow generateManuals.js to build manuals in a chosen language with the same fallback logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7bc7598cc83319eba98fdb5ec60d6