### PR TITLE
Support root configuration import

### DIFF
--- a/api-server/routes/config.js
+++ b/api-server/routes/config.js
@@ -5,7 +5,7 @@ import { getEmploymentSession } from '../../db/index.js';
 
 const router = express.Router();
 
-router.post('/import/:type', requireAuth, async (req, res, next) => {
+router.post('/import/:type?', requireAuth, async (req, res, next) => {
   try {
     const companyId = Number(req.query.companyId ?? req.user.companyId);
     const session =

--- a/api-server/services/configImport.js
+++ b/api-server/services/configImport.js
@@ -8,8 +8,12 @@ function isSafePath(file) {
 }
 
 export async function importConfigFiles(files = [], companyId = 0, type = '') {
-  const sourceDir = path.join(baseConfigDir, '0', type);
-  const targetDir = path.join(baseConfigDir, String(companyId), type);
+  const sourceDir = type
+    ? path.join(baseConfigDir, '0', type)
+    : path.join(baseConfigDir, '0');
+  const targetDir = type
+    ? path.join(baseConfigDir, String(companyId), type)
+    : path.join(baseConfigDir, String(companyId));
   const results = [];
   try {
     await fs.mkdir(targetDir, { recursive: true });

--- a/docs/config-import.md
+++ b/docs/config-import.md
@@ -1,0 +1,22 @@
+# Configuration Import Structure
+
+Default configuration templates live in the repository under `config/0/`.
+Each tenant receives its own copy of these files under `config/<companyId>/`.
+
+The `/api/config/import` endpoint copies a set of files from `config/0/`
+into the tenant directory. Pass a JSON body with a `files` array listing the
+filenames to copy and optionally a `companyId` query parameter.
+
+```bash
+POST /api/config/import?companyId=1
+{ "files": ["generalConfig.json"] }
+```
+
+When the route is called without a `type` segment (i.e. `type=''`), files are
+resolved relative to the root of the configuration folder (`config/0/`).
+Subdirectories may still be used by providing a `type` segment in the URL, in
+which case files are resolved under `config/0/<type>/`.
+
+Add new configuration files to `config/0/` (or a subdirectory) following this
+layout so they can be imported consistently for new tenants.
+

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -504,7 +504,7 @@ export default function FormsManagement() {
     if (!window.confirm('Import default forms configuration?')) return;
     try {
       const res = await fetch(
-        `/api/config/import/forms?companyId=${encodeURIComponent(company ?? '')}`,
+        `/api/config/import?companyId=${encodeURIComponent(company ?? '')}`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
+++ b/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
@@ -63,7 +63,7 @@ export default function GeneralConfiguration() {
     if (!window.confirm('Import default configuration?')) return;
     try {
       const res = await fetch(
-        `/api/config/import/general?companyId=${encodeURIComponent(company ?? '')}`,
+        `/api/config/import?companyId=${encodeURIComponent(company ?? '')}`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/src/erp.mgt.mn/pages/PosTxnConfig.jsx
+++ b/src/erp.mgt.mn/pages/PosTxnConfig.jsx
@@ -313,7 +313,7 @@ export default function PosTxnConfig() {
     if (!window.confirm('Import default POS transaction configuration?')) return;
     try {
       const res = await fetch(
-        `/api/config/import/pos_txn?companyId=${encodeURIComponent(company ?? '')}`,
+        `/api/config/import?companyId=${encodeURIComponent(company ?? '')}`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/src/erp.mgt.mn/pages/RelationsConfig.jsx
+++ b/src/erp.mgt.mn/pages/RelationsConfig.jsx
@@ -82,7 +82,7 @@ export default function RelationsConfig() {
     if (!window.confirm('Import default relations configuration?')) return;
     try {
       const res = await fetch(
-        `/api/config/import/relations?companyId=${encodeURIComponent(company ?? '')}`,
+        `/api/config/import?companyId=${encodeURIComponent(company ?? '')}`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/src/erp.mgt.mn/pages/ReportBuilder.jsx
+++ b/src/erp.mgt.mn/pages/ReportBuilder.jsx
@@ -145,9 +145,7 @@ function ReportBuilderInner() {
     if (!window.confirm('Import default report builder configuration?')) return;
     try {
       const res = await fetch(
-        `/api/config/import/report_builder?companyId=${encodeURIComponent(
-          company ?? '',
-        )}`,
+        `/api/config/import?companyId=${encodeURIComponent(company ?? '')}`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- Allow `importConfigFiles` to resolve an empty type to the root config directory
- Make the `/api/config/import` route optional so requests can omit the type segment
- Update UI import actions to hit `/api/config/import` without a type and document the layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc3d35230483318e10931f5c284e69