### PR TITLE
Use toast notifications for user deletion

### DIFF
--- a/src/erp.mgt.mn/pages/Users.jsx
+++ b/src/erp.mgt.mn/pages/Users.jsx
@@ -1,12 +1,14 @@
 // src/erp.mgt.mn/pages/Users.jsx
 import React, { useEffect, useState, useContext } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
+import { useToast } from '../context/ToastContext.jsx';
 import { debugLog } from '../utils/debug.js';
 
 export default function Users() {
   const [usersList, setUsersList] = useState([]);
   const [filter, setFilter] = useState('');
   const { company } = useContext(AuthContext);
+  const { addToast } = useToast();
 
   useEffect(() => {
     debugLog('Component mounted: Users');
@@ -69,10 +71,11 @@ export default function Users() {
       } catch {
         // ignore json errors
       }
-      alert(message);
+      addToast(message, 'error');
       return;
     }
     loadUsers();
+    addToast('User deleted', 'success');
   }
 
   return (

--- a/tests/pages/Users.test.js
+++ b/tests/pages/Users.test.js
@@ -37,6 +37,7 @@ if (typeof mock.import !== 'function') {
         },
         '../context/AuthContext.jsx': { AuthContext: {} },
         '../utils/debug.js': { debugLog: () => {} },
+        '../context/ToastContext.jsx': { useToast: () => ({ addToast: () => {} }) },
       },
     );
 


### PR DESCRIPTION
## Summary
- Replace alert with toast context error in Users page deletion
- Show success toast after user deletion
- Adjust Users page test to mock ToastContext

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfa98bef908331a6b1033bebfa50fc