### PR TITLE
Use procedures endpoint in allowed reports config

### DIFF
--- a/api-server/routes/report_builder.js
+++ b/api-server/routes/report_builder.js
@@ -101,12 +101,11 @@ router.get('/fields', requireAuth, async (req, res, next) => {
 // List stored procedures
 router.get('/procedures', requireAuth, async (req, res, next) => {
   try {
-    const { prefix = '' } = req.query;
     const companyId = Number(req.query.companyId ?? req.user.companyId);
-    const names = (await listReportProcedures(prefix)).filter(
-      (n) =>
-        n.startsWith(`${prefix}0_`) || n.startsWith(`${prefix}${companyId}_`),
-    );
+    const names = (await listReportProcedures()).filter((n) => {
+      const parts = n.split('_');
+      return parts[1] === '0' || parts[1] === String(companyId);
+    });
 
     // Determine which procedures are default by checking procedure files
     const tenantDirPath = tenantProcDir(companyId);

--- a/src/erp.mgt.mn/pages/AllowedReportsConfig.jsx
+++ b/src/erp.mgt.mn/pages/AllowedReportsConfig.jsx
@@ -33,7 +33,7 @@ export default function AllowedReportsConfig() {
         setIsDefault(true);
       });
 
-    fetch('/api/report_builder/procedure-files', { credentials: 'include' })
+    fetch('/api/report_builder/procedures', { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : { names: [] }))
       .then((data) => setProcOptions(data.names || []))
       .catch(() => setProcOptions([]));


### PR DESCRIPTION
## Summary
- Fetch available report procedures from `/api/report_builder/procedures` instead of procedure files
- Backend procedures route no longer requires a prefix and returns tenant and default procedures with `isDefault` flags

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0f8fdd3e88331bb185b36f9e561d5