### PR TITLE
Normalize ISO timestamps without placeholders

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -2404,6 +2404,11 @@ const TableManager = forwardRef(function TableManager({
                   fieldTypeMap[c] === 'time'
                 ) {
                   display = normalizeDateInput(raw, placeholders[c]);
+                } else if (
+                  placeholders[c] === undefined &&
+                  /^\d{4}-\d{2}-\d{2}T/.test(raw)
+                ) {
+                  display = normalizeDateInput(raw, 'YYYY-MM-DD');
                 }
                 const showFull = display.length > 20;
                 return (


### PR DESCRIPTION
## Summary
- Convert ISO timestamp strings to short dates when no placeholder metadata exists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbfdd3375c8331b2aae72ecd31fc45