### PR TITLE
Handle varied @babel/traverse exports

### DIFF
--- a/api-server/utils/translationHelpers.js
+++ b/api-server/utils/translationHelpers.js
@@ -8,7 +8,25 @@ try {
   parser = parserMod.default || parserMod;
   try {
     const traverseModule = await import('@babel/traverse');
-    traverse = traverseModule.default;
+    const candidates = [
+      traverseModule?.default,
+      traverseModule?.default?.default,
+      traverseModule?.traverse,
+      traverseModule,
+    ];
+    for (const candidate of candidates) {
+      if (typeof candidate === 'function') {
+        traverse = candidate;
+        break;
+      }
+    }
+    if (!traverse) {
+      console.warn(
+        '[translations] Failed to load @babel/traverse; falling back to regex parsing: No traverse function export found.',
+      );
+      traverse = null;
+      parser = null;
+    }
   } catch (err) {
     console.warn(
       `[translations] Failed to load @babel/traverse; falling back to regex parsing: ${err.message}`,


### PR DESCRIPTION
## Summary
- resolve the @babel/traverse import by checking several common export shapes
- fall back to regex parsing when no callable traverse export is found, matching the existing parser fallback

## Testing
- node api-server/services/translationsExport.js

------
https://chatgpt.com/codex/tasks/task_e_68ccec1c92608331b28a3c683ac922fc