### PR TITLE
Ensure disabled relation display uses case-insensitive fields

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -1052,7 +1052,8 @@ const RowFormModal = function RowFormModal({
         }
         if (parts.length === 0) parts.push(val);
         (cfg.displayFields || []).forEach((df) => {
-          if (row[df] !== undefined) parts.push(row[df]);
+          const fieldVal = getRowValueCaseInsensitive(row, df);
+          if (fieldVal !== undefined) parts.push(fieldVal);
         });
         display = parts.join(' - ');
       } else if (
@@ -1072,7 +1073,8 @@ const RowFormModal = function RowFormModal({
         }
         if (parts.length === 0) parts.push(val);
         (cfg.displayFields || []).forEach((df) => {
-          if (row[df] !== undefined) parts.push(row[df]);
+          const fieldVal = getRowValueCaseInsensitive(row, df);
+          if (fieldVal !== undefined) parts.push(fieldVal);
         });
         display = parts.join(' - ');
       } else if (
@@ -1089,7 +1091,8 @@ const RowFormModal = function RowFormModal({
         }
         if (parts.length === 0) parts.push(val);
         (cfg.displayFields || []).forEach((df) => {
-          if (row[df] !== undefined) parts.push(row[df]);
+          const fieldVal = getRowValueCaseInsensitive(row, df);
+          if (fieldVal !== undefined) parts.push(fieldVal);
         });
         display = parts.join(' - ');
       }

--- a/tests/components/relationIdFieldOverride.test.js
+++ b/tests/components/relationIdFieldOverride.test.js
@@ -295,7 +295,7 @@ if (!haveReact) {
             },
             relationData: {
               other_id: {
-                1: { ID: 1, CODE: 'A123', name: 'Alpha' },
+                1: { ID: 1, CODE: 'A123', NAME: 'Alpha' },
               },
             },
             disabledFields: ['other_id'],


### PR DESCRIPTION
## Summary
- ensure disabled relation display strings use case-insensitive lookups for configured, view, and auto-select relations
- adjust relation display test data so differing column casing still renders descriptive text

## Testing
- node --test tests/components/relationIdFieldOverride.test.js *(skipped: React dependencies unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb7cbf7d1c83319c2f38973cffa2a7