### PR TITLE
Allow editing seed rows before seeding companies

### DIFF
--- a/api-server/controllers/tenantTablesController.js
+++ b/api-server/controllers/tenantTablesController.js
@@ -174,18 +174,25 @@ export async function seedCompany(req, res, next) {
     }
     const recordMap = {};
     for (const rec of records || []) {
-      if (
-        rec?.table &&
-        Array.isArray(rec.rows) &&
-        rec.rows.length > 0
-      ) {
-        recordMap[rec.table] = rec.rows;
-      } else if (
-        rec?.table &&
-        Array.isArray(rec.ids) &&
-        rec.ids.length > 0
-      ) {
-        recordMap[rec.table] = rec.ids;
+      if (!rec?.table) continue;
+      const tableName = String(rec.table);
+      if (Array.isArray(rec.rows) && rec.rows.length > 0) {
+        const sanitized = [];
+        for (const row of rec.rows) {
+          if (!row || typeof row !== 'object' || Array.isArray(row)) {
+            return res.status(400).json({
+              message: `Invalid manual row payload for table ${tableName}`,
+            });
+          }
+          sanitized.push({ ...row });
+        }
+        if (sanitized.length > 0) {
+          recordMap[tableName] = sanitized;
+          continue;
+        }
+      }
+      if (Array.isArray(rec.ids) && rec.ids.length > 0) {
+        recordMap[tableName] = rec.ids;
       }
     }
 


### PR DESCRIPTION
## Summary
- add editable copies of default seed rows in the tenant tables registry and allow adding custom rows before submitting
- send either selected ids or full manual row payloads for each seeded table depending on whether edits or custom rows are present
- validate manual row payloads in the seed-company controller and cover the new payload shape with automated tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccc6c18e3483319e4cf5a79d20b66e