### PR TITLE
Capture module metadata in exported translations

### DIFF
--- a/tests/services/manualTranslations.test.js
+++ b/tests/services/manualTranslations.test.js
@@ -15,7 +15,21 @@ test('exported texts are merged into manual translations', async () => {
   fs.mkdirSync(path.dirname(exportedPath), { recursive: true });
   fs.writeFileSync(
     exportedPath,
-    JSON.stringify({ foo: 'Foo', nested: { bar: 'Bar' } }, null, 2),
+    JSON.stringify(
+      {
+        translations: {
+          foo: 'Foo',
+          nested: { bar: 'Bar' },
+          plain: 'Plain Text',
+        },
+        meta: {
+          foo: { module: 'pages/FooPage', context: 'button' },
+          'nested.bar': { module: 'pages/NestedPage', context: 'label' },
+        },
+      },
+      null,
+      2,
+    ),
   );
   try {
     const data = await loadTranslations();
@@ -25,6 +39,10 @@ test('exported texts are merged into manual translations', async () => {
     assert(tooltipFoo, 'tooltip foo entry exists');
     assert.equal(localeFoo.values.en, 'Foo');
     assert.equal(tooltipFoo.values.en, 'Foo');
+    assert.equal(localeFoo.module, 'pages/FooPage');
+    assert.equal(localeFoo.context, 'button');
+    assert.equal(tooltipFoo.module, 'pages/FooPage');
+    assert.equal(tooltipFoo.context, 'button');
     const otherLang = data.languages.find((l) => l !== 'en');
     if (otherLang) {
       assert.equal(localeFoo.values[otherLang], '');
@@ -36,6 +54,14 @@ test('exported texts are merged into manual translations', async () => {
     assert(nestedTooltip, 'nested tooltip entry exists');
     assert.equal(nestedLocale.values.en, 'Bar');
     assert.equal(nestedTooltip.values.en, 'Bar');
+    assert.equal(nestedLocale.module, 'pages/NestedPage');
+    assert.equal(nestedLocale.context, 'label');
+    assert.equal(nestedTooltip.module, 'pages/NestedPage');
+    assert.equal(nestedTooltip.context, 'label');
+    const plainLocale = data.entries.find((e) => e.type === 'locale' && e.key === 'plain');
+    assert(plainLocale, 'plain locale entry exists');
+    assert.equal(plainLocale.module, '');
+    assert.equal(plainLocale.context, '');
   } finally {
     cleanup();
   }

--- a/tests/services/translationsExport.test.js
+++ b/tests/services/translationsExport.test.js
@@ -94,11 +94,22 @@ export default function Tmp() {
   await exportTranslations(0);
   const exportedPath = path.join('config', '0', 'exportedtexts.json');
   const exported = JSON.parse(fs.readFileSync(exportedPath, 'utf8'));
+  const { translations, meta } = exported;
   restore();
   fs.unlinkSync(tmpFile);
-  assert.equal(exported['Test Button'], 'Test Button');
-  assert.equal(exported['Test Option'], 'Test Option');
-  assert.equal(exported['Test Label'], 'Test Label');
+  assert.equal(translations['Test Button'], 'Test Button');
+  assert.equal(translations['Test Option'], 'Test Option');
+  assert.equal(translations['Test Label'], 'Test Label');
+  assert.equal(meta['Test Button'].module, 'TmpTranslation');
+  assert.equal(meta['Test Button'].context, 'button');
+  assert.equal(meta['Test Option'].module, 'TmpTranslation');
+  assert.equal(meta['Test Option'].context, 'option');
+  assert.equal(meta['Test Label'].module, 'TmpTranslation');
+  assert.equal(meta['Test Label'].context, 'label');
+  assert.equal(meta.wrapped.module, 'TmpTranslation');
+  assert.equal(meta.wrapped.context, 'translation_call');
+  assert.equal(meta['Wrapped Button'].module, 'TmpTranslation');
+  assert.equal(meta['Wrapped Button'].context, 'translation_call');
   await db.pool.end();
 });
 
@@ -129,9 +140,11 @@ test('deeply nested header mappings are flattened', async () => {
   }
   const exportedPath = path.join('config', '0', 'exportedtexts.json');
   const exported = JSON.parse(fs.readFileSync(exportedPath, 'utf8'));
-  assert.equal(exported.root.title, 'Root Title');
-  assert.equal(exported.root.items[0].name, 'Item Name');
-  assert.equal(exported.root.items[0].children[1].more[0].deep, 'Deep');
+  const { translations, meta } = exported;
+  assert.equal(translations.root.title, 'Root Title');
+  assert.equal(translations.root.items[0].name, 'Item Name');
+  assert.equal(translations.root.items[0].children[1].more[0].deep, 'Deep');
+  assert.equal(meta['root.title'].context, 'header_mapping');
   fs.writeFileSync(headerMappingsPath, original);
   fs.unlinkSync(exportedPath);
   await db.pool.end();


### PR DESCRIPTION
## Summary
- enrich the translation export pipeline to capture module and UI context metadata alongside generated keys
- surface module and context information from exported metadata when loading manual translations, defaulting to empty strings when unavailable
- update service tests to cover the expanded export format and manual translation payload structure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cfba3652fc83318f2ffb6d8822f2e7