### PR TITLE
Improve report builder config parsing

### DIFF
--- a/src/erp.mgt.mn/pages/ReportBuilder.jsx
+++ b/src/erp.mgt.mn/pages/ReportBuilder.jsx
@@ -4,6 +4,7 @@ import buildReportSql from '../utils/buildReportSql.js';
 import ErrorBoundary from '../components/ErrorBoundary.jsx';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import formatSqlValue from '../utils/formatSqlValue.js';
+import parseConfigFromSql from '../utils/parseConfigFromSql.js';
 import { useToast } from '../context/ToastContext.jsx';
 import { AuthContext } from '../context/AuthContext.jsx';
 
@@ -1502,10 +1503,11 @@ function ReportBuilderInner() {
       if (cfg) {
         applyConfig(cfg);
       } else {
-        addToast('No embedded config found', 'error');
+        addToast('No embedded config found in procedure', 'error');
       }
     } catch (err) {
-      addToast('Failed to load config from procedure', 'error');
+      console.error(err);
+      addToast('Invalid embedded config JSON', 'error');
     }
   }
 
@@ -1586,16 +1588,6 @@ function ReportBuilderInner() {
       addToast('Imported', 'success');
     } catch (err) {
       addToast(`Import failed: ${err.message}`, 'error');
-    }
-  }
-
-  function parseConfigFromSql(sql) {
-    const match = sql.match(/\/\*\s*RB_CONFIG([\s\S]*?)RB_CONFIG\s*\*\//i);
-    if (!match) return null;
-    try {
-      return JSON.parse(match[1]);
-    } catch {
-      return null;
     }
   }
 

--- a/src/erp.mgt.mn/utils/parseConfigFromSql.js
+++ b/src/erp.mgt.mn/utils/parseConfigFromSql.js
@@ -1,0 +1,9 @@
+export default function parseConfigFromSql(sql) {
+  const match = sql.match(/\/\*\s*RB_CONFIG([\s\S]*?)RB_CONFIG\s*\*\//i);
+  if (!match) return null;
+  try {
+    return JSON.parse(match[1]);
+  } catch (err) {
+    throw new Error('Invalid RB_CONFIG JSON');
+  }
+}

--- a/tests/utils/parseConfigFromSql.test.js
+++ b/tests/utils/parseConfigFromSql.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import parseConfigFromSql from '../../src/erp.mgt.mn/utils/parseConfigFromSql.js';
+
+test('parseConfigFromSql extracts valid config', () => {
+  const sql = "SELECT 1; /* RB_CONFIG {\"foo\":\"bar\"} RB_CONFIG */";
+  assert.deepEqual(parseConfigFromSql(sql), { foo: 'bar' });
+});
+
+test('parseConfigFromSql throws on malformed JSON', () => {
+  const sql = "SELECT 1; /* RB_CONFIG {foo:'bar'} RB_CONFIG */";
+  assert.throws(() => parseConfigFromSql(sql), /Invalid RB_CONFIG JSON/);
+});
+
+test('parseConfigFromSql returns null when block missing', () => {
+  const sql = 'SELECT 1;';
+  assert.equal(parseConfigFromSql(sql), null);
+});


### PR DESCRIPTION
## Summary
- Log errors and surface detailed toasts when loading procedure configs
- Throw explicit error on invalid RB_CONFIG JSON and centralize parser
- Test parsing for valid, malformed, and missing RB_CONFIG blocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c10d52cb588331a8cf5cf0355c6371