### PR TITLE
Enforce system settings permissions on config import

### DIFF
--- a/api-server/routes/config.js
+++ b/api-server/routes/config.js
@@ -1,12 +1,16 @@
 import express from 'express';
 import { requireAuth } from '../middlewares/auth.js';
 import { importConfigFiles } from '../services/configImport.js';
+import { getEmploymentSession } from '../../db/index.js';
 
 const router = express.Router();
 
 router.post('/import/:type', requireAuth, async (req, res, next) => {
   try {
     const companyId = Number(req.query.companyId ?? req.user.companyId);
+    const session =
+      req.session || (await getEmploymentSession(req.user.empid, companyId));
+    if (!session?.permissions?.system_settings) return res.sendStatus(403);
     const type = req.params.type || '';
     const files = Array.isArray(req.body?.files) ? req.body.files : [];
     const results = await importConfigFiles(files, companyId, type);


### PR DESCRIPTION
## Summary
- check `system_settings` permission before importing configuration files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc359bba40833191a58ea176b86f9f