### PR TITLE
refactor: map display fields by column

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -65,7 +65,6 @@ const RowFormModal = function RowFormModal({
   const renderCount = useRef(0);
   const warned = useRef(false);
   const procCache = useRef({});
-  const warnedDisplay = useRef(new Set());
   const [tableDisplayFields, setTableDisplayFields] = useState({});
   useEffect(() => {
     fetch('/api/display_fields', { credentials: 'include' })
@@ -133,21 +132,31 @@ const RowFormModal = function RowFormModal({
     return map;
   }, [relationConfigs, columnCaseMap]);
 
-  const autoSelectConfigs = React.useMemo(() => {
-    const map = {};
+  const displayIndex = React.useMemo(() => {
+    const index = {};
     Object.entries(tableDisplayFields || {}).forEach(([tbl, cfg]) => {
       const id = cfg.idField;
       if (!id) return;
-      const key = columnCaseMap[id.toLowerCase()];
-      if (key) {
-        map[key] = { table: tbl, idField: cfg.idField, displayFields: cfg.displayFields || [] };
-      } else if (!warnedDisplay.current.has(`${tbl}.${id}`)) {
-        console.warn(`tableDisplayFields: no column '${id}' found for table '${tbl}'`);
-        warnedDisplay.current.add(`${tbl}.${id}`);
+      index[id.toLowerCase()] = {
+        table: tbl,
+        idField: cfg.idField,
+        displayFields: cfg.displayFields || [],
+      };
+    });
+    return index;
+  }, [tableDisplayFields]);
+
+  // Only columns present in columnCaseMap are evaluated, preventing cross-table false positives.
+  const autoSelectConfigs = React.useMemo(() => {
+    const map = {};
+    Object.entries(columnCaseMap || {}).forEach(([lower, key]) => {
+      const cfg = displayIndex[lower];
+      if (cfg) {
+        map[key] = cfg;
       }
     });
     return map;
-  }, [columnCaseMap, tableDisplayFields]);
+  }, [columnCaseMap, displayIndex]);
   const [formVals, setFormVals] = useState(() => {
     const init = {};
     const now = new Date();


### PR DESCRIPTION
## Summary
- build display index keyed by id field
- derive auto select configs from current table columns
- document columnCaseMap limitation to avoid false positives

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc68b54fa4833187a0e359f75cc25b