### PR TITLE
Defer view lookups until field focus

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -620,10 +620,12 @@ export default forwardRef(function InlineTransactionTable({
 
   function handleFocusField(col) {
     showTriggerInfo(col);
-    if (viewSourceMap[col]) {
-      loadView(viewSourceMap[col]);
+    if (!fetchFlags[col]) {
+      if (viewSourceMap[col]) {
+        loadView(viewSourceMap[col]);
+      }
+      setFetchFlags((f) => ({ ...f, [col]: true }));
     }
-    setFetchFlags((f) => ({ ...f, [col]: true }));
   }
 
   function addRow() {


### PR DESCRIPTION
## Summary
- Avoid repeated view loading by gating on per-field fetch flags in `InlineTransactionTable`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfbb709b6c8331996000437637437a