### PR TITLE
Integrate i18n for user menu texts

### DIFF
--- a/src/erp.mgt.mn/components/LogoutButton.jsx
+++ b/src/erp.mgt.mn/components/LogoutButton.jsx
@@ -2,9 +2,11 @@
 import { useContext } from 'react';
 import { useAuth } from '../hooks/useAuth.jsx';    // <-- import the hook, not `logout` directly
 import { AuthContext } from '../context/AuthContext.jsx';
+import I18nContext from '../context/I18nContext.jsx';
 
 export default function LogoutButton() {
   const { user, setUser } = useContext(AuthContext);
+  const { t } = useContext(I18nContext);
 
   // Destructure `logout` from the hook:
   const { logout } = useAuth();
@@ -20,9 +22,5 @@ export default function LogoutButton() {
 
   if (!user) return null;
 
-  return (
-    <button onClick={handleLogout}>
-      Logout
-    </button>
-  );
+  return <button onClick={handleLogout}>{t('logout', 'Logout')}</button>;
 }

--- a/src/erp.mgt.mn/components/UserMenu.jsx
+++ b/src/erp.mgt.mn/components/UserMenu.jsx
@@ -1,11 +1,13 @@
 import React, { useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext.jsx';
+import I18nContext from '../context/I18nContext.jsx';
 
 export default function UserMenu({ user, onLogout, onResetGuide }) {
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
   const { session } = useContext(AuthContext);
+  const { t } = useContext(I18nContext);
 
   if (!user) return null;
 
@@ -31,7 +33,7 @@ export default function UserMenu({ user, onLogout, onResetGuide }) {
       {open && (
         <div style={styles.menu}>
           <button style={styles.menuItem} onClick={handleChangePassword}>
-            Нууц үг солих
+            {t('userMenu.changePassword', 'Change password')}
           </button>
           <button
             style={styles.menuItem}
@@ -40,9 +42,11 @@ export default function UserMenu({ user, onLogout, onResetGuide }) {
               onResetGuide && onResetGuide();
             }}
           >
-            Show page guide
+            {t('userMenu.showPageGuide', 'Show page guide')}
           </button>
-          <button style={styles.menuItem} onClick={handleLogout}>Гарах</button>
+          <button style={styles.menuItem} onClick={handleLogout}>
+            {t('logout', 'Logout')}
+          </button>
         </div>
       )}
     </div>

--- a/src/erp.mgt.mn/components/UserProfile.jsx
+++ b/src/erp.mgt.mn/components/UserProfile.jsx
@@ -1,12 +1,14 @@
 import { useContext } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
+import I18nContext from '../context/I18nContext.jsx';
 
 export default function UserProfile() {
   const { user, session } = useContext(AuthContext);
+  const { t } = useContext(I18nContext);
   if (!user) return null;
   return (
     <div>
-      Logged in as: {session?.employee_name || user.empid}
+      {t('userProfile.loggedInAs', 'Logged in as')}: {session?.employee_name || user.empid}
       {session?.employee_name && ` (${user.empid})`}
       {session?.company_name && ` - ${session.company_name}`}
       {session?.department_name && ` - ${session.department_name}`}

--- a/src/erp.mgt.mn/locales/en.json
+++ b/src/erp.mgt.mn/locales/en.json
@@ -829,5 +829,9 @@
   "close": "Close",
   "cancel": "Cancel",
   "prev": "Prev",
-  "next": "Next"
+  "next": "Next",
+  "logout": "Logout",
+  "userMenu.changePassword": "Change password",
+  "userMenu.showPageGuide": "Show page guide",
+  "userProfile.loggedInAs": "Logged in as"
 }

--- a/src/erp.mgt.mn/locales/mn.json
+++ b/src/erp.mgt.mn/locales/mn.json
@@ -829,5 +829,9 @@
   "close": "Close",
   "cancel": "Cancel",
   "prev": "Prev",
-  "next": "Next"
+  "next": "Next",
+  "logout": "Гарах",
+  "userMenu.changePassword": "Нууц үг солих",
+  "userMenu.showPageGuide": "Show page guide",
+  "userProfile.loggedInAs": "Logged in as"
 }


### PR DESCRIPTION
## Summary
- switch the user menu, logout button, and user profile header to pull labels from the i18n context
- add translation keys for the updated labels so they can be exported

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfabef5cec833187e80e2ec48a2158