### PR TITLE
feat: add field type mapping to details

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -1304,6 +1304,7 @@ export default forwardRef(function InlineTransactionTable({
         columns={previewRow ? Object.keys(previewRow) : []}
         relations={relations}
         labels={labels}
+        fieldTypeMap={fieldTypeMap}
       />
       <RowImageUploadModal
         visible={uploadRow !== null}

--- a/src/erp.mgt.mn/components/ReportTable.jsx
+++ b/src/erp.mgt.mn/components/ReportTable.jsx
@@ -55,7 +55,13 @@ function isCountColumn(name) {
   return f === 'count' || f === 'count()' || f.startsWith('count(');
 }
 
-export default function ReportTable({ procedure = '', params = {}, rows = [], buttonPerms = {} }) {
+export default function ReportTable({
+  procedure = '',
+  params = {},
+  rows = [],
+  buttonPerms = {},
+  fieldTypeMap = {},
+}) {
   const { user, branch, department } = useContext(AuthContext);
   const generalConfig = useGeneralConfig();
   const [page, setPage] = useState(1);
@@ -91,15 +97,22 @@ export default function ReportTable({ procedure = '', params = {}, rows = [], bu
   const placeholders = useMemo(() => {
     const map = {};
     columns.forEach((c) => {
-      const lower = c.toLowerCase();
-      if (lower.includes('time') && !lower.includes('date')) {
+      const typ = fieldTypeMap[c];
+      if (typ === 'time') {
         map[c] = 'HH:MM:SS';
-      } else if (lower.includes('timestamp') || lower.includes('date')) {
+      } else if (typ === 'date' || typ === 'datetime') {
         map[c] = 'YYYY-MM-DD';
+      } else if (!typ || typ === 'string') {
+        const lower = c.toLowerCase();
+        if (lower.includes('time') && !lower.includes('date')) {
+          map[c] = 'HH:MM:SS';
+        } else if (lower.includes('timestamp') || lower.includes('date')) {
+          map[c] = 'YYYY-MM-DD';
+        }
       }
     });
     return map;
-  }, [columns]);
+  }, [columns, fieldTypeMap]);
 
   const filtered = useMemo(() => {
     if (!search) return rows;
@@ -186,15 +199,22 @@ export default function ReportTable({ procedure = '', params = {}, rows = [], bu
   const modalPlaceholders = useMemo(() => {
     const map = {};
     modalColumns.forEach((c) => {
-      const lower = c.toLowerCase();
-      if (lower.includes('time') && !lower.includes('date')) {
+      const typ = fieldTypeMap[c];
+      if (typ === 'time') {
         map[c] = 'HH:MM:SS';
-      } else if (lower.includes('timestamp') || lower.includes('date')) {
+      } else if (typ === 'date' || typ === 'datetime') {
         map[c] = 'YYYY-MM-DD';
+      } else if (!typ || typ === 'string') {
+        const lower = c.toLowerCase();
+        if (lower.includes('time') && !lower.includes('date')) {
+          map[c] = 'HH:MM:SS';
+        } else if (lower.includes('timestamp') || lower.includes('date')) {
+          map[c] = 'YYYY-MM-DD';
+        }
       }
     });
     return map;
-  }, [modalColumns]);
+  }, [modalColumns, fieldTypeMap]);
 
   const modalAlign = useMemo(() => {
     const map = {};

--- a/src/erp.mgt.mn/components/RowDetailModal.jsx
+++ b/src/erp.mgt.mn/components/RowDetailModal.jsx
@@ -3,7 +3,16 @@ import Modal from './Modal.jsx';
 import { useTranslation } from 'react-i18next';
 import normalizeDateInput from '../utils/normalizeDateInput.js';
 
-export default function RowDetailModal({ visible, onClose, row = {}, columns = [], relations = {}, references = [], labels = {} }) {
+export default function RowDetailModal({
+  visible,
+  onClose,
+  row = {},
+  columns = [],
+  relations = {},
+  references = [],
+  labels = {},
+  fieldTypeMap = {},
+}) {
   const { t } = useTranslation();
   if (!visible) return null;
 
@@ -19,15 +28,22 @@ export default function RowDetailModal({ visible, onClose, row = {}, columns = [
   const placeholders = React.useMemo(() => {
     const map = {};
     cols.forEach((c) => {
-      const lower = c.toLowerCase();
-      if (lower.includes('time') && !lower.includes('date')) {
+      const typ = fieldTypeMap[c];
+      if (typ === 'time') {
         map[c] = 'HH:MM:SS';
-      } else if (lower.includes('timestamp') || lower.includes('date')) {
+      } else if (typ === 'date' || typ === 'datetime') {
         map[c] = 'YYYY-MM-DD';
+      } else if (!typ || typ === 'string') {
+        const lower = c.toLowerCase();
+        if (lower.includes('time') && !lower.includes('date')) {
+          map[c] = 'HH:MM:SS';
+        } else if (lower.includes('timestamp') || lower.includes('date')) {
+          map[c] = 'YYYY-MM-DD';
+        }
       }
     });
     return map;
-  }, [cols]);
+  }, [cols, fieldTypeMap]);
 
   return (
     <Modal visible={visible} title={t('row_details', 'Row Details')} onClose={onClose}>

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -1516,6 +1516,7 @@ const RowFormModal = function RowFormModal({
         columns={previewRow ? Object.keys(previewRow) : []}
         relations={relations}
         labels={labels}
+        fieldTypeMap={fieldTypeMap}
       />
     </>
   );

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -2693,6 +2693,7 @@ const TableManager = forwardRef(function TableManager({
         relations={relationOpts}
         references={detailRefs}
         labels={labels}
+        fieldTypeMap={fieldTypeMap}
       />
       <RowImageUploadModal
         visible={uploadRow !== null}

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -28,6 +28,20 @@ function normalizeDateInput(value, format) {
   return v;
 }
 
+function buildFieldTypeMap(rows) {
+  const map = {};
+  if (!Array.isArray(rows) || rows.length === 0) return map;
+  Object.keys(rows[0]).forEach((c) => {
+    const lower = c.toLowerCase();
+    if (lower.includes('time') && !lower.includes('date')) {
+      map[c] = 'time';
+    } else if (lower.includes('timestamp') || lower.includes('date')) {
+      map[c] = 'date';
+    }
+  });
+  return map;
+}
+
 function isEqual(a, b) {
   try {
     return JSON.stringify(a) === JSON.stringify(b);
@@ -445,7 +459,12 @@ useEffect(() => {
           `${label} returned ${rows.length} row${rows.length === 1 ? '' : 's'}`,
           'success',
         );
-        setReportResult({ name: selectedProc, params: paramMap, rows });
+        setReportResult({
+          name: selectedProc,
+          params: paramMap,
+          rows,
+          fieldTypeMap: buildFieldTypeMap(rows),
+        });
       } else {
         addToast('Failed to run procedure', 'error');
       }
@@ -627,7 +646,8 @@ useEffect(() => {
           procedure={reportResult.name}
           params={reportResult.params}
           rows={reportResult.rows}
-          buttonPerms={buttonPerms}
+           buttonPerms={buttonPerms}
+           fieldTypeMap={reportResult.fieldTypeMap}
         />
       )}
       {transactionNames.length === 0 && (

--- a/src/erp.mgt.mn/pages/Reports.jsx
+++ b/src/erp.mgt.mn/pages/Reports.jsx
@@ -19,6 +19,20 @@ function normalizeDateInput(value, format) {
   return v;
 }
 
+function buildFieldTypeMap(rows) {
+  const map = {};
+  if (!Array.isArray(rows) || rows.length === 0) return map;
+  Object.keys(rows[0]).forEach((c) => {
+    const lower = c.toLowerCase();
+    if (lower.includes('time') && !lower.includes('date')) {
+      map[c] = 'time';
+    } else if (lower.includes('timestamp') || lower.includes('date')) {
+      map[c] = 'date';
+    }
+  });
+  return map;
+}
+
 export default function Reports() {
   const { company, branch, user } = useContext(AuthContext);
   const buttonPerms = useButtonPerms();
@@ -173,7 +187,12 @@ export default function Reports() {
           `${label} returned ${rows.length} row${rows.length === 1 ? '' : 's'}`,
           'success',
         );
-        setResult({ name: selectedProc, params: paramMap, rows });
+        setResult({
+          name: selectedProc,
+          params: paramMap,
+          rows,
+          fieldTypeMap: buildFieldTypeMap(rows),
+        });
       } else {
         addToast('Failed to run procedure', 'error');
       }
@@ -286,6 +305,7 @@ export default function Reports() {
           params={result.params}
           rows={result.rows}
           buttonPerms={buttonPerms}
+          fieldTypeMap={result.fieldTypeMap}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- support explicit field type map in detail modal for more accurate date formatting
- allow ReportTable to consume field type hints and normalize dates
- forward field type info from calling pages and TableManager

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbf5c3c2d48331bc6a4a65624a180c