### PR TITLE
feat: filter report procedures by tenant

### DIFF
--- a/api-server/routes/report_procedures.js
+++ b/api-server/routes/report_procedures.js
@@ -7,7 +7,8 @@ const router = express.Router();
 router.get('/', requireAuth, async (req, res, next) => {
   try {
     const { branchId, departmentId, prefix = '' } = req.query;
-    const forms = await listTransactionNames({ branchId, departmentId });
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
+    const forms = await listTransactionNames({ branchId, departmentId }, companyId);
     const set = new Set();
     Object.values(forms).forEach((info) => {
       if (Array.isArray(info.procedures)) {

--- a/tests/routes/report_procedures.test.js
+++ b/tests/routes/report_procedures.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import { listTransactionNames } from '../../api-server/services/transactionFormConfig.js';
+import { tenantConfigPath } from '../../api-server/utils/configPaths.js';
+
+function withTempFile(companyId = 0) {
+  const file = tenantConfigPath('transactionForms.json', companyId);
+  return fs
+    .readFile(file, 'utf8')
+    .then((orig) => ({ file, restore: () => fs.writeFile(file, orig) }))
+    .catch(() => ({ file, restore: () => fs.rm(file, { force: true }) }));
+}
+
+function collectProcedures(forms) {
+  const set = new Set();
+  Object.values(forms).forEach((info) => {
+    (info.procedures || []).forEach((p) => set.add(p));
+  });
+  return Array.from(set).sort();
+}
+
+await test('listTransactionNames filters procedures by companyId', async () => {
+  const base = await withTempFile(0);
+  const tenant = await withTempFile(77);
+  await fs.writeFile(
+    base.file,
+    JSON.stringify({ tbl: { Base: { procedures: ['baseProc'] } } })
+  );
+  await fs.writeFile(
+    tenant.file,
+    JSON.stringify({ tbl: { Tenant: { procedures: ['tenantProc'] } } })
+  );
+  const baseForms = await listTransactionNames({}, 0);
+  const tenantForms = await listTransactionNames({}, 77);
+  assert.deepEqual(collectProcedures(baseForms), ['baseProc']);
+  assert.deepEqual(collectProcedures(tenantForms), ['tenantProc']);
+  await tenant.restore();
+  await base.restore();
+});


### PR DESCRIPTION
## Summary
- ensure report_procedures route respects companyId and forwards tenant to listTransactionNames
- add regression test verifying transaction forms are isolated per company

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf9bb948408331ac388bf495901ad2