### PR TITLE
Fix modal dragging translation handling

### DIFF
--- a/src/erp.mgt.mn/components/Modal.jsx
+++ b/src/erp.mgt.mn/components/Modal.jsx
@@ -24,11 +24,13 @@ export default function Modal({ visible, title, onClose, children, width = 'auto
   }
 
   function startDrag(e) {
-    const rect = modalRef.current?.getBoundingClientRect() || { left: 0, top: 0 };
-    const offsetX = e.clientX - rect.left;
-    const offsetY = e.clientY - rect.top;
+    const startX = e.clientX;
+    const startY = e.clientY;
+    const startPos = { ...posRef.current };
     function move(ev) {
-      posRef.current = { x: ev.clientX - offsetX, y: ev.clientY - offsetY };
+      const deltaX = ev.clientX - startX;
+      const deltaY = ev.clientY - startY;
+      posRef.current = { x: startPos.x + deltaX, y: startPos.y + deltaY };
       if (modalRef.current) {
         modalRef.current.style.transform = `translate(${posRef.current.x}px, ${posRef.current.y}px)`;
       }
@@ -64,6 +66,7 @@ export default function Modal({ visible, title, onClose, children, width = 'auto
     overflowY: 'auto',
     width,
     minWidth: '300px',
+    transform: `translate(${posRef.current.x}px, ${posRef.current.y}px)`,
   };
 
   const headerStyle = {


### PR DESCRIPTION
## Summary
- update the modal drag handler to track pointer deltas and accumulate translation
- persist the stored offset in the modal style so re-renders keep the dragged position

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccd67d610c833180e1986a517a760c