### PR TITLE
Use abortable fetches for metadata requests

### DIFF
--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -414,7 +414,9 @@ export default function PosTransactionsPage() {
         )
         .catch(() => {});
       if (!loadedTablesRef.current.has(tbl)) {
-        fetch(`/api/tables/${encodeURIComponent(tbl)}/columns`, { credentials: 'include' })
+        fetchWithAbort(`/api/tables/${encodeURIComponent(tbl)}/columns`, {
+          credentials: 'include',
+        })
           .then((res) => (res.ok ? res.json() : []))
           .then(async (cols) => {
             setColumnMeta((m) => ({ ...m, [tbl]: cols || [] }));
@@ -429,7 +431,10 @@ export default function PosTransactionsPage() {
           .catch(() => {
             loadedTablesRef.current.add(tbl);
           });
-        fetch(`/api/proc_triggers?table=${encodeURIComponent(tbl)}`, { credentials: 'include' })
+        fetchWithAbort(
+          `/api/proc_triggers?table=${encodeURIComponent(tbl)}`,
+          { credentials: 'include' },
+        )
           .then((res) => (res.ok ? res.json() : {}))
           .then((data) => setProcTriggersMap((m) => ({ ...m, [tbl]: data || {} })))
           .catch(() => {});


### PR DESCRIPTION
## Summary
- use `fetchWithAbort` for table column and trigger requests
- ensure controllers are tracked and aborted when transaction changes

## Testing
- `npm test` *(fails: commitUploadedImages stops when aborted, deleteImage moves file to deleted_images)*

------
https://chatgpt.com/codex/tasks/task_e_68bf97d41e60833187eb48803d8b1c99