### PR TITLE
Reset loading state when tables visibility changes

### DIFF
--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -393,6 +393,7 @@ export default function PosTransactionsPage() {
 
   useEffect(() => {
     loadedTablesRef.current.clear();
+    loadingTablesRef.current.clear();
   }, [visibleTablesKey]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Clear both loaded and loading table caches when the set of visible tables changes

## Testing
- `npm test`
- Manual: hid a table and re-added it to verify relations load again

------
https://chatgpt.com/codex/tasks/task_e_68bf96fefaec8331b3e141663c47fff5