### PR TITLE
Fix hook order in RowDetailModal

### DIFF
--- a/src/erp.mgt.mn/components/RowDetailModal.jsx
+++ b/src/erp.mgt.mn/components/RowDetailModal.jsx
@@ -14,16 +14,6 @@ export default function RowDetailModal({
   fieldTypeMap = {},
 }) {
   const { t } = useTranslation();
-  if (!visible) return null;
-
-  const labelMap = {};
-  Object.entries(relations).forEach(([col, opts]) => {
-    labelMap[col] = {};
-    opts.forEach((o) => {
-      labelMap[col][o.value] = o.label;
-    });
-  });
-
   const cols = columns.length > 0 ? columns : Object.keys(row);
   const placeholders = React.useMemo(() => {
     const map = {};
@@ -37,6 +27,16 @@ export default function RowDetailModal({
     });
     return map;
   }, [cols, fieldTypeMap]);
+
+  if (!visible) return null;
+
+  const labelMap = {};
+  Object.entries(relations).forEach(([col, opts]) => {
+    labelMap[col] = {};
+    opts.forEach((o) => {
+      labelMap[col][o.value] = o.label;
+    });
+  });
 
   return (
     <Modal visible={visible} title={t('row_details', 'Row Details')} onClose={onClose}>

--- a/tests/components/rowDetailModalHooks.test.js
+++ b/tests/components/rowDetailModalHooks.test.js
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+global.document = { createElement: () => ({}) };
+global.window = {
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  dispatchEvent: () => {},
+};
+
+let React, act, createRoot;
+let haveReact = true;
+try {
+  const reactMod = await import('react');
+  React = reactMod.default || reactMod;
+  ({ act } = await import('react-dom/test-utils'));
+  ({ createRoot } = await import('react-dom/client'));
+} catch {
+  haveReact = false;
+}
+
+if (!haveReact) {
+  test('RowDetailModal hook order stable when toggling visibility', { skip: true }, () => {});
+} else {
+  test('RowDetailModal hook order stable when toggling visibility', async (t) => {
+    const { default: RowDetailModal } = await t.mock.import(
+      '../../src/erp.mgt.mn/components/RowDetailModal.jsx',
+      {
+        './Modal.jsx': { default: () => null },
+        'react-i18next': { useTranslation: () => ({ t: (_, d) => d }) },
+      },
+    );
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(React.createElement(RowDetailModal, { visible: false }));
+    });
+
+    assert.doesNotThrow(() => {
+      act(() => {
+        root.render(React.createElement(RowDetailModal, { visible: true }));
+      });
+    });
+
+    root.unmount();
+  });
+}


### PR DESCRIPTION
## Summary
- ensure RowDetailModal computes columns and placeholders before visibility check so hooks run consistently
- add test to verify toggling visibility doesn't break hook order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc0e99fdb48331a71e2a7c0b5a1295