### PR TITLE
Implement tenant full backup and restore flow

### DIFF
--- a/api-server/routes/companies.js
+++ b/api-server/routes/companies.js
@@ -6,6 +6,7 @@ import {
   deleteCompanyHandler,
   listCompanyBackupsHandler,
   restoreCompanyBackupHandler,
+  restoreCompanyFullBackupHandler,
 } from '../controllers/companyController.js';
 import { requireAuth } from '../middlewares/auth.js';
 
@@ -13,6 +14,11 @@ const router = express.Router();
 router.get('/', requireAuth, listCompaniesHandler);
 router.get('/backups', requireAuth, listCompanyBackupsHandler);
 router.post('/backups/restore', requireAuth, restoreCompanyBackupHandler);
+router.post(
+  '/backups/restore/full',
+  requireAuth,
+  restoreCompanyFullBackupHandler,
+);
 router.post('/', requireAuth, createCompanyHandler);
 router.put('/:id', requireAuth, updateCompanyHandler);
 router.delete('/:id', requireAuth, deleteCompanyHandler);

--- a/tests/db/companyFullBackup.test.js
+++ b/tests/db/companyFullBackup.test.js
@@ -1,0 +1,257 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fs } from 'fs';
+import path from 'path';
+import {
+  createCompanyFullBackup,
+  restoreCompanyFullBackup,
+  pool,
+} from '../../db/index.js';
+
+function splitTopLevel(str, delimiter = ',') {
+  const segments = [];
+  let current = '';
+  let depth = 0;
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < str.length; i += 1) {
+    const char = str[i];
+    if (char === '\\') {
+      current += char;
+      if (i + 1 < str.length) {
+        current += str[i + 1];
+        i += 1;
+      }
+      continue;
+    }
+    if (!inDouble && char === "'") {
+      inSingle = !inSingle;
+      current += char;
+      continue;
+    }
+    if (!inSingle && char === '"') {
+      inDouble = !inDouble;
+      current += char;
+      continue;
+    }
+    if (!inSingle && !inDouble) {
+      if (char === '(') {
+        depth += 1;
+      } else if (char === ')') {
+        depth = Math.max(depth - 1, 0);
+      }
+      if (char === delimiter && depth === 0) {
+        segments.push(current.trim());
+        current = '';
+        continue;
+      }
+    }
+    current += char;
+  }
+  if (current.trim()) {
+    segments.push(current.trim());
+  }
+  return segments;
+}
+
+function parseSqlValue(raw) {
+  const trimmed = raw.trim();
+  if (!trimmed || /^NULL$/i.test(trimmed)) return null;
+  if (/^'.*'$/.test(trimmed) || /^".*"$/.test(trimmed)) {
+    const inner = trimmed.slice(1, -1);
+    return inner.replace(/\\'/g, "'").replace(/\\"/g, '"');
+  }
+  const numeric = Number(trimmed);
+  if (!Number.isNaN(numeric)) return numeric;
+  return trimmed;
+}
+
+test('createCompanyFullBackup and restoreCompanyFullBackup round trip', async (t) => {
+  const sourceId = 5;
+  const targetId = 8;
+  const configRoot = path.join(process.cwd(), 'config');
+  await fs.rm(path.join(configRoot, String(sourceId)), { recursive: true, force: true });
+  await fs.rm(path.join(configRoot, String(targetId)), { recursive: true, force: true });
+
+  const dataset = {
+    orders: [
+      { company_id: sourceId, id: 1, amount: 45, note: 'Alpha' },
+      { company_id: targetId, id: 2, amount: 15, note: 'Stale target row' },
+    ],
+    invoices: [
+      { company_id: sourceId, invoice_id: 3, total: 120.5, status: 'open' },
+    ],
+  };
+
+  const columnMap = {
+    orders: ['company_id', 'id', 'amount', 'note'],
+    invoices: ['invoice_id', 'company_id', 'total', 'status'],
+  };
+
+  const originalQuery = pool.query;
+  const originalGetConnection = pool.getConnection;
+  t.after(async () => {
+    pool.query = originalQuery;
+    pool.getConnection = originalGetConnection;
+    await fs.rm(path.join(configRoot, String(sourceId)), { recursive: true, force: true });
+    await fs.rm(path.join(configRoot, String(targetId)), { recursive: true, force: true });
+  });
+
+  pool.query = async (sql, params) => {
+    if (
+      typeof sql === 'string' &&
+      sql.includes('FROM information_schema.COLUMNS') &&
+      sql.includes("COLUMN_NAME = 'company_id'")
+    ) {
+      return [[
+        { tableName: 'orders' },
+        { tableName: 'invoices' },
+      ]];
+    }
+    if (typeof sql === 'string' && sql.startsWith('SELECT COLUMN_NAME')) {
+      const tableName = params?.[0];
+      const cols = columnMap[tableName] || [];
+      return [cols.map((name) => ({ COLUMN_NAME: name }))];
+    }
+    if (typeof sql === 'string' && sql.startsWith('SELECT * FROM ??')) {
+      const [tableName, companyId] = params;
+      const rows = (dataset[tableName] || []).filter(
+        (row) => Number(row.company_id) === Number(companyId),
+      );
+      return [rows.map((row) => ({ ...row }))];
+    }
+    if (
+      typeof sql === 'string' &&
+      sql.includes('FROM information_schema.COLUMNS')
+    ) {
+      // listTableColumnsDetailed or similar isn't used here, return empty
+      return [[]];
+    }
+    return [[]];
+  };
+
+  const executed = [];
+  pool.getConnection = async () => ({
+    beginTransaction: async () => {},
+    commit: async () => {},
+    rollback: async () => {},
+    release: () => {},
+    query: async (statement) => {
+      const trimmed = statement.trim().replace(/;$/, '');
+      executed.push(trimmed);
+      if (/^DELETE\s+FROM/i.test(trimmed)) {
+        const match = trimmed.match(
+          /^DELETE\s+FROM\s+`?([A-Za-z0-9_]+)`?\s+WHERE\s+`?company_id`?\s*=\s*(\d+)$/i,
+        );
+        if (!match) return [{}];
+        const [, tableName, idStr] = match;
+        const companyId = Number(idStr);
+        const before = (dataset[tableName] || []).length;
+        dataset[tableName] = (dataset[tableName] || []).filter(
+          (row) => Number(row.company_id) !== companyId,
+        );
+        const after = dataset[tableName].length;
+        return [{ affectedRows: before - after }];
+      }
+      if (/^INSERT\s+INTO/i.test(trimmed)) {
+        const match = trimmed.match(
+          /^INSERT\s+INTO\s+`?([A-Za-z0-9_]+)`?\s*\(([^)]+)\)\s*VALUES\s*\((.*)\)$/i,
+        );
+        if (!match) return [{}];
+        const [, tableName, columnSegment, valueSegment] = match;
+        const columns = splitTopLevel(columnSegment).map((col) =>
+          col.replace(/`/g, '').trim(),
+        );
+        const values = splitTopLevel(valueSegment).map(parseSqlValue);
+        const record = {};
+        columns.forEach((col, idx) => {
+          record[col] = values[idx];
+        });
+        if (!dataset[tableName]) dataset[tableName] = [];
+        dataset[tableName].push(record);
+        return [{ affectedRows: 1 }];
+      }
+      return [{}];
+    },
+  });
+
+  const sourceOrdersSnapshot = dataset.orders
+    .filter((row) => row.company_id === sourceId)
+    .map((row) => ({ ...row }));
+  const sourceInvoicesSnapshot = dataset.invoices
+    .filter((row) => row.company_id === sourceId)
+    .map((row) => ({ ...row }));
+
+  const entry = await createCompanyFullBackup(sourceId, {
+    backupName: 'all data',
+    requestedBy: 77,
+    companyName: 'SourceCo',
+  });
+
+  assert.equal(entry.type, 'full');
+  assert.equal(entry.companyId, sourceId);
+  assert.equal(entry.tableCount, 2);
+  assert.ok(entry.fileName.endsWith('.sql'));
+
+  const backupFilePath = path.join(
+    configRoot,
+    String(sourceId),
+    'backups',
+    'full-data',
+    entry.fileName,
+  );
+  const backupSql = await fs.readFile(backupFilePath, 'utf8');
+  assert.ok(
+    backupSql.includes(
+      `DELETE FROM \`orders\` WHERE \`company_id\` = ${sourceId};`,
+    ),
+    'backup should delete existing tenant rows',
+  );
+  assert.match(backupSql, /INSERT INTO `orders`/);
+
+  const catalogPath = path.join(
+    configRoot,
+    String(sourceId),
+    'backups',
+    'full-data',
+    'index.json',
+  );
+  const catalogRaw = await fs.readFile(catalogPath, 'utf8');
+  const catalog = JSON.parse(catalogRaw);
+  assert.equal(catalog[0].type, 'full');
+
+  const summary = await restoreCompanyFullBackup(
+    sourceId,
+    entry.fileName,
+    targetId,
+    'EMP-5',
+  );
+
+  assert.equal(summary.type, 'full');
+  assert.equal(summary.sourceCompanyId, sourceId);
+  assert.equal(summary.targetCompanyId, targetId);
+  assert.ok(executed.some((stmt) => stmt.includes('DELETE FROM `orders`')));
+
+  const targetOrders = dataset.orders
+    .filter((row) => row.company_id === targetId)
+    .map((row) => ({ ...row, company_id: sourceId }))
+    .sort((a, b) => a.id - b.id);
+  const normalizedSourceOrders = sourceOrdersSnapshot
+    .map((row) => ({ ...row }))
+    .sort((a, b) => a.id - b.id);
+  assert.deepEqual(targetOrders, normalizedSourceOrders);
+
+  const targetInvoices = dataset.invoices
+    .filter((row) => row.company_id === targetId)
+    .map((row) => ({ ...row, company_id: sourceId }))
+    .sort((a, b) => a.invoice_id - b.invoice_id);
+  const normalizedSourceInvoices = sourceInvoicesSnapshot
+    .map((row) => ({ ...row }))
+    .sort((a, b) => a.invoice_id - b.invoice_id);
+  assert.deepEqual(targetInvoices, normalizedSourceInvoices);
+
+  const staleRows = dataset.orders.filter(
+    (row) => row.company_id === targetId && row.note === 'Stale target row',
+  );
+  assert.equal(staleRows.length, 0);
+});

--- a/tests/pages/Companies.test.js
+++ b/tests/pages/Companies.test.js
@@ -1,0 +1,212 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+if (typeof mock.import !== 'function') {
+  test('Companies page sends full backup payload on delete', { skip: true }, () => {});
+  test('Companies page restores full backups via dedicated endpoint', { skip: true }, () => {});
+} else {
+  const ensureWindow = () => {
+    if (!global.window) global.window = {};
+    if (!global.window.confirm) global.window.confirm = () => true;
+    if (!global.window.prompt) global.window.prompt = () => '';
+    if (!global.window.dispatchEvent) global.window.dispatchEvent = () => {};
+  };
+
+  function createReactStub(states, setters, indexRef) {
+    return {
+      useState(initial) {
+        const idx = indexRef.current;
+        if (states.length <= idx) {
+          states[idx] = initial;
+        }
+        const setter = (value) => {
+          states[idx] = typeof value === 'function' ? value(states[idx]) : value;
+        };
+        setters[idx] = setter;
+        indexRef.current += 1;
+        return [states[idx], setter];
+      },
+      useEffect(fn) {
+        fn();
+      },
+      useMemo(fn) {
+        return fn();
+      },
+      createElement(type, props, ...children) {
+        return { type, props: { ...(props || {}), children } };
+      },
+    };
+  }
+
+  function findNode(node, predicate) {
+    if (!node || typeof node !== 'object') return null;
+    if (predicate(node)) return node;
+    const children = node.props?.children;
+    if (!children) return null;
+    const list = Array.isArray(children) ? children : [children];
+    for (const child of list) {
+      const found = findNode(child, predicate);
+      if (found) return found;
+    }
+    return null;
+  }
+
+  test('Companies page sends full backup payload on delete', async () => {
+    ensureWindow();
+    const fetchCalls = [];
+    const companies = [{ id: 14, name: 'FullCo' }];
+    global.fetch = async (url, options) => {
+      fetchCalls.push({ url, options });
+      if (url === '/api/companies') {
+        return { ok: true, json: async () => companies };
+      }
+      if (url === '/api/companies/backups') {
+        return { ok: true, json: async () => ({ backups: [] }) };
+      }
+      if (url === '/api/companies/14') {
+        return {
+          ok: true,
+          json: async () => ({
+            backup: { type: 'full' },
+            company: { id: 14, name: 'FullCo' },
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    };
+
+    const states = [];
+    const setters = [];
+    const indexRef = { current: 0 };
+    const reactMock = createReactStub(states, setters, indexRef);
+
+    const confirmResponses = [true, true];
+    let confirmIndex = 0;
+    global.window.confirm = () => confirmResponses[confirmIndex++] ?? true;
+    global.window.prompt = () => 'Full export';
+
+    const { default: CompaniesPage } = await mock.import(
+      '../../src/erp.mgt.mn/pages/Companies.jsx',
+      {
+        react: {
+          default: reactMock,
+          useState: reactMock.useState,
+          useEffect: reactMock.useEffect,
+          useMemo: reactMock.useMemo,
+          createElement: reactMock.createElement,
+        },
+        'react-router-dom': { useNavigate: () => () => {} },
+        '../context/ToastContext.jsx': { useToast: () => ({ addToast: () => {} }) },
+        '../hooks/useModules.js': { useModules: () => [] },
+        '../utils/modulePath.js': { default: () => '' },
+      },
+    );
+
+    function render() {
+      indexRef.current = 0;
+      return CompaniesPage();
+    }
+
+    render();
+    await Promise.resolve();
+    const tree = render();
+
+    const deleteButton = findNode(
+      tree,
+      (node) => node.type === 'button' && node.props?.children?.includes('Delete'),
+    );
+    assert.ok(deleteButton, 'Delete button not found');
+    await deleteButton.props.onClick();
+
+    const deleteCall = fetchCalls.find((call) => call.url === '/api/companies/14');
+    assert.ok(deleteCall, 'Delete request not issued');
+    const payload = JSON.parse(deleteCall.options?.body || '{}');
+    assert.equal(payload.backupType, 'full');
+
+    delete global.fetch;
+  });
+
+  test('Companies page restores full backups via dedicated endpoint', async () => {
+    ensureWindow();
+    const fetchCalls = [];
+    const companies = [{ id: 7, name: 'Target' }];
+    const backups = [
+      {
+        fileName: 'full.sql',
+        companyId: 3,
+        type: 'full',
+        companyName: 'Source',
+      },
+    ];
+    global.fetch = async (url, options) => {
+      fetchCalls.push({ url, options });
+      if (url === '/api/companies') {
+        return { ok: true, json: async () => companies };
+      }
+      if (url === '/api/companies/backups') {
+        return { ok: true, json: async () => ({ backups }) };
+      }
+      if (url === '/api/companies/backups/restore/full') {
+        return {
+          ok: true,
+          json: async () => ({ summary: { tables: [{ tableName: 'orders' }] } }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    };
+
+    const states = [];
+    const setters = [];
+    const indexRef = { current: 0 };
+    const reactMock = createReactStub(states, setters, indexRef);
+
+    const { default: CompaniesPage } = await mock.import(
+      '../../src/erp.mgt.mn/pages/Companies.jsx',
+      {
+        react: {
+          default: reactMock,
+          useState: reactMock.useState,
+          useEffect: reactMock.useEffect,
+          useMemo: reactMock.useMemo,
+          createElement: reactMock.createElement,
+        },
+        'react-router-dom': { useNavigate: () => () => {} },
+        '../context/ToastContext.jsx': { useToast: () => ({ addToast: () => {} }) },
+        '../hooks/useModules.js': { useModules: () => [] },
+        '../utils/modulePath.js': { default: () => '' },
+      },
+    );
+
+    function render() {
+      indexRef.current = 0;
+      return CompaniesPage();
+    }
+
+    render();
+    await Promise.resolve();
+    // set backup target selection
+    if (setters[5]) {
+      setters[5]({ 'full.sql': String(companies[0].id) });
+    }
+    const tree = render();
+
+    const restoreButton = findNode(
+      tree,
+      (node) =>
+        node.type === 'button' &&
+        node.props?.children?.includes('Restore') &&
+        node.props?.onClick,
+    );
+    assert.ok(restoreButton, 'Restore button not found');
+    await restoreButton.props.onClick();
+
+    const restoreCall = fetchCalls.find((call) =>
+      call.url === '/api/companies/backups/restore/full',
+    );
+    assert.ok(restoreCall, 'Full restore endpoint not called');
+    const payload = JSON.parse(restoreCall.options?.body || '{}');
+    assert.equal(payload.type, 'full');
+
+    delete global.fetch;
+  });
+}


### PR DESCRIPTION
## Summary
- add full backup creation and restore helpers that dump all tenant tables with a company_id column and reload them safely
- extend company delete and restore handlers plus routes to surface the broader backup capabilities
- update the Companies admin page and add db/controller/page tests covering the new flows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd817686308331be7effd44889cd32