### PR TITLE
Handle delete errors and show toast

### DIFF
--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -460,10 +460,20 @@ export default function FormsManagement() {
   async function handleDelete() {
     if (!table || !name) return;
     if (!window.confirm('Delete transaction configuration?')) return;
-    await fetch(`/api/transaction_forms?table=${encodeURIComponent(table)}&name=${encodeURIComponent(name)}`, {
-      method: 'DELETE',
-      credentials: 'include',
-    });
+    try {
+      const res = await fetch(
+        `/api/transaction_forms?table=${encodeURIComponent(table)}&name=${encodeURIComponent(name)}`,
+        {
+          method: 'DELETE',
+          credentials: 'include',
+        },
+      );
+      if (!res.ok) throw new Error('failed');
+      addToast('Deleted', 'success');
+    } catch {
+      addToast('Delete failed', 'error');
+      return;
+    }
     refreshTxnModules();
     refreshModules();
     setNames((n) => n.filter((x) => x !== name));


### PR DESCRIPTION
## Summary
- Wrap delete request in try/catch in FormsManagement
- Show success or error toast based on fetch result

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfa71cf1d88331898b9491d29185b9