### PR TITLE
Embed report builder config in stored procedures

### DIFF
--- a/src/erp.mgt.mn/utils/buildStoredProcedure.js
+++ b/src/erp.mgt.mn/utils/buildStoredProcedure.js
@@ -33,8 +33,10 @@ export default function buildStoredProcedure(definition = {}) {
     paramLines ? `  ${paramLines}` : '',
     ')',
     'BEGIN',
-    config ? `  /*RB_CONFIG${JSON.stringify(config)}RB_CONFIG*/` : '',
     selectSql + ';',
+    config
+      ? `  /*REPORT_BUILDER_CONFIG ${JSON.stringify(config)} */`
+      : '',
     'END $$',
     'DELIMITER ;',
   ]

--- a/src/erp.mgt.mn/utils/parseProcedureConfig.js
+++ b/src/erp.mgt.mn/utils/parseProcedureConfig.js
@@ -1,0 +1,9 @@
+export default function parseProcedureConfig(sql = '') {
+  const match = sql.match(/\/\*REPORT_BUILDER_CONFIG\s*([\s\S]*?)\*\//i);
+  if (!match) return null;
+  try {
+    return JSON.parse(match[1]);
+  } catch (err) {
+    throw new Error('Invalid REPORT_BUILDER_CONFIG JSON');
+  }
+}

--- a/tests/pages/ReportBuilder.test.js
+++ b/tests/pages/ReportBuilder.test.js
@@ -1,0 +1,77 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+if (typeof mock.import !== 'function') {
+  test('ReportBuilder loads config from procedure', { skip: true }, () => {});
+} else {
+  test('ReportBuilder loads config from procedure', async () => {
+    const states = [];
+    let loadConfigHandler;
+    const reactMock = {
+      useState(initial) {
+        const idx = states.length;
+        states.push(initial);
+        return [states[idx], (v) => (states[idx] = v)];
+      },
+      useEffect() {},
+      useContext() {
+        return { company: 0, permissions: { permissions: { system_settings: true } }, session: {} };
+      },
+      createElement(type, props, ...children) {
+        if (typeof type === 'function') {
+          return type({ ...props, children });
+        }
+        const text = children.flat ? children.flat().join('') : children.join('');
+        if (type === 'button' && text.includes('Load config from stored procedure')) {
+          loadConfigHandler = props.onClick;
+        }
+        return null;
+      },
+    };
+
+    const addToastCalls = [];
+    const sql = 'SELECT 1; /*REPORT_BUILDER_CONFIG {"procName":"abc","unionQueries":[]} */';
+    let fetchUrl;
+    global.fetch = async (url) => {
+      fetchUrl = url;
+      return { ok: true, json: async () => ({ sql }) };
+    };
+
+    const { default: ReportBuilder } = await mock.import(
+      '../../src/erp.mgt.mn/pages/ReportBuilder.jsx',
+      {
+        react: {
+          default: reactMock,
+          useState: reactMock.useState,
+          useEffect: reactMock.useEffect,
+          useContext: reactMock.useContext,
+          createElement: reactMock.createElement,
+        },
+        '../utils/buildStoredProcedure.js': { default: () => '' },
+        '../utils/buildReportSql.js': { default: () => '' },
+        '../components/ErrorBoundary.jsx': { default: (p) => p.children },
+        '../hooks/useGeneralConfig.js': { default: () => ({ general: {} }) },
+        '../utils/formatSqlValue.js': { default: (v) => v },
+        '../context/ToastContext.jsx': {
+          useToast: () => ({ addToast: (msg, type) => addToastCalls.push({ msg, type }) }),
+        },
+        '../context/AuthContext.jsx': { AuthContext: {} },
+      },
+    );
+
+    ReportBuilder();
+
+    // selectedDbProcedure
+    states[28] = 'proc1';
+    states[29] = '';
+    states[30] = '';
+
+    await loadConfigHandler();
+
+    assert.equal(fetchUrl, '/api/report_builder/procedures/proc1');
+    assert.equal(states[4], 'abc');
+    assert.equal(addToastCalls.length, 0);
+
+    delete global.fetch;
+  });
+}

--- a/tests/utils/buildStoredProcedure.test.js
+++ b/tests/utils/buildStoredProcedure.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import buildStoredProcedure from '../../src/erp.mgt.mn/utils/buildStoredProcedure.js';
+import parseProcedureConfig from '../../src/erp.mgt.mn/utils/parseProcedureConfig.js';
 
 // minimal report definition
 const report = { from: { table: 'tbl' } };
@@ -13,4 +14,10 @@ test('buildStoredProcedure inserts configured prefix', () => {
   });
   assert.ok(sql.includes('DROP PROCEDURE IF EXISTS sp_sales;'));
   assert.ok(sql.includes('CREATE PROCEDURE sp_sales('));
+});
+
+test('buildStoredProcedure embeds REPORT_BUILDER_CONFIG block', () => {
+  const config = { procName: 'sales', unionQueries: [] };
+  const sql = buildStoredProcedure({ name: 'sales', report, config });
+  assert.deepEqual(parseProcedureConfig(sql), config);
 });

--- a/tests/utils/parseProcedureConfig.test.js
+++ b/tests/utils/parseProcedureConfig.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import parseProcedureConfig from '../../src/erp.mgt.mn/utils/parseProcedureConfig.js';
+
+test('parseProcedureConfig extracts config', () => {
+  const sql = 'SELECT 1; /*REPORT_BUILDER_CONFIG {"foo":"bar"} */';
+  assert.deepEqual(parseProcedureConfig(sql), { foo: 'bar' });
+});
+
+test('parseProcedureConfig throws on malformed JSON', () => {
+  const sql = 'SELECT 1; /*REPORT_BUILDER_CONFIG {foo} */';
+  assert.throws(() => parseProcedureConfig(sql), /Invalid REPORT_BUILDER_CONFIG JSON/);
+});
+
+test('parseProcedureConfig returns null when block missing', () => {
+  const sql = 'SELECT 1;';
+  assert.equal(parseProcedureConfig(sql), null);
+});


### PR DESCRIPTION
## Summary
- Append serialized report builder configuration to generated stored procedure SQL
- Extract embedded configuration via new `parseProcedureConfig` utility
- Load config from database procedures in ReportBuilder and wire the load button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c110fcb8688331b90a6cd5d2222a94