### PR TITLE
Expose default config flag and warn on default settings

### DIFF
--- a/src/erp.mgt.mn/hooks/useGeneralConfig.js
+++ b/src/erp.mgt.mn/hooks/useGeneralConfig.js
@@ -3,11 +3,13 @@ import { useEffect, useState } from 'react';
 const cache = { data: null };
 
 export function updateCache(data) {
-  cache.data = data;
-  if (data?.general) {
-    window.erpDebug = !!data.general.debugLoggingEnabled;
+  cache.data = { ...data, isDefault: data?.isDefault ?? false };
+  if (cache.data?.general) {
+    window.erpDebug = !!cache.data.general.debugLoggingEnabled;
   }
-  window.dispatchEvent(new CustomEvent('generalConfigUpdated', { detail: data }));
+  window.dispatchEvent(
+    new CustomEvent('generalConfigUpdated', { detail: cache.data }),
+  );
 }
 
 export default function useGeneralConfig() {
@@ -21,12 +23,12 @@ export default function useGeneralConfig() {
       }
     } else {
       fetch('/api/general_config', { credentials: 'include' })
-        .then(res => (res.ok ? res.json() : {}))
+        .then(res => (res.ok ? res.json() : { isDefault: true }))
         .then(data => {
           updateCache(data);
-          setCfg(data);
+          setCfg(cache.data);
         })
-        .catch(() => setCfg({}));
+        .catch(() => setCfg({ isDefault: true }));
     }
     const handler = e => {
       setCfg(e.detail);
@@ -38,5 +40,5 @@ export default function useGeneralConfig() {
     return () => window.removeEventListener('generalConfigUpdated', handler);
   }, []);
 
-  return cfg || {};
+  return cfg || { isDefault: true };
 }

--- a/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
+++ b/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
@@ -125,6 +125,11 @@ export default function GeneralConfiguration() {
       <TooltipWrapper title={t('general_configuration', { ns: 'tooltip', defaultValue: 'Configure global settings' })}>
         <h2>{t('generalConfiguration', 'General Configuration')}</h2>
       </TooltipWrapper>
+      {isDefault && (
+        <div style={{ color: 'orange', marginBottom: '0.5rem' }}>
+          Using default configuration
+        </div>
+      )}
       <div className="tab-button-group" style={{ marginBottom: '0.5rem' }}>
         <TooltipWrapper title={t('tab_forms', { ns: 'tooltip', defaultValue: 'Form options' })}>
           <button
@@ -173,6 +178,7 @@ export default function GeneralConfiguration() {
           Images
         </button>
       </div>
+      <fieldset disabled={isDefault} style={{ border: 'none', padding: 0 }}>
       {tab === 'forms' || tab === 'pos' ? (
         <>
           <div style={{ marginBottom: '0.5rem' }}>
@@ -589,11 +595,12 @@ export default function GeneralConfiguration() {
           </div>
         </>
       )}
+      </fieldset>
       <div>
         <button onClick={handleImport} style={{ marginRight: '0.5rem' }}>
           Import Defaults
         </button>
-        <button onClick={handleSave} disabled={saving}>
+        <button onClick={handleSave} disabled={saving || isDefault}>
           Save
         </button>
       </div>

--- a/src/erp.mgt.mn/pages/PosTxnConfig.jsx
+++ b/src/erp.mgt.mn/pages/PosTxnConfig.jsx
@@ -476,6 +476,12 @@ export default function PosTxnConfig() {
   return (
     <div>
       <h2>POS Transaction Config</h2>
+      {isDefault && (
+        <div style={{ color: 'orange', marginBottom: '0.5rem' }}>
+          Using default configuration
+        </div>
+      )}
+      <fieldset disabled={isDefault} style={{ border: 'none', padding: 0, margin: 0 }}>
       <div style={{ marginBottom: '1rem' }}>
         <select value={name} onChange={(e) => loadConfig(e.target.value)}>
           <option value="">-- select config --</option>
@@ -897,11 +903,12 @@ export default function PosTxnConfig() {
           ))}
         </select>
       </div>
+      </fieldset>
       <div style={{ marginTop: '1rem' }}>
         <button onClick={handleImport} style={{ marginRight: '0.5rem' }}>
           Import Defaults
         </button>
-        <button onClick={handleSave}>Save</button>
+        <button onClick={handleSave} disabled={isDefault}>Save</button>
       </div>
     </div>
   );

--- a/src/erp.mgt.mn/pages/RelationsConfig.jsx
+++ b/src/erp.mgt.mn/pages/RelationsConfig.jsx
@@ -139,9 +139,15 @@ export default function RelationsConfig() {
   return (
     <div>
       <h2>Relations Display Fields</h2>
+      {isDefault && (
+        <div style={{ color: 'orange', marginBottom: '0.5rem' }}>
+          Using default configuration
+        </div>
+      )}
       <div style={{ marginBottom: '0.5rem' }}>
         <button onClick={handleImport}>Import Defaults</button>
       </div>
+      <fieldset disabled={isDefault} style={{ border: 'none', padding: 0, margin: 0 }}>
       <div>
         <label>
           Table:
@@ -196,6 +202,7 @@ export default function RelationsConfig() {
           </button>
         </div>
       )}
+    </fieldset>
     </div>
   );
 }

--- a/tests/hooks/useGeneralConfig.test.js
+++ b/tests/hooks/useGeneralConfig.test.js
@@ -71,6 +71,7 @@ if (!haveReact) {
     assert.equal(value.general.editLabelsEnabled, false);
     assert.equal(window.erpDebug, false);
     assert.equal(listeners.generalConfigUpdated.size, 1);
+    assert.equal(value.isDefault, false);
 
     await act(async () => {
       updateCache({ general: { editLabelsEnabled: true, debugLoggingEnabled: true } });
@@ -79,6 +80,7 @@ if (!haveReact) {
 
     assert.equal(value.general.editLabelsEnabled, true);
     assert.equal(window.erpDebug, true);
+    assert.equal(value.isDefault, false);
 
     unmount();
     assert.equal(listeners.generalConfigUpdated.size, 0);


### PR DESCRIPTION
## Summary
- surface `isDefault` flag from general config hook
- warn users when editing default configuration files
- block saving configs until defaults imported
- fix unmatched fieldset in relations config that caused build error

## Testing
- `npm test`
- `npm run build` *(fails: Missing script "build")*


------
https://chatgpt.com/codex/tasks/task_e_68bfd93cc430833180565624ca6effb4