### PR TITLE
Add tenant default export button and API

### DIFF
--- a/api-server/controllers/tenantTablesController.js
+++ b/api-server/controllers/tenantTablesController.js
@@ -11,6 +11,7 @@ import {
   insertTenantDefaultRow,
   updateTenantDefaultRow as updateTenantDefaultRowDb,
   deleteTenantDefaultRow,
+  exportTenantTableDefaults,
 } from '../../db/index.js';
 import { hasAction } from '../utils/hasAction.js';
 import { GLOBAL_COMPANY_ID } from '../../config/0/constants.js';
@@ -213,6 +214,21 @@ export async function seedCompany(req, res, next) {
       req.user.empid,
     );
     res.json(summary || {});
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function exportDefaults(req, res, next) {
+  try {
+    if (!(await ensureAdmin(req))) return res.sendStatus(403);
+    const versionNameRaw = req.body?.versionName;
+    const trimmed = typeof versionNameRaw === 'string' ? versionNameRaw.trim() : '';
+    if (!trimmed) {
+      return res.status(400).json({ message: 'versionName is required' });
+    }
+    const metadata = await exportTenantTableDefaults(trimmed, req.user?.empid ?? null);
+    res.json(metadata);
   } catch (err) {
     next(err);
   }

--- a/api-server/routes/tenant_tables.js
+++ b/api-server/routes/tenant_tables.js
@@ -8,6 +8,7 @@ import {
   getTenantTable,
   resetSharedTenantKeys,
   seedDefaults,
+  exportDefaults,
   seedExistingCompanies,
   seedCompany,
   insertDefaultTenantRow,
@@ -24,6 +25,7 @@ router.get('/options', requireAuth, listTenantTableOptions);
 router.get('/:table_name', requireAuth, getTenantTable);
 router.post('/zero-keys', requireAuth, resetSharedTenantKeys);
 router.post('/seed-defaults', requireAuth, seedDefaults);
+router.post('/export-defaults', requireAuth, exportDefaults);
 router.post('/seed-companies', requireAuth, seedExistingCompanies);
 router.post('/seed-company', requireAuth, seedCompany);
 router.post('/:table_name/default-rows', requireAuth, insertDefaultTenantRow);

--- a/tests/db/exportTenantTableDefaults.test.js
+++ b/tests/db/exportTenantTableDefaults.test.js
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import path from 'path';
+import * as db from '../../db/index.js';
+
+await test('exportTenantTableDefaults writes SQL snapshot for shared and seed tables', async () => {
+  const origQuery = db.pool.query;
+  const calls = [];
+  db.pool.query = async (sql, params) => {
+    const trimmed = sql.trim();
+    calls.push({ sql: trimmed, params });
+    if (trimmed.startsWith('SELECT table_name')) {
+      return [[
+        { table_name: 'shared_defaults', is_shared: 1, seed_on_create: 0 },
+        { table_name: 'seed_defaults', is_shared: 0, seed_on_create: 1 },
+      ]];
+    }
+    if (trimmed.startsWith('SELECT COLUMN_NAME')) {
+      const tableName = params?.[0];
+      if (tableName === 'shared_defaults') {
+        return [[
+          { COLUMN_NAME: 'company_id' },
+          { COLUMN_NAME: 'id' },
+          { COLUMN_NAME: 'label' },
+        ]];
+      }
+      if (tableName === 'seed_defaults') {
+        return [[
+          { COLUMN_NAME: 'company_id' },
+          { COLUMN_NAME: 'code' },
+        ]];
+      }
+    }
+    if (trimmed.startsWith('SELECT * FROM ?? WHERE company_id = ?')) {
+      const tableName = params?.[0];
+      if (tableName === 'shared_defaults') {
+        return [[
+          { company_id: 0, id: 1, label: 'Welcome' },
+          { company_id: 0, id: 2, label: 'Goodbye' },
+        ]];
+      }
+      if (tableName === 'seed_defaults') {
+        return [[{ company_id: 0, code: 'X' }]];
+      }
+    }
+    return [[], []];
+  };
+
+  let exportPath;
+  try {
+    const result = await db.exportTenantTableDefaults('Baseline Defaults', 77);
+    assert.equal(result.versionName, 'baseline-defaults');
+    assert.match(result.fileName, /baseline-defaults\.sql$/);
+    assert.equal(result.relativePath, `defaults/${result.fileName}`);
+    assert.equal(result.tableCount, 2);
+    assert.equal(result.rowCount, 3);
+    exportPath = path.join(process.cwd(), 'config', '0', result.relativePath);
+    const fileContent = await fs.readFile(exportPath, 'utf8');
+    assert.equal(fileContent, result.sql);
+    assert.match(fileContent, /INSERT INTO `shared_defaults`/);
+    assert.match(fileContent, /INSERT INTO `seed_defaults`/);
+    assert.ok(calls.some((c) => c.sql.startsWith('SELECT table_name')));
+  } finally {
+    db.pool.query = origQuery;
+    if (exportPath) {
+      await fs.unlink(exportPath).catch(() => {});
+    }
+  }
+});
+
+await test('exportTenantTableDefaults rejects blank export names', async () => {
+  await assert.rejects(
+    () => db.exportTenantTableDefaults('   '),
+    /export name is required/i,
+  );
+});


### PR DESCRIPTION
## Summary
- add a Save defaults action to the tenant tables registry UI that prompts for an export name, triggers the export, and downloads the SQL snapshot
- implement the export-defaults endpoint and database helper to write tenant default rows for shared/seed tables into timestamped scripts stored under `config/0/defaults`
- cover successful and failing export scenarios with new controller and database tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccf92939a483318a3ca4340371c8cd