### PR TITLE
Use information_schema for primary key lookup

### DIFF
--- a/tests/controllers/companyController.test.js
+++ b/tests/controllers/companyController.test.js
@@ -164,8 +164,11 @@ test('deleteCompanyHandler deletes company with cascade', async () => {
   const calls = [];
   const restore = mockPool(async (sql, params) => {
     calls.push({ sql, params });
-    if (sql.startsWith('SHOW KEYS')) {
-      return [[{ Column_name: 'id' }]];
+    if (
+      sql.includes('information_schema.STATISTICS') &&
+      sql.includes("INDEX_NAME = 'PRIMARY'")
+    ) {
+      return [[{ COLUMN_NAME: 'id', SEQ_IN_INDEX: 1 }]];
     }
     if (sql.includes('information_schema.KEY_COLUMN_USAGE')) {
       return [[{ TABLE_NAME: 'orders', COLUMN_NAME: 'company_id', REFERENCED_COLUMN_NAME: 'id' }]];

--- a/tests/controllers/tableController.test.js
+++ b/tests/controllers/tableController.test.js
@@ -206,8 +206,10 @@ test('addRow populates created_by and created_at when absent', async () => {
 
 test('updateRow populates updated_by and updated_at when absent', async () => {
   const restore = mockPool(async (sql, params) => {
-    if (sql.startsWith('SHOW KEYS FROM')) {
-      return [[{ Column_name: 'id' }]];
+    if (
+      sql.includes('information_schema.STATISTICS') && sql.includes("INDEX_NAME = 'PRIMARY'")
+    ) {
+      return [[{ COLUMN_NAME: 'id', SEQ_IN_INDEX: 1 }]];
     }
     if (sql.startsWith('SELECT * FROM `test`')) {
       return [[{ id: 1 }]];
@@ -245,8 +247,10 @@ test('updateRow populates updated_by and updated_at when absent', async () => {
 
 test('updateRow forwards user companyId to updateTableRow', async () => {
   const restore = mockPool(async (sql, params) => {
-    if (sql.startsWith('SHOW KEYS FROM')) {
-      return [[{ Column_name: 'id' }]];
+    if (
+      sql.includes('information_schema.STATISTICS') && sql.includes("INDEX_NAME = 'PRIMARY'")
+    ) {
+      return [[{ COLUMN_NAME: 'id', SEQ_IN_INDEX: 1 }]];
     }
     if (sql.includes('information_schema.COLUMNS')) {
       return [[
@@ -280,8 +284,10 @@ test('updateRow forwards user companyId to updateTableRow', async () => {
 
 test('deleteRow forwards user companyId to deleteTableRow', async () => {
   const restore = mockPool(async (sql, params) => {
-    if (sql.startsWith('SHOW KEYS FROM')) {
-      return [[{ Column_name: 'id' }]];
+    if (
+      sql.includes('information_schema.STATISTICS') && sql.includes("INDEX_NAME = 'PRIMARY'")
+    ) {
+      return [[{ COLUMN_NAME: 'id', SEQ_IN_INDEX: 1 }]];
     }
     if (sql.includes('information_schema.COLUMNS')) {
       return [[{ COLUMN_NAME: 'id' }, { COLUMN_NAME: 'company_id' }]];

--- a/tests/db/references.test.js
+++ b/tests/db/references.test.js
@@ -23,8 +23,10 @@ test('listRowReferences counts referencing rows', async () => {
   let step = 0;
   const restore = mockPool(async (sql, params) => {
     step++;
-    if (sql.startsWith('SHOW KEYS')) {
-      return [[{ Column_name: 'id', Seq_in_index: 1 }]];
+    if (
+      sql.includes('information_schema.STATISTICS') && sql.includes("INDEX_NAME = 'PRIMARY'")
+    ) {
+      return [[{ COLUMN_NAME: 'id', SEQ_IN_INDEX: 1 }]];
     }
     if (sql.includes('information_schema.KEY_COLUMN_USAGE')) {
       if (params[0] === 'users') {
@@ -61,10 +63,12 @@ test('listRowReferences counts referencing rows', async () => {
 
 test('listRowReferences handles composite foreign keys', async () => {
   const restore = mockPool(async (sql, params) => {
-    if (sql.startsWith('SHOW KEYS')) {
+    if (
+      sql.includes('information_schema.STATISTICS') && sql.includes("INDEX_NAME = 'PRIMARY'")
+    ) {
       return [[
-        { Column_name: 'company_id', Seq_in_index: 1 },
-        { Column_name: 'id', Seq_in_index: 2 },
+        { COLUMN_NAME: 'company_id', SEQ_IN_INDEX: 1 },
+        { COLUMN_NAME: 'id', SEQ_IN_INDEX: 2 },
       ]];
     }
     if (sql.includes('information_schema.KEY_COLUMN_USAGE')) {
@@ -109,8 +113,10 @@ test('deleteTableRowCascade deletes related rows first', async () => {
   const calls = [];
   const restore = mockPool(async (sql, params) => {
     calls.push({ sql, params });
-    if (sql.startsWith('SHOW KEYS')) {
-      return [[{ Column_name: 'id' }]];
+    if (
+      sql.includes('information_schema.STATISTICS') && sql.includes("INDEX_NAME = 'PRIMARY'")
+    ) {
+      return [[{ COLUMN_NAME: 'id', SEQ_IN_INDEX: 1 }]];
     }
     if (sql.includes('information_schema.KEY_COLUMN_USAGE')) {
       return [[{ TABLE_NAME: 'orders', COLUMN_NAME: 'user_id', REFERENCED_COLUMN_NAME: 'id' }]];


### PR DESCRIPTION
## Summary
- query information_schema.STATISTICS for primary keys and unique indexes
- update tests to mock new primary/unique key lookups

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba45b3c42c8331bc4ef29fe859df3d