### PR TITLE
Handle ORDER BY and LIMIT when parsing procedure config

### DIFF
--- a/tests/utils/parseProcedureConfig.test.js
+++ b/tests/utils/parseProcedureConfig.test.js
@@ -60,3 +60,11 @@ test('parseProcedureConfig tolerates ORDER BY and positional GROUP BY', () => {
   assert.equal(result.config.fromTable, 'prod');
   assert.equal(result.config.fields.length, 2);
 });
+
+test('parseProcedureConfig converts SQL with ORDER BY and LIMIT', () => {
+  const sql = `CREATE PROCEDURE t() BEGIN SELECT p.id, p.name FROM prod p ORDER BY p.name LIMIT 5; END`;
+  const result = parseProcedureConfig(sql);
+  assert.equal(result.converted, true);
+  assert.equal(result.config.fromTable, 'prod');
+  assert.equal(result.config.fields.length, 2);
+});


### PR DESCRIPTION
## Summary
- Extend SQL conversion to detect earliest WHERE/GROUP BY/ORDER BY/HAVING/LIMIT clauses
- Remove non-group clauses before parsing GROUP BY
- Add regression test for ORDER BY with LIMIT

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c138938b74833193094c93a2e869d6