### PR TITLE
Add tenant default export button and API

### DIFF
--- a/api-server/controllers/tenantTablesController.js
+++ b/api-server/controllers/tenantTablesController.js
@@ -11,6 +11,7 @@ import {
   insertTenantDefaultRow,
   updateTenantDefaultRow as updateTenantDefaultRowDb,
   deleteTenantDefaultRow,
+  exportTenantTableDefaults,
 } from '../../db/index.js';
 import { hasAction } from '../utils/hasAction.js';
 import { GLOBAL_COMPANY_ID } from '../../config/0/constants.js';
@@ -213,6 +214,21 @@ export async function seedCompany(req, res, next) {
       req.user.empid,
     );
     res.json(summary || {});
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function exportDefaults(req, res, next) {
+  try {
+    if (!(await ensureAdmin(req))) return res.sendStatus(403);
+    const versionNameRaw = req.body?.versionName;
+    const trimmed = typeof versionNameRaw === 'string' ? versionNameRaw.trim() : '';
+    if (!trimmed) {
+      return res.status(400).json({ message: 'versionName is required' });
+    }
+    const metadata = await exportTenantTableDefaults(trimmed, req.user?.empid ?? null);
+    res.json(metadata);
   } catch (err) {
     next(err);
   }

--- a/api-server/routes/tenant_tables.js
+++ b/api-server/routes/tenant_tables.js
@@ -8,6 +8,7 @@ import {
   getTenantTable,
   resetSharedTenantKeys,
   seedDefaults,
+  exportDefaults,
   seedExistingCompanies,
   seedCompany,
   insertDefaultTenantRow,
@@ -24,6 +25,7 @@ router.get('/options', requireAuth, listTenantTableOptions);
 router.get('/:table_name', requireAuth, getTenantTable);
 router.post('/zero-keys', requireAuth, resetSharedTenantKeys);
 router.post('/seed-defaults', requireAuth, seedDefaults);
+router.post('/export-defaults', requireAuth, exportDefaults);
 router.post('/seed-companies', requireAuth, seedExistingCompanies);
 router.post('/seed-company', requireAuth, seedCompany);
 router.post('/:table_name/default-rows', requireAuth, insertDefaultTenantRow);

--- a/db/index.js
+++ b/db/index.js
@@ -1332,6 +1332,201 @@ export async function seedDefaultsForSeedTables(userId) {
   }
 }
 
+function sanitizeExportName(name) {
+  if (!name && name !== 0) return '';
+  const normalized = String(name)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return normalized;
+}
+
+function formatExportTimestamp(date = new Date()) {
+  const pad = (value) => String(value).padStart(2, '0');
+  return (
+    `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}` +
+    `-${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`
+  );
+}
+
+export async function exportTenantTableDefaults(versionName, requestedBy = null) {
+  const safeName = sanitizeExportName(versionName);
+  if (!safeName) {
+    const err = new Error('A valid export name is required');
+    err.status = 400;
+    throw err;
+  }
+
+  const generatedAt = new Date();
+  const timestampPart = formatExportTimestamp(generatedAt);
+  const fileName = `${timestampPart}_${safeName}.sql`;
+  const relativePathRaw = path.join('tenant_table_exports', fileName);
+  const relativePath = relativePathRaw.replace(/\\/g, '/');
+  const filePath = tenantConfigPath(relativePathRaw);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+
+  let tableRows;
+  try {
+    [tableRows] = await pool.query(
+      `SELECT table_name
+         FROM tenant_tables
+        WHERE is_shared = 1 OR seed_on_create = 1
+        ORDER BY table_name`,
+    );
+  } catch (err) {
+    if (err?.code === 'ER_NO_SUCH_TABLE') {
+      tableRows = [];
+    } else {
+      throw err;
+    }
+  }
+
+  const tableNames = Array.from(
+    new Set(
+      (tableRows || [])
+        .map((row) => row?.table_name)
+        .filter((name) => typeof name === 'string' && name.trim()),
+    ),
+  );
+
+  const lines = [];
+  lines.push('-- Tenant table defaults export');
+  lines.push(`-- Version: ${safeName}`);
+  lines.push(`-- Generated at: ${generatedAt.toISOString()}`);
+  if (requestedBy !== null && requestedBy !== undefined) {
+    lines.push(`-- Requested by: ${requestedBy}`);
+  }
+  lines.push('');
+  lines.push('START TRANSACTION;');
+
+  const tableSummaries = [];
+  let exportedTables = 0;
+  let totalRows = 0;
+
+  if (tableNames.length === 0) {
+    lines.push('-- No tenant tables matched the export criteria.');
+  }
+
+  for (const rawName of tableNames) {
+    const tableName = String(rawName);
+    let columns = [];
+    try {
+      columns = await listTableColumns(tableName);
+    } catch (err) {
+      tableSummaries.push({
+        tableName,
+        rows: 0,
+        skipped: true,
+        reason: 'column_lookup_failed',
+        error: err.message,
+      });
+      lines.push('');
+      lines.push(`-- Skipped ${tableName}: failed to load column metadata (${err.message}).`);
+      continue;
+    }
+
+    if (!Array.isArray(columns) || columns.length === 0) {
+      tableSummaries.push({
+        tableName,
+        rows: 0,
+        skipped: true,
+        reason: 'no_columns',
+      });
+      lines.push('');
+      lines.push(`-- Skipped ${tableName}: no columns available.`);
+      continue;
+    }
+
+    const lowerCols = columns.map((col) => String(col).toLowerCase());
+    if (!lowerCols.includes('company_id')) {
+      tableSummaries.push({
+        tableName,
+        rows: 0,
+        skipped: true,
+        reason: 'missing_company_id',
+      });
+      lines.push('');
+      lines.push(`-- Skipped ${tableName}: company_id column not found.`);
+      continue;
+    }
+
+    let rows;
+    try {
+      [rows] = await pool.query('SELECT * FROM ?? WHERE company_id = ?', [
+        tableName,
+        GLOBAL_COMPANY_ID,
+      ]);
+    } catch (err) {
+      tableSummaries.push({
+        tableName,
+        rows: 0,
+        skipped: true,
+        reason: 'row_fetch_failed',
+        error: err.message,
+      });
+      lines.push('');
+      lines.push(`-- Skipped ${tableName}: failed to load rows (${err.message}).`);
+      continue;
+    }
+
+    const normalizedRows = Array.isArray(rows) ? rows : [];
+    const rowCount = normalizedRows.length;
+    tableSummaries.push({ tableName, rows: rowCount, skipped: false });
+    exportedTables += 1;
+    totalRows += rowCount;
+
+    lines.push('');
+    lines.push(`-- Table: ${tableName}`);
+    lines.push(
+      `DELETE FROM ${escapeIdentifier(tableName)} WHERE ${escapeIdentifier(
+        'company_id',
+      )} = ${GLOBAL_COMPANY_ID};`,
+    );
+
+    if (rowCount === 0) {
+      lines.push('-- No rows to export.');
+      continue;
+    }
+
+    const columnIdentifiers = columns.map((col) => escapeIdentifier(col));
+    for (const row of normalizedRows) {
+      const values = columns.map((col) => {
+        if (row && Object.prototype.hasOwnProperty.call(row, col)) {
+          const val = row[col];
+          return mysql.escape(val === undefined ? null : val);
+        }
+        return 'NULL';
+      });
+      lines.push(
+        `INSERT INTO ${escapeIdentifier(tableName)} (${columnIdentifiers.join(
+          ', ',
+        )}) VALUES (${values.join(', ')});`,
+      );
+    }
+  }
+
+  lines.push('');
+  lines.push('COMMIT;');
+  const sql = lines.join('\n');
+  await fs.writeFile(filePath, sql, 'utf8');
+
+  return {
+    fileName,
+    relativePath,
+    generatedAt: generatedAt.toISOString(),
+    versionName: safeName,
+    originalName: versionName,
+    tableCount: exportedTables,
+    rowCount: totalRows,
+    fileSize: Buffer.byteLength(sql, 'utf8'),
+    requestedBy: requestedBy ?? null,
+    tables: tableSummaries,
+    sql,
+  };
+}
+
 export async function seedSeedTablesForCompanies(userId = null) {
   const [companies] = await pool.query(
     `SELECT id FROM companies WHERE id > ?`,

--- a/tests/db/exportTenantTableDefaults.test.js
+++ b/tests/db/exportTenantTableDefaults.test.js
@@ -1,0 +1,76 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import path from 'path';
+import * as db from '../../db/index.js';
+
+await test('exportTenantTableDefaults writes SQL snapshot for shared and seed tables', async () => {
+  const origQuery = db.pool.query;
+  const calls = [];
+  db.pool.query = async (sql, params) => {
+    const trimmed = sql.trim();
+    calls.push({ sql: trimmed, params });
+    if (trimmed.startsWith('SELECT table_name')) {
+      return [[
+        { table_name: 'shared_defaults', is_shared: 1, seed_on_create: 0 },
+        { table_name: 'seed_defaults', is_shared: 0, seed_on_create: 1 },
+      ]];
+    }
+    if (trimmed.startsWith('SELECT COLUMN_NAME')) {
+      const tableName = params?.[0];
+      if (tableName === 'shared_defaults') {
+        return [[
+          { COLUMN_NAME: 'company_id' },
+          { COLUMN_NAME: 'id' },
+          { COLUMN_NAME: 'label' },
+        ]];
+      }
+      if (tableName === 'seed_defaults') {
+        return [[
+          { COLUMN_NAME: 'company_id' },
+          { COLUMN_NAME: 'code' },
+        ]];
+      }
+    }
+    if (trimmed.startsWith('SELECT * FROM ?? WHERE company_id = ?')) {
+      const tableName = params?.[0];
+      if (tableName === 'shared_defaults') {
+        return [[
+          { company_id: 0, id: 1, label: 'Welcome' },
+          { company_id: 0, id: 2, label: 'Goodbye' },
+        ]];
+      }
+      if (tableName === 'seed_defaults') {
+        return [[{ company_id: 0, code: 'X' }]];
+      }
+    }
+    return [[], []];
+  };
+
+  let exportPath;
+  try {
+    const result = await db.exportTenantTableDefaults('Baseline Defaults', 77);
+    assert.equal(result.versionName, 'baseline-defaults');
+    assert.match(result.fileName, /baseline-defaults\.sql$/);
+    assert.equal(result.tableCount, 2);
+    assert.equal(result.rowCount, 3);
+    exportPath = path.join(process.cwd(), 'config', '0', result.relativePath);
+    const fileContent = await fs.readFile(exportPath, 'utf8');
+    assert.equal(fileContent, result.sql);
+    assert.match(fileContent, /INSERT INTO `shared_defaults`/);
+    assert.match(fileContent, /INSERT INTO `seed_defaults`/);
+    assert.ok(calls.some((c) => c.sql.startsWith('SELECT table_name')));
+  } finally {
+    db.pool.query = origQuery;
+    if (exportPath) {
+      await fs.unlink(exportPath).catch(() => {});
+    }
+  }
+});
+
+await test('exportTenantTableDefaults rejects blank export names', async () => {
+  await assert.rejects(
+    () => db.exportTenantTableDefaults('   '),
+    /export name is required/i,
+  );
+});


### PR DESCRIPTION
## Summary
- add a Save defaults action to the tenant tables registry UI that prompts for a version name, triggers the export, and downloads the SQL snapshot
- implement the export-defaults endpoint and database helper to write tenant default rows for shared/seed tables into timestamped scripts
- cover successful and failing export scenarios with new controller and database tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccf92939a483318a3ca4340371c8cd