### PR TITLE
Enhance coding tables insert summary toasts

### DIFF
--- a/src/erp.mgt.mn/pages/CodingTables.jsx
+++ b/src/erp.mgt.mn/pages/CodingTables.jsx
@@ -2064,17 +2064,29 @@ export default function CodingTablesPage() {
       const errSummaryString = Object.entries(errorSummaryMap)
         .map(([key, count]) => `${key}: ${count}`)
         .join('; ');
-      const baseSummary = `Inserted to main: ${insertedMainCount}. _other: ${insertedOtherCount}. Duplicates: ${dupCount}.`;
-      const errorSuffix = errSummaryString ? ` ${errSummaryString}` : '';
-      setSummaryInfo(`${baseSummary}${errorSuffix}`);
+      const totalInsertedCount = insertedMainCount + insertedOtherCount;
+      const baseSummary = [
+        `Inserted to main: ${insertedMainCount}.`,
+        `_other: ${insertedOtherCount}.`,
+        `Total: ${totalInsertedCount}.`,
+        `Duplicates: ${dupCount}.`,
+      ].join(' ');
+      const errorSuffix = errSummaryString ? ` Errors: ${errSummaryString}` : '';
+      const combinedSummary = `${baseSummary}${errorSuffix}`;
+      setSummaryInfo(combinedSummary);
 
+      let toastSeverity = 'success';
+      let statusMessage = 'Insert completed successfully.';
       if (errors.length > 0) {
-        addToast('Some records failed to insert', 'error');
+        toastSeverity = 'error';
+        statusMessage = aborted
+          ? `Insert interrupted with row errors after ${totalInsertedCount} rows processed.`
+          : 'Row insert errors encountered.';
       } else if (aborted) {
-        addToast('Insert interrupted', 'warning');
-      } else {
-        addToast('Records inserted', 'success');
+        toastSeverity = 'warning';
+        statusMessage = `Insert interrupted after ${totalInsertedCount} rows processed.`;
       }
+      addToast(`${statusMessage} ${combinedSummary}`.trim(), toastSeverity);
       if (payload.message) {
         addToast(payload.message, 'info');
       }


### PR DESCRIPTION
## Summary
- include total inserted counts in the existing insert summary and reuse it for UI feedback
- replace generic insert result toasts with detailed summaries and status-based severities while keeping staging info notices

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca28c87a90833193a02b5c3d8e1a89