### PR TITLE
Add company deletion backups and restore flow

### DIFF
--- a/api-server/controllers/companyController.js
+++ b/api-server/controllers/companyController.js
@@ -5,8 +5,22 @@ import {
   deleteTableRowCascade,
   getEmploymentSession,
   getUserLevelActions,
+  createCompanySeedBackup,
+  listCompanySeedBackupsForUser,
+  restoreCompanySeedBackup,
 } from '../../db/index.js';
 import { hasAction } from '../utils/hasAction.js';
+
+async function hasSystemSettingsAccess(req) {
+  const session =
+    req.session ||
+    (await getEmploymentSession(req.user.empid, req.user.companyId));
+  if (await hasAction(session, 'system_settings')) {
+    return true;
+  }
+  const actions = await getUserLevelActions(req.user.userLevel);
+  return !!actions?.permissions?.system_settings;
+}
 
 export async function listCompaniesHandler(req, res, next) {
   try {
@@ -23,14 +37,8 @@ export async function createCompanyHandler(req, res, next) {
     const body = req.body || {};
     const { seedTables, seedRecords, overwrite = false, ...company } = body;
     company.created_by = req.user.empid;
-    const session =
-      req.session ||
-      (await getEmploymentSession(req.user.empid, req.user.companyId));
-    if (!(await hasAction(session, 'system_settings'))) {
-      const actions = await getUserLevelActions(req.user.userLevel);
-      if (!actions?.permissions?.system_settings) {
-        return res.sendStatus(403);
-      }
+    if (!(await hasSystemSettingsAccess(req))) {
+      return res.sendStatus(403);
     }
     const shouldSeed =
       Object.prototype.hasOwnProperty.call(body, 'seedTables') ||
@@ -58,14 +66,8 @@ export async function updateCompanyHandler(req, res, next) {
     const updates = { ...req.body };
     delete updates.created_by;
     delete updates.created_at;
-    const session =
-      req.session ||
-      (await getEmploymentSession(req.user.empid, req.user.companyId));
-    if (!(await hasAction(session, 'system_settings'))) {
-      const actions = await getUserLevelActions(req.user.userLevel);
-      if (!actions?.permissions?.system_settings) {
-        return res.sendStatus(403);
-      }
+    if (!(await hasSystemSettingsAccess(req))) {
+      return res.sendStatus(403);
     }
     await updateTableRow('companies', req.params.id, updates);
     res.sendStatus(204);
@@ -77,18 +79,126 @@ export async function updateCompanyHandler(req, res, next) {
 export async function deleteCompanyHandler(req, res, next) {
   try {
     res.locals.logTable = 'companies';
-    const session =
-      req.session ||
-      (await getEmploymentSession(req.user.empid, req.user.companyId));
-    if (!(await hasAction(session, 'system_settings'))) {
-      const actions = await getUserLevelActions(req.user.userLevel);
-      if (!actions?.permissions?.system_settings) {
-        return res.sendStatus(403);
-      }
+    if (!(await hasSystemSettingsAccess(req))) {
+      return res.sendStatus(403);
     }
-    await deleteTableRowCascade('companies', req.params.id, req.params.id);
-    res.sendStatus(204);
+    const rawId = req.params.id;
+    const companyId = Number(rawId);
+    if (!Number.isFinite(companyId) || companyId <= 0) {
+      return res.status(400).json({ message: 'A valid company id is required' });
+    }
+
+    const ownedCompanies = await listCompanies(req.user.empid);
+    const company = (ownedCompanies || []).find((c) => Number(c.id) === companyId);
+    if (!company) {
+      return res.status(404).json({ message: 'Company not found' });
+    }
+
+    const createBackup = !!req.body?.createBackup;
+    const backupNameRaw = req.body?.backupName;
+    const trimmedBackupName =
+      typeof backupNameRaw === 'string' ? backupNameRaw.trim() : '';
+    if (createBackup && !trimmedBackupName) {
+      return res
+        .status(400)
+        .json({ message: 'backupName is required when createBackup is true' });
+    }
+
+    let backupMetadata = null;
+    if (createBackup) {
+      backupMetadata = await createCompanySeedBackup(companyId, {
+        backupName: trimmedBackupName,
+        originalBackupName:
+          typeof backupNameRaw === 'string' ? backupNameRaw : trimmedBackupName,
+        requestedBy: req.user?.empid ?? null,
+        companyName:
+          company.name || company.company_name || company.companyName || '',
+      });
+    }
+
+    await deleteTableRowCascade('companies', companyId, companyId);
+    res.status(200).json({
+      backup: backupMetadata || null,
+      company: {
+        id: companyId,
+        name: company.name || company.company_name || company.companyName || '',
+      },
+    });
   } catch (err) {
     res.status(err.status || 500).json({ message: err.message });
+  }
+}
+
+export async function listCompanyBackupsHandler(req, res, next) {
+  try {
+    if (!(await hasSystemSettingsAccess(req))) {
+      return res.sendStatus(403);
+    }
+    const ownedCompanies = await listCompanies(req.user.empid);
+    const backups = await listCompanySeedBackupsForUser(
+      req.user.empid,
+      ownedCompanies,
+    );
+    res.json({ backups });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function restoreCompanyBackupHandler(req, res, next) {
+  try {
+    if (!(await hasSystemSettingsAccess(req))) {
+      return res.sendStatus(403);
+    }
+    const body = req.body || {};
+    const { sourceCompanyId, targetCompanyId, fileName } = body;
+    const sourceId = Number(sourceCompanyId);
+    const targetId = Number(targetCompanyId);
+    if (!Number.isFinite(sourceId) || sourceId <= 0) {
+      return res
+        .status(400)
+        .json({ message: 'sourceCompanyId is required and must be positive' });
+    }
+    if (!Number.isFinite(targetId) || targetId <= 0) {
+      return res
+        .status(400)
+        .json({ message: 'targetCompanyId is required and must be positive' });
+    }
+    if (!fileName || typeof fileName !== 'string') {
+      return res.status(400).json({ message: 'fileName is required' });
+    }
+
+    const ownedCompanies = await listCompanies(req.user.empid);
+    const targetCompany = (ownedCompanies || []).find(
+      (c) => Number(c.id) === targetId,
+    );
+    if (!targetCompany) {
+      return res.status(403).json({ message: 'Target company not found' });
+    }
+
+    const accessibleBackups = await listCompanySeedBackupsForUser(
+      req.user.empid,
+      ownedCompanies,
+    );
+    const hasAccess = accessibleBackups.some(
+      (entry) => entry.companyId === sourceId && entry.fileName === fileName.trim(),
+    );
+    if (!hasAccess) {
+      return res.status(404).json({ message: 'Backup not found' });
+    }
+
+    const summary = await restoreCompanySeedBackup(
+      sourceId,
+      fileName,
+      targetId,
+      req.user?.empid ?? null,
+    );
+    res.json({ summary });
+  } catch (err) {
+    if (err?.status) {
+      res.status(err.status).json({ message: err.message });
+      return;
+    }
+    next(err);
   }
 }

--- a/api-server/routes/companies.js
+++ b/api-server/routes/companies.js
@@ -4,11 +4,15 @@ import {
   createCompanyHandler,
   updateCompanyHandler,
   deleteCompanyHandler,
+  listCompanyBackupsHandler,
+  restoreCompanyBackupHandler,
 } from '../controllers/companyController.js';
 import { requireAuth } from '../middlewares/auth.js';
 
 const router = express.Router();
 router.get('/', requireAuth, listCompaniesHandler);
+router.get('/backups', requireAuth, listCompanyBackupsHandler);
+router.post('/backups/restore', requireAuth, restoreCompanyBackupHandler);
 router.post('/', requireAuth, createCompanyHandler);
 router.put('/:id', requireAuth, updateCompanyHandler);
 router.delete('/:id', requireAuth, deleteCompanyHandler);


### PR DESCRIPTION
## Summary
- add controller support for saving optional backups on deletion plus endpoints to list and restore backups
- extend database utilities to create, enumerate, and restore company seed backups
- enhance the Companies management page with backup prompts and restore controls
- cover backup creation, listing, and restore flows with controller tests

## Testing
- node --test tests/controllers/companyController.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cd0d290f308331acc7f43711cdbc30