### PR TITLE
Allow admins to bypass procedure protection

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -1160,14 +1160,14 @@ export async function zeroSharedTenantKeys(userId) {
   }
 }
 
-export async function saveStoredProcedure(sql) {
+export async function saveStoredProcedure(sql, { allowProtected = false } = {}) {
   const cleaned = sql
     .replace(/^DELIMITER \$\$/gm, '')
     .replace(/^DELIMITER ;/gm, '')
     .replace(/END\s*\$\$/gm, 'END;');
   const nameMatch = cleaned.match(/CREATE\s+PROCEDURE\s+`?([^\s`(]+)`?/i);
   const procName = nameMatch ? nameMatch[1] : null;
-  if (await isProtectedProcedure(procName)) {
+  if (!allowProtected && (await isProtectedProcedure(procName))) {
     const err = new Error('Procedure not allowed');
     err.status = 403;
     throw err;
@@ -1199,9 +1199,9 @@ export async function listReportProcedures(prefix = '') {
   return rows.map((r) => r.ROUTINE_NAME);
 }
 
-export async function deleteProcedure(name) {
+export async function deleteProcedure(name, { allowProtected = false } = {}) {
   if (!name) return;
-  if (await isProtectedProcedure(name)) {
+  if (!allowProtected && (await isProtectedProcedure(name))) {
     const err = new Error('Procedure not allowed');
     err.status = 403;
     throw err;


### PR DESCRIPTION
## Summary
- Load employment session and compute admin rights before saving or deleting report builder procedures
- Permit admins to save or delete protected procedures via new allowProtected option

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c10208ba448331889893dc049866b6