### PR TITLE
fix: handle module structures

### DIFF
--- a/src/erp.mgt.mn/pages/UserManualExport.jsx
+++ b/src/erp.mgt.mn/pages/UserManualExport.jsx
@@ -111,11 +111,14 @@ export default function UserManualExport() {
           if (!struct[k])
             struct[k] = { buttons: [], functions: [], forms: [], reports: [] };
         };
-        (data.modules || []).forEach((m) => addModule(m.key));
+        const modules = Array.isArray(data.modules)
+          ? data.modules
+          : Object.values(data.modules || {});
+        modules.forEach((m) => addModule(m.key || m));
         const forms = data.forms || {};
         for (const [fKey, f] of Object.entries(forms)) {
           const mKey = f.module || f.moduleKey || "misc";
-          if (!(data.modules || []).some((m) => m.key === mKey)) continue;
+          if (!modules.some((m) => (m.key || m) === mKey)) continue;
           addModule(mKey);
           struct[mKey].forms.push({ key: fKey, ...f });
           (f.buttons || []).forEach((b) =>


### PR DESCRIPTION
## Summary
- normalize module data before adding to manual export structure
- avoid errors when permission modules returned as keyed object

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7be53932c8331b4d54df1d0f9d767