### PR TITLE
Normalize procedure parsing and add regression test

### DIFF
--- a/src/erp.mgt.mn/pages/ReportBuilder.jsx
+++ b/src/erp.mgt.mn/pages/ReportBuilder.jsx
@@ -1534,12 +1534,14 @@ function ReportBuilderInner() {
         } else {
           addToast('Loaded config from embedded block', 'success');
         }
+      } else if (parsed?.error) {
+        addToast(`SQL parsing failed: ${parsed.error}`, 'error');
       } else {
         addToast('No embedded config found in procedure', 'error');
       }
     } catch (err) {
       console.error(err);
-      addToast('Invalid embedded config JSON', 'error');
+      addToast(`SQL parsing error: ${err.message}`, 'error');
     }
   }
 

--- a/src/erp.mgt.mn/utils/parseProcedureConfig.js
+++ b/src/erp.mgt.mn/utils/parseProcedureConfig.js
@@ -29,9 +29,13 @@ function convertSql(sql) {
   const procName = nameMatch ? nameMatch[1] : '';
 
   // Extract body inside BEGIN..END and strip comments
-  const bodyMatch = sql.match(/BEGIN\s+([\s\S]*?)END/i);
+  const bodyMatch = sql.match(/BEGIN\s+([\s\S]*)END/i);
   let body = bodyMatch ? bodyMatch[1] : sql;
-  body = body.replace(/\/\*[\s\S]*?\*\//g, ' ').trim();
+  body = body
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/--.*$/gm, ' ')
+    .replace(/#.*$/gm, ' ')
+    .trim();
 
   const selIdx = body.toUpperCase().indexOf('SELECT');
   if (selIdx === -1) return null;

--- a/tests/utils/parseProcedureConfig.test.js
+++ b/tests/utils/parseProcedureConfig.test.js
@@ -23,3 +23,17 @@ test('parseProcedureConfig converts SQL when block missing', () => {
   assert.equal(result.config.fields.length, 2);
   assert.equal(result.config.groups.length, 2);
 });
+
+test('parseProcedureConfig handles line comments in SHOW CREATE PROCEDURE output', () => {
+  const sql = `CREATE DEFINER=\`root\`@\`localhost\` PROCEDURE \`t\`()
+BEGIN
+  SELECT p.id, p.name FROM prod p -- list products
+  WHERE p.id = 1 # filter
+  GROUP BY p.id, p.name;
+END`;
+  const result = parseProcedureConfig(sql);
+  assert.equal(result.converted, true);
+  assert.equal(result.config.fromTable, 'prod');
+  assert.equal(result.config.fields.length, 2);
+  assert.equal(result.config.groups.length, 2);
+});


### PR DESCRIPTION
## Summary
- capture full procedure body and strip line comments before conversion
- add regression test for SHOW CREATE PROCEDURE output
- surface detailed SQL parsing errors in ReportBuilder

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c12657b6648331bab7afdb463e3c06