### PR TITLE
feat: embed report builder config

### DIFF
--- a/src/erp.mgt.mn/utils/buildStoredProcedure.js
+++ b/src/erp.mgt.mn/utils/buildStoredProcedure.js
@@ -10,7 +10,7 @@ import buildReportSql from './buildReportSql.js';
  * @returns {string}
  */
 export default function buildStoredProcedure(definition = {}) {
-  const { name, params = [], report, prefix = '' } = definition;
+  const { name, params = [], report, prefix = '', config } = definition;
   if (!name) throw new Error('procedure name is required');
   if (!report) throw new Error('report definition is required');
 
@@ -33,6 +33,7 @@ export default function buildStoredProcedure(definition = {}) {
     paramLines ? `  ${paramLines}` : '',
     ')',
     'BEGIN',
+    config ? `  /*RB_CONFIG${JSON.stringify(config)}RB_CONFIG*/` : '',
     selectSql + ';',
     'END $$',
     'DELIMITER ;',


### PR DESCRIPTION
## Summary
- centralize report builder config construction
- embed serialized config comment in generated procedures
- reuse config builder for saves

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1079a820c83319fb33863a0b726b2