### PR TITLE
feat: lazy load view metadata

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -46,6 +46,7 @@ export default forwardRef(function InlineTransactionTable({
   viewSource = {},
   viewDisplays = {},
   viewColumns = {},
+  loadView = () => {},
   procTriggers = {},
   user = {},
   company,
@@ -280,6 +281,7 @@ export default forwardRef(function InlineTransactionTable({
   const [invalidCell, setInvalidCell] = useState(null);
   const [previewRow, setPreviewRow] = useState(null);
   const [uploadRow, setUploadRow] = useState(null);
+  const [fetchFlags, setFetchFlags] = useState({});
   const procCache = useRef({});
 
   const inputFontSize = Math.max(10, labelFontSize);
@@ -617,6 +619,10 @@ export default forwardRef(function InlineTransactionTable({
 
   function handleFocusField(col) {
     showTriggerInfo(col);
+    if (viewSourceMap[col]) {
+      loadView(viewSourceMap[col]);
+      setFetchFlags((f) => ({ ...f, [col]: true }));
+    }
   }
 
   function addRow() {
@@ -1189,6 +1195,7 @@ export default forwardRef(function InlineTransactionTable({
       const labelFields = cfg.displayFields || [];
       return (
         <AsyncSearchSelect
+          shouldFetch={fetchFlags[f]}
           table={view}
           searchColumn={idField}
           searchColumns={[idField, ...labelFields]}

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -58,6 +58,7 @@ const RowFormModal = function RowFormModal({
   viewSource = {},
   viewDisplays = {},
   viewColumns = {},
+  loadView = () => {},
   procTriggers = {},
   autoFillSession = true,
 }) {
@@ -218,6 +219,7 @@ const RowFormModal = function RowFormModal({
   const [seedOptions, setSeedOptions] = useState([]);
   const [seedRecordOptions, setSeedRecordOptions] = useState({});
   const [openSeed, setOpenSeed] = useState({});
+  const [fetchFlags, setFetchFlags] = useState({});
 
   useEffect(() => {
     if (!useGrid) return;
@@ -811,6 +813,10 @@ const RowFormModal = function RowFormModal({
 
   async function handleFocusField(col) {
     showTriggerInfo(col);
+    if (viewSourceMap[col]) {
+      loadView(viewSourceMap[col]);
+      setFetchFlags((f) => ({ ...f, [col]: true }));
+    }
   }
 
   async function submitForm() {
@@ -1087,7 +1093,7 @@ const RowFormModal = function RowFormModal({
     ) : viewSourceMap[c] && !Array.isArray(relations[c]) ? (
       formVisible && (
         <AsyncSearchSelect
-          shouldFetch={false}
+          shouldFetch={fetchFlags[c]}
           title={tip}
           table={viewSourceMap[c]}
           searchColumn={viewDisplays[viewSourceMap[c]]?.idField || c}
@@ -1292,6 +1298,7 @@ const RowFormModal = function RowFormModal({
             viewSource={viewSourceMap}
             viewDisplays={viewDisplays}
             viewColumns={viewColumns}
+            loadView={loadView}
             procTriggers={procTriggers}
             user={user}
             company={company}


### PR DESCRIPTION
## Summary
- add `loadView` helper in PosTransactions to cache view metadata
- defer view metadata and record fetching until fields receive focus
- pass `loadView` to RowFormModal and InlineTransactionTable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf9cd12ca88331a951597239fec79f