### PR TITLE
Disable save without required relation selections

### DIFF
--- a/src/erp.mgt.mn/components/TableRelationsEditor.jsx
+++ b/src/erp.mgt.mn/components/TableRelationsEditor.jsx
@@ -52,6 +52,18 @@ export default function TableRelationsEditor({ table }) {
   const hasCustomSelection = Boolean(
     selectedColumn && customRelations?.[selectedColumn],
   );
+  const canSave = useMemo(
+    () => Boolean(selectedColumn && targetTable && targetColumn),
+    [selectedColumn, targetTable, targetColumn],
+  );
+  const selectionHint = useMemo(() => {
+    if (canSave) return '';
+    if (!selectedColumn) return 'Select a source column to get started.';
+    if (!targetTable) return 'Choose the target table for the relationship.';
+    if (!targetColumn)
+      return 'Pick a column from the target table to finish the mapping.';
+    return '';
+  }, [canSave, selectedColumn, targetColumn, targetTable]);
 
   const loadData = useCallback(async () => {
     if (!table) {
@@ -376,12 +388,27 @@ export default function TableRelationsEditor({ table }) {
                 </select>
               </label>
             </div>
+            {selectionHint && (
+              <p
+                style={{
+                  margin: '0 0 0.5rem',
+                  color: '#555',
+                  fontSize: '0.85rem',
+                }}
+              >
+                {selectionHint}
+              </p>
+            )}
             <div style={{ display: 'flex', gap: '0.5rem' }}>
               <button
                 type="button"
                 data-testid="relations-save"
                 onClick={handleSave}
-                disabled={saving}
+                disabled={saving || !canSave}
+                style={{
+                  opacity: saving || !canSave ? 0.6 : 1,
+                  cursor: saving || !canSave ? 'not-allowed' : 'pointer',
+                }}
               >
                 {saving ? 'Saving…' : 'Save Relation'}
               </button>


### PR DESCRIPTION
## Summary
- derive a memoized flag indicating when a relation is ready to save
- show inline guidance and disable the save button until selections are complete

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfa67ce5d08331ad52142f9039d15b