### PR TITLE
feat: separate completion flags for translation helpers

### DIFF
--- a/src/erp.mgt.mn/pages/ManualTranslationsTab.jsx
+++ b/src/erp.mgt.mn/pages/ManualTranslationsTab.jsx
@@ -11,7 +11,8 @@ export default function ManualTranslationsTab() {
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
   const [searchTerm, setSearchTerm] = useState('');
-  const [completing, setCompleting] = useState(false);
+  const [completingEnMn, setCompletingEnMn] = useState(false);
+  const [completingOther, setCompletingOther] = useState(false);
   const abortRef = useRef(false);
 
   useEffect(() => {
@@ -101,7 +102,7 @@ export default function ManualTranslationsTab() {
 
   async function completeEnMn() {
     abortRef.current = false;
-    setCompleting(true);
+    setCompletingEnMn(true);
     const updated = [];
     const toSave = [];
     let rateLimited = false;
@@ -149,7 +150,7 @@ export default function ManualTranslationsTab() {
     }
     setEntries(updated);
     if (rateLimited) {
-      setCompleting(false);
+      setCompletingEnMn(false);
       window.dispatchEvent(
         new CustomEvent('toast', {
           detail: {
@@ -161,7 +162,7 @@ export default function ManualTranslationsTab() {
       return;
     }
     if (abortRef.current) {
-      setCompleting(false);
+      setCompletingEnMn(false);
       return;
     }
     for (const entry of toSave) {
@@ -173,7 +174,7 @@ export default function ManualTranslationsTab() {
       });
     }
     if (toSave.length) await load();
-    setCompleting(false);
+    setCompletingEnMn(false);
     window.dispatchEvent(
       new CustomEvent('toast', {
         detail: { message: t('translationsCompleted', 'Translations completed'), type: 'success' },
@@ -183,7 +184,7 @@ export default function ManualTranslationsTab() {
 
   async function completeOtherLanguages() {
     abortRef.current = false;
-    setCompleting(true);
+    setCompletingOther(true);
     const restLanguages = languages.filter((l) => l !== 'en' && l !== 'mn');
     const updated = [];
     const toSave = [];
@@ -241,7 +242,7 @@ export default function ManualTranslationsTab() {
     }
     setEntries(updated);
     if (rateLimited) {
-      setCompleting(false);
+      setCompletingOther(false);
       window.dispatchEvent(
         new CustomEvent('toast', {
           detail: {
@@ -253,7 +254,7 @@ export default function ManualTranslationsTab() {
       return;
     }
     if (abortRef.current) {
-      setCompleting(false);
+      setCompletingOther(false);
       return;
     }
     for (const entry of toSave) {
@@ -265,7 +266,7 @@ export default function ManualTranslationsTab() {
       });
     }
     if (toSave.length) await load();
-    setCompleting(false);
+    setCompletingOther(false);
     if (toSave.length) {
       window.dispatchEvent(
         new CustomEvent('toast', {
@@ -298,17 +299,25 @@ export default function ManualTranslationsTab() {
     <div>
       <div style={{ marginBottom: '0.5rem', display: 'flex', gap: '0.5rem' }}>
         <button type="button" onClick={addRow}>{t('addRow', 'Add Row')}</button>
-        <button type="button" onClick={completeEnMn} disabled={completing}>
-          {completing
+        <button
+          type="button"
+          onClick={completeEnMn}
+          disabled={completingEnMn || completingOther}
+        >
+          {completingEnMn
             ? t('completing', 'Completing...')
             : t('completeEnMn', 'Complete en/mn translations')}
         </button>
-        <button type="button" onClick={completeOtherLanguages} disabled={completing}>
-          {completing
+        <button
+          type="button"
+          onClick={completeOtherLanguages}
+          disabled={completingEnMn || completingOther}
+        >
+          {completingOther
             ? t('completing', 'Completing...')
             : t('completeOtherLangs', 'Complete other languages translations')}
         </button>
-        {completing && (
+        {(completingEnMn || completingOther) && (
           <button type="button" onClick={() => (abortRef.current = true)}>
             {t('cancel', 'Cancel')}
           </button>


### PR DESCRIPTION
## Summary
- split `completing` into `completingEnMn` and `completingOther`
- ensure each translation completion button toggles its own flag and only shows "Completing..." when active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1462389708331bb40c20d34ed2b63