### PR TITLE
Handle translation generation cleanup

### DIFF
--- a/api-server/routes/translation_generator.js
+++ b/api-server/routes/translation_generator.js
@@ -79,9 +79,12 @@ router.get('/', requireAuth, async (req, res, next) => {
       if (currentController === controller) currentController = null;
     });
 
-    req.on('close', () => {
+    const handleClose = () => {
       controller.abort();
-    });
+      if (currentController === controller) currentController = null;
+    };
+    req.on('close', handleClose);
+    res.on('close', handleClose);
   } catch (err) {
     next(err);
   }

--- a/src/erp.mgt.mn/pages/GenerateTranslationsTab.jsx
+++ b/src/erp.mgt.mn/pages/GenerateTranslationsTab.jsx
@@ -8,8 +8,10 @@ export default function GenerateTranslationsTab() {
   const [source, setSource] = useState(null);
 
   useEffect(() => {
+    window.addEventListener('beforeunload', cancel);
     return () => {
-      if (source) source.close();
+      window.removeEventListener('beforeunload', cancel);
+      if (source) cancel();
     };
   }, [source]);
 


### PR DESCRIPTION
## Summary
- cancel translation generation on window unload and component unmount
- abort server-side translation generator when client closes connection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc4aa303648331a060ddb57b6e695e