### PR TITLE
Handle array/object inputs in manual export and permissions

### DIFF
--- a/src/erp.mgt.mn/pages/UserManualExport.jsx
+++ b/src/erp.mgt.mn/pages/UserManualExport.jsx
@@ -119,16 +119,15 @@ export default function UserManualExport() {
             struct[k] = { buttons: [], functions: [], forms: [], reports: [] };
         };
 
-        const modNodes = Array.isArray(data.modules)
+        const modules = Array.isArray(data.modules)
           ? data.modules
           : Object.values(data.modules || {});
-        const collect = (nodes) =>
-          nodes.forEach((m) => {
+        const visit = (ms) =>
+          ms.forEach((m) => {
             addModule(m.key);
-            if (Array.isArray(m.children) && m.children.length)
-              collect(m.children);
+            if (m.children?.length) visit(m.children);
           });
-        collect(modNodes);
+        visit(modules);
 
         const buttonObjs = Array.isArray(data.buttons)
           ? data.buttons
@@ -255,7 +254,10 @@ export default function UserManualExport() {
         }
         tfData = tfData || transactionForms;
         Object.values(tfData || {}).forEach((forms) => {
-          Object.entries(forms || {}).forEach(([tName, cfg]) => {
+          const entries = Array.isArray(forms)
+            ? forms.map((f) => [f.key, f])
+            : Object.entries(forms || {});
+          entries.forEach(([tName, cfg]) => {
             const mKey = cfg.moduleKey;
             if (!mKey) return;
             addModule(mKey);


### PR DESCRIPTION
## Summary
- Recursively collect modules from either arrays or objects when building the user manual and transaction form lists
- Normalize permission payloads to support array or object structures for modules, forms, and action collections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7ca048fa08331a7f50edf34aae5b6