### PR TITLE
Warn when shared and seed toggles conflict

### DIFF
--- a/src/erp.mgt.mn/locales/de.json
+++ b/src/erp.mgt.mn/locales/de.json
@@ -1045,5 +1045,7 @@
   "close": "Close",
   "cancel": "Cancel",
   "prev": "Prev",
-  "next": "Next"
+  "next": "Next",
+  "sharedTablesSeedToggleWarning": "Seed on Create tables must remain tenant-specific. The Shared column has been unchecked.",
+  "sharedTablesShareToggleWarning": "Shared tables always read from tenant key 0. The Seed on Create column has been unchecked."
 }

--- a/src/erp.mgt.mn/locales/en.json
+++ b/src/erp.mgt.mn/locales/en.json
@@ -653,6 +653,8 @@
   "route_disabled": "This route is disabled",
   "sales": "Sales Dashboard",
   "seedOnCreate": "Seed on Create",
+  "sharedTablesSeedToggleWarning": "Seed on Create tables must remain tenant-specific. The Shared column has been unchecked.",
+  "sharedTablesShareToggleWarning": "Shared tables always read from tenant key 0. The Seed on Create column has been unchecked.",
   "selectCompany": "Select company",
   "selectUserLevel": "Select user level",
   "select_printer": "Select printer",

--- a/src/erp.mgt.mn/locales/es.json
+++ b/src/erp.mgt.mn/locales/es.json
@@ -1145,5 +1145,7 @@
   "close": "Close",
   "cancel": "Cancel",
   "prev": "Prev",
-  "next": "Next"
+  "next": "Next",
+  "sharedTablesSeedToggleWarning": "Seed on Create tables must remain tenant-specific. The Shared column has been unchecked.",
+  "sharedTablesShareToggleWarning": "Shared tables always read from tenant key 0. The Seed on Create column has been unchecked."
 }

--- a/src/erp.mgt.mn/locales/fr.json
+++ b/src/erp.mgt.mn/locales/fr.json
@@ -47,5 +47,7 @@
   "close": "Close",
   "cancel": "Cancel",
   "prev": "Prev",
-  "next": "Next"
+  "next": "Next",
+  "sharedTablesSeedToggleWarning": "Seed on Create tables must remain tenant-specific. The Shared column has been unchecked.",
+  "sharedTablesShareToggleWarning": "Shared tables always read from tenant key 0. The Seed on Create column has been unchecked."
 }

--- a/src/erp.mgt.mn/locales/ja.json
+++ b/src/erp.mgt.mn/locales/ja.json
@@ -822,5 +822,7 @@
   "close": "Close",
   "cancel": "Cancel",
   "prev": "Prev",
-  "next": "Next"
+  "next": "Next",
+  "sharedTablesSeedToggleWarning": "Seed on Create tables must remain tenant-specific. The Shared column has been unchecked.",
+  "sharedTablesShareToggleWarning": "Shared tables always read from tenant key 0. The Seed on Create column has been unchecked."
 }

--- a/src/erp.mgt.mn/locales/ko.json
+++ b/src/erp.mgt.mn/locales/ko.json
@@ -822,5 +822,7 @@
   "close": "Close",
   "cancel": "Cancel",
   "prev": "Prev",
-  "next": "Next"
+  "next": "Next",
+  "sharedTablesSeedToggleWarning": "Seed on Create tables must remain tenant-specific. The Shared column has been unchecked.",
+  "sharedTablesShareToggleWarning": "Shared tables always read from tenant key 0. The Seed on Create column has been unchecked."
 }

--- a/src/erp.mgt.mn/locales/mn.json
+++ b/src/erp.mgt.mn/locales/mn.json
@@ -829,5 +829,7 @@
   "close": "Close",
   "cancel": "Cancel",
   "prev": "Prev",
-  "next": "Next"
+  "next": "Next",
+  "sharedTablesSeedToggleWarning": "Seed on Create tables must remain tenant-specific. The Shared column has been unchecked.",
+  "sharedTablesShareToggleWarning": "Shared tables always read from tenant key 0. The Seed on Create column has been unchecked."
 }

--- a/src/erp.mgt.mn/locales/ru.json
+++ b/src/erp.mgt.mn/locales/ru.json
@@ -47,5 +47,7 @@
   "close": "Close",
   "cancel": "Cancel",
   "prev": "Prev",
-  "next": "Next"
+  "next": "Next",
+  "sharedTablesSeedToggleWarning": "Seed on Create tables must remain tenant-specific. The Shared column has been unchecked.",
+  "sharedTablesShareToggleWarning": "Shared tables always read from tenant key 0. The Seed on Create column has been unchecked."
 }

--- a/src/erp.mgt.mn/locales/zh.json
+++ b/src/erp.mgt.mn/locales/zh.json
@@ -822,5 +822,7 @@
   "close": "Close",
   "cancel": "Cancel",
   "prev": "Prev",
-  "next": "Next"
+  "next": "Next",
+  "sharedTablesSeedToggleWarning": "Seed on Create tables must remain tenant-specific. The Shared column has been unchecked.",
+  "sharedTablesShareToggleWarning": "Shared tables always read from tenant key 0. The Seed on Create column has been unchecked."
 }


### PR DESCRIPTION
## Summary
- show warning toasts in the Tenant Tables Registry when toggling Shared or Seed on Create while the other flag is active
- keep track of the last toggled column so save validation can surface the matching warning copy
- add the new warning messages to each locale file so the toasts have translated text available

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbbc08123c8331986e0f0085382342