### PR TITLE
Handle conflicts when seeding default tenant tables

### DIFF
--- a/api-server/controllers/tenantTablesController.js
+++ b/api-server/controllers/tenantTablesController.js
@@ -108,6 +108,15 @@ export async function seedDefaults(req, res, next) {
     await seedDefaultsForSeedTables(req.user.empid);
     res.sendStatus(204);
   } catch (err) {
+    if (err?.status === 409 && err?.conflicts) {
+      res.status(409).json({
+        message:
+          err.message ||
+          'Cannot populate defaults because tenant data exists in seed tables.',
+        conflicts: err.conflicts,
+      });
+      return;
+    }
     next(err);
   }
 }

--- a/tests/db/seedTenantTables.test.js
+++ b/tests/db/seedTenantTables.test.js
@@ -170,8 +170,8 @@ await test('seedDefaultsForSeedTables updates audit columns when present', async
   const updates = calls.filter((c) => c.sql.startsWith('UPDATE ?? SET company_id'));
   assert.equal(updates.length, 2);
   assert.match(updates[0].sql, /updated_by = \?, updated_at = NOW\(\)/);
-  assert.deepEqual(updates[0].params, ['t1', 0, 55]);
-  assert.deepEqual(updates[1].params, ['t2', 0, 55]);
+  assert.deepEqual(updates[0].params, ['t1', 0, 55, 0]);
+  assert.deepEqual(updates[1].params, ['t2', 0, 55, 0]);
 });
 
 await test('zeroSharedTenantKeys updates audit columns when present', async () => {


### PR DESCRIPTION
## Summary
- detect tenant data while seeding default tables, short-circuit with a 409 error, and limit updates to global rows only
- bubble the conflict payload through `/api/tenant_tables/seed-defaults` and surface the warning in the tenant tables registry UI
- align the seed defaults unit test with the new `company_id` filter

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb9bdf95c08331a2f4741b2814129e