### PR TITLE
Localize modules page strings

### DIFF
--- a/src/erp.mgt.mn/pages/Modules.jsx
+++ b/src/erp.mgt.mn/pages/Modules.jsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { refreshModules } from '../hooks/useModules.js';
 
 export default function ModulesPage() {
   const [modules, setModules] = useState([]);
+  const { t } = useTranslation();
 
   function loadModules() {
     fetch('/api/modules', { credentials: 'include' })
@@ -19,13 +21,18 @@ export default function ModulesPage() {
   }, []);
 
   async function handleAdd() {
-    const moduleKey = prompt('Module key?');
+    const moduleKeyPrompt = t('modules_prompt_module_key', 'Module key?');
+    const moduleKey = prompt(moduleKeyPrompt);
     if (!moduleKey) return;
-    const label = prompt('Label?');
+    const labelPrompt = t('modules_prompt_label', 'Label?');
+    const label = prompt(labelPrompt);
     if (!label) return;
-    const parentKey = prompt('Parent key (optional)?', '');
-    const showInSidebar = window.confirm('Show in sidebar?');
-    const showInHeader = window.confirm('Show in header?');
+    const parentKeyPrompt = t('modules_prompt_parent_key', 'Parent key (optional)?');
+    const parentKey = prompt(parentKeyPrompt, '');
+    const showInSidebarConfirm = t('modules_confirm_show_in_sidebar', 'Show in sidebar?');
+    const showInSidebar = window.confirm(showInSidebarConfirm);
+    const showInHeaderConfirm = t('modules_confirm_show_in_header', 'Show in header?');
+    const showInHeader = window.confirm(showInHeaderConfirm);
     const res = await fetch('/api/modules', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -39,7 +46,8 @@ export default function ModulesPage() {
       }),
     });
     if (!res.ok) {
-      alert('Failed to save module');
+      const saveFailedMessage = t('modules_alert_save_failed', 'Failed to save module');
+      alert(saveFailedMessage);
       return;
     }
     loadModules();
@@ -47,11 +55,15 @@ export default function ModulesPage() {
   }
 
   async function handleEdit(m) {
-    const label = prompt('Label?', m.label);
+    const labelPrompt = t('modules_prompt_label', 'Label?');
+    const label = prompt(labelPrompt, m.label);
     if (!label) return;
-    const parentKey = prompt('Parent key (optional)?', m.parent_key || '');
-    const showInSidebar = window.confirm('Show in sidebar?');
-    const showInHeader = window.confirm('Show in header?');
+    const parentKeyPrompt = t('modules_prompt_parent_key', 'Parent key (optional)?');
+    const parentKey = prompt(parentKeyPrompt, m.parent_key || '');
+    const showInSidebarConfirm = t('modules_confirm_show_in_sidebar', 'Show in sidebar?');
+    const showInSidebar = window.confirm(showInSidebarConfirm);
+    const showInHeaderConfirm = t('modules_confirm_show_in_header', 'Show in header?');
+    const showInHeader = window.confirm(showInHeaderConfirm);
     const res = await fetch(`/api/modules/${m.module_key}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
@@ -64,7 +76,8 @@ export default function ModulesPage() {
       }),
     });
     if (!res.ok) {
-      alert('Failed to update module');
+      const updateFailedMessage = t('modules_alert_update_failed', 'Failed to update module');
+      alert(updateFailedMessage);
       return;
     }
     loadModules();
@@ -77,35 +90,50 @@ export default function ModulesPage() {
       credentials: 'include'
     });
     if (!res.ok) {
-      alert('Failed to populate permissions');
+      const populateFailedMessage = t('modules_alert_populate_failed', 'Failed to populate permissions');
+      alert(populateFailedMessage);
       return;
     }
-    alert('Permissions populated');
+    const populateSuccessMessage = t('modules_alert_populate_success', 'Permissions populated');
+    alert(populateSuccessMessage);
   }
+
+  const modulesHeading = t('modules_heading', 'Modules');
+  const addModuleLabel = t('modules_button_add', 'Add Module');
+  const populatePermissionsLabel = t('modules_button_populate', 'Populate Permissions');
+  const refreshMenusLabel = t('modules_button_refresh', 'Refresh Menus');
+  const noModulesText = t('modules_empty', 'No modules.');
+  const keyHeader = t('modules_table_header_key', 'Key');
+  const labelHeader = t('modules_table_header_label', 'Label');
+  const parentHeader = t('modules_table_header_parent', 'Parent');
+  const sidebarHeader = t('modules_table_header_sidebar', 'Sidebar');
+  const headerHeader = t('modules_table_header_header', 'Header');
+  const actionHeader = t('modules_table_header_action', 'Action');
+  const editButtonLabel = t('modules_button_edit', 'Edit');
 
   return (
     <div>
-      <h2>Modules</h2>
-      <button onClick={handleAdd}>Add Module</button>
+      <h2>{modulesHeading}</h2>
+      <button onClick={handleAdd}>{addModuleLabel}</button>
       <button onClick={handlePopulate} style={{ marginLeft: '0.5rem' }}>
-        Populate Permissions
+        {populatePermissionsLabel}
       </button>
       <button onClick={refreshModules} style={{ marginLeft: '0.5rem' }}>
-        Refresh Menus
+        {refreshMenusLabel}
       </button>
       {modules.length === 0 ? (
-        <p>No modules.</p>
+        <p>{noModulesText}</p>
       ) : (
         <div className="table-container overflow-x-auto" style={{ maxHeight: '70vh' }}>
         <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '0.5rem' }}>
           <thead>
             <tr style={{ backgroundColor: '#e5e7eb' }}>
-              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Key</th>
-              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Label</th>
-              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Parent</th>
-              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Sidebar</th>
-              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Header</th>
-              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>Action</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{keyHeader}</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{labelHeader}</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{parentHeader}</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{sidebarHeader}</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{headerHeader}</th>
+              <th style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>{actionHeader}</th>
             </tr>
           </thead>
           <tbody>
@@ -117,7 +145,7 @@ export default function ModulesPage() {
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db', textAlign: 'center' }}>{m.show_in_sidebar ? '✓' : ''}</td>
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db', textAlign: 'center' }}>{m.show_in_header ? '✓' : ''}</td>
                 <td style={{ padding: '0.5rem', border: '1px solid #d1d5db' }}>
-                  <button onClick={() => handleEdit(m)}>Edit</button>
+                  <button onClick={() => handleEdit(m)}>{editButtonLabel}</button>
                 </td>
               </tr>
             ))}


### PR DESCRIPTION
## Summary
- add react-i18next translation hook to the modules management page
- translate prompts, alerts, table headings, buttons, and empty state using `t('key', 'Default text')`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfb5c597b483318b7b8e2f5a27e31e