### PR TITLE
Use column metadata for date/time placeholders

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -90,6 +90,23 @@ export default forwardRef(function InlineTransactionTable({
     [disabledFields],
   );
 
+  const columnTypeMap = React.useMemo(() => {
+    const map = {};
+    const cols = viewColumns[tableName] || [];
+    cols.forEach((c) => {
+      const name = typeof c === 'string' ? c : c.name;
+      if (!name) return;
+      const key = columnCaseMap[name.toLowerCase()] || name;
+      const typ =
+        (typeof c === 'string'
+          ? ''
+          : c.type || c.columnType || c.dataType || c.DATA_TYPE || '')
+          .toLowerCase();
+      if (typ) map[key] = typ;
+    });
+    return map;
+  }, [viewColumns, tableName, columnCaseMap]);
+
   function fillSessionDefaults(obj) {
     const row = { ...obj };
     if (user?.empid !== undefined) {
@@ -114,7 +131,13 @@ export default forwardRef(function InlineTransactionTable({
     }
     const now = formatTimestamp(new Date()).slice(0, 10);
     dateField.forEach((f) => {
-      if (row[f] === undefined || row[f] === '') row[f] = now;
+      const typ = fieldTypeMap[f] || columnTypeMap[f] || '';
+      if (
+        (typ.includes('date') || typ.includes('time')) &&
+        (row[f] === undefined || row[f] === '')
+      ) {
+        row[f] = now;
+      }
     });
     return row;
   }
@@ -144,35 +167,19 @@ export default forwardRef(function InlineTransactionTable({
   const totalAmountSet = new Set(totalAmountFields);
   const totalCurrencySet = new Set(totalCurrencyFields);
 
-  const columnTypeMap = React.useMemo(() => {
-    const map = {};
-    const cols = viewColumns[tableName] || [];
-    cols.forEach((c) => {
-      const name = typeof c === 'string' ? c : c.name;
-      if (!name) return;
-      const key = columnCaseMap[name.toLowerCase()] || name;
-      const typ =
-        (typeof c === 'string'
-          ? ''
-          : c.type || c.columnType || c.dataType || c.DATA_TYPE || '')
-          .toLowerCase();
-      if (typ) map[key] = typ;
-    });
-    return map;
-  }, [viewColumns, tableName, columnCaseMap]);
-
   const placeholders = React.useMemo(() => {
     const map = {};
     fields.forEach((f) => {
-      const lower = f.toLowerCase();
-      const typ = fieldTypeMap[f] || columnTypeMap[f] || '';
-      if (typ.includes('time')) {
-        map[f] = 'HH:MM:SS';
+      const typ = (columnTypeMap[f] || '').toLowerCase();
+      if (typ.includes('timestamp') || typ.includes('datetime')) {
+        map[f] = 'YYYY-MM-DD HH:MM:SS';
       } else if (typ.includes('date')) {
         map[f] = 'YYYY-MM-DD';
-      } else if (lower.includes('time') && !lower.includes('date')) {
+      } else if (typ.includes('time')) {
         map[f] = 'HH:MM:SS';
-      } else if (lower.includes('timestamp') || lower.includes('date')) {
+      } else if (fieldTypeMap[f] === 'time') {
+        map[f] = 'HH:MM:SS';
+      } else if (fieldTypeMap[f] === 'date') {
         map[f] = 'YYYY-MM-DD';
       }
     });

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -22,6 +22,7 @@ const RowFormModal = function RowFormModal({
   relationConfigs = {},
   relationData = {},
   fieldTypeMap = {},
+  columnPlaceholders = {},
   disabledFields = [],
   labels = {},
   requiredFields = [],
@@ -109,17 +110,11 @@ const RowFormModal = function RowFormModal({
     const init = {};
     const now = new Date();
     columns.forEach((c) => {
-      const lower = c.toLowerCase();
-      let placeholder = '';
-      if (lower.includes('time') && !lower.includes('date')) {
-        placeholder = 'HH:MM:SS';
-      } else if (lower.includes('timestamp') || lower.includes('date')) {
-        placeholder = 'YYYY-MM-DD';
-      }
+      const placeholder = columnPlaceholders[c] || '';
       const raw = row ? String(row[c] ?? '') : String(defaultValues[c] ?? '');
       let val = normalizeDateInput(raw, placeholder);
       const missing = !row || row[c] === undefined || row[c] === '';
-      if (missing && !val && dateField.includes(c)) {
+      if (missing && !val && dateField.includes(c) && placeholder) {
         if (placeholder === 'YYYY-MM-DD') val = formatTimestamp(now).slice(0, 10);
         else if (placeholder === 'HH:MM:SS') val = formatTimestamp(now).slice(11, 19);
         else val = formatTimestamp(now);
@@ -141,13 +136,7 @@ const RowFormModal = function RowFormModal({
     const extras = {};
     Object.entries(row || {}).forEach(([k, v]) => {
       if (!columns.includes(k)) {
-        const lower = k.toLowerCase();
-        let placeholder = '';
-        if (lower.includes('time') && !lower.includes('date')) {
-          placeholder = 'HH:MM:SS';
-        } else if (lower.includes('timestamp') || lower.includes('date')) {
-          placeholder = 'YYYY-MM-DD';
-        }
+        const placeholder = columnPlaceholders[k] || '';
         extras[k] = normalizeDateInput(String(v ?? ''), placeholder);
       }
     });
@@ -206,23 +195,10 @@ const RowFormModal = function RowFormModal({
     },
     [onRowsChange],
   );
-  const placeholders = React.useMemo(() => {
-    const map = {};
-    const cols = new Set([
-      ...columns,
-      ...Object.keys(row || {}),
-      ...Object.keys(defaultValues || {}),
-    ]);
-    cols.forEach((c) => {
-      const lower = c.toLowerCase();
-      if (lower.includes('time') && !lower.includes('date')) {
-        map[c] = 'HH:MM:SS';
-      } else if (lower.includes('timestamp') || lower.includes('date')) {
-        map[c] = 'YYYY-MM-DD';
-      }
-    });
-    return map;
-  }, [columns, row, defaultValues]);
+  const placeholders = React.useMemo(
+    () => ({ ...columnPlaceholders }),
+    [columnPlaceholders],
+  );
 
   useEffect(() => {
     const extras = {};
@@ -399,7 +375,7 @@ const RowFormModal = function RowFormModal({
       const raw = row ? String(row[c] ?? '') : String(defaultValues[c] ?? '');
       let v = normalizeDateInput(raw, placeholders[c]);
       const missing = !row || row[c] === undefined || row[c] === '';
-      if (missing && !v && dateField.includes(c)) {
+      if (missing && !v && dateField.includes(c) && placeholders[c]) {
         const now = new Date();
         if (placeholders[c] === 'YYYY-MM-DD') v = formatTimestamp(now).slice(0, 10);
         else if (placeholders[c] === 'HH:MM:SS') v = formatTimestamp(now).slice(11, 19);

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1756,17 +1756,19 @@ const TableManager = forwardRef(function TableManager({
   let columns = ordered.filter((c) => !hiddenColumns.includes(c));
   const placeholders = useMemo(() => {
     const map = {};
-    const cols = new Set(allColumns);
-    cols.forEach((c) => {
-      const lower = c.toLowerCase();
-      if (lower.includes('time') && !lower.includes('date')) {
-        map[c] = 'HH:MM:SS';
-      } else if (lower.includes('timestamp') || lower.includes('date')) {
-        map[c] = 'YYYY-MM-DD';
+    columnMeta.forEach((c) => {
+      const typ = (c.type || c.columnType || c.dataType || c.DATA_TYPE || '')
+        .toLowerCase();
+      if (typ.includes('timestamp') || typ.includes('datetime')) {
+        map[c.name] = 'YYYY-MM-DD HH:MM:SS';
+      } else if (typ.includes('date')) {
+        map[c.name] = 'YYYY-MM-DD';
+      } else if (typ.includes('time')) {
+        map[c.name] = 'HH:MM:SS';
       }
     });
     return map;
-  }, [allColumns]);
+  }, [columnMeta]);
 
   const relationOpts = {};
   ordered.forEach((c) => {
@@ -1799,8 +1801,9 @@ const TableManager = forwardRef(function TableManager({
       const avg = getAverageLength(c, rows);
       let w;
       if (avg <= 4) w = ch(Math.max(avg + 1, 5));
-      else if (placeholders[c] && placeholders[c].includes('YYYY-MM-DD'))
-        w = ch(12);
+      else if (placeholders[c] === 'YYYY-MM-DD HH:MM:SS') w = ch(20);
+      else if (placeholders[c] === 'YYYY-MM-DD') w = ch(12);
+      else if (placeholders[c] === 'HH:MM:SS') w = ch(12);
       else if (avg <= 10) w = ch(12);
       else w = ch(20);
       map[c] = Math.min(w, MAX_WIDTH);
@@ -2395,7 +2398,9 @@ const TableManager = forwardRef(function TableManager({
                 let display = raw;
                 if (c === 'TotalCur' || totalCurrencySet.has(c)) {
                   display = currencyFmt.format(Number(r[c] || 0));
-                } else if (placeholders[c]) {
+                } else if (
+                  fieldTypeMap[c] === 'date' || fieldTypeMap[c] === 'time'
+                ) {
                   display = normalizeDateInput(raw, placeholders[c]);
                 }
                 const showFull = display.length > 20;
@@ -2638,6 +2643,7 @@ const TableManager = forwardRef(function TableManager({
         relationConfigs={relationConfigs}
         relationData={refRows}
         fieldTypeMap={fieldTypeMap}
+        columnPlaceholders={placeholders}
         disabledFields={disabledFields}
         labels={labels}
         requiredFields={formConfig?.requiredFields || []}


### PR DESCRIPTION
## Summary
- ensure date pickers and auto-fill use database column types only
- build inline table placeholders from column metadata
- pass DB-derived placeholders into RowFormModal for precise date inputs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba78b819088331a752a06b2545a54b