### PR TITLE
Auto-select default seed tables in tenant registry modal

### DIFF
--- a/src/erp.mgt.mn/pages/TenantTablesRegistry.jsx
+++ b/src/erp.mgt.mn/pages/TenantTablesRegistry.jsx
@@ -332,6 +332,27 @@ export default function TenantTablesRegistry() {
     }
   }, []);
 
+  useEffect(() => {
+    if (!seedModalOpen) return;
+    if (!Array.isArray(tables) || tables.length === 0) return;
+    if (Object.keys(selectedTables || {}).length > 0) return;
+
+    const defaults = tables.filter((table) => table?.seedOnCreate && table?.tableName);
+    if (defaults.length === 0) return;
+
+    setSelectedTables(() => {
+      const initial = {};
+      for (const table of defaults) {
+        initial[table.tableName] = true;
+      }
+      return initial;
+    });
+
+    for (const table of defaults) {
+      loadTableRecords(table.tableName);
+    }
+  }, [seedModalOpen, tables, selectedTables, loadTableRecords]);
+
   const resetTables = Array.isArray(lastResetSummary?.tables)
     ? lastResetSummary.tables
     : [];


### PR DESCRIPTION
## Summary
- auto-select default seed tables when the company seeding modal opens without a prior selection
- trigger record loading for the preselected tables so Populate/Repopulate buttons enable immediately

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cce4f13a608331a0b14706e874c660