### PR TITLE
Normalize view and relation map keys for case-insensitive lookups

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -280,7 +280,14 @@ const TableManager = forwardRef(function TableManager({
     [columnMeta],
   );
 
-  const viewSourceMap = formConfig?.viewSource || {};
+  const viewSourceMap = useMemo(() => {
+    const map = {};
+    Object.entries(formConfig?.viewSource || {}).forEach(([k, v]) => {
+      const key = columnCaseMap[k.toLowerCase()] || k;
+      map[key] = v;
+    });
+    return map;
+  }, [formConfig?.viewSource, columnCaseMap]);
 
   const branchIdFields = useMemo(() => {
     if (formConfig?.branchIdFields?.length)
@@ -613,7 +620,7 @@ const TableManager = forwardRef(function TableManager({
   }, [requestStatus, table, user?.empid, dateFilter]);
 
   useEffect(() => {
-    if (!table) return;
+    if (!table || Object.keys(columnCaseMap).length === 0) return;
     let canceled = false;
     async function load() {
       try {
@@ -638,7 +645,8 @@ const TableManager = forwardRef(function TableManager({
         if (canceled) return;
         const map = {};
         rels.forEach((r) => {
-          map[r.COLUMN_NAME] = {
+          const key = columnCaseMap[r.COLUMN_NAME.toLowerCase()] || r.COLUMN_NAME;
+          map[key] = {
             table: r.REFERENCED_TABLE_NAME,
             column: r.REFERENCED_COLUMN_NAME,
           };
@@ -800,7 +808,7 @@ const TableManager = forwardRef(function TableManager({
     return () => {
       canceled = true;
     };
-  }, [table]);
+  }, [table, columnCaseMap]);
 
   useEffect(() => {
     if (!table || columnMeta.length === 0) return;


### PR DESCRIPTION
## Summary
- Normalize view source configuration keys using columnCaseMap
- Normalize relation mapping keys using columnCaseMap and pass them through props

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba7acbc9988331a4223746eba50e9c