### PR TITLE
Normalize stored procedure input

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -1162,6 +1162,7 @@ export async function zeroSharedTenantKeys(userId) {
 
 export async function saveStoredProcedure(sql, { allowProtected = false } = {}) {
   const cleaned = sql
+    .replace(/CREATE\s+DEFINER=`[^`]+`@`[^`]+`\s+PROCEDURE/gi, 'CREATE PROCEDURE')
     .replace(/^DELIMITER \$\$/gm, '')
     .replace(/^DELIMITER ;/gm, '')
     .replace(/END\s*\$\$/gm, 'END;');


### PR DESCRIPTION
## Summary
- Strip DEFINER clause from stored procedure scripts before saving
- Ensure CREATE matching regex captures complete procedure body

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1077a7b848331807da135c2493f92