### PR TITLE
feat: allow translation generation from exported file

### DIFF
--- a/api-server/routes/translation_generator.js
+++ b/api-server/routes/translation_generator.js
@@ -30,7 +30,11 @@ router.get('/', requireAuth, async (req, res, next) => {
 
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = path.dirname(__filename);
-    const scriptPath = path.resolve(__dirname, '../../scripts/generateTranslations.cli.js');
+    const scriptPath = path.resolve(
+      __dirname,
+      '../../scripts/generateTranslations.cli.js',
+    );
+    const textsPath = req.query.file;
 
     const sendError = (err) => {
       res.write(`event: generator_error\ndata: ${err.message}\n\n`);
@@ -41,7 +45,9 @@ router.get('/', requireAuth, async (req, res, next) => {
 
     let child;
     try {
-      child = spawn(process.execPath, [scriptPath], {
+      const args = [scriptPath];
+      if (textsPath) args.push(textsPath);
+      child = spawn(process.execPath, args, {
         signal: controller.signal,
       });
     } catch (err) {

--- a/scripts/generateTranslations.cli.js
+++ b/scripts/generateTranslations.cli.js
@@ -18,7 +18,12 @@ process.on('uncaughtException', (err) => {
 
 async function main() {
   try {
-    await generateTranslations({ onLog: console.log, signal: controller.signal });
+    const textsPath = process.argv[2];
+    await generateTranslations({
+      onLog: console.log,
+      signal: controller.signal,
+      textsPath,
+    });
     await generateTooltipTranslations({ onLog: console.log, signal: controller.signal });
   } catch (err) {
     console.error('[gen-i18n] FATAL', err);

--- a/src/erp.mgt.mn/pages/GenerateTranslationsTab.jsx
+++ b/src/erp.mgt.mn/pages/GenerateTranslationsTab.jsx
@@ -6,6 +6,7 @@ export default function GenerateTranslationsTab() {
   const [logs, setLogs] = useState([]);
   const [status, setStatus] = useState('');
   const [source, setSource] = useState(null);
+  const [filePath, setFilePath] = useState('');
 
   useEffect(() => {
     window.addEventListener('beforeunload', cancel);
@@ -19,7 +20,10 @@ export default function GenerateTranslationsTab() {
     if (source) return;
     setLogs([]);
     setStatus(t('generationStarted', 'Generation started'));
-    const es = new EventSource('/api/translations/generate');
+    const url = filePath
+      ? `/api/translations/generate?file=${encodeURIComponent(filePath)}`
+      : '/api/translations/generate';
+    const es = new EventSource(url);
     es.onmessage = (e) => {
       if (e.data === '[DONE]') {
         setStatus(t('generationCompleted', 'Generation completed'));
@@ -57,6 +61,13 @@ export default function GenerateTranslationsTab() {
   return (
     <div>
       <div style={{ marginBottom: '0.5rem' }}>
+        <input
+          type="text"
+          placeholder={t('exportedFilePath', 'Exported texts JSON path')}
+          value={filePath}
+          onChange={(e) => setFilePath(e.target.value)}
+          style={{ marginRight: '0.5rem' }}
+        />
         <button onClick={start} disabled={!!source}>
           {t('start', 'Start')}
         </button>


### PR DESCRIPTION
## Summary
- load translation keys from an exported texts JSON instead of scanning source
- allow API and UI to forward a provided JSON path to the generator
- update generator CLI to accept file path argument

## Testing
- `npm test`
- `node scripts/generateTranslations.cli.js sample_texts.json >/tmp/gen.log && tail -n 5 /tmp/gen.log` *(verified locales and tooltip files generated from provided JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68c0eccb9e388331af437dc66e5ab55a