### PR TITLE
Refactor config path resolution to expose defaults

### DIFF
--- a/api-server/controllers/permissionsController.js
+++ b/api-server/controllers/permissionsController.js
@@ -6,14 +6,14 @@ import {
   listModules,
 } from '../../db/index.js';
 import fs from 'fs/promises';
-import { resolveConfigPathSync } from '../utils/configPaths.js';
+import { getConfigPathSync } from '../utils/configPaths.js';
 
 export async function listGroups(req, res, next) {
   try {
-    const actionsPath = resolveConfigPathSync(
-      'permissionActions.json',
-      req.user.companyId,
-    );
+      const { path: actionsPath } = getConfigPathSync(
+        'permissionActions.json',
+        req.user.companyId,
+      );
     const raw = await fs.readFile(actionsPath, 'utf8');
     const registry = JSON.parse(raw);
     const allForms = registry.forms || {};

--- a/api-server/services/aiInventoryService.js
+++ b/api-server/services/aiInventoryService.js
@@ -1,16 +1,19 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { getResponseWithFile } from '../utils/openaiClient.js';
-import { tenantConfigPath, resolveConfigPath } from '../utils/configPaths.js';
+import { tenantConfigPath, getConfigPath } from '../utils/configPaths.js';
 
 async function readData(companyId = 0) {
-  try {
-    const filePath = await resolveConfigPath('aiInventoryResults.json', companyId);
-    const data = await fs.readFile(filePath, 'utf8');
-    return JSON.parse(data);
-  } catch {
-    return {};
-  }
+    try {
+      const { path: filePath } = await getConfigPath(
+        'aiInventoryResults.json',
+        companyId,
+      );
+      const data = await fs.readFile(filePath, 'utf8');
+      return JSON.parse(data);
+    } catch {
+      return {};
+    }
 }
 
 async function writeData(data, companyId = 0) {

--- a/api-server/services/codingTableConfig.js
+++ b/api-server/services/codingTableConfig.js
@@ -1,29 +1,24 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { tenantConfigPath } from '../utils/configPaths.js';
+import { tenantConfigPath, getConfigPath } from '../utils/configPaths.js';
 
 async function ensureDir(companyId = 0) {
   const filePath = tenantConfigPath('codingTableConfigs.json', companyId);
   await fs.mkdir(path.dirname(filePath), { recursive: true });
 }
 
-async function readConfig(companyId = 0) {
-  const tenantFile = tenantConfigPath('codingTableConfigs.json', companyId);
-  let filePath = tenantFile;
-  let isDefault = false;
-  try {
-    await fs.access(tenantFile);
-  } catch {
-    filePath = tenantConfigPath('codingTableConfigs.json', 0);
-    isDefault = true;
+  async function readConfig(companyId = 0) {
+    const { path: filePath, isDefault } = await getConfigPath(
+      'codingTableConfigs.json',
+      companyId,
+    );
+    try {
+      const data = await fs.readFile(filePath, 'utf8');
+      return { cfg: JSON.parse(data), isDefault };
+    } catch {
+      return { cfg: {}, isDefault: true };
+    }
   }
-  try {
-    const data = await fs.readFile(filePath, 'utf8');
-    return { cfg: JSON.parse(data), isDefault };
-  } catch {
-    return { cfg: {}, isDefault: true };
-  }
-}
 
 async function writeConfig(cfg, companyId = 0) {
   await ensureDir(companyId);

--- a/api-server/services/displayFieldConfig.js
+++ b/api-server/services/displayFieldConfig.js
@@ -1,25 +1,20 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { listTableColumnMeta } from '../../db/index.js';
-import { tenantConfigPath } from '../utils/configPaths.js';
+import { tenantConfigPath, getConfigPath } from '../utils/configPaths.js';
 
-async function readConfig(companyId = 0) {
-  const tenantFile = tenantConfigPath('tableDisplayFields.json', companyId);
-  let filePath = tenantFile;
-  let isDefault = false;
-  try {
-    await fs.access(tenantFile);
-  } catch {
-    filePath = tenantConfigPath('tableDisplayFields.json', 0);
-    isDefault = true;
+  async function readConfig(companyId = 0) {
+    const { path: filePath, isDefault } = await getConfigPath(
+      'tableDisplayFields.json',
+      companyId,
+    );
+    try {
+      const data = await fs.readFile(filePath, 'utf8');
+      return { cfg: JSON.parse(data), isDefault };
+    } catch {
+      return { cfg: {}, isDefault: true };
+    }
   }
-  try {
-    const data = await fs.readFile(filePath, 'utf8');
-    return { cfg: JSON.parse(data), isDefault };
-  } catch {
-    return { cfg: {}, isDefault: true };
-  }
-}
 
 async function writeConfig(cfg, companyId = 0) {
   const filePath = tenantConfigPath('tableDisplayFields.json', companyId);

--- a/api-server/services/generatedSql.js
+++ b/api-server/services/generatedSql.js
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { pool } from '../../db/index.js';
-import { tenantConfigPath, resolveConfigPath } from '../utils/configPaths.js';
+import { tenantConfigPath, getConfigPath } from '../utils/configPaths.js';
 
 async function ensureDir(companyId = 0) {
   const filePath = tenantConfigPath('generatedSql.json', companyId);
@@ -9,13 +9,16 @@ async function ensureDir(companyId = 0) {
 }
 
 async function readMap(companyId = 0) {
-  try {
-    const jsonPath = await resolveConfigPath('generatedSql.json', companyId);
-    const data = await fs.readFile(jsonPath, 'utf8');
-    return JSON.parse(data);
-  } catch {
-    return {};
-  }
+    try {
+      const { path: jsonPath } = await getConfigPath(
+        'generatedSql.json',
+        companyId,
+      );
+      const data = await fs.readFile(jsonPath, 'utf8');
+      return JSON.parse(data);
+    } catch {
+      return {};
+    }
 }
 
 async function writeFiles(map, companyId = 0) {

--- a/api-server/services/headerMappings.js
+++ b/api-server/services/headerMappings.js
@@ -1,15 +1,18 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { tenantConfigPath, resolveConfigPath } from '../utils/configPaths.js';
+import { tenantConfigPath, getConfigPath } from '../utils/configPaths.js';
 
 async function readMappings(companyId = 0) {
-  try {
-    const filePath = await resolveConfigPath('headerMappings.json', companyId);
-    const data = await fs.readFile(filePath, 'utf8');
-    return JSON.parse(data);
-  } catch {
-    return {};
-  }
+    try {
+      const { path: filePath } = await getConfigPath(
+        'headerMappings.json',
+        companyId,
+      );
+      const data = await fs.readFile(filePath, 'utf8');
+      return JSON.parse(data);
+    } catch {
+      return {};
+    }
 }
 
 async function writeMappings(map, companyId = 0) {

--- a/api-server/services/posTransactionConfig.js
+++ b/api-server/services/posTransactionConfig.js
@@ -1,24 +1,19 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { tenantConfigPath } from '../utils/configPaths.js';
+import { tenantConfigPath, getConfigPath } from '../utils/configPaths.js';
 
-async function readConfig(companyId = 0) {
-  const tenantFile = tenantConfigPath('posTransactionConfig.json', companyId);
-  let filePath = tenantFile;
-  let isDefault = false;
-  try {
-    await fs.access(tenantFile);
-  } catch {
-    filePath = tenantConfigPath('posTransactionConfig.json', 0);
-    isDefault = true;
+  async function readConfig(companyId = 0) {
+    const { path: filePath, isDefault } = await getConfigPath(
+      'posTransactionConfig.json',
+      companyId,
+    );
+    try {
+      const data = await fs.readFile(filePath, 'utf8');
+      return { cfg: JSON.parse(data), isDefault };
+    } catch {
+      return { cfg: {}, isDefault: true };
+    }
   }
-  try {
-    const data = await fs.readFile(filePath, 'utf8');
-    return { cfg: JSON.parse(data), isDefault };
-  } catch {
-    return { cfg: {}, isDefault: true };
-  }
-}
 
 async function writeConfig(cfg, companyId = 0) {
   const filePath = tenantConfigPath('posTransactionConfig.json', companyId);

--- a/api-server/services/posTransactionLayout.js
+++ b/api-server/services/posTransactionLayout.js
@@ -1,15 +1,18 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { tenantConfigPath, resolveConfigPath } from '../utils/configPaths.js';
+import { tenantConfigPath, getConfigPath } from '../utils/configPaths.js';
 
 async function readLayout(companyId = 0) {
-  try {
-    const filePath = await resolveConfigPath('posTransactionLayout.json', companyId);
-    const data = await fs.readFile(filePath, 'utf8');
-    return JSON.parse(data);
-  } catch {
-    return {};
-  }
+    try {
+      const { path: filePath } = await getConfigPath(
+        'posTransactionLayout.json',
+        companyId,
+      );
+      const data = await fs.readFile(filePath, 'utf8');
+      return JSON.parse(data);
+    } catch {
+      return {};
+    }
 }
 
 async function writeLayout(cfg, companyId = 0) {

--- a/api-server/services/posTransactionPending.js
+++ b/api-server/services/posTransactionPending.js
@@ -1,16 +1,19 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { tenantConfigPath, resolveConfigPath } from '../utils/configPaths.js';
+import { tenantConfigPath, getConfigPath } from '../utils/configPaths.js';
 
-async function readData(companyId = 0) {
-  try {
-    const filePath = await resolveConfigPath('posPendingTransactions.json', companyId);
-    const data = await fs.readFile(filePath, 'utf8');
-    return JSON.parse(data);
-  } catch {
-    return {};
+  async function readData(companyId = 0) {
+    try {
+      const { path: filePath } = await getConfigPath(
+        'posPendingTransactions.json',
+        companyId,
+      );
+      const data = await fs.readFile(filePath, 'utf8');
+      return JSON.parse(data);
+    } catch {
+      return {};
+    }
   }
-}
 
 async function writeData(data, companyId = 0) {
   const filePath = tenantConfigPath('posPendingTransactions.json', companyId);

--- a/api-server/services/postPosTransaction.js
+++ b/api-server/services/postPosTransaction.js
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { pool } from '../../db/index.js';
-import { resolveConfigPath } from '../utils/configPaths.js';
+import { getConfigPath } from '../utils/configPaths.js';
 
 function getValue(row, field) {
   const val = row?.[field];
@@ -107,7 +107,10 @@ export async function postPosTransaction(
   sessionInfo = {},
   companyId = 0,
 ) {
-  const cfgPath = await resolveConfigPath('posTransactionConfig.json', companyId);
+    const { path: cfgPath } = await getConfigPath(
+      'posTransactionConfig.json',
+      companyId,
+    );
   const cfgRaw = await fs.readFile(cfgPath, 'utf8');
   const json = JSON.parse(cfgRaw);
   const cfg = json['POS_Modmarket'];

--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -1,24 +1,19 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { tenantConfigPath } from '../utils/configPaths.js';
+import { tenantConfigPath, getConfigPath } from '../utils/configPaths.js';
 
-async function readConfig(companyId = 0) {
-  const tenantFile = tenantConfigPath('transactionForms.json', companyId);
-  let filePath = tenantFile;
-  let isDefault = false;
-  try {
-    await fs.access(tenantFile);
-  } catch {
-    filePath = tenantConfigPath('transactionForms.json', 0);
-    isDefault = true;
+  async function readConfig(companyId = 0) {
+    const { path: filePath, isDefault } = await getConfigPath(
+      'transactionForms.json',
+      companyId,
+    );
+    try {
+      const data = await fs.readFile(filePath, 'utf8');
+      return { cfg: JSON.parse(data), isDefault };
+    } catch {
+      return { cfg: {}, isDefault: true };
+    }
   }
-  try {
-    const data = await fs.readFile(filePath, 'utf8');
-    return { cfg: JSON.parse(data), isDefault };
-  } catch {
-    return { cfg: {}, isDefault: true };
-  }
-}
 
 async function writeConfig(cfg, companyId = 0) {
   const filePath = tenantConfigPath('transactionForms.json', companyId);

--- a/api-server/utils/configPaths.js
+++ b/api-server/utils/configPaths.js
@@ -6,17 +6,19 @@ export function tenantConfigPath(file, companyId = 0) {
   return path.join(process.cwd(), 'config', String(companyId), file);
 }
 
-export async function resolveConfigPath(file, companyId = 0) {
+export async function getConfigPath(file, companyId = 0) {
   const tenant = tenantConfigPath(file, companyId);
   try {
     await fs.access(tenant);
-    return tenant;
+    return { path: tenant, isDefault: false };
   } catch {
-    return tenantConfigPath(file, 0);
+    return { path: tenantConfigPath(file, 0), isDefault: true };
   }
 }
 
-export function resolveConfigPathSync(file, companyId = 0) {
+export function getConfigPathSync(file, companyId = 0) {
   const tenant = tenantConfigPath(file, companyId);
-  return existsSync(tenant) ? tenant : tenantConfigPath(file, 0);
+  return existsSync(tenant)
+    ? { path: tenant, isDefault: false }
+    : { path: tenantConfigPath(file, 0), isDefault: true };
 }

--- a/db/index.js
+++ b/db/index.js
@@ -40,10 +40,7 @@ try {
 import defaultModules from "./defaultModules.js";
 import { logDb } from "./debugLog.js";
 import fs from "fs/promises";
-import {
-  tenantConfigPath,
-  resolveConfigPath,
-} from "../api-server/utils/configPaths.js";
+import { tenantConfigPath, getConfigPath } from "../api-server/utils/configPaths.js";
 import { getDisplayFields as getDisplayCfg } from "../api-server/services/displayFieldConfig.js";
 import { GLOBAL_COMPANY_ID } from "../config/0/constants.js";
 import { formatDateForDb } from "../api-server/utils/formatDate.js";
@@ -53,7 +50,7 @@ const permissionRegistryCache = new Map();
 async function loadPermissionRegistry(companyId = GLOBAL_COMPANY_ID) {
   if (!permissionRegistryCache.has(companyId)) {
     try {
-      const actionsPath = await resolveConfigPath(
+      const { path: actionsPath } = await getConfigPath(
         "permissionActions.json",
         companyId,
       );
@@ -81,7 +78,7 @@ const softDeleteConfigCache = new Map();
 async function loadSoftDeleteConfig(companyId = GLOBAL_COMPANY_ID) {
   if (!softDeleteConfigCache.has(companyId)) {
     try {
-      const cfgPath = await resolveConfigPath(
+      const { path: cfgPath } = await getConfigPath(
         "softDeleteTables.json",
         companyId,
       );
@@ -2075,7 +2072,7 @@ export async function getProcedureRawRows(
           }
         }
         try {
-          const tfPath = await resolveConfigPath('transactionForms.json');
+          const { path: tfPath } = await getConfigPath('transactionForms.json');
           const txt = await fs.readFile(tfPath, 'utf8');
           const cfg = JSON.parse(txt);
           const set = new Set();
@@ -2112,7 +2109,7 @@ export async function getProcedureRawRows(
           }
         } catch {}
         try {
-          const dfPath = await resolveConfigPath('tableDisplayFields.json');
+          const { path: dfPath } = await getConfigPath('tableDisplayFields.json');
           const dfTxt = await fs.readFile(dfPath, 'utf8');
           const dfCfg = JSON.parse(dfTxt);
           if (Array.isArray(dfCfg[table]?.displayFields)) {

--- a/scripts/generateTranslations.js
+++ b/scripts/generateTranslations.js
@@ -1,7 +1,7 @@
 // scripts/generateTranslations.js
 import fs from 'fs';
 import path from 'path';
-import { resolveConfigPathSync } from '../api-server/utils/configPaths.js';
+import { getConfigPathSync } from '../api-server/utils/configPaths.js';
 let OpenAI;
 try {
   ({ default: OpenAI } = await import('../api-server/utils/openaiClient.js'));
@@ -23,11 +23,11 @@ const languageNames = {
   ru: 'Russian',
 };
 const companyId = process.env.COMPANY_ID || 0;
-const headerMappingsPath = resolveConfigPathSync(
+const { path: headerMappingsPath } = getConfigPathSync(
   'headerMappings.json',
   companyId,
 );
-const transactionFormsPath = resolveConfigPathSync(
+const { path: transactionFormsPath } = getConfigPathSync(
   'transactionForms.json',
   companyId,
 );
@@ -364,7 +364,7 @@ export async function generateTranslations({ onLog = console.log, signal } = {})
   try {
     const ulaConfig = JSON.parse(
       fs.readFileSync(
-        resolveConfigPathSync('userLevelActions.json', companyId),
+        getConfigPathSync('userLevelActions.json', companyId).path,
         'utf8',
       ),
     );
@@ -413,7 +413,7 @@ export async function generateTranslations({ onLog = console.log, signal } = {})
   try {
     const posConfig = JSON.parse(
       fs.readFileSync(
-        resolveConfigPathSync('posTransactionConfig.json', companyId),
+        getConfigPathSync('posTransactionConfig.json', companyId).path,
         'utf8',
       ),
     );


### PR DESCRIPTION
## Summary
- replace implicit config fallbacks with `getConfigPath` returning `{path,isDefault}`
- update services to use `getConfigPath` and avoid unnecessary tenant-0 copies
- adjust loaders and scripts to new helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfdb01ce448331af1e60658633d8c4