### PR TITLE
Localize user menu and profile labels

### DIFF
--- a/src/erp.mgt.mn/components/LogoutButton.jsx
+++ b/src/erp.mgt.mn/components/LogoutButton.jsx
@@ -2,9 +2,11 @@
 import { useContext } from 'react';
 import { useAuth } from '../hooks/useAuth.jsx';    // <-- import the hook, not `logout` directly
 import { AuthContext } from '../context/AuthContext.jsx';
+import I18nContext from '../context/I18nContext.jsx';
 
 export default function LogoutButton() {
   const { user, setUser } = useContext(AuthContext);
+  const { t } = useContext(I18nContext);
 
   // Destructure `logout` from the hook:
   const { logout } = useAuth();
@@ -22,7 +24,7 @@ export default function LogoutButton() {
 
   return (
     <button onClick={handleLogout}>
-      Logout
+      {t('logout', 'Logout')}
     </button>
   );
 }

--- a/src/erp.mgt.mn/components/UserMenu.jsx
+++ b/src/erp.mgt.mn/components/UserMenu.jsx
@@ -1,11 +1,13 @@
 import React, { useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext.jsx';
+import I18nContext from '../context/I18nContext.jsx';
 
 export default function UserMenu({ user, onLogout, onResetGuide }) {
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
   const { session } = useContext(AuthContext);
+  const { t } = useContext(I18nContext);
 
   if (!user) return null;
 
@@ -31,7 +33,7 @@ export default function UserMenu({ user, onLogout, onResetGuide }) {
       {open && (
         <div style={styles.menu}>
           <button style={styles.menuItem} onClick={handleChangePassword}>
-            Нууц үг солих
+            {t('userMenu.changePassword', 'Нууц үг солих')}
           </button>
           <button
             style={styles.menuItem}
@@ -40,9 +42,11 @@ export default function UserMenu({ user, onLogout, onResetGuide }) {
               onResetGuide && onResetGuide();
             }}
           >
-            Show page guide
+            {t('userMenu.showPageGuide', 'Show page guide')}
           </button>
-          <button style={styles.menuItem} onClick={handleLogout}>Гарах</button>
+          <button style={styles.menuItem} onClick={handleLogout}>
+            {t('userMenu.logout', 'Гарах')}
+          </button>
         </div>
       )}
     </div>

--- a/src/erp.mgt.mn/components/UserProfile.jsx
+++ b/src/erp.mgt.mn/components/UserProfile.jsx
@@ -1,17 +1,52 @@
 import { useContext } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
+import I18nContext from '../context/I18nContext.jsx';
 
 export default function UserProfile() {
   const { user, session } = useContext(AuthContext);
+  const { t } = useContext(I18nContext);
+
+  const loggedInAs = t('userProfile.loggedInAs', 'Logged in as:');
+  const employeeIdPrefix = t('userProfile.employeeIdPrefix', ' (');
+  const employeeIdSuffix = t('userProfile.employeeIdSuffix', ')');
+  const detailSeparator = t('userProfile.detailSeparator', ' - ');
+
   if (!user) return null;
   return (
     <div>
-      Logged in as: {session?.employee_name || user.empid}
-      {session?.employee_name && ` (${user.empid})`}
-      {session?.company_name && ` - ${session.company_name}`}
-      {session?.department_name && ` - ${session.department_name}`}
-      {session?.branch_name && ` - ${session.branch_name}`}
-      {session?.user_level_name && ` - ${session.user_level_name}`}
+      {loggedInAs}{' '}
+      {session?.employee_name || user.empid}
+      {session?.employee_name && (
+        <>
+          {employeeIdPrefix}
+          {user.empid}
+          {employeeIdSuffix}
+        </>
+      )}
+      {session?.company_name && (
+        <>
+          {detailSeparator}
+          {session.company_name}
+        </>
+      )}
+      {session?.department_name && (
+        <>
+          {detailSeparator}
+          {session.department_name}
+        </>
+      )}
+      {session?.branch_name && (
+        <>
+          {detailSeparator}
+          {session.branch_name}
+        </>
+      )}
+      {session?.user_level_name && (
+        <>
+          {detailSeparator}
+          {session.user_level_name}
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- pull user menu labels from the i18n context so they can be translated
- render the logout button text via the shared `t('logout', 'Logout')` helper
- translate the static fragments of the user profile header through the i18n context

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cfb00771e48331a8433004f5c6a024