### PR TITLE
Filter report procedures by tenant

### DIFF
--- a/api-server/routes/report_builder.js
+++ b/api-server/routes/report_builder.js
@@ -105,7 +105,10 @@ router.get('/procedures', requireAuth, async (req, res, next) => {
   try {
     const { prefix = '' } = req.query;
     const companyId = Number(req.query.companyId ?? req.user.companyId);
-    const names = await listReportProcedures(prefix);
+    const names = (await listReportProcedures(prefix)).filter(
+      (n) =>
+        n.startsWith(`${prefix}0_`) || n.startsWith(`${prefix}${companyId}_`),
+    );
 
     // Determine which procedures are default by checking procedure files
     const tenantDirPath = tenantProcDir(companyId);


### PR DESCRIPTION
## Summary
- Filter report procedure names by tenant on backend
- Limit ReportBuilder UI to show default and current-tenant procedures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0e7922e7c83319b4eed65d893b886