### PR TITLE
Lazy-load view options after first focus

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -219,10 +219,14 @@ const RowFormModal = function RowFormModal({
   const [seedOptions, setSeedOptions] = useState([]);
   const [seedRecordOptions, setSeedRecordOptions] = useState({});
   const [openSeed, setOpenSeed] = useState({});
-  const [fetchFlags, setFetchFlags] = useState({});
+  const fetchFlagsRef = useRef({});
+  const [fetchFlags, setFetchFlags] = useState(fetchFlagsRef.current);
 
   useEffect(() => {
-    if (visible) setFetchFlags({});
+    if (visible) {
+      fetchFlagsRef.current = {};
+      setFetchFlags(fetchFlagsRef.current);
+    }
   }, [visible]);
 
   useEffect(() => {
@@ -817,11 +821,12 @@ const RowFormModal = function RowFormModal({
 
   async function handleFocusField(col) {
     showTriggerInfo(col);
-    if (viewSourceMap[col]) {
-      loadView(viewSourceMap[col]);
-    }
-    if (!fetchFlags[col]) {
-      setFetchFlags((f) => ({ ...f, [col]: true }));
+    if (!fetchFlagsRef.current[col]) {
+      if (viewSourceMap[col]) {
+        loadView(viewSourceMap[col]);
+      }
+      fetchFlagsRef.current[col] = true;
+      setFetchFlags({ ...fetchFlagsRef.current });
     }
   }
 


### PR DESCRIPTION
## Summary
- track per-field fetch flags in RowFormModal to avoid duplicate view loads
- gate AsyncSearchSelect option fetching behind first focus

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfcf3d71948331854443bf6ddd6757