### PR TITLE
Normalize warning toasts with icon and styling

### DIFF
--- a/src/erp.mgt.mn/context/ToastContext.jsx
+++ b/src/erp.mgt.mn/context/ToastContext.jsx
@@ -1,15 +1,33 @@
 import React, { createContext, useCallback, useContext, useState, useEffect, useMemo } from 'react';
 import { trackSetState } from '../utils/debug.js';
 
+const DEFAULT_TOAST_TYPE = 'info';
+const TOAST_ICONS = {
+  success: '✅',
+  error: '❌',
+  warning: '⚠️',
+  info: 'ℹ️',
+};
+
+function normalizeToastType(type) {
+  const normalized = (type || DEFAULT_TOAST_TYPE).toString().toLowerCase();
+  if (normalized === 'warn' || normalized === 'warning') return 'warning';
+  if (normalized === 'success' || normalized === 'error' || normalized === 'info' || normalized === 'warning') {
+    return normalized;
+  }
+  return DEFAULT_TOAST_TYPE;
+}
+
 const ToastContext = createContext({ addToast: () => {} });
 
 export function ToastProvider({ children }) {
   const [toasts, setToasts] = useState([]);
 
-  const addToast = useCallback((message, type = 'info') => {
+  const addToast = useCallback((message, type = DEFAULT_TOAST_TYPE) => {
     const id = Date.now() + Math.random();
+    const normalizedType = normalizeToastType(type);
     trackSetState('ToastProvider.setToasts');
-    setToasts((t) => [...t, { id, message, type }]);
+    setToasts((t) => [...t, { id, message, type: normalizedType }]);
     setTimeout(() => {
       trackSetState('ToastProvider.setToasts');
       setToasts((t) => t.filter((toast) => toast.id !== id));
@@ -31,11 +49,14 @@ export function ToastProvider({ children }) {
     <ToastContext.Provider value={value}>
       {children}
       <div className="toast-container">
-        {toasts.map((t) => (
-          <div key={t.id} className={`toast toast-${t.type}`}>
-            {t.type === 'success' ? '✅' : t.type === 'error' ? '❌' : 'ℹ️'} {t.message}
-          </div>
-        ))}
+        {toasts.map((t) => {
+          const icon = TOAST_ICONS[t.type] || TOAST_ICONS[DEFAULT_TOAST_TYPE];
+          return (
+            <div key={t.id} className={`toast toast-${t.type}`}>
+              {icon} {t.message}
+            </div>
+          );
+        })}
       </div>
     </ToastContext.Provider>
   );

--- a/src/erp.mgt.mn/index.css
+++ b/src/erp.mgt.mn/index.css
@@ -124,6 +124,8 @@ footer { text-align:center; padding:1rem; background:#f1f1f1; font-size:0.9rem; 
 
 .toast-success { color: #16a34a; }
 .toast-error { color: #dc2626; }
+.toast-info { color: #1d4ed8; border-color: #bfdbfe; background: #eff6ff; }
+.toast-warning { color: #92400e; border-color: #fbbf24; background: #fffbeb; }
 
 @keyframes fade-slide {
   from { opacity: 0; transform: translateX(20px); }


### PR DESCRIPTION
## Summary
- normalize toast types so warning variants render with a dedicated icon
- centralize toast icon lookup while keeping class names aligned with normalized types
- add warning (and info) toast color treatments for clearer visual cues

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca283a96d88331a4362a8b6aeb2c44