### PR TITLE
feat: confirm before leaving pending requests

### DIFF
--- a/src/erp.mgt.mn/utils/csrfFetch.js
+++ b/src/erp.mgt.mn/utils/csrfFetch.js
@@ -2,10 +2,21 @@ import { API_BASE } from './apiBase.js';
 
 let tokenPromise;
 const controllers = new Set();
-window.addEventListener('beforeunload', () => {
+
+function abortAll() {
   controllers.forEach(controller => controller.abort());
   controllers.clear();
+}
+
+window.addEventListener('beforeunload', event => {
+  if (controllers.size) {
+    event.preventDefault();
+    event.returnValue = '';
+  }
 });
+
+window.addEventListener('unload', abortAll);
+window.addEventListener('pagehide', abortAll);
 
 function dispatchStart(key) {
   window.dispatchEvent(new CustomEvent('loading:start', { detail: { key } }));


### PR DESCRIPTION
## Summary
- track pending fetch controllers
- prompt before unloading when requests are running
- cancel pending operations after confirmation

## Testing
- `npm test` (fails: deleteImage moves file to deleted_images, listTableRows allows zero-valued filters)


------
https://chatgpt.com/codex/tasks/task_e_68bc56b82da88331a88175882fc267cc