### PR TITLE
refactor: centralize date normalization utility

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -13,6 +13,7 @@ import buildImageName from '../utils/buildImageName.js';
 import slugify from '../utils/slugify.js';
 import formatTimestamp from '../utils/formatTimestamp.js';
 import callProcedure from '../utils/callProcedure.js';
+import normalizeDateInput from '../utils/normalizeDateInput.js';
 
 const currencyFmt = new Intl.NumberFormat('en-US', {
   minimumFractionDigits: 2,
@@ -22,16 +23,6 @@ const currencyFmt = new Intl.NumberFormat('en-US', {
 function normalizeNumberInput(value) {
   if (typeof value !== 'string') return value;
   return value.replace(',', '.');
-}
-
-function normalizeDateInput(value, format) {
-  if (typeof value !== 'string') return value;
-  let v = value.trim().replace(/^(\d{4})[.,](\d{2})[.,](\d{2})/, '$1-$2-$3');
-  if (/^\d{4}-\d{2}-\d{2}T/.test(v) && !isNaN(Date.parse(v))) {
-    const local = formatTimestamp(new Date(v));
-    return format === 'HH:MM:SS' ? local.slice(11, 19) : local.slice(0, 10);
-  }
-  return v;
 }
 
 export default forwardRef(function InlineTransactionTable({

--- a/src/erp.mgt.mn/components/ReportTable.jsx
+++ b/src/erp.mgt.mn/components/ReportTable.jsx
@@ -4,6 +4,7 @@ import useGeneralConfig, { updateCache } from '../hooks/useGeneralConfig.js';
 import useHeaderMappings from '../hooks/useHeaderMappings.js';
 import Modal from './Modal.jsx';
 import formatTimestamp from '../utils/formatTimestamp.js';
+import normalizeDateInput from '../utils/normalizeDateInput.js';
 
 function ch(n) {
   return Math.round(n * 8);
@@ -30,16 +31,6 @@ function formatNumber(val) {
   if (val === null || val === undefined || val === '') return '';
   const num = Number(String(val).replace(',', '.'));
   return Number.isNaN(num) ? '' : numberFmt.format(num);
-}
-
-function normalizeDateInput(value, format) {
-  if (typeof value !== 'string') return value;
-  let v = value.trim().replace(/^(\d{4})[.,](\d{2})[.,](\d{2})/, '$1-$2-$3');
-  if (/^\d{4}-\d{2}-\d{2}T/.test(v) && !isNaN(Date.parse(v))) {
-    const local = formatTimestamp(new Date(v));
-    return format === 'HH:MM:SS' ? local.slice(11, 19) : local.slice(0, 10);
-  }
-  return v;
 }
 
 function formatCellValue(val, placeholder) {

--- a/src/erp.mgt.mn/components/RowDetailModal.jsx
+++ b/src/erp.mgt.mn/components/RowDetailModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Modal from './Modal.jsx';
-import formatTimestamp from '../utils/formatTimestamp.js';
 import { useTranslation } from 'react-i18next';
+import normalizeDateInput from '../utils/normalizeDateInput.js';
 
 export default function RowDetailModal({ visible, onClose, row = {}, columns = [], relations = {}, references = [], labels = {} }) {
   const { t } = useTranslation();
@@ -28,16 +28,6 @@ export default function RowDetailModal({ visible, onClose, row = {}, columns = [
     });
     return map;
   }, [cols]);
-
-  function normalizeDateInput(value, format) {
-    if (typeof value !== 'string') return value;
-    let v = value.trim().replace(/^(\d{4})[.,](\d{2})[.,](\d{2})/, '$1-$2-$3');
-    if (/^\d{4}-\d{2}-\d{2}T/.test(v) && !isNaN(Date.parse(v))) {
-      const local = formatTimestamp(new Date(v));
-      return format === 'HH:MM:SS' ? local.slice(11, 19) : local.slice(0, 10);
-    }
-    return v;
-  }
 
   return (
     <Modal visible={visible} title={t('row_details', 'Row Details')} onClose={onClose}>

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -7,6 +7,7 @@ import TooltipWrapper from './TooltipWrapper.jsx';
 import { useTranslation } from 'react-i18next';
 import { AuthContext } from '../context/AuthContext.jsx';
 import formatTimestamp from '../utils/formatTimestamp.js';
+import normalizeDateInput from '../utils/normalizeDateInput.js';
 import callProcedure from '../utils/callProcedure.js';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import { API_BASE } from '../utils/apiBase.js';
@@ -373,16 +374,6 @@ const RowFormModal = function RowFormModal({
         </table>
       </div>
     );
-  }
-
-  function normalizeDateInput(value, format) {
-    if (typeof value !== 'string') return value;
-    let v = value.trim().replace(/^(\d{4})[.,](\d{2})[.,](\d{2})/, '$1-$2-$3');
-    if (/^\d{4}-\d{2}-\d{2}T/.test(v) && !isNaN(Date.parse(v))) {
-      const local = formatTimestamp(new Date(v));
-      return format === 'HH:MM:SS' ? local.slice(11, 19) : local.slice(0, 10);
-    }
-    return v;
   }
 
   function normalizeNumberInput(value) {

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -26,6 +26,7 @@ import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import { API_BASE } from '../utils/apiBase.js';
 import { useTranslation } from 'react-i18next';
 import TooltipWrapper from './TooltipWrapper.jsx';
+import normalizeDateInput from '../utils/normalizeDateInput.js';
 
 function ch(n) {
   return Math.round(n * 8);
@@ -66,16 +67,6 @@ const currencyFmt = new Intl.NumberFormat('en-US', {
   minimumFractionDigits: 2,
   maximumFractionDigits: 2,
 });
-
-function normalizeDateInput(value, format) {
-  if (typeof value !== 'string') return value;
-  let v = value.trim().replace(/^(\d{4})[.,](\d{2})[.,](\d{2})/, '$1-$2-$3');
-  if (/^\d{4}-\d{2}-\d{2}T/.test(v) && !isNaN(Date.parse(v))) {
-    const local = formatTimestamp(new Date(v));
-    return format === 'HH:MM:SS' ? local.slice(11, 19) : local.slice(0, 10);
-  }
-  return v;
-}
 
 function applyDateParams(params, filter) {
   if (!filter) return;

--- a/src/erp.mgt.mn/utils/normalizeDateInput.js
+++ b/src/erp.mgt.mn/utils/normalizeDateInput.js
@@ -1,0 +1,11 @@
+import formatTimestamp from './formatTimestamp.js';
+
+export default function normalizeDateInput(value, format) {
+  if (typeof value !== 'string') return value;
+  let v = value.trim().replace(/^(\d{4})[.,](\d{2})[.,](\d{2})/, '$1-$2-$3');
+  if (/^\d{4}-\d{2}-\d{2}T/.test(v) && !isNaN(Date.parse(v))) {
+    const local = formatTimestamp(new Date(v));
+    return format === 'HH:MM:SS' ? local.slice(11, 19) : local.slice(0, 10);
+  }
+  return v;
+}


### PR DESCRIPTION
## Summary
- extract shared normalizeDateInput utility for consistent date handling
- replace duplicate date normalization in TableManager, InlineTransactionTable, RowFormModal, RowDetailModal, and ReportTable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbf323d55c8331b1ab678e07850d37