### PR TITLE
Avoid unnecessary row normalization effect rerenders

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -275,7 +275,7 @@ export default forwardRef(function InlineTransactionTable({
     if (JSON.stringify(normalized) !== JSON.stringify(rows)) {
       setRows(normalized);
     }
-  }, [initRows, minRows, defaultValues, placeholders, user?.empid, company]);
+  }, [initRows, minRows, defaultValues, placeholders]);
   const inputRefs = useRef({});
   const focusRow = useRef(0);
   const addBtnRef = useRef(null);


### PR DESCRIPTION
## Summary
- avoid resynchronizing rows when user or company change by removing them from normalization effect's dependency array
- normalize rows only when data changes

## Testing
- `npm test`
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd3cbb6048331a2837097a1a16af7