### PR TITLE
Handle SQL execution aborts

### DIFF
--- a/api-server/routes/generated_sql.js
+++ b/api-server/routes/generated_sql.js
@@ -19,13 +19,15 @@ router.post('/', requireAuth, async (req, res, next) => {
 });
 
 router.post('/execute', requireAuth, async (req, res, next) => {
+  const controller = new AbortController();
+  req.on('close', () => controller.abort());
   try {
     const { sql } = req.body;
     if (!sql) {
       return res.status(400).json({ message: 'sql required' });
     }
-    const { inserted, failed } = await runSql(sql);
-    res.json({ inserted, failed });
+    const { inserted, failed, aborted } = await runSql(sql, controller.signal);
+    res.json({ inserted, failed, aborted });
   } catch (err) {
     next(err);
   }

--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -1441,6 +1441,9 @@ export default function CodingTablesPage() {
         return { inserted: totalInserted, failed: failedAll, aborted: true };
       }
       const data = await res.json().catch(() => ({}));
+      if (data.aborted) {
+        return { inserted: totalInserted, failed: failedAll, aborted: true };
+      }
       const inserted = data.inserted || 0;
       if (Array.isArray(data.failed) && data.failed.length > 0) {
         const errMsg = data.failed


### PR DESCRIPTION
## Summary
- Allow `/execute` route to abort SQL execution when the request closes
- Add optional abort signal to `runSql` and destroy connection when aborted
- Stop `runStatements` after an aborted response from the server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc4cc97b408331ab78e84c778a9f58