### PR TITLE
Normalize date inputs across components

### DIFF
--- a/src/erp.mgt.mn/components/CustomDatePicker.jsx
+++ b/src/erp.mgt.mn/components/CustomDatePicker.jsx
@@ -1,15 +1,20 @@
 import React from 'react';
+import normalizeDateInput from '../utils/normalizeDateInput.js';
 
 /**
  * Simple wrapper around the native date input so we can swap in a
  * custom date picker implementation later without touching callers.
  */
 export default function CustomDatePicker({ value, onChange, ...rest }) {
+  const handleChange = (e) => {
+    const v = normalizeDateInput(e.target.value, 'YYYY-MM-DD');
+    onChange(v);
+  };
   return (
     <input
       type="date"
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
+      value={normalizeDateInput(value, 'YYYY-MM-DD')}
+      onChange={handleChange}
       style={{ padding: '0.25em', ...(rest.style || {}) }}
       {...rest}
     />

--- a/src/erp.mgt.mn/components/DateRangePicker.jsx
+++ b/src/erp.mgt.mn/components/DateRangePicker.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import CustomDatePicker from './CustomDatePicker.jsx';
 import formatTimestamp from '../utils/formatTimestamp.js';
+import normalizeDateInput from '../utils/normalizeDateInput.js';
 
 /**
  * Reusable date range picker with common presets.
@@ -8,8 +9,12 @@ import formatTimestamp from '../utils/formatTimestamp.js';
  */
 export default function DateRangePicker({ start, end, onChange, style }) {
   const [preset, setPreset] = useState('today');
-  const [customStart, setCustomStart] = useState(start || '');
-  const [customEnd, setCustomEnd] = useState(end || '');
+  const [customStart, setCustomStart] = useState(() =>
+    normalizeDateInput(start || '', 'YYYY-MM-DD'),
+  );
+  const [customEnd, setCustomEnd] = useState(() =>
+    normalizeDateInput(end || '', 'YYYY-MM-DD'),
+  );
 
   useEffect(() => {
     const fmt = (d) => formatTimestamp(d).slice(0, 10);
@@ -97,12 +102,12 @@ export default function DateRangePicker({ start, end, onChange, style }) {
         <>
           <CustomDatePicker
             value={customStart}
-            onChange={setCustomStart}
+            onChange={(v) => setCustomStart(normalizeDateInput(v, 'YYYY-MM-DD'))}
             style={{ marginRight: '0.25rem' }}
           />
           <CustomDatePicker
             value={customEnd}
-            onChange={setCustomEnd}
+            onChange={(v) => setCustomEnd(normalizeDateInput(v, 'YYYY-MM-DD'))}
             style={{ marginRight: '0.5rem' }}
           />
         </>

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -17,16 +17,7 @@ import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import useHeaderMappings from '../hooks/useHeaderMappings.js';
 import CustomDatePicker from '../components/CustomDatePicker.jsx';
 import useButtonPerms from '../hooks/useButtonPerms.js';
-
-function normalizeDateInput(value, format) {
-  if (typeof value !== 'string') return value;
-  let v = value.trim().replace(/^(\d{4})[.,](\d{2})[.,](\d{2})/, '$1-$2-$3');
-  if (/^\d{4}-\d{2}-\d{2}T/.test(v) && !isNaN(Date.parse(v))) {
-    const local = formatTimestamp(new Date(v));
-    return format === 'HH:MM:SS' ? local.slice(11, 19) : local.slice(0, 10);
-  }
-  return v;
-}
+import normalizeDateInput from '../utils/normalizeDateInput.js';
 
 function isEqual(a, b) {
   try {

--- a/src/erp.mgt.mn/pages/Reports.jsx
+++ b/src/erp.mgt.mn/pages/Reports.jsx
@@ -8,16 +8,7 @@ import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import useHeaderMappings from '../hooks/useHeaderMappings.js';
 import CustomDatePicker from '../components/CustomDatePicker.jsx';
 import useButtonPerms from '../hooks/useButtonPerms.js';
-
-function normalizeDateInput(value, format) {
-  if (typeof value !== 'string') return value;
-  let v = value.trim().replace(/^(\d{4})[.,](\d{2})[.,](\d{2})/, '$1-$2-$3');
-  if (/^\d{4}-\d{2}-\d{2}T/.test(v) && !isNaN(Date.parse(v))) {
-    const local = formatTimestamp(new Date(v));
-    return format === 'HH:MM:SS' ? local.slice(11, 19) : local.slice(0, 10);
-  }
-  return v;
-}
+import normalizeDateInput from '../utils/normalizeDateInput.js';
 
 export default function Reports() {
   const { company, branch, user } = useContext(AuthContext);


### PR DESCRIPTION
## Summary
- Import shared normalizeDateInput helper into date-handling components
- Normalize date field values before rendering or updating state to avoid raw ISO timestamps

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbfb1597a08331b8a2d960e6c89f9e