### PR TITLE
Fix coding table insert SQL and add coverage

### DIFF
--- a/api-server/services/codingTablesInsert.js
+++ b/api-server/services/codingTablesInsert.js
@@ -43,12 +43,13 @@ function buildInsertCommand(tableName, row) {
   if (columns.length === 0) {
     return null;
   }
-  const columnTokens = columns.map(() => '??').join(', ');
-  const valueTokens = columns.map(() => '?').join(', ');
-  const values = columns.map((col) => row[col]);
+  const safeColumns = columns.map((col) => assertSafeIdentifier(col, 'column'));
+  const columnList = safeColumns.map((col) => `\`${col}\``).join(', ');
+  const valueTokens = safeColumns.map(() => '?').join(', ');
+  const values = safeColumns.map((col) => row[col]);
   return {
-    sql: `INSERT INTO ?? (${columnTokens}) VALUES (${valueTokens})`,
-    params: [safeTable, ...columns, ...values],
+    sql: `INSERT INTO \`${safeTable}\` (${columnList}) VALUES (${valueTokens})`,
+    params: values,
   };
 }
 

--- a/api-server/utils/translationHelpers.js
+++ b/api-server/utils/translationHelpers.js
@@ -1,8 +1,32 @@
 import fs from 'fs';
 import path from 'path';
-import * as parser from '@babel/parser';
-import traverseModule from '@babel/traverse';
-const traverse = traverseModule.default;
+
+let parserModule;
+try {
+  parserModule = await import('@babel/parser');
+} catch (err) {
+  parserModule = null;
+  console.warn(
+    `[translations] Babel parser not available; falling back to regex parsing: ${err.message}`,
+  );
+}
+
+let traverse;
+if (parserModule) {
+  try {
+    const traverseModule = await import('@babel/traverse');
+    traverse = traverseModule.default;
+  } catch (err) {
+    traverse = null;
+    console.warn(
+      `[translations] Babel traverse not available; falling back to regex parsing: ${err.message}`,
+    );
+  }
+} else {
+  traverse = null;
+}
+
+const parser = parserModule;
 
 export function sortObj(o) {
   return Object.keys(o)
@@ -10,30 +34,18 @@ export function sortObj(o) {
     .reduce((acc, k) => ((acc[k] = o[k]), acc), {});
 }
 
-export function collectPhrasesFromPages(dir) {
-  const files = [];
-  function walk(d) {
-    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
-      const full = path.join(d, entry.name);
-      if (entry.isDirectory()) walk(full);
-      else if (/\.(jsx?|tsx?)$/.test(entry.name)) files.push(full);
-    }
+const UI_TAGS = new Set(['button', 'label', 'option']);
+
+function collectPhrasesWithBabel(content, file) {
+  if (!parser || !traverse) {
+    return null;
   }
-  walk(dir);
-  const pairs = [];
-  const uiTags = new Set(['button', 'label', 'option']);
-  for (const file of files) {
-    const content = fs.readFileSync(file, 'utf8');
-    let ast;
-    try {
-      ast = parser.parse(content, {
-        sourceType: 'module',
-        plugins: ['jsx', 'typescript', 'classProperties', 'dynamicImport'],
-      });
-    } catch (err) {
-      console.warn(`[translations] Failed to parse ${file}: ${err.message}`);
-      continue;
-    }
+  try {
+    const ast = parser.parse(content, {
+      sourceType: 'module',
+      plugins: ['jsx', 'typescript', 'classProperties', 'dynamicImport'],
+    });
+    const pairs = [];
     traverse(ast, {
       CallExpression(path) {
         const callee = path.get('callee');
@@ -53,7 +65,7 @@ export function collectPhrasesFromPages(dir) {
         const namePath = path.get('openingElement.name');
         if (!namePath.isJSXIdentifier()) return;
         const tag = namePath.node.name;
-        if (!uiTags.has(tag)) return;
+        if (!UI_TAGS.has(tag)) return;
         for (const child of path.get('children')) {
           if (child.isJSXText()) {
             const val = child.node.value.trim();
@@ -68,6 +80,57 @@ export function collectPhrasesFromPages(dir) {
         }
       },
     });
+    return pairs;
+  } catch (err) {
+    console.warn(`[translations] Failed to parse ${file}: ${err.message}`);
+    return null;
+  }
+}
+
+function collectPhrasesWithRegex(content) {
+  const pairs = [];
+  const callRegex = /t\(\s*(['"])(.*?)\1\s*(?:,\s*(['"])(.*?)\3)?/g;
+  for (const match of content.matchAll(callRegex)) {
+    const key = match[2];
+    if (!key) continue;
+    const alt = match[4];
+    pairs.push({ key, text: alt ?? key });
+  }
+  const tagRegex = /<(button|label|option)\b[^>]*>([\s\S]*?)<\/\1>/gi;
+  for (const match of content.matchAll(tagRegex)) {
+    const inner = match[2];
+    if (!inner) continue;
+    const cleaned = inner
+      .replace(/\{[^}]*\}/g, '')
+      .replace(/<[^>]*>/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (cleaned) {
+      pairs.push({ key: cleaned, text: cleaned });
+    }
+  }
+  return pairs;
+}
+
+export function collectPhrasesFromPages(dir) {
+  const files = [];
+  function walk(d) {
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      const full = path.join(d, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (/\.(jsx?|tsx?)$/.test(entry.name)) files.push(full);
+    }
+  }
+  walk(dir);
+  const pairs = [];
+  for (const file of files) {
+    const content = fs.readFileSync(file, 'utf8');
+    const babelPairs = collectPhrasesWithBabel(content, file);
+    if (babelPairs) {
+      pairs.push(...babelPairs);
+    } else {
+      pairs.push(...collectPhrasesWithRegex(content));
+    }
   }
   return pairs;
 }

--- a/tests/services/codingTablesInsert.test.js
+++ b/tests/services/codingTablesInsert.test.js
@@ -1,0 +1,123 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { insertCodingTableRows } from '../../api-server/services/codingTablesInsert.js';
+import { pool } from '../../db/index.js';
+
+test('insertCodingTableRows inserts rows without staging using inline identifiers', async (t) => {
+  const executes = [];
+  let released = false;
+  const connection = {
+    async execute(sql, params) {
+      executes.push({ sql, params });
+      return [{}];
+    },
+    async query() {
+      throw new Error('query should not be called when staging is disabled');
+    },
+    release() {
+      released = true;
+    },
+  };
+  const originalGetConnection = pool.getConnection;
+  pool.getConnection = async () => connection;
+
+  let result;
+  try {
+    result = await insertCodingTableRows({
+      table: 'codes',
+      mainRows: [{ code: 'A', label: 'Alpha' }],
+      otherRows: [{ code: 'B', label: 'Beta' }],
+      useStaging: false,
+    });
+  } finally {
+    pool.getConnection = originalGetConnection;
+  }
+
+  assert.equal(executes.length, 2);
+  assert.equal(
+    executes[0].sql,
+    'INSERT INTO `codes` (`code`, `label`) VALUES (?, ?)',
+  );
+  assert.deepEqual(executes[0].params, ['A', 'Alpha']);
+  assert.equal(
+    executes[1].sql,
+    'INSERT INTO `codes_other` (`code`, `label`) VALUES (?, ?)',
+  );
+  assert.deepEqual(executes[1].params, ['B', 'Beta']);
+  assert.equal(result.insertedMain, 1);
+  assert.equal(result.insertedOther, 1);
+  assert.equal(result.errors.length, 0);
+  assert.equal(result.stagingUsed, false);
+  assert.ok(released);
+});
+
+test('insertCodingTableRows uses staging path without identifier placeholders', async (t) => {
+  const executes = [];
+  const queries = [];
+  let stageName;
+  let released = false;
+  const connection = {
+    async execute(sql, params) {
+      executes.push({ sql, params });
+      return [{}];
+    },
+    async query(sql, params) {
+      queries.push({ sql, params });
+      if (sql.startsWith('CREATE TEMPORARY TABLE')) {
+        [stageName] = params;
+      }
+      return [{}];
+    },
+    release() {
+      released = true;
+    },
+  };
+  const originalGetConnection = pool.getConnection;
+  pool.getConnection = async () => connection;
+
+  const mainRows = [
+    { code: 'A', label: 'Alpha' },
+    { code: 'B', label: 'Beta' },
+  ];
+
+  let result;
+  try {
+    result = await insertCodingTableRows({
+      table: 'codes',
+      mainRows,
+      otherRows: [{ code: 'C', label: 'Gamma' }],
+      useStaging: true,
+    });
+  } finally {
+    pool.getConnection = originalGetConnection;
+  }
+
+  assert.ok(stageName, 'staging table should be created');
+  assert.match(stageName, /^[A-Za-z0-9_]+$/);
+  const stageSql = `INSERT INTO \`${stageName}\` (\`code\`, \`label\`) VALUES (?, ?)`;
+  const stageCalls = executes.filter((call) => call.sql === stageSql);
+  assert.equal(stageCalls.length, mainRows.length);
+  stageCalls.forEach((call, index) => {
+    assert.deepEqual(call.params, [mainRows[index].code, mainRows[index].label]);
+  });
+  const otherCall = executes.find((call) => call.sql.startsWith('INSERT INTO `codes_other`'));
+  assert.ok(otherCall, 'other rows should insert directly');
+  assert.equal(
+    otherCall.sql,
+    'INSERT INTO `codes_other` (`code`, `label`) VALUES (?, ?)',
+  );
+  assert.deepEqual(otherCall.params, ['C', 'Gamma']);
+  assert.equal(result.insertedMain, mainRows.length);
+  assert.equal(result.insertedOther, 1);
+  assert.equal(result.errors.length, 0);
+  assert.equal(result.stagingUsed, true);
+  assert.ok(released);
+  assert.ok(
+    queries.some((entry) => entry.sql.startsWith('CREATE TEMPORARY TABLE')),
+    'staging should create a temp table',
+  );
+  assert.ok(
+    queries.some((entry) => entry.sql.startsWith('DROP TEMPORARY TABLE IF EXISTS')),
+    'staging should drop the temp table when finished',
+  );
+});


### PR DESCRIPTION
## Summary
- inline sanitized table and column names when building coding table insert SQL so `connection.execute` no longer sees identifier placeholders
- add service tests covering staging and non-staging coding table inserts using the updated helper
- allow translation helpers to fall back to regex parsing when Babel packages are unavailable so tests run in restricted environments

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca17dcfd9083318b847db5a2292116