### PR TITLE
Skip network calls for hidden POS forms

### DIFF
--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -310,30 +310,67 @@ export default function PosTransactionsPage() {
       .catch(() => setLayout({}));
   }, [name]);
 
+  const { formList, visibleTables } = React.useMemo(() => {
+    if (!config) return { formList: [], visibleTables: new Set() };
+    const arr = [
+      { table: config.masterTable, type: config.masterType, position: config.masterPosition, view: config.masterView },
+      ...config.tables,
+    ];
+    const seen = new Set();
+    const filtered = arr.filter((t) => {
+      if (!t.table) return false;
+      if (seen.has(t.table)) return false;
+      seen.add(t.table);
+      return true;
+    });
+    const visibleSet = new Set(
+      filtered
+        .filter((t) => t.position !== 'hidden')
+        .map((t) => t.table),
+    );
+    const order = [
+      'top_row',
+      'upper_left',
+      'upper_right',
+      'left',
+      'right',
+      'lower_left',
+      'lower_right',
+      'bottom_row',
+      'hidden',
+    ];
+    return {
+      formList: filtered.sort(
+        (a, b) => order.indexOf(a.position) - order.indexOf(b.position),
+      ),
+      visibleTables: visibleSet,
+    };
+  }, [config]);
+
   useEffect(() => {
     if (!config) return;
-    const tables = [config.masterTable, ...config.tables.map(t => t.table)];
-    const forms = [config.masterForm || '', ...config.tables.map(t => t.form)];
+    const tables = [config.masterTable, ...config.tables.map((t) => t.table)];
+    const forms = [config.masterForm || '', ...config.tables.map((t) => t.form)];
     tables.forEach((tbl, idx) => {
       const form = forms[idx];
-      if (!tbl || !form) return;
+      if (!tbl || !form || !visibleTables.has(tbl)) return;
       fetch(`/api/transaction_forms?table=${encodeURIComponent(tbl)}&name=${encodeURIComponent(form)}`, { credentials: 'include' })
-        .then(res => res.ok ? res.json() : null)
-        .then(cfg => setFormConfigs(f => ({ ...f, [tbl]: cfg || {} })))
+        .then((res) => (res.ok ? res.json() : null))
+        .then((cfg) => setFormConfigs((f) => ({ ...f, [tbl]: cfg || {} })))
         .catch(() => {});
       fetch(`/api/tables/${encodeURIComponent(tbl)}/columns`, { credentials: 'include' })
-        .then(res => res.ok ? res.json() : [])
-        .then(cols => {
-          setColumnMeta(m => ({ ...m, [tbl]: cols || [] }));
+        .then((res) => (res.ok ? res.json() : []))
+        .then((cols) => {
+          setColumnMeta((m) => ({ ...m, [tbl]: cols || [] }));
           loadRelations(tbl);
         })
         .catch(() => {});
       fetch(`/api/proc_triggers?table=${encodeURIComponent(tbl)}`, { credentials: 'include' })
-        .then(res => res.ok ? res.json() : {})
-        .then(data => setProcTriggersMap(m => ({ ...m, [tbl]: data || {} })))
+        .then((res) => (res.ok ? res.json() : {}))
+        .then((data) => setProcTriggersMap((m) => ({ ...m, [tbl]: data || {} })))
         .catch(() => {});
     });
-  }, [config]);
+  }, [config, visibleTables]);
 
   useEffect(() => {
     if (!config) { setSessionFields([]); return; }
@@ -370,6 +407,7 @@ export default function PosTransactionsPage() {
   useEffect(() => {
     const viewsByName = {};
     Object.entries(formConfigs).forEach(([tbl, fc]) => {
+      if (!visibleTables.has(tbl)) return;
       const views = Object.values(fc.viewSource || {});
       views.forEach((v) => {
         if (!v) return;
@@ -423,7 +461,7 @@ export default function PosTransactionsPage() {
           // ignore errors to allow retry
         });
     });
-  }, [formConfigs]);
+  }, [formConfigs, visibleTables]);
 
   useEffect(() => {
     if (!config) return;
@@ -1000,37 +1038,7 @@ export default function PosTransactionsPage() {
     window.removeEventListener('mousemove', onDrag);
     window.removeEventListener('mouseup', endDrag);
   }
-
   const configNames = Object.keys(configs);
-
-  const formList = React.useMemo(() => {
-    if (!config) return [];
-    const arr = [
-      { table: config.masterTable, type: config.masterType, position: config.masterPosition, view: config.masterView },
-      ...config.tables,
-    ];
-    const seen = new Set();
-    const filtered = arr.filter((t) => {
-      if (!t.table) return false;
-      if (seen.has(t.table)) return false;
-      seen.add(t.table);
-      return true;
-    });
-    const order = [
-      'top_row',
-      'upper_left',
-      'upper_right',
-      'left',
-      'right',
-      'lower_left',
-      'lower_right',
-      'bottom_row',
-      'hidden',
-    ];
-    return filtered.sort(
-      (a, b) => order.indexOf(a.position) - order.indexOf(b.position),
-    );
-  }, [config]);
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- Track visible POS transaction tables using `visibleTables`
- Load form configs, columns, relations, and view sources only for tables that are visible
- Ensure `visibleTables` is defined before any effects or handlers use it, preventing runtime errors

## Testing
- `npm test` *(fails: listTableRows allows zero-valued filters)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5d3c0c4083319ac66d6cd88fbc5f