### PR TITLE
Add tenant seed backup workflow

### DIFF
--- a/tests/controllers/companyController.test.js
+++ b/tests/controllers/companyController.test.js
@@ -409,7 +409,7 @@ test(
       id: 7,
       title: 'Welcome',
     });
-    assert.equal(seedRes.body?.posts?.count, 1);
+    assert.equal(seedRes.body?.summary?.posts?.count, 1);
     assert.ok(queryMock.mock.calls.length > 0);
   },
 );


### PR DESCRIPTION
## Summary
- prompt for a backup name before seeding defaults or per-company data and surface the last backup in the tenant tables registry
- create tenant seed backups before overwriting data, catalog them per company, and return metadata alongside seeding summaries
- adjust controllers and automated tests to pass backup metadata through the stack and verify backup behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd033d5c208331870cda056ea051ab