### PR TITLE
Fix company backup handlers to use numeric user id

### DIFF
--- a/api-server/controllers/companyController.js
+++ b/api-server/controllers/companyController.js
@@ -110,7 +110,7 @@ export async function deleteCompanyHandler(req, res, next) {
         backupName: trimmedBackupName,
         originalBackupName:
           typeof backupNameRaw === 'string' ? backupNameRaw : trimmedBackupName,
-        requestedBy: req.user?.empid ?? null,
+        requestedBy: req.user?.id ?? null,
         companyName:
           company.name || company.company_name || company.companyName || '',
       });
@@ -135,10 +135,8 @@ export async function listCompanyBackupsHandler(req, res, next) {
       return res.sendStatus(403);
     }
     const ownedCompanies = await listCompanies(req.user.empid);
-    const backups = await listCompanySeedBackupsForUser(
-      req.user.empid,
-      ownedCompanies,
-    );
+    const userId = req.user?.id;
+    const backups = await listCompanySeedBackupsForUser(userId, ownedCompanies);
     res.json({ backups });
   } catch (err) {
     next(err);
@@ -169,6 +167,7 @@ export async function restoreCompanyBackupHandler(req, res, next) {
     }
 
     const ownedCompanies = await listCompanies(req.user.empid);
+    const userId = req.user?.id;
     const targetCompany = (ownedCompanies || []).find(
       (c) => Number(c.id) === targetId,
     );
@@ -177,7 +176,7 @@ export async function restoreCompanyBackupHandler(req, res, next) {
     }
 
     const accessibleBackups = await listCompanySeedBackupsForUser(
-      req.user.empid,
+      userId,
       ownedCompanies,
     );
     const hasAccess = accessibleBackups.some(


### PR DESCRIPTION
## Summary
- ensure company backup create/list/restore handlers use the authenticated user's numeric id when filtering backups and recording the requester
- update company controller tests to exercise backup workflows with alphanumeric employee codes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd1ddbdda08331948377bf86dbcaee