### PR TITLE
Handle partial SQL conversion and warn in UI

### DIFF
--- a/src/erp.mgt.mn/pages/ReportBuilder.jsx
+++ b/src/erp.mgt.mn/pages/ReportBuilder.jsx
@@ -1529,10 +1529,18 @@ function ReportBuilderInner() {
                 body: JSON.stringify(parsed.config),
               },
             );
-            addToast('Generated config from SQL', 'success');
+            if (parsed.partial) {
+              addToast('Generated config with limited clauses', 'warning');
+            } else {
+              addToast('Generated config from SQL', 'success');
+            }
           } catch (err) {
             console.error(err);
-            addToast('Generated config from SQL (save failed)', 'error');
+            if (parsed.partial) {
+              addToast('Generated config with limited clauses (save failed)', 'warning');
+            } else {
+              addToast('Generated config from SQL (save failed)', 'error');
+            }
           }
         } else {
           addToast('Loaded config from embedded block', 'success');

--- a/tests/utils/parseProcedureConfig.test.js
+++ b/tests/utils/parseProcedureConfig.test.js
@@ -52,3 +52,11 @@ END`;
   assert.equal(result.config.fromTable, 'prod');
   assert.equal(result.config.fields.length, 2);
 });
+
+test('parseProcedureConfig tolerates ORDER BY and positional GROUP BY', () => {
+  const sql = `CREATE PROCEDURE t() BEGIN SELECT p.id, p.name FROM prod p GROUP BY 1 ORDER BY p.name; END`;
+  const result = parseProcedureConfig(sql);
+  assert.equal(result.converted, true);
+  assert.equal(result.config.fromTable, 'prod');
+  assert.equal(result.config.fields.length, 2);
+});


### PR DESCRIPTION
## Summary
- Allow partial SQL conversion in `parseProcedureConfig` by stripping trailing ORDER BY/LIMIT/HAVING, accepting `AS`/missing join aliases, and returning empty filter/group arrays
- Warn users when only partial clauses are parsed
- Add regression test covering ORDER BY with positional GROUP BY

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1313dac7c83318e0b243a36b2d27a