### PR TITLE
Refactor translation module DB pool handling

### DIFF
--- a/api-server/services/translationsExport.js
+++ b/api-server/services/translationsExport.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { getConfigPathSync, tenantConfigPath } from '../utils/configPaths.js';
 import { slugify } from '../utils/slugify.js';
 import {
@@ -179,4 +180,22 @@ export async function exportTranslations(companyId = 0) {
   fs.writeFileSync(exportPath, JSON.stringify(sorted, null, 2));
   console.log(`Exported translations written to ${exportPath}`);
   return exportPath;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const companyId = Number(process.argv[2] || 0);
+  const run = async () => {
+    try {
+      await exportTranslations(companyId);
+    } catch (err) {
+      console.error(err);
+      process.exit(1);
+    } finally {
+      try {
+        const db = await import('../../db/index.js');
+        await db.pool.end();
+      } catch {}
+    }
+  };
+  run();
 }

--- a/api-server/utils/translationHelpers.js
+++ b/api-server/utils/translationHelpers.js
@@ -36,15 +36,11 @@ export async function fetchModules() {
       const [rows] = await db.pool.query(
         'SELECT module_key AS moduleKey, label FROM modules',
       );
-      await db.pool.end();
       return rows.map((r) => ({ moduleKey: r.moduleKey, label: r.label }));
     } catch (err) {
       console.warn(
         `[translations] DB query failed; falling back to defaults: ${err.message}`,
       );
-      try {
-        await db.pool.end();
-      } catch {}
     }
   } catch (err) {
     console.warn(

--- a/scripts/generateTranslations.js
+++ b/scripts/generateTranslations.js
@@ -214,11 +214,12 @@ export async function generateTranslations({ onLog = console.log, signal } = {})
     if (signal?.aborted) throw new Error('Aborted');
   };
 
-  log('[gen-i18n] START');
-  const base = JSON.parse(fs.readFileSync(headerMappingsPath, 'utf8'));
-  const modules = await fetchModules();
-  let headerMappingsUpdated = false;
-  const entryMap = new Map();
+  try {
+    log('[gen-i18n] START');
+    const base = JSON.parse(fs.readFileSync(headerMappingsPath, 'utf8'));
+    const modules = await fetchModules();
+    let headerMappingsUpdated = false;
+    const entryMap = new Map();
 
   function addEntry(key, sourceText, sourceLang, origin) {
     if (
@@ -784,6 +785,12 @@ export async function generateTranslations({ onLog = console.log, signal } = {})
     }
   }
   log('[gen-i18n] DONE');
+  } finally {
+    try {
+      const db = await import('../db/index.js');
+      await db.pool.end();
+    } catch {}
+  }
 }
 
 export async function generateTooltipTranslations({ onLog = console.log, signal } = {}) {

--- a/tests/services/translationsExport.test.js
+++ b/tests/services/translationsExport.test.js
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { exportTranslations } from '../../api-server/services/translationsExport.js';
+import { login } from '../../api-server/controllers/authController.js';
+import * as db from '../../db/index.js';
+
+function mockPoolSequential(responses = []) {
+  const orig = db.pool.query;
+  let i = 0;
+  db.pool.query = async (...args) => {
+    const res = responses[i];
+    i += 1;
+    if (typeof res === 'function') return res(...args);
+    return res;
+  };
+  return () => {
+    db.pool.query = orig;
+  };
+}
+
+function createRes() {
+  return {
+    code: 200,
+    body: undefined,
+    cookies: {},
+    status(c) {
+      this.code = c;
+      return this;
+    },
+    json(b) {
+      this.body = b;
+    },
+    cookie(name, val) {
+      this.cookies[name] = val;
+    },
+  };
+}
+
+test('login succeeds after exporting translations', async () => {
+  const sessions = [
+    {
+      company_id: 0,
+      branch_id: 1,
+      department_id: 1,
+      position_id: 1,
+      position: 'P',
+      senior_empid: null,
+      employee_name: 'Emp0',
+      user_level: 1,
+      user_level_name: 'Admin',
+      permission_list: '',
+    },
+  ];
+  const restore = mockPoolSequential([
+    [[{ moduleKey: 'm1', label: 'Module 1' }]],
+    [[{ id: 1, empid: 1, password: 'hashed' }]],
+    [sessions],
+    [[]],
+    [[]],
+  ]);
+
+  await exportTranslations(0);
+  const res = createRes();
+  await login({ body: { empid: 1, password: 'pw', companyId: 0 } }, res, () => {});
+  restore();
+  assert.equal(res.code, 200);
+  await db.pool.end();
+});


### PR DESCRIPTION
## Summary
- keep shared DB pool alive in translation helpers
- close DB pool in translation generation and export scripts
- add regression test ensuring login works after exporting translations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0e02c01008331bedc5b736ed67dad