### PR TITLE
Fix tenant table snapshot route order and add test

### DIFF
--- a/api-server/routes/tenantTablesRouterFactory.js
+++ b/api-server/routes/tenantTablesRouterFactory.js
@@ -1,0 +1,60 @@
+export function createTenantTablesRouter({ createRouter, requireAuth, controller }) {
+  if (typeof createRouter !== 'function') {
+    throw new TypeError('createRouter must be a function');
+  }
+  if (typeof requireAuth !== 'function') {
+    throw new TypeError('requireAuth must be a function');
+  }
+  if (!controller || typeof controller !== 'object') {
+    throw new TypeError('controller must be an object');
+  }
+
+  const router = createRouter();
+  if (!router || typeof router !== 'object') {
+    throw new TypeError('createRouter must return a router instance');
+  }
+
+  const {
+    listTenantTables,
+    createTenantTable,
+    updateTenantTable,
+    listTenantTableOptions,
+    getTenantTable,
+    resetSharedTenantKeys,
+    seedDefaults,
+    exportDefaults,
+    seedExistingCompanies,
+    seedCompany,
+    insertDefaultTenantRow,
+    updateDefaultTenantRow,
+    deleteDefaultTenantRow,
+    listDefaultSnapshots,
+    restoreDefaults,
+  } = controller;
+
+  router.get('/', requireAuth, listTenantTables);
+  router.post('/', requireAuth, createTenantTable);
+  router.put('/:table_name', requireAuth, updateTenantTable);
+  router.get('/options', requireAuth, listTenantTableOptions);
+  router.post('/zero-keys', requireAuth, resetSharedTenantKeys);
+  router.post('/seed-defaults', requireAuth, seedDefaults);
+  router.post('/export-defaults', requireAuth, exportDefaults);
+  router.get('/default-snapshots', requireAuth, listDefaultSnapshots);
+  router.post('/restore-defaults', requireAuth, restoreDefaults);
+  router.post('/seed-companies', requireAuth, seedExistingCompanies);
+  router.post('/seed-company', requireAuth, seedCompany);
+  router.get('/:table_name', requireAuth, getTenantTable);
+  router.post('/:table_name/default-rows', requireAuth, insertDefaultTenantRow);
+  router.put(
+    '/:table_name/default-rows/:row_id',
+    requireAuth,
+    updateDefaultTenantRow,
+  );
+  router.delete(
+    '/:table_name/default-rows/:row_id',
+    requireAuth,
+    deleteDefaultTenantRow,
+  );
+
+  return router;
+}

--- a/api-server/routes/tenant_tables.js
+++ b/api-server/routes/tenant_tables.js
@@ -1,47 +1,12 @@
 import express from 'express';
 import { requireAuth } from '../middlewares/auth.js';
-import {
-  listTenantTables,
-  createTenantTable,
-  updateTenantTable,
-  listTenantTableOptions,
-  getTenantTable,
-  resetSharedTenantKeys,
-  seedDefaults,
-  exportDefaults,
-  seedExistingCompanies,
-  seedCompany,
-  insertDefaultTenantRow,
-  updateDefaultTenantRow,
-  deleteDefaultTenantRow,
-  listDefaultSnapshots,
-  restoreDefaults,
-} from '../controllers/tenantTablesController.js';
+import * as tenantTablesController from '../controllers/tenantTablesController.js';
+import { createTenantTablesRouter } from './tenantTablesRouterFactory.js';
 
-const router = express.Router();
-
-router.get('/', requireAuth, listTenantTables);
-router.post('/', requireAuth, createTenantTable);
-router.put('/:table_name', requireAuth, updateTenantTable);
-router.get('/options', requireAuth, listTenantTableOptions);
-router.get('/:table_name', requireAuth, getTenantTable);
-router.post('/zero-keys', requireAuth, resetSharedTenantKeys);
-router.post('/seed-defaults', requireAuth, seedDefaults);
-router.post('/export-defaults', requireAuth, exportDefaults);
-router.get('/default-snapshots', requireAuth, listDefaultSnapshots);
-router.post('/restore-defaults', requireAuth, restoreDefaults);
-router.post('/seed-companies', requireAuth, seedExistingCompanies);
-router.post('/seed-company', requireAuth, seedCompany);
-router.post('/:table_name/default-rows', requireAuth, insertDefaultTenantRow);
-router.put(
-  '/:table_name/default-rows/:row_id',
+const router = createTenantTablesRouter({
+  createRouter: () => express.Router(),
   requireAuth,
-  updateDefaultTenantRow,
-);
-router.delete(
-  '/:table_name/default-rows/:row_id',
-  requireAuth,
-  deleteDefaultTenantRow,
-);
+  controller: tenantTablesController,
+});
 
 export default router;

--- a/tests/api/tenantTablesDefaultSnapshots.test.js
+++ b/tests/api/tenantTablesDefaultSnapshots.test.js
@@ -1,0 +1,163 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createTenantTablesRouter } from '../../api-server/routes/tenantTablesRouterFactory.js';
+
+function splitPath(path) {
+  const trimmed = path.replace(/^\/+|\/+$/g, '');
+  if (!trimmed) return [];
+  return trimmed.split('/');
+}
+
+function matchPath(pattern, actual) {
+  const params = {};
+  const patternParts = splitPath(pattern);
+  const actualParts = splitPath(actual);
+  if (patternParts.length !== actualParts.length) {
+    return null;
+  }
+  for (let i = 0; i < patternParts.length; i += 1) {
+    const part = patternParts[i];
+    const actualPart = actualParts[i];
+    if (part.startsWith(':')) {
+      params[part.slice(1)] = actualPart;
+      continue;
+    }
+    if (part !== actualPart) {
+      return null;
+    }
+  }
+  return params;
+}
+
+class RouterDouble {
+  constructor() {
+    this.routes = [];
+  }
+
+  register(method, path, handlers) {
+    this.routes.push({ method, path, handlers });
+  }
+
+  get(path, ...handlers) {
+    this.register('GET', path, handlers);
+  }
+
+  post(path, ...handlers) {
+    this.register('POST', path, handlers);
+  }
+
+  put(path, ...handlers) {
+    this.register('PUT', path, handlers);
+  }
+
+  delete(path, ...handlers) {
+    this.register('DELETE', path, handlers);
+  }
+
+  async dispatch(method, path, req, res) {
+    for (const route of this.routes) {
+      if (route.method !== method) continue;
+      const params = matchPath(route.path, path);
+      if (!params) continue;
+      req.params = params;
+      let index = -1;
+      const next = async () => {
+        index += 1;
+        const handler = route.handlers[index];
+        if (!handler) return;
+        if (handler.length >= 3) {
+          await handler(req, res, next);
+        } else {
+          await handler(req, res);
+          await next();
+        }
+      };
+      await next();
+      return true;
+    }
+    return false;
+  }
+}
+
+function createResponseDouble() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.headers['content-type'] = 'application/json; charset=utf-8';
+      this.body = payload;
+      return this;
+    },
+    sendStatus(code) {
+      this.statusCode = code;
+      this.body = undefined;
+      return this;
+    },
+  };
+}
+
+function createUnexpectedHandler(name) {
+  return async () => {
+    throw new Error(`Unexpected call to ${name}`);
+  };
+}
+
+test('GET /api/tenant_tables/default-snapshots returns snapshots', async () => {
+  const routerDouble = new RouterDouble();
+  const snapshots = [
+    { fileName: 'tenant-defaults-20240101.json', createdAt: '2024-01-01T00:00:00.000Z' },
+  ];
+  let snapshotCalls = 0;
+  let tableCalls = 0;
+
+  const controller = {
+    listTenantTables: createUnexpectedHandler('listTenantTables'),
+    createTenantTable: createUnexpectedHandler('createTenantTable'),
+    updateTenantTable: createUnexpectedHandler('updateTenantTable'),
+    listTenantTableOptions: createUnexpectedHandler('listTenantTableOptions'),
+    getTenantTable: async (req, res) => {
+      tableCalls += 1;
+      res.status(404).json({ message: 'Table not found' });
+    },
+    resetSharedTenantKeys: createUnexpectedHandler('resetSharedTenantKeys'),
+    seedDefaults: createUnexpectedHandler('seedDefaults'),
+    exportDefaults: createUnexpectedHandler('exportDefaults'),
+    seedExistingCompanies: createUnexpectedHandler('seedExistingCompanies'),
+    seedCompany: createUnexpectedHandler('seedCompany'),
+    insertDefaultTenantRow: createUnexpectedHandler('insertDefaultTenantRow'),
+    updateDefaultTenantRow: createUnexpectedHandler('updateDefaultTenantRow'),
+    deleteDefaultTenantRow: createUnexpectedHandler('deleteDefaultTenantRow'),
+    listDefaultSnapshots: async (req, res) => {
+      snapshotCalls += 1;
+      res.json({ snapshots });
+    },
+    restoreDefaults: createUnexpectedHandler('restoreDefaults'),
+  };
+
+  const router = createTenantTablesRouter({
+    createRouter: () => routerDouble,
+    requireAuth: (req, res, next) => {
+      req.user = { empid: 5, companyId: 0, userLevel: 2 };
+      next();
+    },
+    controller,
+  });
+
+  assert.equal(router, routerDouble);
+
+  const req = { headers: {} };
+  const res = createResponseDouble();
+  const matched = await router.dispatch('GET', '/default-snapshots', req, res);
+
+  assert.equal(matched, true);
+  assert.equal(res.statusCode, 200);
+  assert.ok(res.headers['content-type']?.includes('application/json'));
+  assert.deepEqual(res.body, { snapshots });
+  assert.equal(snapshotCalls, 1);
+  assert.equal(tableCalls, 0);
+});


### PR DESCRIPTION
## Summary
- refactor the tenant tables router to build through a factory so the default-snapshot route is registered ahead of the generic table handler
- cover the default-snapshots endpoint with a focused test harness that confirms it returns the snapshot payload and bypasses the table lookup

## Testing
- npm test -- tests/api/tenantTablesDefaultSnapshots.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cd0343d9f88331868292754ac328c8