### PR TITLE
Use fieldTypeMap for date inputs and normalize ISO dates

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -166,9 +166,9 @@ export default forwardRef(function InlineTransactionTable({
     fields.forEach((f) => {
       const lower = f.toLowerCase();
       const typ = fieldTypeMap[f] || columnTypeMap[f] || '';
-      if (typ.includes('time')) {
+      if (typ === 'time') {
         map[f] = 'HH:MM:SS';
-      } else if (typ.includes('date')) {
+      } else if (typ === 'date' || typ === 'datetime') {
         map[f] = 'YYYY-MM-DD';
       } else if (lower.includes('time') && !lower.includes('date')) {
         map[f] = 'HH:MM:SS';
@@ -184,16 +184,22 @@ export default forwardRef(function InlineTransactionTable({
     fields.forEach((f) => {
       const lower = f.toLowerCase();
       const typ = fieldTypeMap[f] || columnTypeMap[f] || '';
-      if (placeholders[f] === 'HH:MM:SS' || typ.includes('time')) map[f] = 'time';
-      else if (placeholders[f] === 'YYYY-MM-DD' || typ.includes('date')) map[f] = 'date';
-      else if (
+      if (typ === 'time' || placeholders[f] === 'HH:MM:SS') {
+        map[f] = 'time';
+      } else if (
+        typ === 'date' ||
+        typ === 'datetime' ||
+        placeholders[f] === 'YYYY-MM-DD'
+      ) {
+        map[f] = 'date';
+      } else if (
         typ.match(/int|decimal|numeric|double|float|real|number|bigint/) ||
         typeof defaultValues[f] === 'number' ||
         totalAmountSet.has(f) ||
         totalCurrencySet.has(f)
-      )
+      ) {
         map[f] = 'number';
-      else if (lower.includes('email')) map[f] = 'email';
+      } else if (lower.includes('email')) map[f] = 'email';
       else if (lower.includes('phone')) map[f] = 'tel';
       else map[f] = 'text';
     });
@@ -1137,11 +1143,16 @@ export default forwardRef(function InlineTransactionTable({
       );
     }
     const fieldType = fieldInputTypes[f];
+    const rawVal = typeof val === 'object' ? val.value : val;
+    const normalizedVal =
+      fieldType === 'date'
+        ? normalizeDateInput(String(rawVal ?? ''), 'YYYY-MM-DD')
+        : rawVal;
     const commonProps = {
       className: `w-full border px-1 ${invalid ? 'border-red-500 bg-red-100' : ''}`,
       style: { ...inputStyle },
-      value: typeof val === 'object' ? val.value : val,
-      title: typeof val === 'object' ? val.value : val,
+      value: normalizedVal,
+      title: normalizedVal,
       onChange: (e) => handleChange(idx, f, e.target.value),
       ref: (el) => (inputRefs.current[`${idx}-${colIdx}`] = el),
       onKeyDown: (e) => handleKeyDown(e, idx, colIdx),

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -110,10 +110,15 @@ const RowFormModal = function RowFormModal({
     const now = new Date();
     columns.forEach((c) => {
       const lower = c.toLowerCase();
+      const typ = fieldTypeMap[c];
       let placeholder = '';
-      if (lower.includes('time') && !lower.includes('date')) {
+      if (typ === 'time' || (!typ && lower.includes('time') && !lower.includes('date'))) {
         placeholder = 'HH:MM:SS';
-      } else if (lower.includes('timestamp') || lower.includes('date')) {
+      } else if (
+        typ === 'date' ||
+        typ === 'datetime' ||
+        (!typ && (lower.includes('timestamp') || lower.includes('date')))
+      ) {
         placeholder = 'YYYY-MM-DD';
       }
       const raw = row ? String(row[c] ?? '') : String(defaultValues[c] ?? '');
@@ -142,10 +147,15 @@ const RowFormModal = function RowFormModal({
     Object.entries(row || {}).forEach(([k, v]) => {
       if (!columns.includes(k)) {
         const lower = k.toLowerCase();
+        const typ = fieldTypeMap[k];
         let placeholder = '';
-        if (lower.includes('time') && !lower.includes('date')) {
+        if (typ === 'time' || (!typ && lower.includes('time') && !lower.includes('date'))) {
           placeholder = 'HH:MM:SS';
-        } else if (lower.includes('timestamp') || lower.includes('date')) {
+        } else if (
+          typ === 'date' ||
+          typ === 'datetime' ||
+          (!typ && (lower.includes('timestamp') || lower.includes('date')))
+        ) {
           placeholder = 'YYYY-MM-DD';
         }
         extras[k] = normalizeDateInput(String(v ?? ''), placeholder);
@@ -215,14 +225,19 @@ const RowFormModal = function RowFormModal({
     ]);
     cols.forEach((c) => {
       const lower = c.toLowerCase();
-      if (lower.includes('time') && !lower.includes('date')) {
+      const typ = fieldTypeMap[c];
+      if (typ === 'time' || (!typ && lower.includes('time') && !lower.includes('date'))) {
         map[c] = 'HH:MM:SS';
-      } else if (lower.includes('timestamp') || lower.includes('date')) {
+      } else if (
+        typ === 'date' ||
+        typ === 'datetime' ||
+        (!typ && (lower.includes('timestamp') || lower.includes('date')))
+      ) {
         map[c] = 'YYYY-MM-DD';
       }
     });
     return map;
-  }, [columns, row, defaultValues]);
+  }, [columns, row, defaultValues, fieldTypeMap]);
 
   useEffect(() => {
     const extras = {};
@@ -1092,8 +1107,9 @@ const RowFormModal = function RowFormModal({
         title={tip}
         ref={(el) => (inputRefs.current[c] = el)}
         type={(() => {
-          if (placeholders[c] === 'YYYY-MM-DD') return 'date';
-          if (placeholders[c] === 'HH:MM:SS') return 'time';
+          const typ = fieldTypeMap[c];
+          if (typ === 'date' || typ === 'datetime' || placeholders[c] === 'YYYY-MM-DD') return 'date';
+          if (typ === 'time' || placeholders[c] === 'HH:MM:SS') return 'time';
           const lower = c.toLowerCase();
           if (lower.includes('email')) return 'email';
           if (/(amount|qty|count|price|total|number|qty|quantity)/i.test(lower))
@@ -1108,7 +1124,11 @@ const RowFormModal = function RowFormModal({
             : undefined;
         })()}
         placeholder={placeholders[c] || ''}
-        value={formVals[c]}
+        value={
+          fieldTypeMap[c] === 'date' || fieldTypeMap[c] === 'datetime'
+            ? normalizeDateInput(formVals[c], 'YYYY-MM-DD')
+            : formVals[c]
+        }
         onChange={(e) => {
           setFormVals((prev) => {
             if (prev[c] === e.target.value) return prev;


### PR DESCRIPTION
## Summary
- Respect `TableManager`'s `fieldTypeMap` so datetime columns render as `<input type="date">`
- Normalize ISO date strings to `YYYY-MM-DD` before binding to date inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba797f4ea0833184e6ed2c05bd6a41