### PR TITLE
feat: add companyId support for config services

### DIFF
--- a/api-server/controllers/generalConfigController.js
+++ b/api-server/controllers/generalConfigController.js
@@ -4,12 +4,13 @@ import { hasAction } from '../utils/hasAction.js';
 
 export async function fetchGeneralConfig(req, res, next) {
   try {
+    const companyId = Number(req.query?.companyId ?? req.user.companyId);
     const session =
       req.session ||
-      (await getEmploymentSession(req.user.empid, req.user.companyId));
+      (await getEmploymentSession(req.user.empid, companyId));
     if (!(await hasAction(session, 'system_settings'))) return res.sendStatus(403);
     const getter = req.getGeneralConfig || cfgSvc.getGeneralConfig;
-    const cfg = await getter();
+    const cfg = await getter(companyId);
     res.json(cfg);
   } catch (err) {
     next(err);
@@ -18,12 +19,13 @@ export async function fetchGeneralConfig(req, res, next) {
 
 export async function saveGeneralConfig(req, res, next) {
   try {
+    const companyId = Number(req.query?.companyId ?? req.user.companyId);
     const session =
       req.session ||
-      (await getEmploymentSession(req.user.empid, req.user.companyId));
+      (await getEmploymentSession(req.user.empid, companyId));
     if (!(await hasAction(session, 'system_settings'))) return res.sendStatus(403);
     const updater = req.updateGeneralConfig || cfgSvc.updateGeneralConfig;
-    const cfg = await updater(req.body || {});
+    const cfg = await updater(req.body || {}, companyId);
     res.json(cfg);
   } catch (err) {
     next(err);

--- a/api-server/routes/ai_inventory.js
+++ b/api-server/routes/ai_inventory.js
@@ -14,8 +14,9 @@ const upload = multer({ storage: multer.memoryStorage() });
 router.post('/identify', requireAuth, upload.single('image'), async (req, res, next) => {
   try {
     if (!req.file) return res.status(400).json({ message: 'missing image' });
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const items = await identifyItems(req.file.buffer, req.file.mimetype);
-    const result = await saveResult(req.user.empid, items, req.user.companyId);
+    const result = await saveResult(req.user.empid, items, companyId);
     res.json(result);
   } catch (err) {
     next(err);
@@ -24,7 +25,8 @@ router.post('/identify', requireAuth, upload.single('image'), async (req, res, n
 
 router.get('/results', requireAuth, async (req, res, next) => {
   try {
-    const data = await listResults(req.user.companyId);
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
+    const data = await listResults(companyId);
     res.json(data);
   } catch (err) {
     next(err);
@@ -33,7 +35,8 @@ router.get('/results', requireAuth, async (req, res, next) => {
 
 router.post('/results/:id/confirm', requireAuth, async (req, res, next) => {
   try {
-    const rec = await confirmResult(req.params.id, req.user.companyId);
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
+    const rec = await confirmResult(req.params.id, companyId);
     if (!rec) return res.sendStatus(404);
     res.json(rec);
   } catch (err) {

--- a/api-server/routes/coding_table_configs.js
+++ b/api-server/routes/coding_table_configs.js
@@ -11,12 +11,13 @@ const router = express.Router();
 
 router.get('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const table = req.query.table;
     if (table) {
-      const cfg = await getConfig(table, req.user.companyId);
+      const cfg = await getConfig(table, companyId);
       res.json(cfg);
     } else {
-      const all = await getAllConfigs(req.user.companyId);
+      const all = await getAllConfigs(companyId);
       res.json(all);
     }
   } catch (err) {
@@ -26,9 +27,10 @@ router.get('/', requireAuth, async (req, res, next) => {
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const { table, config } = req.body;
     if (!table) return res.status(400).json({ message: 'table is required' });
-    await setConfig(table, config || {}, req.user.companyId);
+    await setConfig(table, config || {}, companyId);
     res.status(200).json({ message: 'Config saved successfully' });
   } catch (err) {
     next(err);
@@ -37,9 +39,10 @@ router.post('/', requireAuth, async (req, res, next) => {
 
 router.delete('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const table = req.query.table;
     if (!table) return res.status(400).json({ message: 'table is required' });
-    await deleteConfig(table, req.user.companyId);
+    await deleteConfig(table, companyId);
     res.sendStatus(204);
   } catch (err) {
     next(err);

--- a/api-server/routes/display_fields.js
+++ b/api-server/routes/display_fields.js
@@ -11,12 +11,13 @@ const router = express.Router();
 
 router.get('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const table = req.query.table;
     if (table) {
-      const config = await getDisplayFields(table, req.user.companyId);
+      const config = await getDisplayFields(table, companyId);
       res.json(config);
     } else {
-      const configs = await getAllDisplayFields(req.user.companyId);
+      const configs = await getAllDisplayFields(companyId);
       res.json(configs);
     }
   } catch (err) {
@@ -26,9 +27,10 @@ router.get('/', requireAuth, async (req, res, next) => {
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const { table, idField, displayFields } = req.body;
     if (!table) return res.status(400).json({ message: 'table is required' });
-    await setDisplayFields(table, { idField, displayFields }, req.user.companyId);
+    await setDisplayFields(table, { idField, displayFields }, companyId);
     res.sendStatus(204);
   } catch (err) {
     next(err);
@@ -37,9 +39,10 @@ router.post('/', requireAuth, async (req, res, next) => {
 
 router.delete('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const table = req.query.table;
     if (!table) return res.status(400).json({ message: 'table is required' });
-    await removeDisplayFields(table, req.user.companyId);
+    await removeDisplayFields(table, companyId);
     res.sendStatus(204);
   } catch (err) {
     next(err);

--- a/api-server/routes/general_config.js
+++ b/api-server/routes/general_config.js
@@ -7,7 +7,8 @@ const router = express.Router();
 
 router.get('/', requireAuth, async (req, res, next) => {
   try {
-    const cfg = await getGeneralConfig(req.user.companyId);
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
+    const cfg = await getGeneralConfig(companyId);
     res.json(cfg);
   } catch (err) {
     next(err);
@@ -16,11 +17,12 @@ router.get('/', requireAuth, async (req, res, next) => {
 
 router.put('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const session =
       req.session ||
-      (await getEmploymentSession(req.user.empid, req.user.companyId));
+      (await getEmploymentSession(req.user.empid, companyId));
     if (!session?.permissions?.system_settings) return res.sendStatus(403);
-    const cfg = await updateGeneralConfig(req.body || {}, req.user.companyId);
+    const cfg = await updateGeneralConfig(req.body || {}, companyId);
     res.json(cfg);
   } catch (err) {
     next(err);

--- a/api-server/routes/generated_sql.js
+++ b/api-server/routes/generated_sql.js
@@ -6,11 +6,12 @@ const router = express.Router();
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const { table, sql } = req.body;
     if (!table || !sql) {
       return res.status(400).json({ message: 'table and sql required' });
     }
-    await saveSql(table, sql, req.user.companyId);
+    await saveSql(table, sql, companyId);
     res.sendStatus(204);
   } catch (err) {
     next(err);

--- a/api-server/routes/header_mappings.js
+++ b/api-server/routes/header_mappings.js
@@ -9,9 +9,10 @@ const router = express.Router();
 // "lang" selects a localized value when available.
 router.get('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const { headers: headersParam, lang } = req.query;
     const headers = headersParam ? headersParam.split(',') : [];
-    const map = await getMappings(headers, lang, req.user.companyId);
+    const map = await getMappings(headers, lang, companyId);
     res.json(map);
   } catch (err) {
     next(err);
@@ -28,7 +29,8 @@ const postRateLimiter = rateLimit({
 // Body: { "sales": { "en": "Sales Dashboard" } }
 router.post('/', requireAuth, postRateLimiter, async (req, res, next) => {
   try {
-    await addMappings(req.body || {}, req.user.companyId);
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
+    await addMappings(req.body || {}, companyId);
     res.sendStatus(204);
   } catch (err) {
     next(err);

--- a/api-server/routes/pos_txn_config.js
+++ b/api-server/routes/pos_txn_config.js
@@ -11,12 +11,13 @@ const router = express.Router();
 
 router.get('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const name = req.query.name;
     if (name) {
-      const cfg = await getConfig(name, req.user.companyId);
+      const cfg = await getConfig(name, companyId);
       res.json(cfg || {});
     } else {
-      const all = await getAllConfigs(req.user.companyId);
+      const all = await getAllConfigs(companyId);
       res.json(all);
     }
   } catch (err) {
@@ -26,9 +27,10 @@ router.get('/', requireAuth, async (req, res, next) => {
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const { name, config } = req.body;
     if (!name) return res.status(400).json({ message: 'name is required' });
-    await setConfig(name, config || {}, req.user.companyId);
+    await setConfig(name, config || {}, companyId);
     res.sendStatus(204);
   } catch (err) {
     next(err);
@@ -37,9 +39,10 @@ router.post('/', requireAuth, async (req, res, next) => {
 
 router.delete('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const name = req.query.name;
     if (!name) return res.status(400).json({ message: 'name is required' });
-    await deleteConfig(name, req.user.companyId);
+    await deleteConfig(name, companyId);
     res.sendStatus(204);
   } catch (err) {
     next(err);

--- a/api-server/routes/pos_txn_layout.js
+++ b/api-server/routes/pos_txn_layout.js
@@ -6,12 +6,13 @@ const router = express.Router();
 
 router.get('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const name = req.query.name;
     if (name) {
-      const cfg = await getLayout(name, req.user.companyId);
+      const cfg = await getLayout(name, companyId);
       res.json(cfg || {});
     } else {
-      const all = await getAllLayouts(req.user.companyId);
+      const all = await getAllLayouts(companyId);
       res.json(all);
     }
   } catch (err) {
@@ -21,9 +22,10 @@ router.get('/', requireAuth, async (req, res, next) => {
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const { name, layout } = req.body;
     if (!name) return res.status(400).json({ message: 'name is required' });
-    await setLayout(name, layout || {}, req.user.companyId);
+    await setLayout(name, layout || {}, companyId);
     res.sendStatus(204);
   } catch (err) {
     next(err);

--- a/api-server/routes/pos_txn_pending.js
+++ b/api-server/routes/pos_txn_pending.js
@@ -6,15 +6,16 @@ const router = express.Router();
 
 router.get('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const { id, name } = req.query;
     if (id) {
-      const rec = await getPending(id, req.user.companyId);
+      const rec = await getPending(id, companyId);
       if (!rec || (rec.session?.employeeId && rec.session.employeeId !== req.user.empid)) {
         return res.status(404).json({ message: 'Not found' });
       }
       res.json(rec || {});
     } else {
-      const list = await listPending(name, req.user.empid, req.user.companyId);
+      const list = await listPending(name, req.user.empid, companyId);
       res.json(list);
     }
   } catch (err) {
@@ -24,6 +25,7 @@ router.get('/', requireAuth, async (req, res, next) => {
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const { id, name, data, masterId, session } = req.body;
     if (!name) return res.status(400).json({ message: 'name is required' });
     const info = { ...(session || {}), employeeId: req.user.empid };
@@ -31,7 +33,7 @@ router.post('/', requireAuth, async (req, res, next) => {
       id,
       { name, data, masterId, session: info },
       req.user.empid,
-      req.user.companyId,
+      companyId,
     );
     res.json({ id: result.id });
   } catch (err) {
@@ -41,9 +43,10 @@ router.post('/', requireAuth, async (req, res, next) => {
 
 router.delete('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const { id } = req.query;
     if (!id) return res.status(400).json({ message: 'id is required' });
-    await deletePending(id, req.user.companyId);
+    await deletePending(id, companyId);
     res.sendStatus(204);
   } catch (err) {
     next(err);

--- a/api-server/routes/pos_txn_post.js
+++ b/api-server/routes/pos_txn_post.js
@@ -6,10 +6,11 @@ const router = express.Router();
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const { data, session } = req.body;
     if (!data) return res.status(400).json({ message: 'invalid data' });
     const info = { ...(session || {}), userId: req.user.id };
-    const id = await postPosTransaction(data, info, req.user.companyId);
+    const id = await postPosTransaction(data, info, companyId);
     res.json({ id });
   } catch (err) {
     next(err);

--- a/api-server/routes/transaction_forms.js
+++ b/api-server/routes/transaction_forms.js
@@ -13,19 +13,20 @@ const router = express.Router();
 
 router.get('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const { table, name, moduleKey, branchId, departmentId, proc } = req.query;
     if (proc) {
-      const tbl = await findTableByProcedure(proc, req.user.companyId);
+      const tbl = await findTableByProcedure(proc, companyId);
       if (tbl) res.json({ table: tbl });
       else res.status(404).json({ message: 'Table not found' });
     } else if (table && name) {
-      const cfg = await getFormConfig(table, name, req.user.companyId);
+      const cfg = await getFormConfig(table, name, companyId);
       res.json(cfg);
     } else if (table) {
-      const all = await getConfigsByTable(table, req.user.companyId);
+      const all = await getConfigsByTable(table, companyId);
       res.json(all);
     } else {
-      const names = await listTransactionNames({ moduleKey, branchId, departmentId }, req.user.companyId);
+      const names = await listTransactionNames({ moduleKey, branchId, departmentId }, companyId);
       res.json(names);
     }
   } catch (err) {
@@ -35,10 +36,11 @@ router.get('/', requireAuth, async (req, res, next) => {
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const { table, name, config } = req.body;
     if (!table || !name)
       return res.status(400).json({ message: 'table and name are required' });
-    await setFormConfig(table, name, config, {}, req.user.companyId);
+    await setFormConfig(table, name, config, {}, companyId);
     res.sendStatus(204);
   } catch (err) {
     next(err);
@@ -47,10 +49,11 @@ router.post('/', requireAuth, async (req, res, next) => {
 
 router.delete('/', requireAuth, async (req, res, next) => {
   try {
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     const { table, name } = req.query;
     if (!table || !name)
       return res.status(400).json({ message: 'table and name are required' });
-    await deleteFormConfig(table, name, req.user.companyId);
+    await deleteFormConfig(table, name, companyId);
     res.sendStatus(204);
   } catch (err) {
     next(err);

--- a/api-server/services/headerMappings.js
+++ b/api-server/services/headerMappings.js
@@ -45,8 +45,8 @@ export async function getMappings(headers = [], lang, companyId = 0) {
   return result;
 }
 
-export async function addMappings(newMap) {
-  const map = await readMappings();
+export async function addMappings(newMap, companyId = 0) {
+  const map = await readMappings(companyId);
   for (const [k, v] of Object.entries(newMap)) {
     if (v == null) continue;
     if (

--- a/tests/api/detectIncompleteImages.test.js
+++ b/tests/api/detectIncompleteImages.test.js
@@ -17,7 +17,7 @@ function mockPool(handler) {
   return () => { db.pool.query = orig; };
 }
 
-const cfgPath = path.join(process.cwd(), 'config', 'transactionForms.json');
+const cfgPath = path.join(process.cwd(), 'config', '0', 'transactionForms.json');
 const baseDir = path.join(process.cwd(), 'uploads', 'txn_images', 'transactions_test');
 
 await test('detectIncompleteImages finds and fixes files', async () => {

--- a/tests/db/codingTableConfig.test.js
+++ b/tests/db/codingTableConfig.test.js
@@ -4,7 +4,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { setConfig } from '../../api-server/services/codingTableConfig.js';
 
-const filePath = path.join(process.cwd(), 'config', 'codingTableConfigs.json');
+const filePath = path.join(process.cwd(), 'config', '0', 'codingTableConfigs.json');
 
 function withTempFile() {
   return fs.readFile(filePath, 'utf8')

--- a/tests/db/columnMeta.test.js
+++ b/tests/db/columnMeta.test.js
@@ -4,7 +4,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import * as db from '../../db/index.js';
 
-const filePath = path.join(process.cwd(), 'config', 'headerMappings.json');
+const filePath = path.join(process.cwd(), 'config', '0', 'headerMappings.json');
 
 function mockPool(handler) {
   const original = db.pool.query;

--- a/tests/db/procedureRawRows.test.js
+++ b/tests/db/procedureRawRows.test.js
@@ -58,7 +58,7 @@ END`;
   assert.ok(!/HAVING/i.test(sql));
   assert.ok(!/SUM\(/i.test(sql));
   assert.ok(/after/i.test(sql));
-  await fs.unlink(path.join(process.cwd(), 'config', 'sp_test_rows.sql')).catch(() => {});
+  await fs.unlink(path.join(process.cwd(), 'config', '0', 'sp_test_rows.sql')).catch(() => {});
 });
 
 test('getProcedureRawRows handles nested SUM expressions', { concurrency: false }, async () => {
@@ -84,7 +84,7 @@ END`;
   assert.ok(!/\ba_val\b/i.test(sql));
   assert.ok(!/SUM\(/i.test(sql));
   assert.ok(sql.includes("id = 5"));
-  await fs.unlink(path.join(process.cwd(), 'config', 'sp_case_rows.sql')).catch(() => {});
+  await fs.unlink(path.join(process.cwd(), 'config', '0', 'sp_case_rows.sql')).catch(() => {});
 });
 
 test(
@@ -93,7 +93,7 @@ test(
   async () => {
     const origRead = fs.readFile;
     fs.readFile = async (p, enc) => {
-      if (p.endsWith(path.join('config', 'transactionForms.json'))) {
+      if (p.endsWith(path.join('config', '0', 'transactionForms.json'))) {
         return JSON.stringify({
           trans: {
             general: {
@@ -108,7 +108,7 @@ test(
           },
         });
       }
-      if (p.endsWith(path.join('config', 'tableDisplayFields.json'))) {
+      if (p.endsWith(path.join('config', '0', 'tableDisplayFields.json'))) {
         return JSON.stringify({
           trans: { idField: 'id', displayFields: ['id', 'note', 'hdr', 'main', 'ftr'] },
         });
@@ -138,7 +138,7 @@ END`;
     assert.ok(sql.includes('tr.ftr'));
     assert.deepEqual(displayFields, ['id', 'note', 'hdr', 'main', 'ftr']);
     await fs
-      .unlink(path.join(process.cwd(), 'config', 'sp_vis_rows.sql'))
+      .unlink(path.join(process.cwd(), 'config', '0', 'sp_vis_rows.sql'))
       .catch(() => {});
   },
 );
@@ -169,7 +169,7 @@ END`;
   assert.ok(sql.includes("region = 'West'"));
   assert.ok(sql.includes('id = 5'));
   assert.ok(!sql.includes("name = 'Phones'"));
-  await fs.unlink(path.join(process.cwd(), 'config', 'sp_multi_rows.sql')).catch(() => {});
+  await fs.unlink(path.join(process.cwd(), 'config', '0', 'sp_multi_rows.sql')).catch(() => {});
 });
 
 test('getProcedureRawRows accepts prefixed field names', { concurrency: false }, async () => {
@@ -190,7 +190,7 @@ END`;
   restore();
   assert.ok(sql.includes("region = 'West'"));
   assert.ok(sql.includes('id = 7'));
-  await fs.unlink(path.join(process.cwd(), 'config', 'sp_pref_rows.sql')).catch(() => {});
+  await fs.unlink(path.join(process.cwd(), 'config', '0', 'sp_pref_rows.sql')).catch(() => {});
 });
 
 test('getProcedureRawRows formats date conditions', { concurrency: false }, async () => {
@@ -210,7 +210,7 @@ END`;
   );
   restore();
   assert.ok(sql.includes("trans_date = '2025-08-12'"));
-  await fs.unlink(path.join(process.cwd(), 'config', 'sp_date_rows.sql')).catch(() => {});
+  await fs.unlink(path.join(process.cwd(), 'config', '0', 'sp_date_rows.sql')).catch(() => {});
 });
 
 test('getProcedureRawRows ignores aggregate fields in extraConditions', { concurrency: false }, async () => {
@@ -235,7 +235,7 @@ END`;
   restore();
   assert.ok(sql.includes('id = 1'));
   assert.ok(!sql.includes('total ='));
-  await fs.unlink(path.join(process.cwd(), 'config', 'sp_agg_rows.sql')).catch(() => {});
+  await fs.unlink(path.join(process.cwd(), 'config', '0', 'sp_agg_rows.sql')).catch(() => {});
 });
 
 test('getProcedureRawRows removes non-column aggregate extraConditions', { concurrency: false }, async () => {
@@ -257,7 +257,7 @@ END`;
   restore();
   assert.ok(sql.includes('id = 1'));
   assert.ok(!sql.includes('cnt ='));
-  await fs.unlink(path.join(process.cwd(), 'config', 'sp_agg2_rows.sql')).catch(() => {});
+  await fs.unlink(path.join(process.cwd(), 'config', '0', 'sp_agg2_rows.sql')).catch(() => {});
 });
 
 test('getProcedureRawRows formats time conditions', { concurrency: false }, async () => {
@@ -281,5 +281,5 @@ END`;
   );
   restore();
   assert.ok(sql.includes("trans_time = '12:34:56'"));
-  await fs.unlink(path.join(process.cwd(), 'config', 'sp_time_rows.sql')).catch(() => {});
+  await fs.unlink(path.join(process.cwd(), 'config', '0', 'sp_time_rows.sql')).catch(() => {});
 });

--- a/tests/db/transactionFormConfig.test.js
+++ b/tests/db/transactionFormConfig.test.js
@@ -5,7 +5,7 @@ import path from 'path';
 import { setFormConfig, deleteFormConfig } from '../../api-server/services/transactionFormConfig.js';
 import * as db from '../../db/index.js';
 
-const filePath = path.join(process.cwd(), 'config', 'transactionForms.json');
+const filePath = path.join(process.cwd(), 'config', '0', 'transactionForms.json');
 
 function withTempFile() {
   return fs.readFile(filePath, 'utf8')


### PR DESCRIPTION
## Summary
- pass optional companyId through config routes for multi-tenant support
- add companyId parameter to header mappings service
- adjust tests to use tenant-specific config paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc1daede908331abe399652ac32753