### PR TITLE
Add custom table relations management

### DIFF
--- a/api-server/routes/tables.js
+++ b/api-server/routes/tables.js
@@ -3,6 +3,9 @@ import {
   getTables,
   getTableRows,
   getTableRelations,
+  getCustomTableRelations,
+  upsertCustomTableRelation,
+  deleteCustomTableRelation,
   getTableColumnsMeta,
   saveColumnLabels,
   updateRow,
@@ -16,6 +19,13 @@ const router = express.Router();
 
 router.get('/', requireAuth, getTables);
 // More specific routes must be defined before the generic ':table' pattern
+router.get('/:table/custom-relations', requireAuth, getCustomTableRelations);
+router.put('/:table/custom-relations/:column', requireAuth, upsertCustomTableRelation);
+router.delete(
+  '/:table/custom-relations/:column',
+  requireAuth,
+  deleteCustomTableRelation,
+);
 router.get('/:table/relations', requireAuth, getTableRelations);
 router.get('/:table/columns', requireAuth, getTableColumnsMeta);
 router.put('/:table/labels', requireAuth, saveColumnLabels);

--- a/api-server/services/tableRelationsConfig.js
+++ b/api-server/services/tableRelationsConfig.js
@@ -1,0 +1,56 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { tenantConfigPath, getConfigPath } from '../utils/configPaths.js';
+
+const CONFIG_FILE = 'tableRelations.json';
+
+async function readConfig(companyId = 0) {
+  const { path: filePath, isDefault } = await getConfigPath(CONFIG_FILE, companyId);
+  try {
+    const data = await fs.readFile(filePath, 'utf8');
+    return { cfg: JSON.parse(data), isDefault };
+  } catch {
+    return { cfg: {}, isDefault: true };
+  }
+}
+
+async function writeConfig(cfg, companyId = 0) {
+  const filePath = tenantConfigPath(CONFIG_FILE, companyId);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(cfg, null, 2));
+}
+
+export async function getCustomRelations(table, companyId = 0) {
+  const { cfg, isDefault } = await readConfig(companyId);
+  return { config: cfg[table] || {}, isDefault };
+}
+
+export async function getAllCustomRelations(companyId = 0) {
+  const { cfg, isDefault } = await readConfig(companyId);
+  return { config: cfg, isDefault };
+}
+
+export async function setCustomRelation(table, column, relation, companyId = 0) {
+  if (!table) throw new Error('table is required');
+  if (!column) throw new Error('column is required');
+  const targetTable = relation?.targetTable ? String(relation.targetTable).trim() : '';
+  const targetColumn = relation?.targetColumn ? String(relation.targetColumn).trim() : '';
+  if (!targetTable) throw new Error('targetTable is required');
+  if (!targetColumn) throw new Error('targetColumn is required');
+  const { cfg } = await readConfig(companyId);
+  if (!cfg[table]) cfg[table] = {};
+  cfg[table][column] = { targetTable, targetColumn };
+  await writeConfig(cfg, companyId);
+  return cfg[table][column];
+}
+
+export async function removeCustomRelation(table, column, companyId = 0) {
+  if (!table) throw new Error('table is required');
+  if (!column) throw new Error('column is required');
+  const { cfg } = await readConfig(companyId);
+  if (cfg[table]?.[column]) {
+    delete cfg[table][column];
+    if (Object.keys(cfg[table]).length === 0) delete cfg[table];
+    await writeConfig(cfg, companyId);
+  }
+}

--- a/src/erp.mgt.mn/components/TableRelationsEditor.jsx
+++ b/src/erp.mgt.mn/components/TableRelationsEditor.jsx
@@ -1,0 +1,325 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useToast } from '../context/ToastContext.jsx';
+
+function extractColumnNames(columns) {
+  if (!Array.isArray(columns)) return [];
+  return columns
+    .map((c) => c?.name || c?.COLUMN_NAME || c)
+    .map((name) => String(name || '').trim())
+    .filter((name) => name);
+}
+
+export default function TableRelationsEditor({ table, tables = [] }) {
+  const { addToast } = useToast();
+  const [sourceColumns, setSourceColumns] = useState([]);
+  const [customRelations, setCustomRelations] = useState({});
+  const [selectedColumn, setSelectedColumn] = useState('');
+  const [targetTable, setTargetTable] = useState('');
+  const [targetColumns, setTargetColumns] = useState([]);
+  const [selectedTargetColumn, setSelectedTargetColumn] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const columnCache = useRef(new Map());
+
+  useEffect(() => {
+    if (!table) {
+      setSourceColumns([]);
+      setCustomRelations({});
+      setSelectedColumn('');
+      setTargetTable('');
+      setSelectedTargetColumn('');
+      setTargetColumns([]);
+      return;
+    }
+    let canceled = false;
+    setLoading(true);
+    setSelectedColumn('');
+    setTargetTable('');
+    setSelectedTargetColumn('');
+    setTargetColumns([]);
+    async function load() {
+      const encoded = encodeURIComponent(table);
+      try {
+        const res = await fetch(`/api/tables/${encoded}/columns`, {
+          credentials: 'include',
+        });
+        if (!res.ok) throw new Error('columns');
+        const cols = await res.json().catch(() => []);
+        if (canceled) return;
+        const names = extractColumnNames(cols);
+        setSourceColumns(names);
+        columnCache.current.set(table, names);
+      } catch (err) {
+        if (canceled) return;
+        setSourceColumns([]);
+        addToast('Failed to load table columns', 'error');
+      }
+      try {
+        const res = await fetch(`/api/tables/${encoded}/custom-relations`, {
+          credentials: 'include',
+        });
+        if (!res.ok) throw new Error('relations');
+        const data = await res.json().catch(() => ({}));
+        if (canceled) return;
+        const relations =
+          data && typeof data === 'object' && !Array.isArray(data)
+            ? data.relations ?? data
+            : {};
+        setCustomRelations(relations && typeof relations === 'object' ? relations : {});
+      } catch (err) {
+        if (canceled) return;
+        setCustomRelations({});
+        addToast('Failed to load custom relations', 'error');
+      } finally {
+        if (!canceled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      canceled = true;
+    };
+  }, [table, addToast]);
+
+  useEffect(() => {
+    if (!targetTable) {
+      setTargetColumns([]);
+      setSelectedTargetColumn('');
+      return;
+    }
+    let canceled = false;
+    async function loadTarget() {
+      if (columnCache.current.has(targetTable)) {
+        const cached = columnCache.current.get(targetTable) || [];
+        if (!canceled) {
+          setTargetColumns(cached);
+          setSelectedTargetColumn((current) =>
+            cached.includes(current) ? current : '',
+          );
+        }
+        return;
+      }
+      try {
+        const res = await fetch(
+          `/api/tables/${encodeURIComponent(targetTable)}/columns`,
+          { credentials: 'include' },
+        );
+        if (!res.ok) throw new Error('columns');
+        const cols = await res.json().catch(() => []);
+        if (canceled) return;
+        const names = extractColumnNames(cols);
+        columnCache.current.set(targetTable, names);
+        setTargetColumns(names);
+        setSelectedTargetColumn((current) =>
+          names.includes(current) ? current : '',
+        );
+      } catch (err) {
+        if (canceled) return;
+        setTargetColumns([]);
+        setSelectedTargetColumn('');
+        addToast('Failed to load target columns', 'error');
+      }
+    }
+    loadTarget();
+    return () => {
+      canceled = true;
+    };
+  }, [targetTable, addToast]);
+
+  const relationEntries = useMemo(
+    () =>
+      Object.entries(customRelations || {})
+        .filter(([column, rel]) => column && rel?.targetTable && rel?.targetColumn)
+        .sort(([a], [b]) => a.localeCompare(b)),
+    [customRelations],
+  );
+
+  async function handleSave(e) {
+    e?.preventDefault?.();
+    if (!table) {
+      addToast('Please select a table first', 'error');
+      return;
+    }
+    if (!selectedColumn) {
+      addToast('Please choose a source column', 'error');
+      return;
+    }
+    if (!targetTable) {
+      addToast('Please choose a target table', 'error');
+      return;
+    }
+    if (!selectedTargetColumn) {
+      addToast('Please choose a target column', 'error');
+      return;
+    }
+    setSaving(true);
+    try {
+      const res = await fetch(
+        `/api/tables/${encodeURIComponent(table)}/custom-relations/${encodeURIComponent(
+          selectedColumn,
+        )}`,
+        {
+          method: 'PUT',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            targetTable,
+            targetColumn: selectedTargetColumn,
+          }),
+        },
+      );
+      if (!res.ok) throw new Error('failed');
+      let saved;
+      try {
+        saved = await res.json();
+      } catch {
+        saved = null;
+      }
+      setCustomRelations((prev) => ({
+        ...prev,
+        [selectedColumn]: {
+          targetTable: saved?.targetTable || targetTable,
+          targetColumn: saved?.targetColumn || selectedTargetColumn,
+        },
+      }));
+      addToast('Relation saved', 'success');
+    } catch (err) {
+      addToast('Failed to save relation', 'error');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(column) {
+    if (!table || !column) return;
+    if (typeof window !== 'undefined' && window.confirm) {
+      const confirmed = window.confirm('Delete this custom relation?');
+      if (!confirmed) return;
+    }
+    try {
+      const res = await fetch(
+        `/api/tables/${encodeURIComponent(table)}/custom-relations/${encodeURIComponent(
+          column,
+        )}`,
+        {
+          method: 'DELETE',
+          credentials: 'include',
+        },
+      );
+      if (!res.ok) throw new Error('failed');
+      setCustomRelations((prev) => {
+        const next = { ...prev };
+        delete next[column];
+        return next;
+      });
+      addToast('Relation removed', 'success');
+    } catch (err) {
+      addToast('Failed to remove relation', 'error');
+    }
+  }
+
+  if (!table) {
+    return <p style={{ marginTop: '1rem' }}>Select a table to manage relations.</p>;
+  }
+
+  return (
+    <div style={{ marginTop: '1rem' }}>
+      {loading && <p>Loading relations…</p>}
+      <form onSubmit={handleSave} style={{ marginBottom: '1rem' }}>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <label>
+            Source column:{' '}
+            <select
+              value={selectedColumn}
+              onChange={(e) => setSelectedColumn(e.target.value)}
+              disabled={saving || sourceColumns.length === 0}
+            >
+              <option value="">-- select column --</option>
+              {sourceColumns.map((col) => (
+                <option key={col} value={col}>
+                  {col}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <label>
+            Target table:{' '}
+            <select
+              value={targetTable}
+              onChange={(e) => setTargetTable(e.target.value)}
+              disabled={saving}
+            >
+              <option value="">-- select table --</option>
+              {tables
+                .filter((t) => t !== table)
+                .map((tbl) => (
+                  <option key={tbl} value={tbl}>
+                    {tbl}
+                  </option>
+                ))}
+            </select>
+          </label>
+        </div>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <label>
+            Target column:{' '}
+            <select
+              value={selectedTargetColumn}
+              onChange={(e) => setSelectedTargetColumn(e.target.value)}
+              disabled={saving || !targetTable || targetColumns.length === 0}
+            >
+              <option value="">-- select column --</option>
+              {targetColumns.map((col) => (
+                <option key={col} value={col}>
+                  {col}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <button type="submit" disabled={saving}>
+          {saving ? 'Saving…' : 'Save relation'}
+        </button>
+      </form>
+      <div>
+        <h3>Custom relations</h3>
+        {relationEntries.length === 0 ? (
+          <p>No custom relations configured.</p>
+        ) : (
+          <table
+            style={{ borderCollapse: 'collapse', minWidth: '300px' }}
+            data-testid="custom-relations-table"
+          >
+            <thead>
+              <tr>
+                <th style={{ borderBottom: '1px solid #d1d5db', textAlign: 'left' }}>
+                  Source column
+                </th>
+                <th style={{ borderBottom: '1px solid #d1d5db', textAlign: 'left' }}>
+                  Target
+                </th>
+                <th style={{ borderBottom: '1px solid #d1d5db' }}>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {relationEntries.map(([column, rel]) => (
+                <tr key={column}>
+                  <td style={{ padding: '0.25rem 0.5rem' }}>{column}</td>
+                  <td style={{ padding: '0.25rem 0.5rem' }}>
+                    {rel.targetTable}.{rel.targetColumn}
+                  </td>
+                  <td style={{ padding: '0.25rem 0.5rem' }}>
+                    <button type="button" onClick={() => handleDelete(column)}>
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/erp.mgt.mn/pages/TablesManagement.jsx
+++ b/src/erp.mgt.mn/pages/TablesManagement.jsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import TableManager from '../components/TableManager.jsx';
+import TableRelationsEditor from '../components/TableRelationsEditor.jsx';
 import useButtonPerms from '../hooks/useButtonPerms.js';
 
 export default function TablesManagement() {
   const [tables, setTables] = useState([]);
   const [selectedTable, setSelectedTable] = useState('');
   const [refreshId, setRefreshId] = useState(0);
+  const [activeTab, setActiveTab] = useState('data');
   const buttonPerms = useButtonPerms();
 
   const loadTables = async () => {
@@ -30,25 +32,66 @@ export default function TablesManagement() {
     loadTables();
   }, []);
 
+  const tabButtonStyle = {
+    padding: '0.5rem 1rem',
+    border: '1px solid #d1d5db',
+    backgroundColor: '#f9fafb',
+    cursor: 'pointer',
+    marginRight: '0.5rem',
+  };
+
   return (
     <div>
       <h2>Dynamic Tables</h2>
-      <select value={selectedTable} onChange={(e) => setSelectedTable(e.target.value)}>
-        <option value="">-- select table --</option>
-        {tables.map((t) => (
-          <option key={t} value={t}>
-            {t}
-          </option>
-        ))}
-      </select>
-      <button onClick={loadTables} style={{ marginLeft: '0.5rem' }}>Refresh List</button>
-      {selectedTable && (
+      <div style={{ marginBottom: '0.5rem' }}>
+        <button
+          type="button"
+          onClick={() => setActiveTab('data')}
+          style={{
+            ...tabButtonStyle,
+            backgroundColor: activeTab === 'data' ? '#e5e7eb' : tabButtonStyle.backgroundColor,
+          }}
+        >
+          Data
+        </button>
+        <button
+          type="button"
+          onClick={() => setActiveTab('relations')}
+          style={{
+            ...tabButtonStyle,
+            backgroundColor:
+              activeTab === 'relations' ? '#e5e7eb' : tabButtonStyle.backgroundColor,
+          }}
+        >
+          Relations
+        </button>
+      </div>
+      <div style={{ marginBottom: '0.5rem' }}>
+        <select value={selectedTable} onChange={(e) => setSelectedTable(e.target.value)}>
+          <option value="">-- select table --</option>
+          {tables.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+        <button onClick={loadTables} style={{ marginLeft: '0.5rem' }}>
+          Refresh List
+        </button>
+      </div>
+      {activeTab === 'data' && selectedTable && (
         <TableManager
           table={selectedTable}
           refreshId={refreshId}
           buttonPerms={buttonPerms}
           autoFillSession={false}
         />
+      )}
+      {activeTab === 'data' && !selectedTable && (
+        <p>Select a table to view data.</p>
+      )}
+      {activeTab === 'relations' && (
+        <TableRelationsEditor table={selectedTable} tables={tables} />
       )}
     </div>
   );

--- a/tests/components/TableRelationsEditor.test.jsx
+++ b/tests/components/TableRelationsEditor.test.jsx
@@ -1,0 +1,208 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+if (!global.document) {
+  global.document = { createElement: () => ({}) };
+} else if (!global.document.createElement) {
+  global.document.createElement = () => ({});
+}
+
+if (!global.window) {
+  global.window = {};
+}
+if (!global.window.addEventListener) global.window.addEventListener = () => {};
+if (!global.window.removeEventListener) global.window.removeEventListener = () => {};
+if (!global.window.confirm) global.window.confirm = () => true;
+
+let React;
+let act;
+let createRoot;
+let haveReact = true;
+try {
+  const reactMod = await import('react');
+  React = reactMod.default || reactMod;
+  ({ act } = await import('react-dom/test-utils'));
+  ({ createRoot } = await import('react-dom/client'));
+} catch {
+  haveReact = false;
+}
+
+if (!haveReact) {
+  test('TableRelationsEditor loads relations', { skip: true }, () => {});
+  test('TableRelationsEditor saves and deletes relations', { skip: true }, () => {});
+} else {
+  test('TableRelationsEditor loads relations', async (t) => {
+    const origFetch = global.fetch;
+    const toasts = [];
+    global.fetch = async (input) => {
+      const url = typeof input === 'string' ? input : input?.url || '';
+      if (url === '/api/tables/orders/columns') {
+        return {
+          ok: true,
+          json: async () => [{ name: 'id' }, { name: 'user_id' }],
+        };
+      }
+      if (url === '/api/tables/orders/custom-relations') {
+        return {
+          ok: true,
+          json: async () => ({
+            relations: { user_id: { targetTable: 'users', targetColumn: 'id' } },
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    };
+
+    try {
+      const { default: TableRelationsEditor } = await t.mock.import(
+        '../../src/erp.mgt.mn/components/TableRelationsEditor.jsx',
+        {
+          '../context/ToastContext.jsx': {
+            useToast: () => ({ addToast: (msg, type) => toasts.push({ msg, type }) }),
+          },
+        },
+      );
+
+      const container = document.createElement('div');
+      const root = createRoot(container);
+      await act(async () => {
+        root.render(
+          React.createElement(TableRelationsEditor, {
+            table: 'orders',
+            tables: ['orders', 'users'],
+          }),
+        );
+      });
+      for (let i = 0; i < 5; i += 1) {
+        if (container.querySelector('[data-testid="custom-relations-table"]')) break;
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      const options = Array.from(container.querySelectorAll('select option')).map(
+        (opt) => opt.value,
+      );
+      assert.ok(options.includes('user_id'));
+      const tableText = container.textContent || '';
+      assert.match(tableText, /user_id/);
+      assert.match(tableText, /users\.id/);
+      root.unmount();
+    } finally {
+      global.fetch = origFetch;
+    }
+  });
+
+  test('TableRelationsEditor saves and deletes relations', async (t) => {
+    const origFetch = global.fetch;
+    const toasts = [];
+    const fetchCalls = [];
+    global.fetch = async (input, options = {}) => {
+      const url = typeof input === 'string' ? input : input?.url || '';
+      const method = options?.method || 'GET';
+      fetchCalls.push({ url, method, body: options?.body });
+      if (url === '/api/tables/orders/columns') {
+        return {
+          ok: true,
+          json: async () => [{ name: 'user_id' }, { name: 'company_id' }],
+        };
+      }
+      if (url === '/api/tables/orders/custom-relations') {
+        return { ok: true, json: async () => ({ relations: {} }) };
+      }
+      if (url === '/api/tables/users/columns') {
+        return { ok: true, json: async () => [{ name: 'id' }, { name: 'email' }] };
+      }
+      if (
+        url === '/api/tables/orders/custom-relations/user_id' &&
+        method === 'PUT'
+      ) {
+        return {
+          ok: true,
+          json: async () => ({ targetTable: 'users', targetColumn: 'id' }),
+        };
+      }
+      if (
+        url === '/api/tables/orders/custom-relations/user_id' &&
+        method === 'DELETE'
+      ) {
+        return { ok: true, json: async () => ({}) };
+      }
+      return { ok: true, json: async () => ({}) };
+    };
+
+    try {
+      const { default: TableRelationsEditor } = await t.mock.import(
+        '../../src/erp.mgt.mn/components/TableRelationsEditor.jsx',
+        {
+          '../context/ToastContext.jsx': {
+            useToast: () => ({ addToast: (msg, type) => toasts.push({ msg, type }) }),
+          },
+        },
+      );
+
+      const container = document.createElement('div');
+      const root = createRoot(container);
+      await act(async () => {
+        root.render(
+          React.createElement(TableRelationsEditor, {
+            table: 'orders',
+            tables: ['orders', 'users'],
+          }),
+        );
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const selects = container.querySelectorAll('select');
+      assert.equal(selects.length, 3);
+      await act(async () => {
+        selects[0].value = 'user_id';
+        selects[0].dispatchEvent(new Event('change', { bubbles: true }));
+      });
+      await act(async () => {
+        selects[1].value = 'users';
+        selects[1].dispatchEvent(new Event('change', { bubbles: true }));
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await act(async () => {
+        selects[2].value = 'id';
+        selects[2].dispatchEvent(new Event('change', { bubbles: true }));
+      });
+      const saveBtn = container.querySelector('button[type="submit"]');
+      await act(async () => {
+        saveBtn.dispatchEvent(new Event('click', { bubbles: true }));
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      assert.ok(
+        fetchCalls.some(
+          (c) =>
+            c.url === '/api/tables/orders/custom-relations/user_id' &&
+            c.method === 'PUT' &&
+            typeof c.body === 'string' &&
+            c.body.includes('"targetTable":"users"'),
+        ),
+      );
+      assert.ok(toasts.some((t) => t.msg === 'Relation saved' && t.type === 'success'));
+      let tableText = container.textContent || '';
+      assert.match(tableText, /users\.id/);
+
+      const deleteBtn = container.querySelector('table button');
+      await act(async () => {
+        deleteBtn.dispatchEvent(new Event('click', { bubbles: true }));
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      assert.ok(
+        fetchCalls.some(
+          (c) =>
+            c.url === '/api/tables/orders/custom-relations/user_id' &&
+            c.method === 'DELETE',
+        ),
+      );
+      assert.ok(
+        toasts.some((t) => t.msg === 'Relation removed' && t.type === 'success'),
+      );
+      tableText = container.textContent || '';
+      assert.match(tableText, /No custom relations configured/);
+      root.unmount();
+    } finally {
+      global.fetch = origFetch;
+    }
+  });
+}

--- a/tests/services/tableRelationsConfig.test.js
+++ b/tests/services/tableRelationsConfig.test.js
@@ -1,0 +1,132 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import path from 'path';
+import {
+  getCustomRelations,
+  getAllCustomRelations,
+  setCustomRelation,
+  removeCustomRelation,
+} from '../../api-server/services/tableRelationsConfig.js';
+import { tenantConfigPath } from '../../api-server/utils/configPaths.js';
+
+function withTempFile(companyId = 0) {
+  const file = tenantConfigPath('tableRelations.json', companyId);
+  return fs
+    .readFile(file, 'utf8')
+    .then((orig) => ({
+      file,
+      restore: () => fs.writeFile(file, orig),
+      existed: true,
+    }))
+    .catch(() => ({
+      file,
+      restore: () => fs.rm(file, { force: true }),
+      existed: false,
+    }));
+}
+
+await test('getCustomRelations returns empty config when file missing', async () => {
+  const { restore } = await withTempFile();
+  await fs.rm(tenantConfigPath('tableRelations.json', 0), { force: true });
+  const { config, isDefault } = await getCustomRelations('orders');
+  assert.deepEqual(config, {});
+  assert.equal(isDefault, true);
+  await restore();
+});
+
+await test('setCustomRelation validates target fields', async () => {
+  const { file, restore } = await withTempFile();
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, '{}');
+  await assert.rejects(() =>
+    setCustomRelation('tbl', 'col', { targetColumn: 'id' }),
+  );
+  await assert.rejects(() =>
+    setCustomRelation('tbl', 'col', { targetTable: 'users' }),
+  );
+  await restore();
+});
+
+await test('setCustomRelation stores relation keyed by column', async () => {
+  const { file, restore } = await withTempFile();
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, '{}');
+  await setCustomRelation('orders', 'user_id', {
+    targetTable: 'users',
+    targetColumn: 'id',
+  });
+  const { config } = await getCustomRelations('orders');
+  assert.deepEqual(config, {
+    user_id: { targetTable: 'users', targetColumn: 'id' },
+  });
+  await restore();
+});
+
+await test('removeCustomRelation deletes the entry and prunes empty tables', async () => {
+  const { file, restore } = await withTempFile();
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(
+    file,
+    JSON.stringify(
+      {
+        orders: {
+          user_id: { targetTable: 'users', targetColumn: 'id' },
+          company_id: { targetTable: 'companies', targetColumn: 'id' },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  await removeCustomRelation('orders', 'user_id');
+  let stored = JSON.parse(await fs.readFile(file, 'utf8'));
+  assert.deepEqual(stored, {
+    orders: { company_id: { targetTable: 'companies', targetColumn: 'id' } },
+  });
+  await removeCustomRelation('orders', 'company_id');
+  stored = JSON.parse(await fs.readFile(file, 'utf8'));
+  assert.deepEqual(stored, {});
+  await restore();
+});
+
+await test('tenant-specific relations do not affect base company', async () => {
+  const base = await withTempFile(0);
+  const tenant = await withTempFile(5);
+  await fs.mkdir(path.dirname(base.file), { recursive: true });
+  await fs.writeFile(base.file, '{}');
+  await setCustomRelation(
+    'orders',
+    'user_id',
+    { targetTable: 'users', targetColumn: 'id' },
+    5,
+  );
+  const cfg0 = JSON.parse(await fs.readFile(base.file, 'utf8'));
+  const cfg5 = JSON.parse(await fs.readFile(tenant.file, 'utf8'));
+  assert.deepEqual(cfg0, {});
+  assert.deepEqual(cfg5, {
+    orders: { user_id: { targetTable: 'users', targetColumn: 'id' } },
+  });
+  await base.restore();
+  await tenant.restore();
+});
+
+await test('getAllCustomRelations returns entire config map', async () => {
+  const { file, restore } = await withTempFile();
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(
+    file,
+    JSON.stringify(
+      {
+        orders: { user_id: { targetTable: 'users', targetColumn: 'id' } },
+      },
+      null,
+      2,
+    ),
+  );
+  const { config } = await getAllCustomRelations();
+  assert.deepEqual(config, {
+    orders: { user_id: { targetTable: 'users', targetColumn: 'id' } },
+  });
+  await restore();
+});


### PR DESCRIPTION
## Summary
- add a JSON-backed table relations service with CRUD helpers and integrate it into the tables controller
- expose API endpoints for custom table relations and update Tables Management with a relations editor tab
- expand test coverage for the new service, controller logic, React component, and tighten manual translation loading to avoid race conditions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf7eea96848331bba4c8507cae8507