### PR TITLE
Add tenant table metadata endpoint and tenant key helper

### DIFF
--- a/api-server/controllers/tenantTablesController.js
+++ b/api-server/controllers/tenantTablesController.js
@@ -3,6 +3,7 @@ import {
   upsertTenantTable,
   getEmploymentSession,
   listAllTenantTableOptions,
+  getTenantTable as getTenantTableDb,
   zeroSharedTenantKeys,
   seedDefaultsForSeedTables,
   seedTenantTables,
@@ -25,6 +26,22 @@ export async function listTenantTableOptions(req, res, next) {
     if (!(await ensureAdmin(req))) return res.sendStatus(403);
     const tables = await listAllTenantTableOptions();
     res.json(tables);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getTenantTable(req, res, next) {
+  try {
+    const tableName = req.params.table_name;
+    if (!tableName) {
+      return res.status(400).json({ message: 'table_name is required' });
+    }
+    const table = await getTenantTableDb(tableName);
+    if (!table) {
+      return res.status(404).json({ message: 'Table not found' });
+    }
+    res.json(table);
   } catch (err) {
     next(err);
   }

--- a/api-server/routes/tenant_tables.js
+++ b/api-server/routes/tenant_tables.js
@@ -5,6 +5,7 @@ import {
   createTenantTable,
   updateTenantTable,
   listTenantTableOptions,
+  getTenantTable,
   resetSharedTenantKeys,
   seedDefaults,
   seedExistingCompanies,
@@ -17,6 +18,7 @@ router.get('/', requireAuth, listTenantTables);
 router.post('/', requireAuth, createTenantTable);
 router.put('/:table_name', requireAuth, updateTenantTable);
 router.get('/options', requireAuth, listTenantTableOptions);
+router.get('/:table_name', requireAuth, getTenantTable);
 router.post('/zero-keys', requireAuth, resetSharedTenantKeys);
 router.post('/seed-defaults', requireAuth, seedDefaults);
 router.post('/seed-companies', requireAuth, seedExistingCompanies);

--- a/src/erp.mgt.mn/components/AsyncSearchSelect.jsx
+++ b/src/erp.mgt.mn/components/AsyncSearchSelect.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useContext } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
+import { getTenantKeyList } from '../utils/tenantKeys.js';
 
 export default function AsyncSearchSelect({
   table,
@@ -54,7 +55,7 @@ export default function AsyncSearchSelect({
       const params = new URLSearchParams({ page: p, perPage: 50 });
       const isShared =
         tenantMeta?.isShared ?? tenantMeta?.is_shared ?? false;
-      const keys = tenantMeta?.tenantKeys ?? tenantMeta?.tenant_keys ?? [];
+      const keys = getTenantKeyList(tenantMeta);
       if (!isShared) {
         if (keys.includes('company_id') && effectiveCompanyId != null)
           params.set('company_id', effectiveCompanyId);

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -22,6 +22,7 @@ import CustomDatePicker from './CustomDatePicker.jsx';
 import formatTimestamp from '../utils/formatTimestamp.js';
 import buildImageName from '../utils/buildImageName.js';
 import slugify from '../utils/slugify.js';
+import { getTenantKeyList } from '../utils/tenantKeys.js';
 import useGeneralConfig from '../hooks/useGeneralConfig.js';
 import { API_BASE } from '../utils/apiBase.js';
 import { useTranslation } from 'react-i18next';
@@ -693,8 +694,7 @@ const TableManager = forwardRef(function TableManager({
             }
             const isShared =
               tenantInfo?.isShared ?? tenantInfo?.is_shared ?? false;
-            const tenantKeys =
-              tenantInfo?.tenantKeys ?? tenantInfo?.tenant_keys ?? [];
+            const tenantKeys = getTenantKeyList(tenantInfo);
 
             while (true) {
               const params = new URLSearchParams({ page, perPage });
@@ -1091,7 +1091,7 @@ const TableManager = forwardRef(function TableManager({
       try {
         const params = new URLSearchParams();
         if (tenantInfo && !(tenantInfo.isShared ?? tenantInfo.is_shared)) {
-          const keys = tenantInfo.tenantKeys ?? tenantInfo.tenant_keys ?? [];
+          const keys = getTenantKeyList(tenantInfo);
           if (keys.includes('company_id') && company != null)
             params.set('company_id', company);
           if (keys.includes('branch_id') && branch != null)

--- a/src/erp.mgt.mn/utils/tenantKeys.js
+++ b/src/erp.mgt.mn/utils/tenantKeys.js
@@ -1,0 +1,12 @@
+export function getTenantKeyList(info) {
+  if (!info || typeof info !== 'object') return [];
+  const direct = Array.isArray(info.tenantKeys) ? info.tenantKeys : null;
+  const legacy = Array.isArray(info.tenant_keys) ? info.tenant_keys : null;
+  const source = direct ?? legacy ?? [];
+  const keys = [];
+  for (const key of source) {
+    if (typeof key !== 'string') continue;
+    if (!keys.includes(key)) keys.push(key);
+  }
+  return keys;
+}

--- a/tests/controllers/tenantTablesController.test.js
+++ b/tests/controllers/tenantTablesController.test.js
@@ -1,0 +1,108 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+function createRes() {
+  return {
+    statusCode: undefined,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    sendStatus(code) {
+      this.statusCode = code;
+      return this;
+    },
+  };
+}
+
+async function loadController(overrides = {}) {
+  const baseDb = {
+    listTenantTables: async () => [],
+    upsertTenantTable: async () => ({}),
+    getEmploymentSession: async () => ({}),
+    listAllTenantTableOptions: async () => [],
+    getTenantTable: async () => null,
+    zeroSharedTenantKeys: async () => {},
+    seedDefaultsForSeedTables: async () => {},
+    seedTenantTables: async () => {},
+    listCompanies: async () => [],
+    ...overrides,
+  };
+  const mod = await mock.import(
+    '../../api-server/controllers/tenantTablesController.js',
+    {
+      '../../db/index.js': baseDb,
+    },
+  );
+  return mod.getTenantTable;
+}
+
+if (typeof mock?.import !== 'function') {
+  test('getTenantTable returns tenant metadata', { skip: true }, () => {});
+  test('getTenantTable requires table_name param', { skip: true }, () => {});
+  test('getTenantTable returns 404 when table not found', { skip: true }, () => {});
+  test('getTenantTable forwards database errors', { skip: true }, () => {});
+} else {
+  test('getTenantTable returns tenant metadata', async () => {
+    const req = { params: { table_name: 'users' } };
+    const res = createRes();
+    const stub = mock.fn(async () => ({
+      tableName: 'users',
+      isShared: false,
+      tenantKeys: ['company_id'],
+    }));
+    const getTenantTable = await loadController({ getTenantTable: stub });
+    await getTenantTable(req, res, (err) => {
+      if (err) throw err;
+    });
+    assert.deepEqual(res.body, {
+      tableName: 'users',
+      isShared: false,
+      tenantKeys: ['company_id'],
+    });
+    assert.equal(stub.mock.calls.length, 1);
+  });
+
+  test('getTenantTable requires table_name param', async () => {
+    const req = { params: {} };
+    const res = createRes();
+    const getTenantTable = await loadController();
+    await getTenantTable(req, res, (err) => {
+      if (err) throw err;
+    });
+    assert.equal(res.statusCode, 400);
+    assert.equal(res.body?.message, 'table_name is required');
+  });
+
+  test('getTenantTable returns 404 when table not found', async () => {
+    const req = { params: { table_name: 'missing' } };
+    const res = createRes();
+    const getTenantTable = await loadController({ getTenantTable: async () => null });
+    await getTenantTable(req, res, (err) => {
+      if (err) throw err;
+    });
+    assert.equal(res.statusCode, 404);
+    assert.equal(res.body?.message, 'Table not found');
+  });
+
+  test('getTenantTable forwards database errors', async () => {
+    const req = { params: { table_name: 'users' } };
+    const res = createRes();
+    const failure = new Error('db failed');
+    const getTenantTable = await loadController({
+      getTenantTable: async () => {
+        throw failure;
+      },
+    });
+    let captured;
+    await getTenantTable(req, res, (err) => {
+      captured = err;
+    });
+    assert.equal(captured, failure);
+  });
+}

--- a/tests/db/getTenantTable.test.js
+++ b/tests/db/getTenantTable.test.js
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as db from '../../db/index.js';
+
+function mockPool(handler) {
+  const originalQuery = db.pool.query;
+  db.pool.query = async (sql, params) => {
+    const normalizedSql = typeof sql === 'string' ? sql : sql?.sql || '';
+    const result = await handler(normalizedSql, params);
+    if (result === undefined) {
+      throw new Error(`Unexpected query: ${normalizedSql}`);
+    }
+    return result;
+  };
+  return () => {
+    db.pool.query = originalQuery;
+  };
+}
+
+test('getTenantTable infers tenant keys from columns', async () => {
+  const restore = mockPool((sql) => {
+    if (sql.includes('FROM tenant_tables')) {
+      return [[{ is_shared: 1, seed_on_create: 0 }]];
+    }
+    if (sql.includes('information_schema.COLUMNS')) {
+      return [[
+        { COLUMN_NAME: 'Company_ID' },
+        { COLUMN_NAME: 'branch_id' },
+        { COLUMN_NAME: 'name' },
+      ]];
+    }
+    return undefined;
+  });
+  try {
+    const table = await db.getTenantTable('code_branches');
+    assert.deepEqual(table, {
+      tableName: 'code_branches',
+      isShared: true,
+      tenantKeys: ['Company_ID', 'branch_id'],
+    });
+  } finally {
+    restore();
+  }
+});
+
+test('getTenantTable returns null when table missing', async () => {
+  const restore = mockPool((sql) => {
+    if (sql.includes('FROM tenant_tables')) {
+      return [[{ is_shared: 0, seed_on_create: 0 }]];
+    }
+    if (sql.includes('information_schema.COLUMNS')) {
+      return [[]];
+    }
+    return undefined;
+  });
+  try {
+    const table = await db.getTenantTable('missing_table');
+    assert.equal(table, null);
+  } finally {
+    restore();
+  }
+});

--- a/tests/utils/tenantKeys.test.js
+++ b/tests/utils/tenantKeys.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getTenantKeyList } from '../../src/erp.mgt.mn/utils/tenantKeys.js';
+
+test('getTenantKeyList prefers camelCase tenantKeys', () => {
+  const keys = getTenantKeyList({ tenantKeys: ['company_id', 'branch_id'], tenant_keys: ['ignore'] });
+  assert.deepEqual(keys, ['company_id', 'branch_id']);
+});
+
+test('getTenantKeyList falls back to legacy tenant_keys', () => {
+  const keys = getTenantKeyList({ tenant_keys: ['department_id', 3, 'department_id'] });
+  assert.deepEqual(keys, ['department_id']);
+});
+
+test('getTenantKeyList handles invalid input', () => {
+  assert.deepEqual(getTenantKeyList(null), []);
+  assert.deepEqual(getTenantKeyList({}), []);
+});


### PR DESCRIPTION
## Summary
- add a GET /api/tenant_tables/:table_name controller and route that returns table metadata with inferred tenant keys
- infer tenant key columns from schema/config in the database layer and expose a tenant key helper for client components
- update AsyncSearchSelect/TableManager to consume camelCase tenantKeys and add targeted tests for the DB helper, controller, and utility

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caaf115c848331b028f70667a600c9