### PR TITLE
fix: call hooks before visibility check

### DIFF
--- a/src/erp.mgt.mn/components/RowDetailModal.jsx
+++ b/src/erp.mgt.mn/components/RowDetailModal.jsx
@@ -14,16 +14,6 @@ export default function RowDetailModal({
   fieldTypeMap = {},
 }) {
   const { t } = useTranslation();
-  if (!visible) return null;
-
-  const labelMap = {};
-  Object.entries(relations).forEach(([col, opts]) => {
-    labelMap[col] = {};
-    opts.forEach((o) => {
-      labelMap[col][o.value] = o.label;
-    });
-  });
-
   const cols = columns.length > 0 ? columns : Object.keys(row);
   const placeholders = React.useMemo(() => {
     const map = {};
@@ -37,6 +27,16 @@ export default function RowDetailModal({
     });
     return map;
   }, [cols, fieldTypeMap]);
+
+  if (!visible) return null;
+
+  const labelMap = {};
+  Object.entries(relations).forEach(([col, opts]) => {
+    labelMap[col] = {};
+    opts.forEach((o) => {
+      labelMap[col][o.value] = o.label;
+    });
+  });
 
   return (
     <Modal visible={visible} title={t('row_details', 'Row Details')} onClose={onClose}>


### PR DESCRIPTION
## Summary
- compute `cols` and `placeholders` unconditionally
- move visibility check after hooks to keep hook order stable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc06e6f740833190eb0c517ee3648e