### PR TITLE
docs: clarify tenant directory layout and config import

### DIFF
--- a/docs/tenant-directory-structure.md
+++ b/docs/tenant-directory-structure.md
@@ -1,0 +1,29 @@
+# Tenant Directory Structure
+
+ERP-Web-Next stores configuration templates and uploaded files in per-tenant folders.
+
+## Configuration files
+
+- Default templates live under `config/0/`.
+- Each tenant receives its own copy in `config/<companyId>/` after import.
+
+Run the migration to move legacy report builder files into the new layout:
+
+```bash
+node scripts/migrateReportBuilder.js
+```
+
+Then import the default configuration set for a tenant:
+
+```bash
+curl -X POST http://localhost:3000/api/config/import?companyId=1 \
+  -H "Content-Type: application/json" \
+  -d '{"files": ["generalConfig.json", "headerMappings.json"]}'
+```
+
+This copies files from `config/0/` into `config/1/` so the new company starts with the standard settings.
+
+## Uploaded files
+
+User uploads are segregated under `uploads/<companyId>/` (e.g. `uploads/1/txn_images`).
+The server resolves paths based on the active tenant to keep files isolated.

--- a/docs/tenant-table-scoping.md
+++ b/docs/tenant-table-scoping.md
@@ -23,6 +23,13 @@ GET /api/tenant_tables/options
 The response is an array with each table's `tableName`, `isShared`, and
 `seedOnCreate` flags (defaulting to `false` when not configured).
 
+## Configuration import
+
+`seedOnCreate` only governs database rows. After creating a company, copy
+default config files from `config/0/` into `config/<companyId>/` via
+`/api/config/import` so the tenant starts with the standard settings. See
+`tenant-directory-structure.md` for commands.
+
 ## Default shared tables
 
 The following tables are preconfigured as shared (`is_shared=1`) so that global rows


### PR DESCRIPTION
## Summary
- document per-tenant config and uploads directories and migration steps
- mention config import alongside tenant-table registry docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc2dd41f348331a4e9f1af38c68178