### PR TITLE
Improve SQL report builder config parsing

### DIFF
--- a/src/erp.mgt.mn/pages/ReportBuilder.jsx
+++ b/src/erp.mgt.mn/pages/ReportBuilder.jsx
@@ -1499,8 +1499,11 @@ function ReportBuilderInner() {
     const sql = await handleLoadDbProcedure(false);
     try {
       const cfg = parseConfigFromSql(sql);
-      if (!cfg) throw new Error('No config');
-      applyConfig(cfg);
+      if (cfg) {
+        applyConfig(cfg);
+      } else {
+        addToast('No embedded config found', 'error');
+      }
     } catch (err) {
       addToast('Failed to load config from procedure', 'error');
     }
@@ -1587,7 +1590,7 @@ function ReportBuilderInner() {
   }
 
   function parseConfigFromSql(sql) {
-    const match = sql.match(/\/\*RB_CONFIG([\s\S]*?)RB_CONFIG\*\//);
+    const match = sql.match(/\/\*\s*RB_CONFIG([\s\S]*?)RB_CONFIG\s*\*\//i);
     if (!match) return null;
     try {
       return JSON.parse(match[1]);


### PR DESCRIPTION
## Summary
- Parse report builder config from procedures using a whitespace-tolerant, case-insensitive regex
- Show a specific toast when no embedded config is present in a procedure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c10b251f708331998a19618deb4525