### PR TITLE
Fix transactions income triggers

### DIFF
--- a/db/mgtmn_erp_db.sql
+++ b/db/mgtmn_erp_db.sql
@@ -21161,22 +21161,36 @@ END
 $$
 DELIMITER ;
 DELIMITER $$
-CREATE TRIGGER `trg_transactions_income_insert` AFTER INSERT ON `transactions_income` FOR EACH ROW BEGIN
-  UPDATE transactions_income ti
-  JOIN code_transaction ct ON ct.UITransType = NEW.TransType
-  SET ti.TRTYPENAME = ct.UITransTypeName,
-      ti.trtype = ct.UITrtype
-  WHERE ti.id = NEW.id;
+CREATE TRIGGER `trg_transactions_income_insert` BEFORE INSERT ON `transactions_income` FOR EACH ROW BEGIN
+  DECLARE v_trtypename VARCHAR(100);
+  DECLARE v_trtype VARCHAR(4);
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET v_trtypename = NULL, v_trtype = NULL;
+
+  SELECT ct.UITransTypeName, ct.UITrtype
+    INTO v_trtypename, v_trtype
+    FROM code_transaction ct
+   WHERE ct.UITransType = NEW.TransType
+   LIMIT 1;
+
+  SET NEW.TRTYPENAME = v_trtypename;
+  SET NEW.trtype = v_trtype;
 END
 $$
 DELIMITER ;
 DELIMITER $$
-CREATE TRIGGER `trg_transactions_income_update` AFTER UPDATE ON `transactions_income` FOR EACH ROW BEGIN
-  UPDATE transactions_income ti
-  JOIN code_transaction ct ON ct.UITransType = NEW.TransType
-  SET ti.TRTYPENAME = ct.UITransTypeName,
-      ti.trtype = ct.UITrtype
-  WHERE ti.id = NEW.id;
+CREATE TRIGGER `trg_transactions_income_update` BEFORE UPDATE ON `transactions_income` FOR EACH ROW BEGIN
+  DECLARE v_trtypename VARCHAR(100);
+  DECLARE v_trtype VARCHAR(4);
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET v_trtypename = NULL, v_trtype = NULL;
+
+  SELECT ct.UITransTypeName, ct.UITrtype
+    INTO v_trtypename, v_trtype
+    FROM code_transaction ct
+   WHERE ct.UITransType = NEW.TransType
+   LIMIT 1;
+
+  SET NEW.TRTYPENAME = v_trtypename;
+  SET NEW.trtype = v_trtype;
 END
 $$
 DELIMITER ;

--- a/db/migrations/2025-11-01_transactions_income_triggers.sql
+++ b/db/migrations/2025-11-01_transactions_income_triggers.sql
@@ -1,0 +1,40 @@
+-- Recreate transactions_income triggers to populate TRTYPENAME and trtype
+-- without performing self-updates that raise ER_CANT_UPDATE_USED_TABLE (1442).
+DROP TRIGGER IF EXISTS `trg_transactions_income_insert`;
+DROP TRIGGER IF EXISTS `trg_transactions_income_update`;
+
+DELIMITER $$
+CREATE TRIGGER `trg_transactions_income_insert` BEFORE INSERT ON `transactions_income`
+FOR EACH ROW
+BEGIN
+  DECLARE v_trtypename VARCHAR(100);
+  DECLARE v_trtype VARCHAR(4);
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET v_trtypename = NULL, v_trtype = NULL;
+
+  SELECT ct.UITransTypeName, ct.UITrtype
+    INTO v_trtypename, v_trtype
+    FROM code_transaction ct
+   WHERE ct.UITransType = NEW.TransType
+   LIMIT 1;
+
+  SET NEW.TRTYPENAME = v_trtypename;
+  SET NEW.trtype = v_trtype;
+END$$
+
+CREATE TRIGGER `trg_transactions_income_update` BEFORE UPDATE ON `transactions_income`
+FOR EACH ROW
+BEGIN
+  DECLARE v_trtypename VARCHAR(100);
+  DECLARE v_trtype VARCHAR(4);
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET v_trtypename = NULL, v_trtype = NULL;
+
+  SELECT ct.UITransTypeName, ct.UITrtype
+    INTO v_trtypename, v_trtype
+    FROM code_transaction ct
+   WHERE ct.UITransType = NEW.TransType
+   LIMIT 1;
+
+  SET NEW.TRTYPENAME = v_trtypename;
+  SET NEW.trtype = v_trtype;
+END$$
+DELIMITER ;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1084,6 +1084,40 @@ CREATE TABLE `transactions_income` (
   `sp_cost_date` date DEFAULT NULL,
   `sp_source_table` varchar(50) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+DELIMITER $$
+CREATE TRIGGER `trg_transactions_income_insert` BEFORE INSERT ON `transactions_income` FOR EACH ROW BEGIN
+  DECLARE v_trtypename VARCHAR(100);
+  DECLARE v_trtype VARCHAR(4);
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET v_trtypename = NULL, v_trtype = NULL;
+
+  SELECT ct.UITransTypeName, ct.UITrtype
+    INTO v_trtypename, v_trtype
+    FROM code_transaction ct
+   WHERE ct.UITransType = NEW.TransType
+   LIMIT 1;
+
+  SET NEW.TRTYPENAME = v_trtypename;
+  SET NEW.trtype = v_trtype;
+END
+$$
+DELIMITER ;
+DELIMITER $$
+CREATE TRIGGER `trg_transactions_income_update` BEFORE UPDATE ON `transactions_income` FOR EACH ROW BEGIN
+  DECLARE v_trtypename VARCHAR(100);
+  DECLARE v_trtype VARCHAR(4);
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET v_trtypename = NULL, v_trtype = NULL;
+
+  SELECT ct.UITransTypeName, ct.UITrtype
+    INTO v_trtypename, v_trtype
+    FROM code_transaction ct
+   WHERE ct.UITransType = NEW.TransType
+   LIMIT 1;
+
+  SET NEW.TRTYPENAME = v_trtypename;
+  SET NEW.trtype = v_trtype;
+END
+$$
+DELIMITER ;
 CREATE TABLE `transactions_income_other` (
   `id` int NOT NULL,
   `or_num` varchar(50) DEFAULT NULL,


### PR DESCRIPTION
## Summary
- convert the transactions_income AFTER triggers into BEFORE triggers that select the UI transaction metadata and assign it directly to the new row
- mirror the trigger definitions in the baseline schema and ship a migration to drop/recreate them without self-updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c91b3bc4408331a7a9565d0d720f01