### PR TITLE
Ensure form reloads on config changes

### DIFF
--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -391,11 +391,26 @@ export default function PosTransactionsPage() {
     [visibleTables],
   );
 
+  // Stable hash of table/form identifiers. Ignores layout-only config so
+  // adjusting positions doesn't trigger reloads.
+  const configVersion = React.useMemo(() => {
+    if (!config) return '';
+    const parts = [
+      config.masterTable,
+      config.masterForm,
+      ...(config.tables || []).flatMap((t) => [t.table, t.form]),
+    ];
+    return parts.filter(Boolean).join('|');
+  }, [config]);
+
   useEffect(() => {
     loadedTablesRef.current.clear();
     loadingTablesRef.current.clear();
-  }, [visibleTablesKey]);
+  }, [visibleTablesKey, configVersion]);
 
+  // Reload form configs and column metadata when either the visible table set
+  // or the form identifiers change. Because configVersion ignores layout-only
+  // changes, layout adjustments still avoid reloads.
   useEffect(() => {
     if (!config) return;
     const tables = [config.masterTable, ...config.tables.map((t) => t.table)];
@@ -440,7 +455,7 @@ export default function PosTransactionsPage() {
           .catch(() => {});
       }
     });
-  }, [visibleTablesKey]);
+  }, [visibleTablesKey, configVersion]);
 
   useEffect(() => {
     if (!config) { setSessionFields([]); return; }


### PR DESCRIPTION
## Summary
- track a stable `configVersion` based on table/form identifiers
- reload form and column metadata when `configVersion` changes
- clarify in comments why layout tweaks avoid reloads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf9868cbb48331964613843eddaf24