### PR TITLE
feat: lazy-load view metadata with caching

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -46,6 +46,7 @@ export default forwardRef(function InlineTransactionTable({
   viewSource = {},
   viewDisplays = {},
   viewColumns = {},
+  viewCache = new Map(),
   loadView = () => {},
   procTriggers = {},
   user = {},

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -58,6 +58,7 @@ const RowFormModal = function RowFormModal({
   viewSource = {},
   viewDisplays = {},
   viewColumns = {},
+  viewCache = new Map(),
   loadView = () => {},
   procTriggers = {},
   autoFillSession = true,
@@ -1298,6 +1299,7 @@ const RowFormModal = function RowFormModal({
             viewSource={viewSourceMap}
             viewDisplays={viewDisplays}
             viewColumns={viewColumns}
+            viewCache={viewCache}
             loadView={loadView}
             procTriggers={procTriggers}
             user={user}


### PR DESCRIPTION
## Summary
- refactor view metadata loading to cache `/api/display_fields` and column info by view name
- provide `loadView` helper and cache maps to transactional form components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfb57e79248331bc857ab092bcd39c