### PR TITLE
Validate table parameter in getRowReferences

### DIFF
--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -203,7 +203,11 @@ export async function deleteRow(req, res, next) {
 
 export async function getRowReferences(req, res, next) {
   try {
-    const refs = await listRowReferences(req.params.table, req.params.id);
+    const table = req.params.table;
+    if (typeof table !== 'string' || table.trim() === '') {
+      return res.status(400).json({ message: 'Table name required' });
+    }
+    const refs = await listRowReferences(table, req.params.id);
     res.json(refs);
   } catch (err) {
     if (err.status === 400) {


### PR DESCRIPTION
## Summary
- validate `req.params.table` in getRowReferences and return 400 error when missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7e3de83688331b3ae44cacbe007a4