### PR TITLE
feat(rowformmodal): lazily fetch select options

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -222,6 +222,10 @@ const RowFormModal = function RowFormModal({
   const [fetchFlags, setFetchFlags] = useState({});
 
   useEffect(() => {
+    if (visible) setFetchFlags({});
+  }, [visible]);
+
+  useEffect(() => {
     if (!useGrid) return;
     if (prevRowsRef.current !== rows) {
       prevRowsRef.current = rows;


### PR DESCRIPTION
## Summary
- Track select fetch state with `fetchFlags` in RowFormModal and reset when modal is opened
- Load view sources on field focus and mark the column as fetched
- Delay AsyncSearchSelect queries until focus using `shouldFetch`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfc097b8808331ab96365378bd9513