### PR TITLE
Limit delete dropdown to tenant procedures

### DIFF
--- a/src/erp.mgt.mn/pages/ReportBuilder.jsx
+++ b/src/erp.mgt.mn/pages/ReportBuilder.jsx
@@ -56,10 +56,18 @@ function ReportBuilderInner() {
   const [dbProcIsDefault, setDbProcIsDefault] = useState(false);
   const [isDefault, setIsDefault] = useState(false);
 
+  const tenantProcedures = dbProcedures.filter((p) => !p.isDefault);
+
   const [customParamName, setCustomParamName] = useState('');
   const [customParamType, setCustomParamType] = useState(PARAM_TYPES[0]);
   const { addToast } = useToast();
   const { company } = useContext(AuthContext);
+
+  useEffect(() => {
+    const firstTenant = tenantProcedures[0];
+    setSelectedDbProcedure(firstTenant?.name || '');
+    setDbProcIsDefault(firstTenant?.isDefault || false);
+  }, [dbProcedures]);
 
   useEffect(() => {
     setUnionQueries((prev) => {
@@ -2734,9 +2742,9 @@ function ReportBuilderInner() {
           }}
           style={{ marginLeft: '0.5rem' }}
         >
-          {dbProcedures.map((p) => (
+          {tenantProcedures.map((p) => (
             <option key={p.name} value={p.name}>
-              {p.name} {p.isDefault ? '(default)' : ''}
+              {p.name}
             </option>
           ))}
         </select>


### PR DESCRIPTION
## Summary
- derive `tenantProcedures` from `dbProcedures`
- show only tenant procedures in delete procedure dropdown
- keep `dbProcedures` for other uses and sync selection when procedures list changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0f3ad49cc8331bb97e7deace0a9c6