### PR TITLE
Enable OpenAI API

### DIFF
--- a/config/0/generalConfig.json
+++ b/config/0/generalConfig.json
@@ -14,7 +14,7 @@
     "boxMaxHeight": 150
   },
   "general": {
-    "aiApiEnabled": false,
+    "aiApiEnabled": true,
     "aiInventoryApiEnabled": false,
     "triggerToastEnabled": false,
     "procToastEnabled": false,


### PR DESCRIPTION
## Summary
- enable OpenAI API feature in general configuration

## Testing
- `npm test` (fails: none, but tests pass as 193 pass, fail 0)

------
https://chatgpt.com/codex/tasks/task_e_68c13eec78f083319a707d5a4a7e325f