### PR TITLE
Add tenant defaults recovery workflow

### DIFF
--- a/api-server/routes/tenant_tables.js
+++ b/api-server/routes/tenant_tables.js
@@ -14,6 +14,8 @@ import {
   insertDefaultTenantRow,
   updateDefaultTenantRow,
   deleteDefaultTenantRow,
+  listDefaultSnapshots,
+  restoreDefaults,
 } from '../controllers/tenantTablesController.js';
 
 const router = express.Router();
@@ -26,6 +28,8 @@ router.get('/:table_name', requireAuth, getTenantTable);
 router.post('/zero-keys', requireAuth, resetSharedTenantKeys);
 router.post('/seed-defaults', requireAuth, seedDefaults);
 router.post('/export-defaults', requireAuth, exportDefaults);
+router.get('/default-snapshots', requireAuth, listDefaultSnapshots);
+router.post('/restore-defaults', requireAuth, restoreDefaults);
 router.post('/seed-companies', requireAuth, seedExistingCompanies);
 router.post('/seed-company', requireAuth, seedCompany);
 router.post('/:table_name/default-rows', requireAuth, insertDefaultTenantRow);

--- a/tests/db/listTenantDefaultSnapshots.test.js
+++ b/tests/db/listTenantDefaultSnapshots.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import path from 'path';
+import * as db from '../../db/index.js';
+
+const defaultsDir = path.join(process.cwd(), 'config', '0', 'defaults');
+
+await test('listTenantDefaultSnapshots returns metadata for stored SQL files', async () => {
+  await fs.mkdir(defaultsDir, { recursive: true });
+  const primaryPath = path.join(defaultsDir, '20240102_baseline.sql');
+  const secondaryPath = path.join(defaultsDir, '20231215_archive.sql');
+  const sharedSql = `-- Tenant table defaults export\n-- Version: Baseline\n-- Generated at: 2024-01-02T12:00:00.000Z\n\nSTART TRANSACTION;\n\n-- Table: shared_defaults\nDELETE FROM \`shared_defaults\` WHERE \`company_id\` = 0;\nINSERT INTO \`shared_defaults\` (\`company_id\`, \`id\`, \`label\`) VALUES ('0', 1, 'Welcome');\n\n-- Table: seed_defaults\nDELETE FROM \`seed_defaults\` WHERE \`company_id\` = 0;\nINSERT INTO \`seed_defaults\` (\`company_id\`, \`code\`) VALUES ('0', 'A');\n\nCOMMIT;\n`;
+  await fs.writeFile(primaryPath, sharedSql, 'utf8');
+  await fs.writeFile(
+    secondaryPath,
+    sharedSql.replace('Baseline', 'Archive').replace('Welcome', 'Legacy'),
+    'utf8',
+  );
+
+  try {
+    const snapshots = await db.listTenantDefaultSnapshots();
+    assert.ok(Array.isArray(snapshots));
+    assert.ok(snapshots.length >= 2);
+    const baseline = snapshots.find((snap) => snap.fileName === '20240102_baseline.sql');
+    assert.ok(baseline, 'baseline snapshot not found');
+    assert.equal(baseline.versionName, 'Baseline');
+    assert.equal(baseline.tableCount, 2);
+    assert.equal(baseline.rowCount, 2);
+    assert.ok(Array.isArray(baseline.tables));
+    const tableNames = baseline.tables.map((t) => t.tableName);
+    assert.ok(tableNames.includes('shared_defaults'));
+    assert.ok(tableNames.includes('seed_defaults'));
+    assert.ok(typeof baseline.generatedAt === 'string');
+  } finally {
+    await fs.unlink(primaryPath).catch(() => {});
+    await fs.unlink(secondaryPath).catch(() => {});
+  }
+});

--- a/tests/db/restoreTenantDefaultSnapshot.test.js
+++ b/tests/db/restoreTenantDefaultSnapshot.test.js
@@ -1,0 +1,99 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import path from 'path';
+import * as db from '../../db/index.js';
+
+const defaultsDir = path.join(process.cwd(), 'config', '0', 'defaults');
+
+await test('restoreTenantDefaultSnapshot runs statements for allowed tables', async () => {
+  await fs.mkdir(defaultsDir, { recursive: true });
+  const fileName = '20240105_restore.sql';
+  const filePath = path.join(defaultsDir, fileName);
+  const sql = `-- Tenant table defaults export\nSTART TRANSACTION;\n-- Table: shared_defaults\nDELETE FROM \`shared_defaults\` WHERE \`company_id\` = 0;\nINSERT INTO \`shared_defaults\` (\`company_id\`, \`id\`, \`label\`) VALUES ('0', 1, 'Hello');\nCOMMIT;\n`;
+  await fs.writeFile(filePath, sql, 'utf8');
+
+  const originalQuery = db.pool.query;
+  const originalGetConnection = db.pool.getConnection;
+  const calls = [];
+  db.pool.query = async (statement) => {
+    calls.push({ type: 'pool', sql: statement });
+    if (/SELECT table_name/.test(statement)) {
+      return [[{ table_name: 'shared_defaults' }]];
+    }
+    return [[]];
+  };
+  const conn = {
+    released: false,
+    async beginTransaction() {
+      calls.push({ type: 'begin' });
+    },
+    async commit() {
+      calls.push({ type: 'commit' });
+    },
+    async rollback() {
+      calls.push({ type: 'rollback' });
+    },
+    release() {
+      this.released = true;
+    },
+    async query(statement) {
+      calls.push({ type: 'exec', sql: statement });
+      if (/DELETE/i.test(statement)) {
+        return [{ affectedRows: 0 }];
+      }
+      if (/INSERT/i.test(statement)) {
+        return [{ affectedRows: 1 }];
+      }
+      return [{}];
+    },
+  };
+  db.pool.getConnection = async () => conn;
+
+  try {
+    const summary = await db.restoreTenantDefaultSnapshot(fileName, 42);
+    assert.equal(summary.fileName, fileName);
+    assert.equal(summary.totalInserted, 1);
+    assert.equal(summary.totalDeleted, 0);
+    assert.ok(Array.isArray(summary.tables));
+    const tableSummary = summary.tables.find((info) => info.tableName === 'shared_defaults');
+    assert.deepEqual(tableSummary, {
+      tableName: 'shared_defaults',
+      deletedRows: 0,
+      insertedRows: 1,
+    });
+    assert.ok(calls.some((entry) => entry.type === 'begin'));
+    assert.ok(calls.some((entry) => entry.type === 'commit'));
+    assert.equal(conn.released, true);
+  } finally {
+    db.pool.query = originalQuery;
+    db.pool.getConnection = originalGetConnection;
+    await fs.unlink(filePath).catch(() => {});
+  }
+});
+
+await test('restoreTenantDefaultSnapshot rejects disallowed tables', async () => {
+  await fs.mkdir(defaultsDir, { recursive: true });
+  const fileName = '20240106_invalid.sql';
+  const filePath = path.join(defaultsDir, fileName);
+  const sql = `-- Tenant table defaults export\nSTART TRANSACTION;\n-- Table: forbidden_defaults\nDELETE FROM \`forbidden_defaults\` WHERE \`company_id\` = 0;\nINSERT INTO \`forbidden_defaults\` (\`company_id\`, \`id\`) VALUES ('0', 1);\nCOMMIT;\n`;
+  await fs.writeFile(filePath, sql, 'utf8');
+
+  const originalQuery = db.pool.query;
+  db.pool.query = async (statement) => {
+    if (/SELECT table_name/.test(statement)) {
+      return [[{ table_name: 'shared_defaults' }]];
+    }
+    return [[]];
+  };
+
+  try {
+    await assert.rejects(
+      () => db.restoreTenantDefaultSnapshot(fileName, 5),
+      /not registered as shared or seed-enabled/i,
+    );
+  } finally {
+    db.pool.query = originalQuery;
+    await fs.unlink(filePath).catch(() => {});
+  }
+});


### PR DESCRIPTION
## Summary
- add database helpers and API endpoints to enumerate stored tenant default snapshots and restore them with safety checks
- extend the tenant tables registry UI with a recover defaults modal that refreshes tenant data after restoration
- cover the snapshot listing and restoration paths with regression tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccfcdb7cec8331afe70bdc6742fd5a