### PR TITLE
Handle errors when deleting POS transaction configs

### DIFF
--- a/src/erp.mgt.mn/pages/PosTxnConfig.jsx
+++ b/src/erp.mgt.mn/pages/PosTxnConfig.jsx
@@ -294,19 +294,27 @@ export default function PosTxnConfig() {
   async function handleDelete() {
     if (!name) return;
     if (!window.confirm('Delete configuration?')) return;
-    await fetch(`/api/pos_txn_config?name=${encodeURIComponent(name)}`, {
-      method: 'DELETE',
-      credentials: 'include',
-    });
-    refreshTxnModules();
-    refreshModules();
-    addToast('Deleted', 'success');
-    setName('');
-    setConfig({ ...emptyConfig });
-    fetch('/api/pos_txn_config', { credentials: 'include' })
-      .then((res) => (res.ok ? res.json() : {}))
-      .then((data) => setConfigs(data))
-      .catch(() => {});
+    try {
+      const res = await fetch(`/api/pos_txn_config?name=${encodeURIComponent(name)}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        addToast('Delete failed', 'error');
+        return;
+      }
+      refreshTxnModules();
+      refreshModules();
+      addToast('Deleted', 'success');
+      setName('');
+      setConfig({ ...emptyConfig });
+      fetch('/api/pos_txn_config', { credentials: 'include' })
+        .then((res) => (res.ok ? res.json() : {}))
+        .then((data) => setConfigs(data))
+        .catch(() => {});
+    } catch {
+      addToast('Delete failed', 'error');
+    }
   }
 
   async function handleImport() {


### PR DESCRIPTION
## Summary
- Ensure POS transaction config deletions check response status and handle errors

## Testing
- `npm test` *(fails: ENOTEMPTY: directory not empty, rmdir '/workspace/erp-web-next/uploads/0/txn_images')*


------
https://chatgpt.com/codex/tasks/task_e_68bfaa167e5c833193c4ae9c1e065828