### PR TITLE
Add API and UI for loading DB procedures

### DIFF
--- a/api-server/routes/report_builder.js
+++ b/api-server/routes/report_builder.js
@@ -9,6 +9,7 @@ import {
   saveView,
   listReportProcedures,
   deleteProcedure,
+  getProcedureSql,
 } from '../../db/index.js';
 
 const PROTECTED_PROCEDURE_PREFIXES = ['dynrep_'];
@@ -135,6 +136,18 @@ router.post('/procedures', requireAuth, async (req, res, next) => {
       return res.status(403).json({ message: 'Procedure not allowed' });
     await saveStoredProcedure(sql);
     res.json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Get a stored procedure SQL
+router.get('/procedures/:name', requireAuth, async (req, res, next) => {
+  try {
+    const { name } = req.params;
+    const sql = await getProcedureSql(name);
+    if (!sql) return res.status(404).json({ message: 'Procedure not found' });
+    res.json({ sql });
   } catch (err) {
     next(err);
   }

--- a/db/index.js
+++ b/db/index.js
@@ -1209,6 +1209,25 @@ export async function deleteProcedure(name) {
   await pool.query(`DROP PROCEDURE IF EXISTS \`${name}\``);
 }
 
+export async function getProcedureSql(name) {
+  if (!name) return null;
+  try {
+    const sql = mysql.format('SHOW CREATE PROCEDURE ??', [name]);
+    const [rows] = await pool.query(sql);
+    const text = rows?.[0]?.['Create Procedure'];
+    if (text) return text;
+  } catch {}
+  try {
+    const [rows] = await pool.query(
+      `SELECT ROUTINE_DEFINITION FROM information_schema.ROUTINES WHERE ROUTINE_SCHEMA = DATABASE() AND ROUTINE_NAME = ?`,
+      [name],
+    );
+    return rows?.[0]?.ROUTINE_DEFINITION || null;
+  } catch {
+    return null;
+  }
+}
+
 export async function getTableColumnLabels(tableName) {
   const [rows] = await pool.query(
     'SELECT column_name, mn_label FROM table_column_labels WHERE table_name = ?',

--- a/src/erp.mgt.mn/pages/ReportBuilder.jsx
+++ b/src/erp.mgt.mn/pages/ReportBuilder.jsx
@@ -1238,6 +1238,20 @@ function ReportBuilderInner() {
     }
   }
 
+  async function handleLoadDbProcedure() {
+    if (!selectedDbProcedure) return;
+    try {
+      const res = await fetch(
+        `/api/report_builder/procedures/${encodeURIComponent(selectedDbProcedure)}`,
+      );
+      const data = await res.json();
+      setProcFileText(data.sql || '');
+      setProcFileIsDefault(dbProcIsDefault);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
   async function handlePostView() {
     if (!viewSql) return;
     if (!window.confirm('POST view to database?')) return;
@@ -2744,6 +2758,12 @@ function ReportBuilderInner() {
             </option>
           ))}
         </select>
+        <button
+          onClick={handleLoadDbProcedure}
+          style={{ marginLeft: '0.5rem' }}
+        >
+          Load Script
+        </button>
         <button
           onClick={handleDeleteProcedure}
           style={{ marginLeft: '0.5rem' }}


### PR DESCRIPTION
## Summary
- add utility to fetch stored procedure SQL from database
- expose GET `/api/report_builder/procedures/:name` endpoint
- allow Report Builder to load a procedure's script into editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0f932085883318ee7773411341fe0