### PR TITLE
Normalize ISO dates in saved transaction cells

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -1052,7 +1052,16 @@ export default forwardRef(function InlineTransactionTable({
       );
     }
     if (rows[idx]?._saved && !collectRows) {
-      return typeof val === 'object' ? val.label : val;
+      const isoDatePattern = /^\d{4}-\d{2}-\d{2}(?:T.*)?$/;
+      const displayVal = typeof val === 'object' ? val.label ?? val.value : val;
+      if (
+        typeof displayVal === 'string' &&
+        isoDatePattern.test(displayVal) &&
+        !placeholders[f]
+      ) {
+        return normalizeDateInput(displayVal, 'YYYY-MM-DD');
+      }
+      return displayVal;
     }
     if (isRel) {
       if (relationConfigs[f]) {


### PR DESCRIPTION
## Summary
- Normalize ISO date strings for saved table cells when no placeholder is set
- Avoid losing object-based values by formatting embedded date strings without mutation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbfe636d9483319559e052f14aba30