### PR TITLE
Use normalizeDateInput for ISO date strings

### DIFF
--- a/src/erp.mgt.mn/components/ReportTable.jsx
+++ b/src/erp.mgt.mn/components/ReportTable.jsx
@@ -45,7 +45,7 @@ function formatCellValue(val, placeholder) {
     return normalizeDateInput(str, placeholder);
   }
   if (/^\d{4}-\d{2}-\d{2}/.test(str)) {
-    return str.slice(0, 10);
+    return normalizeDateInput(str, 'YYYY-MM-DD');
   }
   return str;
 }


### PR DESCRIPTION
## Summary
- ensure report table uses normalizeDateInput for ISO date strings when no placeholder exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc00426f4c8331b4011fa56125e155