### PR TITLE
Embed report builder config in stored procedures

### DIFF
--- a/src/erp.mgt.mn/utils/buildStoredProcedure.js
+++ b/src/erp.mgt.mn/utils/buildStoredProcedure.js
@@ -26,6 +26,10 @@ export default function buildStoredProcedure(definition = {}) {
     .map((l) => `  ${l}`)
     .join('\n');
 
+  const configBlock = `  /*REPORT_BUILDER_CONFIG ${JSON.stringify(
+    config || {},
+  )}*/`;
+
   return [
     `DROP PROCEDURE IF EXISTS ${procName};`,
     'DELIMITER $$',
@@ -34,9 +38,7 @@ export default function buildStoredProcedure(definition = {}) {
     ')',
     'BEGIN',
     selectSql + ';',
-    config
-      ? `  /*REPORT_BUILDER_CONFIG ${JSON.stringify(config)} */`
-      : '',
+    configBlock,
     'END $$',
     'DELIMITER ;',
   ]

--- a/src/erp.mgt.mn/utils/parseProcedureConfig.js
+++ b/src/erp.mgt.mn/utils/parseProcedureConfig.js
@@ -7,7 +7,7 @@
  * @returns {{config: object, converted: boolean}|null}
  */
 export default function parseProcedureConfig(sql = '') {
-  if (!sql) return null;
+  if (!sql) return { error: 'No SQL provided' };
 
   const match = sql.match(/\/\*REPORT_BUILDER_CONFIG\s*([\s\S]*?)\*\//i);
   if (match) {
@@ -19,7 +19,8 @@ export default function parseProcedureConfig(sql = '') {
   }
 
   const config = convertSql(sql);
-  return config ? { config, converted: true } : null;
+  if (config) return { config, converted: true };
+  return { error: 'REPORT_BUILDER_CONFIG not found' };
 }
 
 function convertSql(sql) {

--- a/tests/pages/ReportBuilder.test.js
+++ b/tests/pages/ReportBuilder.test.js
@@ -30,7 +30,7 @@ if (typeof mock.import !== 'function') {
     };
 
     const addToastCalls = [];
-    const sql = 'SELECT 1; /*REPORT_BUILDER_CONFIG {"procName":"abc","unionQueries":[]} */';
+    const sql = 'SELECT 1; /*REPORT_BUILDER_CONFIG {"procName":"abc","unionQueries":[]}*/';
     let fetchUrl;
     global.fetch = async (url) => {
       fetchUrl = url;


### PR DESCRIPTION
## Summary
- Always append a `REPORT_BUILDER_CONFIG` comment when generating stored procedures
- Improve procedure config parsing with error reporting and SQL conversion fallback
- Exercise loading config from a stored procedure in ReportBuilder tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c12214c07083318ec3f43de5e47db3