### PR TITLE
Handle default tenant config fallback

### DIFF
--- a/api-server/app.js
+++ b/api-server/app.js
@@ -42,7 +42,7 @@ app.use(cookieParser());
 app.use(logger);
 
 // Serve uploaded images statically before CSRF so image requests don't require tokens
-const imgCfg = await getGeneralConfig();
+const { config: imgCfg } = await getGeneralConfig();
 const imgBase = imgCfg.images?.basePath || "uploads";
 const projectRoot = path.resolve(__dirname, "../");
 const uploadsRoot = path.isAbsolute(imgBase)

--- a/api-server/controllers/generalConfigController.js
+++ b/api-server/controllers/generalConfigController.js
@@ -10,8 +10,8 @@ export async function fetchGeneralConfig(req, res, next) {
       (await getEmploymentSession(req.user.empid, companyId));
     if (!(await hasAction(session, 'system_settings'))) return res.sendStatus(403);
     const getter = req.getGeneralConfig || cfgSvc.getGeneralConfig;
-    const cfg = await getter(companyId);
-    res.json(cfg);
+    const { config, isDefault } = await getter(companyId);
+    res.json({ ...config, isDefault });
   } catch (err) {
     next(err);
   }

--- a/api-server/middlewares/featureToggle.js
+++ b/api-server/middlewares/featureToggle.js
@@ -3,7 +3,7 @@ import { getGeneralConfig } from '../services/generalConfig.js';
 export default function featureToggle(flag) {
   return async function (req, res, next) {
     try {
-      const cfg = await getGeneralConfig();
+      const { config: cfg } = await getGeneralConfig();
       if (cfg.general?.[flag]) return next();
       res.status(404).json({ message: 'Feature disabled' });
     } catch (err) {

--- a/api-server/routes/coding_table_configs.js
+++ b/api-server/routes/coding_table_configs.js
@@ -14,11 +14,11 @@ router.get('/', requireAuth, async (req, res, next) => {
     const companyId = Number(req.query.companyId ?? req.user.companyId);
     const table = req.query.table;
     if (table) {
-      const cfg = await getConfig(table, companyId);
-      res.json(cfg);
+      const { config, isDefault } = await getConfig(table, companyId);
+      res.json({ ...config, isDefault });
     } else {
-      const all = await getAllConfigs(companyId);
-      res.json(all);
+      const { config, isDefault } = await getAllConfigs(companyId);
+      res.json({ ...config, isDefault });
     }
   } catch (err) {
     next(err);

--- a/api-server/routes/display_fields.js
+++ b/api-server/routes/display_fields.js
@@ -14,11 +14,11 @@ router.get('/', requireAuth, async (req, res, next) => {
     const companyId = Number(req.query.companyId ?? req.user.companyId);
     const table = req.query.table;
     if (table) {
-      const config = await getDisplayFields(table, companyId);
-      res.json(config);
+      const { config, isDefault } = await getDisplayFields(table, companyId);
+      res.json({ ...config, isDefault });
     } else {
-      const configs = await getAllDisplayFields(companyId);
-      res.json(configs);
+      const { config, isDefault } = await getAllDisplayFields(companyId);
+      res.json({ ...config, isDefault });
     }
   } catch (err) {
     next(err);

--- a/api-server/routes/general_config.js
+++ b/api-server/routes/general_config.js
@@ -8,8 +8,8 @@ const router = express.Router();
 router.get('/', requireAuth, async (req, res, next) => {
   try {
     const companyId = Number(req.query.companyId ?? req.user.companyId);
-    const cfg = await getGeneralConfig(companyId);
-    res.json(cfg);
+    const { config, isDefault } = await getGeneralConfig(companyId);
+    res.json({ ...config, isDefault });
   } catch (err) {
     next(err);
   }

--- a/api-server/routes/pos_txn_config.js
+++ b/api-server/routes/pos_txn_config.js
@@ -14,11 +14,11 @@ router.get('/', requireAuth, async (req, res, next) => {
     const companyId = Number(req.query.companyId ?? req.user.companyId);
     const name = req.query.name;
     if (name) {
-      const cfg = await getConfig(name, companyId);
-      res.json(cfg || {});
+      const { config, isDefault } = await getConfig(name, companyId);
+      res.json(config ? { ...config, isDefault } : { isDefault });
     } else {
-      const all = await getAllConfigs(companyId);
-      res.json(all);
+      const { config, isDefault } = await getAllConfigs(companyId);
+      res.json({ ...config, isDefault });
     }
   } catch (err) {
     next(err);

--- a/api-server/routes/report_procedures.js
+++ b/api-server/routes/report_procedures.js
@@ -8,7 +8,10 @@ router.get('/', requireAuth, async (req, res, next) => {
   try {
     const { branchId, departmentId, prefix = '' } = req.query;
     const companyId = Number(req.query.companyId ?? req.user.companyId);
-    const forms = await listTransactionNames({ branchId, departmentId }, companyId);
+    const { names: forms, isDefault } = await listTransactionNames(
+      { branchId, departmentId },
+      companyId,
+    );
     const set = new Set();
     Object.values(forms).forEach((info) => {
       if (Array.isArray(info.procedures)) {
@@ -22,7 +25,7 @@ router.get('/', requireAuth, async (req, res, next) => {
         });
       }
     });
-    res.json({ procedures: Array.from(set) });
+    res.json({ procedures: Array.from(set), isDefault });
   } catch (err) {
     next(err);
   }

--- a/api-server/routes/transaction_forms.js
+++ b/api-server/routes/transaction_forms.js
@@ -16,18 +16,18 @@ router.get('/', requireAuth, async (req, res, next) => {
     const companyId = Number(req.query.companyId ?? req.user.companyId);
     const { table, name, moduleKey, branchId, departmentId, proc } = req.query;
     if (proc) {
-      const tbl = await findTableByProcedure(proc, companyId);
-      if (tbl) res.json({ table: tbl });
-      else res.status(404).json({ message: 'Table not found' });
+      const { table: tbl, isDefault } = await findTableByProcedure(proc, companyId);
+      if (tbl) res.json({ table: tbl, isDefault });
+      else res.status(404).json({ message: 'Table not found', isDefault });
     } else if (table && name) {
-      const cfg = await getFormConfig(table, name, companyId);
-      res.json(cfg);
+      const { config, isDefault } = await getFormConfig(table, name, companyId);
+      res.json({ ...config, isDefault });
     } else if (table) {
-      const all = await getConfigsByTable(table, companyId);
-      res.json(all);
+      const { config, isDefault } = await getConfigsByTable(table, companyId);
+      res.json({ ...config, isDefault });
     } else {
-      const names = await listTransactionNames({ moduleKey, branchId, departmentId }, companyId);
-      res.json(names);
+      const { names, isDefault } = await listTransactionNames({ moduleKey, branchId, departmentId }, companyId);
+      res.json({ ...names, isDefault });
     }
   } catch (err) {
     next(err);

--- a/api-server/routes/transaction_images.js
+++ b/api-server/routes/transaction_images.js
@@ -48,7 +48,7 @@ router.delete('/cleanup/:days?', requireAuth, async (req, res, next) => {
   try {
     let days = parseInt(req.params.days || req.query.days, 10);
     if (!days || Number.isNaN(days)) {
-      const cfg = await getGeneralConfig(req.user.companyId);
+      const { config: cfg } = await getGeneralConfig(req.user.companyId);
       days = cfg.images?.cleanupDays || 30;
     }
     const removed = await cleanupOldImages(days, req.user.companyId);

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -91,7 +91,7 @@ io.use((socket, next) => {
 app.set("io", io);
 
 // Serve uploaded images statically
-const imgCfg = await getGeneralConfig();
+const { config: imgCfg } = await getGeneralConfig();
 const imgBase = imgCfg.images?.basePath || "uploads";
 const projectRoot = path.resolve(__dirname, "../");
 const uploadsRoot = path.isAbsolute(imgBase)

--- a/api-server/services/transactionImageService.js
+++ b/api-server/services/transactionImageService.js
@@ -12,7 +12,7 @@ const __dirname = path.dirname(__filename);
 const projectRoot = path.resolve(__dirname, '../../');
 
 async function getDirs(companyId = 0) {
-  const cfg = await getGeneralConfig(companyId);
+  const { config: cfg } = await getGeneralConfig(companyId);
   const subdir = cfg.general?.imageDir || 'txn_images';
   const rootBase = cfg.images?.basePath || 'uploads';
   const baseName = path.basename(rootBase);
@@ -194,7 +194,10 @@ async function findTxnByParts(inv, sp, transType, timestamp, companyId = 0) {
     return null;
   }
 
-  const cfgMatches = await getConfigsByTransTypeValue(transType, companyId);
+  const { configs: cfgMatches } = await getConfigsByTransTypeValue(
+    transType,
+    companyId,
+  );
   const cfgMap = new Map(
     cfgMatches.map((m) => [m.table.toLowerCase(), m.config]),
   );
@@ -260,7 +263,8 @@ async function findTxnByParts(inv, sp, transType, timestamp, companyId = 0) {
       const rowObj = rows[0];
       let cfgs = {};
       try {
-        cfgs = await getConfigsByTable(tbl, companyId);
+        const { config } = await getConfigsByTable(tbl, companyId);
+        cfgs = config;
       } catch {}
       return { table: tbl, row: rowObj, configs: cfgs, numField: transCol.Field };
     }
@@ -418,7 +422,11 @@ export async function searchImages(term, page = 1, perPage = 20, companyId = 0) 
 }
 
 export async function moveImagesToDeleted(table, row = {}, companyId = 0) {
-  const configs = await getConfigsByTable(table, companyId).catch(() => ({}));
+  let configs = {};
+  try {
+    const { config } = await getConfigsByTable(table, companyId);
+    configs = config;
+  } catch {}
   const cfg = pickConfig(configs, row);
   const names = new Set();
   if (cfg?.imagenameField?.length) {
@@ -775,7 +783,8 @@ async function findTxnByUniqueId(idPart, companyId = 0) {
     if (rows.length) {
       let cfgs = {};
       try {
-        cfgs = await getConfigsByTable(tbl, companyId);
+        const { config } = await getConfigsByTable(tbl, companyId);
+        cfgs = config;
       } catch {}
       return { table: tbl, row: rows[0], configs: cfgs, numField: numCol.Field };
     }

--- a/tests/api/deleteImageMovesFile.test.js
+++ b/tests/api/deleteImageMovesFile.test.js
@@ -6,7 +6,7 @@ import { deleteImage } from '../../api-server/services/transactionImageService.j
 import { getGeneralConfig } from '../../api-server/services/generalConfig.js';
 
 const companyId = 0;
-const cfg = await getGeneralConfig(companyId);
+const { config: cfg } = await getGeneralConfig(companyId);
 const baseDir = path.join(
   process.cwd(),
   cfg.images.basePath || 'uploads',

--- a/tests/api/searchImagesByValue.test.js
+++ b/tests/api/searchImagesByValue.test.js
@@ -9,7 +9,7 @@ const companyId = 0;
 const baseDir = path.join(process.cwd(), 'uploads', String(companyId), 'txn_images', 'search_images_test');
 
 await test('searchImages finds files by field value', { concurrency: false }, async () => {
-  const orig = await getGeneralConfig();
+  const { config: orig } = await getGeneralConfig();
   await updateGeneralConfig({
     images: {
       ignoreOnSearch: [

--- a/tests/controllers/generalConfigController.test.js
+++ b/tests/controllers/generalConfigController.test.js
@@ -24,7 +24,7 @@ test('fetchGeneralConfig requires system_settings permission', async () => {
   const req = {
     user: { empid: 1, companyId: 1 },
     session: { permissions: { system_settings: 0 } },
-    getGeneralConfig: async () => ({})
+    getGeneralConfig: async () => ({ config: {}, isDefault: false })
   };
   const res = createRes();
   await fetchGeneralConfig(req, res, () => {});
@@ -50,11 +50,11 @@ test('saveGeneralConfig allows update with permission', async () => {
     user: { empid: 1, companyId: 1 },
     body: { general: { aiApiEnabled: true } },
     session: { permissions: { system_settings: 1 } },
-    updateGeneralConfig: async (body) => body,
+    updateGeneralConfig: async (body) => ({ ...body, isDefault: false }),
   };
   const res = createRes();
   await saveGeneralConfig(req, res, () => {});
-  assert.deepEqual(res.body, { general: { aiApiEnabled: true } });
+  assert.deepEqual(res.body, { general: { aiApiEnabled: true }, isDefault: false });
 });
 
 test('saveGeneralConfig allows update with user-level permission', async () => {
@@ -66,22 +66,25 @@ test('saveGeneralConfig allows update with user-level permission', async () => {
       user_level: 3,
       __userLevelActions: { permissions: { system_settings: true } },
     },
-    updateGeneralConfig: async (body) => body,
+    updateGeneralConfig: async (body) => ({ ...body, isDefault: false }),
   };
   const res = createRes();
   await saveGeneralConfig(req, res, () => {});
-  assert.deepEqual(res.body, { general: { aiApiEnabled: true } });
+  assert.deepEqual(res.body, { general: { aiApiEnabled: true }, isDefault: false });
 });
 
 test('fetchGeneralConfig allows system admin', async () => {
   const req = {
     user: { empid: 1, companyId: 0 },
     session: { permissions: { system_settings: 1 }, company_id: 0 },
-    getGeneralConfig: async () => ({ general: { aiApiEnabled: true } }),
+    getGeneralConfig: async () => ({
+      config: { general: { aiApiEnabled: true } },
+      isDefault: false,
+    }),
   };
   const res = createRes();
   await fetchGeneralConfig(req, res, () => {});
-  assert.deepEqual(res.body, { general: { aiApiEnabled: true } });
+  assert.deepEqual(res.body, { general: { aiApiEnabled: true }, isDefault: false });
 });
 
 test('saveGeneralConfig allows system admin', async () => {
@@ -89,9 +92,9 @@ test('saveGeneralConfig allows system admin', async () => {
     user: { empid: 1, companyId: 0 },
     body: { general: { aiApiEnabled: true } },
     session: { permissions: { system_settings: 1 }, company_id: 0 },
-    updateGeneralConfig: async (body) => body,
+    updateGeneralConfig: async (body) => ({ ...body, isDefault: false }),
   };
   const res = createRes();
   await saveGeneralConfig(req, res, () => {});
-  assert.deepEqual(res.body, { general: { aiApiEnabled: true } });
+  assert.deepEqual(res.body, { general: { aiApiEnabled: true }, isDefault: false });
 });

--- a/tests/db/displayFieldConfig.test.js
+++ b/tests/db/displayFieldConfig.test.js
@@ -45,7 +45,7 @@ await test('set and get display fields', async (t) => {
   const { file, restore } = await withTempFile();
   await fs.writeFile(file, '{}');
   await setDisplayFields('tbl', { idField: 'id', displayFields: ['a', 'b'] });
-  const cfg = await getDisplayFields('tbl');
+  const { config: cfg } = await getDisplayFields('tbl');
   assert.deepEqual(cfg, { idField: 'id', displayFields: ['a', 'b'] });
   await restore();
 });
@@ -69,11 +69,11 @@ await test('table name lookup is case-sensitive', async (t) => {
     }
     return [[]];
   });
-  const wrong = await getDisplayFields('mixed');
+  const { config: wrong } = await getDisplayFields('mixed');
   assert.deepEqual(wrong, { idField: 'id2', displayFields: ['name'] });
   restoreMeta();
   await removeDisplayFields('mixed');
-  const still = await getDisplayFields('MiXeD');
+  const { config: still } = await getDisplayFields('MiXeD');
   assert.deepEqual(still, { idField: 'id', displayFields: ['x'] });
   await restore();
 });
@@ -92,7 +92,7 @@ await test('removeDisplayFields deletes config', async (t) => {
     }
     return [[]];
   });
-  const cfg = await getDisplayFields('tbl');
+  const { config: cfg } = await getDisplayFields('tbl');
   restoreMeta();
   assert.deepEqual(cfg, { idField: 'id', displayFields: ['name'] });
   await restore();

--- a/tests/routes/report_procedures.test.js
+++ b/tests/routes/report_procedures.test.js
@@ -31,8 +31,8 @@ await test('listTransactionNames filters procedures by companyId', async () => {
     tenant.file,
     JSON.stringify({ tbl: { Tenant: { procedures: ['tenantProc'] } } })
   );
-  const baseForms = await listTransactionNames({}, 0);
-  const tenantForms = await listTransactionNames({}, 77);
+  const { names: baseForms } = await listTransactionNames({}, 0);
+  const { names: tenantForms } = await listTransactionNames({}, 77);
   assert.deepEqual(collectProcedures(baseForms), ['baseProc']);
   assert.deepEqual(collectProcedures(tenantForms), ['tenantProc']);
   await tenant.restore();


### PR DESCRIPTION
## Summary
- fall back to tenant 0 config files and expose `isDefault` flag from config services
- propagate `isDefault` through config-related routes
- adjust middleware, services, and tests for new config response shape

## Testing
- `npm test` *(fails: login prompts for company selection when companyId undefined; login succeeds when companyId is 0; createCompanyHandler allows system admin with companyId=0; saveModule allows update with system_settings permission; populatePermissions succeeds with system_settings permission; listUsers defaults to req.user.companyId and returns users)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd313d7388331bf0bd28d6a174270