### PR TITLE
refactor: remove name-based date detection

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -155,18 +155,11 @@ export default forwardRef(function InlineTransactionTable({
   const placeholders = React.useMemo(() => {
     const map = {};
     fields.forEach((f) => {
-      const lower = f.toLowerCase();
       const typ = fieldTypeMap[f] || columnTypeMap[f] || '';
       if (typ === 'time') {
         map[f] = 'HH:MM:SS';
       } else if (typ === 'date' || typ === 'datetime') {
         map[f] = 'YYYY-MM-DD';
-      } else if (!typ || typ === 'string') {
-        if (lower.includes('time') && !lower.includes('date')) {
-          map[f] = 'HH:MM:SS';
-        } else if (lower.includes('timestamp') || lower.includes('date')) {
-          map[f] = 'YYYY-MM-DD';
-        }
       }
     });
     return map;

--- a/src/erp.mgt.mn/components/ReportTable.jsx
+++ b/src/erp.mgt.mn/components/ReportTable.jsx
@@ -102,13 +102,6 @@ export default function ReportTable({
         map[c] = 'HH:MM:SS';
       } else if (typ === 'date' || typ === 'datetime') {
         map[c] = 'YYYY-MM-DD';
-      } else if (!typ || typ === 'string') {
-        const lower = c.toLowerCase();
-        if (lower.includes('time') && !lower.includes('date')) {
-          map[c] = 'HH:MM:SS';
-        } else if (lower.includes('timestamp') || lower.includes('date')) {
-          map[c] = 'YYYY-MM-DD';
-        }
       }
     });
     return map;
@@ -204,13 +197,6 @@ export default function ReportTable({
         map[c] = 'HH:MM:SS';
       } else if (typ === 'date' || typ === 'datetime') {
         map[c] = 'YYYY-MM-DD';
-      } else if (!typ || typ === 'string') {
-        const lower = c.toLowerCase();
-        if (lower.includes('time') && !lower.includes('date')) {
-          map[c] = 'HH:MM:SS';
-        } else if (lower.includes('timestamp') || lower.includes('date')) {
-          map[c] = 'YYYY-MM-DD';
-        }
       }
     });
     return map;

--- a/src/erp.mgt.mn/components/RowDetailModal.jsx
+++ b/src/erp.mgt.mn/components/RowDetailModal.jsx
@@ -33,13 +33,6 @@ export default function RowDetailModal({
         map[c] = 'HH:MM:SS';
       } else if (typ === 'date' || typ === 'datetime') {
         map[c] = 'YYYY-MM-DD';
-      } else if (!typ || typ === 'string') {
-        const lower = c.toLowerCase();
-        if (lower.includes('time') && !lower.includes('date')) {
-          map[c] = 'HH:MM:SS';
-        } else if (lower.includes('timestamp') || lower.includes('date')) {
-          map[c] = 'YYYY-MM-DD';
-        }
       }
     });
     return map;

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -110,16 +110,11 @@ const RowFormModal = function RowFormModal({
     const init = {};
     const now = new Date();
     columns.forEach((c) => {
-      const lower = c.toLowerCase();
       const typ = fieldTypeMap[c];
       let placeholder = '';
-      if (typ === 'time' || (!typ && lower.includes('time') && !lower.includes('date'))) {
+      if (typ === 'time') {
         placeholder = 'HH:MM:SS';
-      } else if (
-        typ === 'date' ||
-        typ === 'datetime' ||
-        (!typ && (lower.includes('timestamp') || lower.includes('date')))
-      ) {
+      } else if (typ === 'date' || typ === 'datetime') {
         placeholder = 'YYYY-MM-DD';
       }
       const raw = row ? String(row[c] ?? '') : String(defaultValues[c] ?? '');
@@ -147,16 +142,11 @@ const RowFormModal = function RowFormModal({
     const extras = {};
     Object.entries(row || {}).forEach(([k, v]) => {
       if (!columns.includes(k)) {
-        const lower = k.toLowerCase();
         const typ = fieldTypeMap[k];
         let placeholder = '';
-        if (typ === 'time' || (!typ && lower.includes('time') && !lower.includes('date'))) {
+        if (typ === 'time') {
           placeholder = 'HH:MM:SS';
-        } else if (
-          typ === 'date' ||
-          typ === 'datetime' ||
-          (!typ && (lower.includes('timestamp') || lower.includes('date')))
-        ) {
+        } else if (typ === 'date' || typ === 'datetime') {
           placeholder = 'YYYY-MM-DD';
         }
         extras[k] = normalizeDateInput(String(v ?? ''), placeholder);
@@ -225,18 +215,11 @@ const RowFormModal = function RowFormModal({
       ...Object.keys(defaultValues || {}),
     ]);
     cols.forEach((c) => {
-      const lower = c.toLowerCase();
       const typ = fieldTypeMap[c];
       if (typ === 'time') {
         map[c] = 'HH:MM:SS';
       } else if (typ === 'date' || typ === 'datetime') {
         map[c] = 'YYYY-MM-DD';
-      } else if (!typ || typ === 'string') {
-        if (lower.includes('time') && !lower.includes('date')) {
-          map[c] = 'HH:MM:SS';
-        } else if (lower.includes('timestamp') || lower.includes('date')) {
-          map[c] = 'YYYY-MM-DD';
-        }
       }
     });
     return map;

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -28,20 +28,6 @@ function normalizeDateInput(value, format) {
   return v;
 }
 
-function buildFieldTypeMap(rows) {
-  const map = {};
-  if (!Array.isArray(rows) || rows.length === 0) return map;
-  Object.keys(rows[0]).forEach((c) => {
-    const lower = c.toLowerCase();
-    if (lower.includes('time') && !lower.includes('date')) {
-      map[c] = 'time';
-    } else if (lower.includes('timestamp') || lower.includes('date')) {
-      map[c] = 'date';
-    }
-  });
-  return map;
-}
-
 function isEqual(a, b) {
   try {
     return JSON.stringify(a) === JSON.stringify(b);
@@ -463,7 +449,7 @@ useEffect(() => {
           name: selectedProc,
           params: paramMap,
           rows,
-          fieldTypeMap: buildFieldTypeMap(rows),
+          fieldTypeMap: data.fieldTypeMap || {},
         });
       } else {
         addToast('Failed to run procedure', 'error');
@@ -568,24 +554,7 @@ useEffect(() => {
                     />
                     {procParams.map((p, i) => {
                       if (autoParams[i] !== null) return null;
-                      const lower = p.toLowerCase();
                       const val = manualParams[p] || '';
-                      if (lower.includes('date')) {
-                        return (
-                          <CustomDatePicker
-                            key={p}
-                            value={val}
-                            onChange={(v) =>
-                              setManualParams((m) => ({
-                                ...m,
-                                [p]: normalizeDateInput(v, 'YYYY-MM-DD'),
-                              }))
-                            }
-                            placeholder={p}
-                            style={{ marginLeft: '0.5rem' }}
-                          />
-                        );
-                      }
                       return (
                         <input
                           key={p}

--- a/src/erp.mgt.mn/pages/Reports.jsx
+++ b/src/erp.mgt.mn/pages/Reports.jsx
@@ -19,20 +19,6 @@ function normalizeDateInput(value, format) {
   return v;
 }
 
-function buildFieldTypeMap(rows) {
-  const map = {};
-  if (!Array.isArray(rows) || rows.length === 0) return map;
-  Object.keys(rows[0]).forEach((c) => {
-    const lower = c.toLowerCase();
-    if (lower.includes('time') && !lower.includes('date')) {
-      map[c] = 'time';
-    } else if (lower.includes('timestamp') || lower.includes('date')) {
-      map[c] = 'date';
-    }
-  });
-  return map;
-}
-
 export default function Reports() {
   const { company, branch, user } = useContext(AuthContext);
   const buttonPerms = useButtonPerms();
@@ -191,7 +177,7 @@ export default function Reports() {
           name: selectedProc,
           params: paramMap,
           rows,
-          fieldTypeMap: buildFieldTypeMap(rows),
+          fieldTypeMap: data.fieldTypeMap || {},
         });
       } else {
         addToast('Failed to run procedure', 'error');
@@ -258,24 +244,7 @@ export default function Reports() {
               />
               {procParams.map((p, i) => {
                 if (autoParams[i] !== null) return null;
-                const lower = p.toLowerCase();
                 const val = manualParams[p] || '';
-                if (lower.includes('date')) {
-                  return (
-                    <CustomDatePicker
-                      key={p}
-                      value={val}
-                      onChange={(v) =>
-                        setManualParams((m) => ({
-                          ...m,
-                          [p]: normalizeDateInput(v, 'YYYY-MM-DD'),
-                        }))
-                      }
-                      placeholder={p}
-                      style={{ marginLeft: '0.5rem' }}
-                    />
-                  );
-                }
                 return (
                   <input
                     key={p}


### PR DESCRIPTION
## Summary
- derive field types from metadata instead of column names
- default to simple text inputs when field type metadata missing
- obtain field type info for reports directly from server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbf971327c833184eeed20767e4626