### PR TITLE
Add warning toast icon and styling

### DIFF
--- a/src/erp.mgt.mn/context/ToastContext.jsx
+++ b/src/erp.mgt.mn/context/ToastContext.jsx
@@ -3,6 +3,21 @@ import { trackSetState } from '../utils/debug.js';
 
 const ToastContext = createContext({ addToast: () => {} });
 
+const DEFAULT_TOAST_ICON = 'ℹ️';
+
+function getToastIcon(type) {
+  switch (type) {
+    case 'success':
+      return '✅';
+    case 'error':
+      return '❌';
+    case 'warning':
+      return '⚠️';
+    default:
+      return DEFAULT_TOAST_ICON;
+  }
+}
+
 export function ToastProvider({ children }) {
   const [toasts, setToasts] = useState([]);
 
@@ -31,11 +46,16 @@ export function ToastProvider({ children }) {
     <ToastContext.Provider value={value}>
       {children}
       <div className="toast-container">
-        {toasts.map((t) => (
-          <div key={t.id} className={`toast toast-${t.type}`}>
-            {t.type === 'success' ? '✅' : t.type === 'error' ? '❌' : 'ℹ️'} {t.message}
-          </div>
-        ))}
+        {toasts.map((t) => {
+          const rawType = t.type || 'info';
+          const normalizedType = rawType === 'warn' ? 'warning' : rawType;
+          const icon = getToastIcon(normalizedType);
+          return (
+            <div key={t.id} className={`toast toast-${normalizedType}`}>
+              {icon} {t.message}
+            </div>
+          );
+        })}
       </div>
     </ToastContext.Provider>
   );

--- a/src/erp.mgt.mn/index.css
+++ b/src/erp.mgt.mn/index.css
@@ -124,6 +124,7 @@ footer { text-align:center; padding:1rem; background:#f1f1f1; font-size:0.9rem; 
 
 .toast-success { color: #16a34a; }
 .toast-error { color: #dc2626; }
+.toast-warning { color: #d97706; }
 
 @keyframes fade-slide {
   from { opacity: 0; transform: translateX(20px); }


### PR DESCRIPTION
## Summary
- update the toast context to normalize warning types and render a ⚠️ icon
- add a warning toast color so warning notifications are visually distinct

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbd23f6fcc8331a8fe95f451c9bfdd