### PR TITLE
refactor translation paths

### DIFF
--- a/api-server/services/manualTranslations.js
+++ b/api-server/services/manualTranslations.js
@@ -1,7 +1,12 @@
 import fs from 'fs/promises';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
-const localesDir = path.resolve(process.cwd(), 'src', 'erp.mgt.mn', 'locales');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '../../');
+
+const localesDir = path.join(projectRoot, 'src', 'erp.mgt.mn', 'locales');
 const tooltipDir = path.join(localesDir, 'tooltips');
 
 async function listLangs(dir) {


### PR DESCRIPTION
## Summary
- resolve locales/tooltips directories relative to project root

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c14748eb1083319ac0a7e0722b7aae