### PR TITLE
Load select options on demand

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -622,8 +622,8 @@ export default forwardRef(function InlineTransactionTable({
     showTriggerInfo(col);
     if (viewSourceMap[col]) {
       loadView(viewSourceMap[col]);
-      setFetchFlags((f) => ({ ...f, [col]: true }));
     }
+    setFetchFlags((f) => ({ ...f, [col]: true }));
   }
 
   function addRow() {
@@ -1148,6 +1148,7 @@ export default forwardRef(function InlineTransactionTable({
       const inputVal = typeof val === 'object' ? val.value : val;
       return (
         <AsyncSearchSelect
+          shouldFetch={fetchFlags[f]}
           table={conf.table}
           searchColumn={conf.idField || conf.column}
           searchColumns={[conf.idField || conf.column, ...(conf.displayFields || [])]}
@@ -1221,6 +1222,7 @@ export default forwardRef(function InlineTransactionTable({
       const inputVal = typeof val === 'object' ? val.value : val;
       return (
         <AsyncSearchSelect
+          shouldFetch={fetchFlags[f]}
           table={cfg.table}
           searchColumn={cfg.idField}
           searchColumns={[cfg.idField, ...(cfg.displayFields || [])]}


### PR DESCRIPTION
## Summary
- Track per-field fetch flags in `InlineTransactionTable`
- Trigger view loading and mark fields for fetching on focus
- Lazy-load select options only after user focuses relation, view, or auto-select fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfb87138108331a2f57be8e611cd11