### PR TITLE
feat: load tenant-specific locales

### DIFF
--- a/api-server/routes/manual_translations.js
+++ b/api-server/routes/manual_translations.js
@@ -19,7 +19,8 @@ const router = express.Router();
 
 router.get('/', limiter, requireAuth, async (req, res, next) => {
   try {
-    const data = await loadTranslations();
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
+    const data = await loadTranslations(companyId);
     res.json(data);
   } catch (err) {
     next(err);
@@ -28,7 +29,8 @@ router.get('/', limiter, requireAuth, async (req, res, next) => {
 
 router.post('/', limiter, requireAuth, async (req, res, next) => {
   try {
-    await saveTranslation(req.body || {});
+    const companyId = Number(req.body?.companyId ?? req.user.companyId);
+    await saveTranslation({ ...(req.body || {}), companyId });
     res.sendStatus(204);
   } catch (err) {
     next(err);
@@ -38,8 +40,9 @@ router.post('/', limiter, requireAuth, async (req, res, next) => {
 router.delete('/', limiter, requireAuth, async (req, res, next) => {
   try {
     const { key, type = 'locale' } = req.query;
+    const companyId = Number(req.query.companyId ?? req.user.companyId);
     if (!key) return res.status(400).json({ error: 'key required' });
-    await deleteTranslation(key, type);
+    await deleteTranslation(key, type, companyId);
     res.sendStatus(204);
   } catch (err) {
     next(err);

--- a/api-server/services/manualTranslations.js
+++ b/api-server/services/manualTranslations.js
@@ -1,8 +1,12 @@
 import fs from 'fs/promises';
 import path from 'path';
+import { tenantConfigPath } from '../utils/configPaths.js';
 
-const localesDir = path.resolve(process.cwd(), 'src', 'erp.mgt.mn', 'locales');
-const tooltipDir = path.join(localesDir, 'tooltips');
+function getDirs(companyId = 0) {
+  const localesDir = tenantConfigPath('locales', companyId);
+  const tooltipDir = path.join(localesDir, 'tooltips');
+  return { localesDir, tooltipDir };
+}
 
 async function listLangs(dir) {
   try {
@@ -13,7 +17,8 @@ async function listLangs(dir) {
   }
 }
 
-export async function loadTranslations() {
+export async function loadTranslations(companyId = 0) {
+  const { localesDir, tooltipDir } = getDirs(companyId);
   const langs = new Set([
     ...(await listLangs(localesDir)),
     ...(await listLangs(tooltipDir)),
@@ -47,8 +52,14 @@ export async function loadTranslations() {
   return { languages: Array.from(langs), entries: Object.values(entries) };
 }
 
-export async function saveTranslation({ key, type = 'locale', values = {} }) {
+export async function saveTranslation({
+  key,
+  type = 'locale',
+  values = {},
+  companyId = 0,
+}) {
   if (!key) return;
+  const { localesDir, tooltipDir } = getDirs(companyId);
   for (const [lang, val] of Object.entries(values)) {
     const dir = type === 'tooltip' ? tooltipDir : localesDir;
     const file = path.join(dir, `${lang}.json`);
@@ -66,8 +77,13 @@ export async function saveTranslation({ key, type = 'locale', values = {} }) {
   }
 }
 
-export async function deleteTranslation(key, type = 'locale') {
+export async function deleteTranslation(
+  key,
+  type = 'locale',
+  companyId = 0,
+) {
   if (!key) return;
+  const { localesDir, tooltipDir } = getDirs(companyId);
   const dir = type === 'tooltip' ? tooltipDir : localesDir;
   for (const lang of await listLangs(dir)) {
     const file = path.join(dir, `${lang}.json`);

--- a/docs/openai-usage.md
+++ b/docs/openai-usage.md
@@ -27,7 +27,7 @@ The bar adapts to smaller screens and can be reopened via the "AI" button when c
 
 ## Automatic Translation
 
-The front-end utility [`translateWithAI`](../src/erp.mgt.mn/utils/translateWithAI.js) loads strings from the locale files under `src/erp.mgt.mn/locales/`. When a key is missing, it posts the source text to `/api/openai` to request a translation into the desired language. Responses are cached in the browser's `localStorage` using keys of the form `ai-translations-<lang>`. Remove those entries to clear cached translations.
+The front-end utility [`translateWithAI`](../src/erp.mgt.mn/utils/translateWithAI.js) loads strings from tenant-specific locale files under `config/<companyId>/locales/`, falling back to the global set when necessary. When a key is missing, it posts the source text to `/api/openai` to request a translation into the desired language. Responses are cached in the browser's `localStorage` using keys of the form `ai-translations-<lang>`. Remove those entries to clear cached translations.
 
 The API route uses the `OPENAI_API_KEY` environment variable shown above; ensure it is set before starting the server so translation requests succeed. If the feature is disabled or the server returns a 404, the helper silently falls back to the source text without showing error toasts.
 

--- a/docs/translation-schema.md
+++ b/docs/translation-schema.md
@@ -1,6 +1,6 @@
 # Translation Workflow
 
-All UI strings are stored per language under `src/erp.mgt.mn/locales/<lang>.json`.
+All UI strings are stored per language under `config/<companyId>/locales/<lang>.json`.
 These locale files are generated automatically and should **not** be edited or
 committed manually.
 
@@ -16,7 +16,7 @@ npm run generate:translations
 
 The script retrieves translations from the service and falls back to machine
 translation when necessary. New locale files will be written under the
-`locales` directory.
+tenant-specific `config/<companyId>/locales` directory.
 
 Because the files are generated, avoid committing changes to them. CI or
 release builds will regenerate the locales as needed.

--- a/scripts/generateTranslations.js
+++ b/scripts/generateTranslations.js
@@ -1,7 +1,10 @@
 // scripts/generateTranslations.js
 import fs from 'fs';
 import path from 'path';
-import { getConfigPathSync } from '../api-server/utils/configPaths.js';
+import {
+  tenantConfigPath,
+  getConfigPathSync,
+} from '../api-server/utils/configPaths.js';
 let OpenAI;
 try {
   ({ default: OpenAI } = await import('../api-server/utils/openaiClient.js'));
@@ -36,7 +39,7 @@ const { path: transactionFormsPath } = getConfigPathSync(
   'transactionForms.json',
   companyId,
 );
-const localesDir = path.resolve('src/erp.mgt.mn/locales');
+const localesDir = tenantConfigPath('locales', companyId);
 const tooltipsDir = path.join(localesDir, 'tooltips');
 const TIMEOUT_MS = 7000;
 
@@ -792,12 +795,11 @@ export async function generateTooltipTranslations({ onLog = console.log, signal 
     if (signal?.aborted) throw new Error('Aborted');
   };
 
-  const tooltipDir = path.resolve('src/erp.mgt.mn/locales/tooltips');
-  await fs.promises.mkdir(tooltipDir, { recursive: true });
+  await fs.promises.mkdir(tooltipsDir, { recursive: true });
 
   const tipData = {};
   for (const lang of languages) {
-    const p = path.join(tooltipDir, `${lang}.json`);
+    const p = path.join(tooltipsDir, `${lang}.json`);
     tipData[lang] = fs.existsSync(p)
       ? JSON.parse(fs.readFileSync(p, 'utf8'))
       : {};
@@ -806,11 +808,11 @@ export async function generateTooltipTranslations({ onLog = console.log, signal 
   if (tipData.en && tipData.mn) {
     syncKeys(tipData.en, tipData.mn, 'tooltip');
     fs.writeFileSync(
-      path.join(tooltipDir, 'en.json'),
+      path.join(tooltipsDir, 'en.json'),
       JSON.stringify(sortObj(tipData.en), null, 2),
     );
     fs.writeFileSync(
-      path.join(tooltipDir, 'mn.json'),
+      path.join(tooltipsDir, 'mn.json'),
       JSON.stringify(sortObj(tipData.mn), null, 2),
     );
   }
@@ -850,7 +852,7 @@ export async function generateTooltipTranslations({ onLog = console.log, signal 
 
   for (const lang of languages) {
     checkAbort();
-    const langPath = path.join(tooltipDir, `${lang}.json`);
+    const langPath = path.join(tooltipsDir, `${lang}.json`);
     const current = tipData[lang] || {};
     // remove keys not in base to keep key counts aligned
     for (const k of Object.keys(current)) {

--- a/src/erp.mgt.mn/utils/translateWithAI.js
+++ b/src/erp.mgt.mn/utils/translateWithAI.js
@@ -2,14 +2,28 @@ const localeCache = {};
 const aiCache = {};
 let aiDisabled = false;
 
+function getCompanyId() {
+  try {
+    const stored = localStorage.getItem('erp_session_ids');
+    if (stored) return JSON.parse(stored).company ?? 0;
+  } catch {}
+  return 0;
+}
+
 async function loadLocale(lang) {
   if (!localeCache[lang]) {
-    try {
-      localeCache[lang] = (await import(`../locales/${lang}.json`)).default;
-    } catch (err) {
-      console.error('Failed to load locale', lang, err);
-      localeCache[lang] = {};
+    const companyId = getCompanyId();
+    const ids = companyId != null ? [companyId, 0] : [0];
+    for (const id of ids) {
+      try {
+        const res = await fetch(`/config/${id}/locales/${lang}.json`);
+        if (res.ok) {
+          localeCache[lang] = await res.json();
+          break;
+        }
+      } catch {}
     }
+    if (!localeCache[lang]) localeCache[lang] = {};
   }
   return localeCache[lang];
 }

--- a/src/erp.mgt.mn/utils/translateWithCache.js
+++ b/src/erp.mgt.mn/utils/translateWithCache.js
@@ -29,25 +29,41 @@ async function saveNodeCache() {
   await fs.writeFile(nodeCachePath, JSON.stringify(nodeCache, null, 2));
 }
 
+function getCompanyId() {
+  if (typeof process !== 'undefined' && process.versions?.node) {
+    return Number(process.env.COMPANY_ID || 0);
+  }
+  try {
+    const stored = localStorage.getItem('erp_session_ids');
+    if (stored) return JSON.parse(stored).company ?? 0;
+  } catch {}
+  return 0;
+}
+
 async function loadLocale(lang) {
   if (localeCache[lang]) return localeCache[lang];
   try {
     if (typeof process !== 'undefined' && process.versions?.node) {
       const fs = await import('fs/promises');
-      const path = await import('path');
-      const file = path.join(
-        process.cwd(),
-        'src',
-        'erp.mgt.mn',
-        'locales',
-        `${lang}.json`,
+      const { tenantConfigPath } = await import(
+        '../../api-server/utils/configPaths.js'
       );
+      const file = tenantConfigPath(`locales/${lang}.json`, getCompanyId());
       const data = await fs.readFile(file, 'utf8');
       localeCache[lang] = JSON.parse(data);
     } else {
-      localeCache[lang] = (
-        await import(`../locales/${lang}.json`)
-      ).default;
+      const companyId = getCompanyId();
+      const ids = companyId != null ? [companyId, 0] : [0];
+      for (const id of ids) {
+        try {
+          const res = await fetch(`/config/${id}/locales/${lang}.json`);
+          if (res.ok) {
+            localeCache[lang] = await res.json();
+            break;
+          }
+        } catch {}
+      }
+      if (!localeCache[lang]) localeCache[lang] = {};
     }
   } catch {
     localeCache[lang] = {};


### PR DESCRIPTION
## Summary
- generate translations into `config/<companyId>/locales` using `tenantConfigPath`
- load locale JSON from tenant config directory with global fallback
- adjust manual translation routes and docs for new locale location

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0dd5b20c88331bed1bec164d003c2