### PR TITLE
feat: abort coding table upload on client disconnect

### DIFF
--- a/api-server/routes/coding_tables.js
+++ b/api-server/routes/coding_tables.js
@@ -22,6 +22,22 @@ const storage = multer.diskStorage({
 
 const upload = multer({ storage });
 
-router.post('/upload', requireAuth, upload.single('file'), uploadCodingTable);
+router.post(
+  '/upload',
+  requireAuth,
+  upload.single('file'),
+  async (req, res, next) => {
+    const controller = new AbortController();
+    const handleClose = () => controller.abort();
+    req.on('close', handleClose);
+    res.on('close', handleClose);
+    try {
+      await uploadCodingTable(req, res, next, controller.signal);
+    } finally {
+      req.off('close', handleClose);
+      res.off('close', handleClose);
+    }
+  },
+);
 
 export default router;


### PR DESCRIPTION
## Summary
- add AbortController in coding table upload route
- propagate abort signals through coding table import logic and DB helper

## Testing
- `npm test` (fails: 2, passes: 169, skipped: 13)


------
https://chatgpt.com/codex/tasks/task_e_68bc4da00ad483319af55342024f2a93