### PR TITLE
Add drop clause only when replacing procedure

### DIFF
--- a/src/erp.mgt.mn/pages/ReportBuilder.jsx
+++ b/src/erp.mgt.mn/pages/ReportBuilder.jsx
@@ -1207,8 +1207,14 @@ function ReportBuilderInner() {
     }
   }
 
-  async function handlePostProc() {
-    if (!procSql) return;
+  async function handlePostProc(sqlOverride, nameOverride) {
+    if (sqlOverride && typeof sqlOverride.preventDefault === 'function') {
+      sqlOverride = undefined;
+      nameOverride = undefined;
+    }
+    const sqlToPost = sqlOverride ?? procSql;
+    const name = nameOverride ?? procName;
+    if (!sqlToPost) return;
     if (!window.confirm('POST stored procedure to database?')) return;
     const basePrefix = generalConfig?.general?.reportProcPrefix || '';
     const procQuery = basePrefix
@@ -1218,7 +1224,7 @@ function ReportBuilderInner() {
       const res = await fetch(`/api/report_builder/procedures`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sql: procSql }),
+        body: JSON.stringify({ sql: sqlToPost }),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
@@ -1235,7 +1241,7 @@ function ReportBuilderInner() {
       );
       const expectedName = `${basePrefix}${
         company != null ? `${company}_` : ''
-      }${procName}`;
+      }${name}`;
       if (!list.some(({ name }) => name === expectedName)) {
         throw new Error('Save failed');
       }
@@ -1604,13 +1610,15 @@ function ReportBuilderInner() {
       /CREATE\s+DEFINER[^\n]+PROCEDURE/i,
       'CREATE PROCEDURE',
     );
+    let newName;
+    let baseName;
     const nameMatch = sql.match(
       /CREATE\s+PROCEDURE\s+`?([^`(]+)`?\s*\(/i,
     );
     if (nameMatch) {
       const basePrefix = generalConfig?.general?.reportProcPrefix || '';
       const oldName = nameMatch[1];
-      let baseName = oldName;
+      baseName = oldName;
       if (
         basePrefix &&
         baseName.toLowerCase().startsWith(basePrefix.toLowerCase())
@@ -1618,14 +1626,27 @@ function ReportBuilderInner() {
         baseName = baseName.slice(basePrefix.length);
       }
       baseName = baseName.replace(/^\d+_/, '');
-      const newName = `${basePrefix}${company}_${baseName}`;
+      newName = `${basePrefix}${company}_${baseName}`;
       sql = sql.replace(
         /(CREATE\s+PROCEDURE\s+)`?[^`(]+`?/i,
         `$1\`${newName}\``,
       );
+      // strip any leading DROP PROCEDURE statement
+      sql = sql.replace(
+        /^\s*DROP\s+PROCEDURE\s+IF\s+EXISTS[^;]+;\s*/i,
+        '',
+      );
+      // ensure the script starts with a DELIMITER block
+      if (!/^\s*DELIMITER\s+\$\$/i.test(sql)) {
+        sql = `DELIMITER $$\n${sql}`;
+      }
       setProcCompanyId(company);
       setProcName(baseName);
     }
+    // ensure body terminates with END $$\nDELIMITER ;
+    sql = sql.replace(/\nDELIMITER\s*;\s*$/i, '');
+    sql = sql.replace(/\nEND\s*(?:\$\$)?\s*;?\s*$/i, '');
+    sql = `${sql}\nEND $$\nDELIMITER ;`;
     setProcSql(sql);
     setProcFileText(sql);
     const paramsMatch = sql.match(/CREATE\s+PROCEDURE[\s\S]*?\(([^)]*)\)/i);
@@ -1644,6 +1665,19 @@ function ReportBuilderInner() {
     } else {
       setParams([]);
     }
+    return { sql, baseName, newName };
+  }
+
+  async function handleReplaceProcedure() {
+    const { sql, baseName, newName } = handleParseSql();
+    if (
+      !window.confirm(
+        `Replace procedure ${newName} with the current script?`,
+      )
+    )
+      return;
+    const dropSql = `DROP PROCEDURE IF EXISTS \`${newName}\`;\n${sql}`;
+    await handlePostProc(dropSql, baseName);
   }
 
   if (loading) {
@@ -2889,6 +2923,13 @@ function ReportBuilderInner() {
           )}
           <button onClick={handleParseSql} style={{ marginTop: '0.5rem' }}>
             Parse SQL
+          </button>
+          <button
+            onClick={handleReplaceProcedure}
+            style={{ marginTop: '0.5rem', marginLeft: '0.5rem' }}
+            disabled={procFileIsDefault}
+          >
+            Replace Procedure
           </button>
         </section>
       )}


### PR DESCRIPTION
## Summary
- strip any leading `DROP PROCEDURE` when parsing SQL and normalize with `DELIMITER $$`
- add a confirmation prompt and prepend `DROP PROCEDURE IF EXISTS` only when replacing a procedure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c11ad0c7688331a06a03580d332dcc