### PR TITLE
Return seed summaries from tenant seeding endpoints

### DIFF
--- a/api-server/controllers/tenantTablesController.js
+++ b/api-server/controllers/tenantTablesController.js
@@ -123,12 +123,20 @@ export async function seedExistingCompanies(req, res, next) {
       }
     }
     const companies = await listCompanies(req.user.empid);
+    const results = {};
     for (const { id, created_by } of companies) {
       if (id === GLOBAL_COMPANY_ID) continue;
       if (created_by !== req.user.empid) continue;
-      await seedTenantTables(id, tables, recordMap, overwrite, req.user.empid);
+      const summary = await seedTenantTables(
+        id,
+        tables,
+        recordMap,
+        overwrite,
+        req.user.empid,
+      );
+      results[id] = summary || {};
     }
-    res.sendStatus(204);
+    res.json(results);
   } catch (err) {
     next(err);
   }
@@ -165,8 +173,14 @@ export async function seedCompany(req, res, next) {
       return res.sendStatus(403);
     }
 
-    await seedTenantTables(companyId, tables, recordMap, overwrite, req.user.empid);
-    res.sendStatus(204);
+    const summary = await seedTenantTables(
+      companyId,
+      tables,
+      recordMap,
+      overwrite,
+      req.user.empid,
+    );
+    res.json(summary || {});
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
## Summary
- make `seedTenantTables` collect per-table insert counts/ids and return the summary to callers
- update the tenant tables controller to send the summary for both bulk and single-company seeding endpoints
- surface the returned summary in the Tenant Tables Registry UI with toast messaging and a persisted inline report, and extend tests for the new payloads

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb8f7d156c8331aaf7f4b8e5fc624c