### PR TITLE
Add confirmation before importing default configs

### DIFF
--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -611,7 +611,12 @@ export default function FormsManagement() {
   }
 
   async function handleImport() {
-    if (!window.confirm('Import default forms configuration?')) return;
+    if (
+      !window.confirm(
+        'Importing defaults will overwrite the current configuration. Continue?'
+      )
+    )
+      return;
     try {
       const res = await fetch(
         `/api/config/import?companyId=${encodeURIComponent(company ?? '')}`,

--- a/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
+++ b/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
@@ -60,7 +60,12 @@ export default function GeneralConfiguration() {
   }
 
   async function handleImport() {
-    if (!window.confirm('Import default configuration?')) return;
+    if (
+      !window.confirm(
+        'Importing defaults will overwrite the current configuration. Continue?'
+      )
+    )
+      return;
     try {
       const res = await fetch(
         `/api/config/import?companyId=${encodeURIComponent(company ?? '')}`,

--- a/src/erp.mgt.mn/pages/PosTxnConfig.jsx
+++ b/src/erp.mgt.mn/pages/PosTxnConfig.jsx
@@ -318,7 +318,12 @@ export default function PosTxnConfig() {
   }
 
   async function handleImport() {
-    if (!window.confirm('Import default POS transaction configuration?')) return;
+    if (
+      !window.confirm(
+        'Importing defaults will overwrite the current configuration. Continue?'
+      )
+    )
+      return;
     try {
       const res = await fetch(
         `/api/config/import?companyId=${encodeURIComponent(company ?? '')}`,

--- a/src/erp.mgt.mn/pages/RelationsConfig.jsx
+++ b/src/erp.mgt.mn/pages/RelationsConfig.jsx
@@ -79,7 +79,12 @@ export default function RelationsConfig() {
   }
 
   async function handleImport() {
-    if (!window.confirm('Import default relations configuration?')) return;
+    if (
+      !window.confirm(
+        'Importing defaults will overwrite the current configuration. Continue?'
+      )
+    )
+      return;
     try {
       const res = await fetch(
         `/api/config/import?companyId=${encodeURIComponent(company ?? '')}`,

--- a/src/erp.mgt.mn/pages/ReportBuilder.jsx
+++ b/src/erp.mgt.mn/pages/ReportBuilder.jsx
@@ -142,7 +142,12 @@ function ReportBuilderInner() {
   }, [generalConfig?.general?.reportProcPrefix]);
 
   async function handleImport() {
-    if (!window.confirm('Import default report builder configuration?')) return;
+    if (
+      !window.confirm(
+        'Importing defaults will overwrite the current configuration. Continue?'
+      )
+    )
+      return;
     try {
       const res = await fetch(
         `/api/config/import?companyId=${encodeURIComponent(company ?? '')}`,
@@ -150,7 +155,7 @@ function ReportBuilderInner() {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
-          body: JSON.stringify({ files: [] }),
+          body: JSON.stringify({ files: ['headerMappings.json'] }),
         },
       );
       if (!res.ok) throw new Error('failed');


### PR DESCRIPTION
## Summary
- warn users that importing defaults overwrites existing configuration on all config pages
- import correct default file and refresh config after confirmation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfd62a966483318b3593391113c953