### PR TITLE
Export translations to file and return path

### DIFF
--- a/api-server/routes/translations.js
+++ b/api-server/routes/translations.js
@@ -18,7 +18,7 @@ router.get('/export', requireAuth, async (req, res, next) => {
     if (!(await checkPermission(req))) return res.sendStatus(403);
     const companyId = Number(req.query.companyId ?? req.user.companyId);
     const filePath = await exportTranslations(companyId);
-    res.status(200).json({ filePath });
+    res.status(200).json({ success: true, filePath });
   } catch (err) {
     next(err);
   }

--- a/api-server/services/translationsExport.js
+++ b/api-server/services/translationsExport.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { getConfigPathSync } from '../utils/configPaths.js';
+import { getConfigPathSync, tenantConfigPath } from '../utils/configPaths.js';
 import { slugify } from '../utils/slugify.js';
 import {
   collectPhrasesFromPages,
@@ -174,10 +174,8 @@ export async function exportTranslations(companyId = 0) {
   } catch {}
 
   const sorted = sortObj(base);
-  const exportPath = path.join(
-    path.dirname(headerMappingsPath),
-    'exportedtexts.json',
-  );
+  const exportPath = tenantConfigPath('exportedtexts.json', 0);
+  fs.mkdirSync(path.dirname(exportPath), { recursive: true });
   fs.writeFileSync(exportPath, JSON.stringify(sorted, null, 2));
   console.log(`Exported translations written to ${exportPath}`);
   return exportPath;


### PR DESCRIPTION
## Summary
- write exported translations to `config/0/exportedtexts.json`
- respond to translation export requests with a success message and file path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0dc8f463c8331895fe27c2cb237fd