### PR TITLE
refactor: lazy load view columns

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -46,7 +46,6 @@ export default forwardRef(function InlineTransactionTable({
   viewSource = {},
   viewDisplays = {},
   viewColumns = {},
-  viewCache = new Map(),
   loadView = () => {},
   procTriggers = {},
   user = {},

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -58,7 +58,6 @@ const RowFormModal = function RowFormModal({
   viewSource = {},
   viewDisplays = {},
   viewColumns = {},
-  viewCache = new Map(),
   loadView = () => {},
   procTriggers = {},
   autoFillSession = true,
@@ -1301,7 +1300,6 @@ const RowFormModal = function RowFormModal({
             viewSource={viewSourceMap}
             viewDisplays={viewDisplays}
             viewColumns={viewColumns}
-            viewCache={viewCache}
             loadView={loadView}
             procTriggers={procTriggers}
             user={user}

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -1283,7 +1283,6 @@ export default function PosTransactionsPage() {
                     viewSource={fc.viewSource || {}}
                     viewDisplays={viewDisplaysMap[t.table] || {}}
                     viewColumns={viewColumnsMap[t.table] || {}}
-                    viewCache={viewCacheRef.current}
                     loadView={loadView}
                     user={user}
                     


### PR DESCRIPTION
## Summary
- drop unused viewCache prop from POS transaction views
- rely on loadView helper for fetching view metadata on demand

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfbe9f2c6c8331b5829b04e013018f