### PR TITLE
Add translation hooks to mosaic layout and windows

### DIFF
--- a/src/erp.mgt.mn/components/MosaicLayout.jsx
+++ b/src/erp.mgt.mn/components/MosaicLayout.jsx
@@ -1,5 +1,5 @@
 import { Mosaic, MosaicWindow } from 'react-mosaic-component';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import 'react-mosaic-component/react-mosaic-component.css';
 import GLInquiry from '../windows/GLInquiry.jsx';
 import PurchaseOrders from '../windows/PurchaseOrders.jsx';
@@ -8,6 +8,7 @@ import Inventory from '../windows/Inventory.jsx';
 import OrderEntry from '../windows/OrderEntry.jsx';
 import Accounting from '../windows/Accounting.jsx';
 import SalesDashboard from '../windows/SalesDashboard.jsx';
+import I18nContext from '../context/I18nContext.jsx';
 
 export default function MosaicLayout({ initialLayout }) {
   const defaultLayout = {
@@ -17,6 +18,7 @@ export default function MosaicLayout({ initialLayout }) {
     splitPercentage: 70,
   };
   const [layout, setLayout] = useState(initialLayout || defaultLayout);
+  const { t } = useContext(I18nContext);
 
   useEffect(() => {
     if (initialLayout) {
@@ -34,31 +36,31 @@ export default function MosaicLayout({ initialLayout }) {
         let Component;
         switch (id) {
           case 'gl':
-            title = 'General Ledger';
+            title = t('mosaicLayout.generalLedger', 'General Ledger');
             Component = GLInquiry;
             break;
           case 'po':
-            title = 'Purchase Orders';
+            title = t('mosaicLayout.purchaseOrders', 'Purchase Orders');
             Component = PurchaseOrders;
             break;
           case 'sales':
-            title = 'Sales Dashboard';
+            title = t('mosaicLayout.salesDashboard', 'Sales Dashboard');
             Component = TabbedWindows;
             break;
           case 'dashboard':
-            title = 'Dashboard';
+            title = t('mosaicLayout.dashboard', 'Dashboard');
             Component = SalesDashboard;
             break;
           case 'inventory':
-            title = 'Inventory';
+            title = t('mosaicLayout.inventory', 'Inventory');
             Component = Inventory;
             break;
           case 'orders':
-            title = 'Order Entry';
+            title = t('mosaicLayout.orderEntry', 'Order Entry');
             Component = OrderEntry;
             break;
           case 'acct':
-            title = 'Accounting';
+            title = t('mosaicLayout.accounting', 'Accounting');
             Component = Accounting;
             break;
           default:

--- a/src/erp.mgt.mn/windows/Accounting.jsx
+++ b/src/erp.mgt.mn/windows/Accounting.jsx
@@ -1,6 +1,9 @@
-import React from 'react';
+import { useContext } from 'react';
+import I18nContext from '../context/I18nContext.jsx';
 
 export default function Accounting() {
-  return <div>Accounting Module</div>;
+  const { t } = useContext(I18nContext);
+
+  return <div>{t('windows.accounting.placeholder', 'Accounting Module')}</div>;
 }
 

--- a/src/erp.mgt.mn/windows/GLInquiry.jsx
+++ b/src/erp.mgt.mn/windows/GLInquiry.jsx
@@ -1,3 +1,8 @@
+import { useContext } from 'react';
+import I18nContext from '../context/I18nContext.jsx';
+
 export default function GLInquiry() {
-  return <div>General Ledger Inquiry Module</div>;
+  const { t } = useContext(I18nContext);
+
+  return <div>{t('windows.glInquiry.placeholder', 'General Ledger Inquiry Module')}</div>;
 }

--- a/src/erp.mgt.mn/windows/GeneralLedger.jsx
+++ b/src/erp.mgt.mn/windows/GeneralLedger.jsx
@@ -1,3 +1,8 @@
+import { useContext } from 'react';
+import I18nContext from '../context/I18nContext.jsx';
+
 export default function GeneralLedger() {
-  return <div>General Ledger Module</div>;
+  const { t } = useContext(I18nContext);
+
+  return <div>{t('windows.generalLedger.placeholder', 'General Ledger Module')}</div>;
 }

--- a/src/erp.mgt.mn/windows/Inventory.jsx
+++ b/src/erp.mgt.mn/windows/Inventory.jsx
@@ -1,6 +1,9 @@
-import React from 'react';
+import { useContext } from 'react';
+import I18nContext from '../context/I18nContext.jsx';
 
 export default function Inventory() {
-  return <div>Inventory Management Module</div>;
+  const { t } = useContext(I18nContext);
+
+  return <div>{t('windows.inventory.placeholder', 'Inventory Management Module')}</div>;
 }
 

--- a/src/erp.mgt.mn/windows/OrderEntry.jsx
+++ b/src/erp.mgt.mn/windows/OrderEntry.jsx
@@ -1,6 +1,9 @@
-import React from 'react';
+import { useContext } from 'react';
+import I18nContext from '../context/I18nContext.jsx';
 
 export default function OrderEntry() {
-  return <div>Order Entry Module</div>;
+  const { t } = useContext(I18nContext);
+
+  return <div>{t('windows.orderEntry.placeholder', 'Order Entry Module')}</div>;
 }
 

--- a/src/erp.mgt.mn/windows/PurchaseOrders.jsx
+++ b/src/erp.mgt.mn/windows/PurchaseOrders.jsx
@@ -1,3 +1,8 @@
+import { useContext } from 'react';
+import I18nContext from '../context/I18nContext.jsx';
+
 export default function PurchaseOrders() {
-  return <div>Purchase Orders Module</div>;
+  const { t } = useContext(I18nContext);
+
+  return <div>{t('windows.purchaseOrders.placeholder', 'Purchase Orders Module')}</div>;
 }

--- a/src/erp.mgt.mn/windows/ReportsViewer.jsx
+++ b/src/erp.mgt.mn/windows/ReportsViewer.jsx
@@ -1,10 +1,13 @@
-import React from 'react';
+import { useContext } from 'react';
+import I18nContext from '../context/I18nContext.jsx';
 
 export default function ReportsViewer() {
+  const { t } = useContext(I18nContext);
+
   return (
     <div style={{ padding: 10 }}>
-      <h2>📈 Reports Viewer</h2>
-      <p>Generate and view your reports here.</p>
+      <h2>{t('windows.reportsViewer.title', '📈 Reports Viewer')}</h2>
+      <p>{t('windows.reportsViewer.description', 'Generate and view your reports here.')}</p>
     </div>
   );
 }

--- a/src/erp.mgt.mn/windows/SalesDashboard.jsx
+++ b/src/erp.mgt.mn/windows/SalesDashboard.jsx
@@ -1,9 +1,13 @@
-import React from 'react';
+import { useContext } from 'react';
 import PendingRequestWidget from '../components/PendingRequestWidget.jsx';
+import I18nContext from '../context/I18nContext.jsx';
 
 export default function SalesDashboard() {
+  const { t } = useContext(I18nContext);
+  const dashboardLabel = t('windows.salesDashboard.label', 'Sales Dashboard');
+
   return (
-    <div>
+    <div role="region" aria-label={dashboardLabel}>
       <PendingRequestWidget />
     </div>
   );


### PR DESCRIPTION
## Summary
- wire the ERP mosaic layout into the translation context and localize every window title with sensible defaults
- update each ERP window component to read from the translation context instead of rendering literal placeholder copy
- expose translatable labels for the sales dashboard container while leaving locale JSON updates to the translation workflow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfb247c4408331a6517556bd1a942b