### PR TITLE
fix: handle missing row in RowDetailModal

### DIFF
--- a/src/erp.mgt.mn/components/RowDetailModal.jsx
+++ b/src/erp.mgt.mn/components/RowDetailModal.jsx
@@ -14,7 +14,8 @@ export default function RowDetailModal({
   fieldTypeMap = {},
 }) {
   const { t } = useTranslation();
-  const cols = columns.length > 0 ? columns : Object.keys(row);
+  const safeRow = row || {};
+  const cols = columns.length > 0 ? columns : Object.keys(safeRow);
   const placeholders = React.useMemo(() => {
     const map = {};
     cols.forEach((c) => {
@@ -63,7 +64,9 @@ export default function RowDetailModal({
                   }}
                 >
                   {(() => {
-                    const raw = relations[c] ? labelMap[c][row[c]] || row[c] : row[c];
+                    const raw = relations[c]
+                      ? labelMap[c][safeRow[c]] || safeRow[c]
+                      : safeRow[c];
                     const str = String(raw ?? '');
                     let display;
                     if (placeholders[c]) {


### PR DESCRIPTION
## Summary
- avoid accessing undefined row in RowDetailModal by using safeRow fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc107e900c833182fba9b8a66c944b