### PR TITLE
refactor: centralize date normalization

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -12,6 +12,7 @@ import RowImageUploadModal from './RowImageUploadModal.jsx';
 import buildImageName from '../utils/buildImageName.js';
 import slugify from '../utils/slugify.js';
 import formatTimestamp from '../utils/formatTimestamp.js';
+import normalizeDateInput from '../utils/normalizeDateInput.js';
 import callProcedure from '../utils/callProcedure.js';
 
 const currencyFmt = new Intl.NumberFormat('en-US', {
@@ -22,16 +23,6 @@ const currencyFmt = new Intl.NumberFormat('en-US', {
 function normalizeNumberInput(value) {
   if (typeof value !== 'string') return value;
   return value.replace(',', '.');
-}
-
-function normalizeDateInput(value, format) {
-  if (typeof value !== 'string') return value;
-  let v = value.trim().replace(/^(\d{4})[.,](\d{2})[.,](\d{2})/, '$1-$2-$3');
-  if (/^\d{4}-\d{2}-\d{2}T/.test(v) && !isNaN(Date.parse(v))) {
-    const local = formatTimestamp(new Date(v));
-    return format === 'HH:MM:SS' ? local.slice(11, 19) : local.slice(0, 10);
-  }
-  return v;
 }
 
 export default forwardRef(function InlineTransactionTable({
@@ -220,8 +211,9 @@ export default forwardRef(function InlineTransactionTable({
       if (!row || typeof row !== 'object') return row;
       const updated = fillSessionDefaults(row);
       Object.entries(updated).forEach(([k, v]) => {
-        if (placeholders[k]) {
-          updated[k] = normalizeDateInput(String(v ?? ''), placeholders[k]);
+        const format = fieldTypeMap[k] === 'date' ? 'YYYY-MM-DD' : placeholders[k];
+        if (format) {
+          updated[k] = normalizeDateInput(String(v ?? ''), format);
         }
       });
       return updated;
@@ -447,8 +439,9 @@ export default forwardRef(function InlineTransactionTable({
         if (val && typeof val === 'object' && 'value' in val) {
           val = val.value;
         }
-        if (placeholders[key]) {
-          val = normalizeDateInput(val, placeholders[key]);
+        const format = fieldTypeMap[key] === 'date' ? 'YYYY-MM-DD' : placeholders[key];
+        if (format) {
+          val = normalizeDateInput(val, format);
         }
         if (totalCurrencySet.has(key) || totalAmountSet.has(key)) {
           val = normalizeNumberInput(val);
@@ -576,8 +569,9 @@ export default forwardRef(function InlineTransactionTable({
       const prev = rows[rows.length - 1];
       for (const f of fields) {
         let val = prev[f];
-        if (placeholders[f]) {
-          val = normalizeDateInput(val, placeholders[f]);
+        const format = fieldTypeMap[f] === 'date' ? 'YYYY-MM-DD' : placeholders[f];
+        if (format) {
+          val = normalizeDateInput(val, format);
         }
         if (totalCurrencySet.has(f) || totalAmountSet.has(f)) {
           val = normalizeNumberInput(val);
@@ -789,8 +783,9 @@ export default forwardRef(function InlineTransactionTable({
     const row = rows[idx] || {};
     for (const f of requiredFields) {
       let val = row[f];
-      if (placeholders[f]) {
-        val = normalizeDateInput(val, placeholders[f]);
+      const format = fieldTypeMap[f] === 'date' ? 'YYYY-MM-DD' : placeholders[f];
+      if (format) {
+        val = normalizeDateInput(val, format);
       }
       if (totalCurrencySet.has(f)) {
         val = normalizeNumberInput(val);
@@ -839,7 +834,8 @@ export default forwardRef(function InlineTransactionTable({
       const key = columnCaseMap[k.toLowerCase()];
       if (!key) return;
       let val = typeof v === 'object' && v !== null && 'value' in v ? v.value : v;
-      if (placeholders[key]) val = normalizeDateInput(val, placeholders[key]);
+      const format = fieldTypeMap[key] === 'date' ? 'YYYY-MM-DD' : placeholders[key];
+      if (format) val = normalizeDateInput(val, format);
       if (totalAmountSet.has(key) || totalCurrencySet.has(key)) {
         val = normalizeNumberInput(val);
       }

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -7,6 +7,7 @@ import TooltipWrapper from './TooltipWrapper.jsx';
 import { useTranslation } from 'react-i18next';
 import { AuthContext } from '../context/AuthContext.jsx';
 import formatTimestamp from '../utils/formatTimestamp.js';
+import normalizeDateInput from '../utils/normalizeDateInput.js';
 import callProcedure from '../utils/callProcedure.js';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import { API_BASE } from '../utils/apiBase.js';
@@ -122,7 +123,8 @@ const RowFormModal = function RowFormModal({
         placeholder = 'YYYY-MM-DD';
       }
       const raw = row ? String(row[c] ?? '') : String(defaultValues[c] ?? '');
-      let val = normalizeDateInput(raw, placeholder);
+      const format = fieldTypeMap[c] === 'date' ? 'YYYY-MM-DD' : placeholder;
+      let val = normalizeDateInput(raw, format);
       const missing = !row || row[c] === undefined || row[c] === '';
       if (missing && !val && dateField.includes(c)) {
         if (placeholder === 'YYYY-MM-DD') val = formatTimestamp(now).slice(0, 10);
@@ -158,7 +160,8 @@ const RowFormModal = function RowFormModal({
         ) {
           placeholder = 'YYYY-MM-DD';
         }
-        extras[k] = normalizeDateInput(String(v ?? ''), placeholder);
+        const format = typ === 'date' ? 'YYYY-MM-DD' : placeholder;
+        extras[k] = normalizeDateInput(String(v ?? ''), format);
       }
     });
     return extras;
@@ -243,7 +246,8 @@ const RowFormModal = function RowFormModal({
     const extras = {};
     Object.entries(row || {}).forEach(([k, v]) => {
       if (!columns.includes(k)) {
-        extras[k] = normalizeDateInput(String(v ?? ''), placeholders[k]);
+        const format = fieldTypeMap[k] === 'date' ? 'YYYY-MM-DD' : placeholders[k];
+        extras[k] = normalizeDateInput(String(v ?? ''), format);
       }
     });
     setExtraVals(extras);
@@ -374,17 +378,6 @@ const RowFormModal = function RowFormModal({
       </div>
     );
   }
-
-  function normalizeDateInput(value, format) {
-    if (typeof value !== 'string') return value;
-    let v = value.trim().replace(/^(\d{4})[.,](\d{2})[.,](\d{2})/, '$1-$2-$3');
-    if (/^\d{4}-\d{2}-\d{2}T/.test(v) && !isNaN(Date.parse(v))) {
-      const local = formatTimestamp(new Date(v));
-      return format === 'HH:MM:SS' ? local.slice(11, 19) : local.slice(0, 10);
-    }
-    return v;
-  }
-
   function normalizeNumberInput(value) {
     if (typeof value !== 'string') return value;
     return value.replace(',', '.');
@@ -412,7 +405,8 @@ const RowFormModal = function RowFormModal({
     const vals = {};
     columns.forEach((c) => {
       const raw = row ? String(row[c] ?? '') : String(defaultValues[c] ?? '');
-      let v = normalizeDateInput(raw, placeholders[c]);
+      const format = fieldTypeMap[c] === 'date' ? 'YYYY-MM-DD' : placeholders[c];
+      let v = normalizeDateInput(raw, format);
       const missing = !row || row[c] === undefined || row[c] === '';
       if (missing && !v && dateField.includes(c)) {
         const now = new Date();
@@ -514,7 +508,10 @@ const RowFormModal = function RowFormModal({
     let label = undefined;
     let val = e.selectedOption ? e.selectedOption.value : e.target.value;
     if (e.selectedOption) label = e.selectedOption.label;
-    val = normalizeDateInput(val, placeholders[col]);
+    {
+      const format = fieldTypeMap[col] === 'date' ? 'YYYY-MM-DD' : placeholders[col];
+      val = normalizeDateInput(val, format);
+    }
     if (totalAmountSet.has(col) || totalCurrencySet.has(col)) {
       val = normalizeNumberInput(val);
     }
@@ -683,7 +680,8 @@ const RowFormModal = function RowFormModal({
         const row = procCache.current[cacheKey];
         const norm = {};
         Object.entries(row).forEach(([k, v]) => {
-          norm[k] = normalizeDateInput(v, placeholders[k]);
+          const format = fieldTypeMap[k] === 'date' ? 'YYYY-MM-DD' : placeholders[k];
+          norm[k] = normalizeDateInput(v, format);
         });
         setExtraVals((v) => ({ ...v, ...norm }));
         setFormVals((vals) => {
@@ -719,7 +717,8 @@ const RowFormModal = function RowFormModal({
         procCache.current[cacheKey] = row;
         const norm = {};
         Object.entries(row).forEach(([k, v]) => {
-          norm[k] = normalizeDateInput(v, placeholders[k]);
+          const format = fieldTypeMap[k] === 'date' ? 'YYYY-MM-DD' : placeholders[k];
+          norm[k] = normalizeDateInput(v, format);
         });
         setExtraVals((v) => ({ ...v, ...norm }));
         setFormVals((vals) => {
@@ -807,7 +806,8 @@ const RowFormModal = function RowFormModal({
         const normalized = {};
         Object.entries(r).forEach(([k, v]) => {
           const raw = typeof v === 'object' && v !== null && 'value' in v ? v.value : v;
-          let val = normalizeDateInput(raw, placeholders[k]);
+          const format = fieldTypeMap[k] === 'date' ? 'YYYY-MM-DD' : placeholders[k];
+          let val = normalizeDateInput(raw, format);
           if (totalAmountSet.has(k) || totalCurrencySet.has(k)) {
             val = normalizeNumberInput(val);
           }
@@ -911,7 +911,8 @@ const RowFormModal = function RowFormModal({
       }
       const normalized = {};
       Object.entries(merged).forEach(([k, v]) => {
-        let val = normalizeDateInput(v, placeholders[k]);
+        const format = fieldTypeMap[k] === 'date' ? 'YYYY-MM-DD' : placeholders[k];
+        let val = normalizeDateInput(v, format);
         if (totalAmountSet.has(k) || totalCurrencySet.has(k)) {
           val = normalizeNumberInput(val);
         }

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -20,6 +20,7 @@ import ImageSearchModal from './ImageSearchModal.jsx';
 import Modal from './Modal.jsx';
 import CustomDatePicker from './CustomDatePicker.jsx';
 import formatTimestamp from '../utils/formatTimestamp.js';
+import normalizeDateInput from '../utils/normalizeDateInput.js';
 import buildImageName from '../utils/buildImageName.js';
 import slugify from '../utils/slugify.js';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
@@ -66,16 +67,6 @@ const currencyFmt = new Intl.NumberFormat('en-US', {
   minimumFractionDigits: 2,
   maximumFractionDigits: 2,
 });
-
-function normalizeDateInput(value, format) {
-  if (typeof value !== 'string') return value;
-  let v = value.trim().replace(/^(\d{4})[.,](\d{2})[.,](\d{2})/, '$1-$2-$3');
-  if (/^\d{4}-\d{2}-\d{2}T/.test(v) && !isNaN(Date.parse(v))) {
-    const local = formatTimestamp(new Date(v));
-    return format === 'HH:MM:SS' ? local.slice(11, 19) : local.slice(0, 10);
-  }
-  return v;
-}
 
 function applyDateParams(params, filter) {
   if (!filter) return;
@@ -257,8 +248,11 @@ const TableManager = forwardRef(function TableManager({
       const typ = (c.type || c.columnType || c.dataType || c.DATA_TYPE || '').toLowerCase();
       if (typ.match(/int|decimal|numeric|double|float|real|number|bigint/)) {
         map[c.name] = 'number';
-      } else if (typ.includes('date') || typ.includes('time')) {
-        map[c.name] = typ.includes('time') && !typ.includes('date') ? 'time' : 'date';
+      } else if (typ.includes('date') || typ.includes('time') || typ.includes('timestamp')) {
+        map[c.name] =
+          typ.includes('time') && !typ.includes('date') && !typ.includes('timestamp')
+            ? 'time'
+            : 'date';
       } else {
         map[c.name] = 'string';
       }
@@ -1767,7 +1761,9 @@ const TableManager = forwardRef(function TableManager({
     columnMeta.forEach((c) => {
       const typ = (c.type || c.columnType || c.dataType || c.DATA_TYPE || '')
         .toLowerCase();
-      if (typ.includes('timestamp') || typ.includes('datetime')) {
+      if (typ.includes('timestamp')) {
+        map[c.name] = 'YYYY-MM-DD';
+      } else if (typ.includes('datetime')) {
         map[c.name] = 'YYYY-MM-DD HH:MM:SS';
       } else if (typ.includes('date')) {
         map[c.name] = 'YYYY-MM-DD';

--- a/src/erp.mgt.mn/utils/normalizeDateInput.js
+++ b/src/erp.mgt.mn/utils/normalizeDateInput.js
@@ -1,0 +1,11 @@
+import formatTimestamp from './formatTimestamp.js';
+
+export default function normalizeDateInput(value, format) {
+  if (typeof value !== 'string') return value;
+  let v = value.trim().replace(/^(\d{4})[.,](\d{2})[.,](\d{2})/, '$1-$2-$3');
+  if (/^\d{4}-\d{2}-\d{2}T/.test(v) && !isNaN(Date.parse(v))) {
+    const local = formatTimestamp(new Date(v));
+    return format === 'HH:MM:SS' ? local.slice(11, 19) : local.slice(0, 10);
+  }
+  return v;
+}


### PR DESCRIPTION
## Summary
- factor out date normalization into `utils/normalizeDateInput`
- treat `timestamp` columns as dates in `TableManager`
- reuse helper in `InlineTransactionTable` and `RowFormModal` to ensure `YYYY-MM-DD` values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbefb4cd34833185236af6d3425118