### PR TITLE
Support multiple table relation mappings

### DIFF
--- a/api-server/services/tableRelationsConfig.js
+++ b/api-server/services/tableRelationsConfig.js
@@ -47,36 +47,222 @@ function normalizeRelation(relation = {}) {
   return normalized;
 }
 
-export async function listAllCustomRelations(companyId = 0) {
-  const { cfg, isDefault } = await readConfig(companyId);
-  return { config: cfg, isDefault };
+function tryNormalizeRelation(relation) {
+  try {
+    return normalizeRelation(relation);
+  } catch {
+    return null;
+  }
 }
 
-export async function listCustomRelations(table, companyId = 0) {
-  const { cfg, isDefault } = await readConfig(companyId);
-  return { config: cfg?.[table] ?? {}, isDefault };
+function toRelationArray(value) {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => tryNormalizeRelation(item))
+      .filter((item) => item);
+  }
+  const normalized = tryNormalizeRelation(value);
+  return normalized ? [normalized] : [];
 }
 
-export async function saveCustomRelation(table, column, relation, companyId = 0) {
+function ensureRelationArray(cfg, table, column) {
+  if (!cfg[table]) cfg[table] = {};
+  const current = cfg[table][column];
+  if (Array.isArray(current)) {
+    return current;
+  }
+  const normalized = toRelationArray(current);
+  cfg[table][column] = normalized;
+  return cfg[table][column];
+}
+
+function getExistingRelationArray(cfg, table, column) {
+  if (!cfg?.[table]) return null;
+  const current = cfg[table][column];
+  if (Array.isArray(current)) return current;
+  if (current === undefined) return null;
+  const normalized = toRelationArray(current);
+  cfg[table][column] = normalized;
+  return cfg[table][column];
+}
+
+function findRelationIndex(list, match = {}) {
+  if (!Array.isArray(list)) return -1;
+  const tableMatch = match.targetTable ?? match.table;
+  const columnMatch = match.targetColumn ?? match.column;
+  return list.findIndex((rel) => {
+    if (!rel) return false;
+    if (tableMatch && rel.table !== tableMatch) return false;
+    if (columnMatch && rel.column !== columnMatch) return false;
+    if (match.idField && rel.idField !== match.idField) return false;
+    if (match.displayFields) {
+      const relFields = Array.isArray(rel.displayFields) ? rel.displayFields.join('|') : '';
+      const matchFields = Array.isArray(match.displayFields)
+        ? match.displayFields.join('|')
+        : '';
+      if (relFields !== matchFields) return false;
+    }
+    return true;
+  });
+}
+
+function cloneRelations(relations) {
+  return Array.isArray(relations)
+    ? relations.map((rel) => (rel ? { ...rel } : rel)).filter(Boolean)
+    : [];
+}
+
+function normalizeConfig(config) {
+  const normalized = {};
+  if (!config || typeof config !== 'object') return normalized;
+  for (const [table, columns] of Object.entries(config)) {
+    if (!columns || typeof columns !== 'object') continue;
+    const columnMap = {};
+    for (const [column, value] of Object.entries(columns)) {
+      const list = toRelationArray(value);
+      if (list.length > 0) {
+        columnMap[column] = cloneRelations(list);
+      }
+    }
+    if (Object.keys(columnMap).length > 0) {
+      normalized[table] = columnMap;
+    }
+  }
+  return normalized;
+}
+
+async function writeRelation(table, column, relation, companyId = 0, options = {}) {
   if (!table) throw new Error('table is required');
   if (!column) throw new Error('column is required');
   const normalized = normalizeRelation(relation);
   const { cfg } = await readConfig(companyId);
-  if (!cfg[table]) cfg[table] = {};
-  cfg[table][column] = normalized;
+  const list = ensureRelationArray(cfg, table, column);
+
+  let index = -1;
+  if (Number.isInteger(options.index) && options.index >= 0 && options.index < list.length) {
+    index = options.index;
+  } else if (options.match && typeof options.match === 'object') {
+    const found = findRelationIndex(list, options.match);
+    if (found >= 0) index = found;
+  }
+
+  if (index >= 0) {
+    list[index] = normalized;
+  } else {
+    list.push(normalized);
+    index = list.length - 1;
+  }
+
   await writeConfig(cfg, companyId);
-  return normalized;
+  return { relation: normalized, index, relations: cloneRelations(list) };
 }
 
-export async function removeCustomRelation(table, column, companyId = 0) {
+async function removeRelation(table, column, companyId = 0, options = {}) {
   const { cfg } = await readConfig(companyId);
-  if (cfg?.[table]?.[column]) {
+  const list = getExistingRelationArray(cfg, table, column);
+  if (!list) {
+    return { removed: null, index: -1, relations: [] };
+  }
+
+  let index = -1;
+  if (Number.isInteger(options.index) && options.index >= 0 && options.index < list.length) {
+    index = options.index;
+  } else if (options.match && typeof options.match === 'object') {
+    index = findRelationIndex(list, options.match);
+  }
+
+  let removed = null;
+  if (index >= 0) {
+    removed = list.splice(index, 1)[0] ?? null;
+  } else if (!options.index && !options.match) {
+    removed = list.splice(0, list.length);
+  }
+
+  if (list.length === 0) {
     delete cfg[table][column];
     if (Object.keys(cfg[table]).length === 0) {
       delete cfg[table];
     }
+  }
+
+  if (removed !== null) {
     await writeConfig(cfg, companyId);
   }
+
+  return {
+    removed: Array.isArray(removed) ? removed.map((r) => ({ ...r })) : removed,
+    index,
+    relations: cloneRelations(list),
+  };
+}
+
+export async function listAllCustomRelations(companyId = 0) {
+  const { cfg, isDefault } = await readConfig(companyId);
+  return { config: normalizeConfig(cfg), isDefault };
+}
+
+export async function listCustomRelations(table, companyId = 0) {
+  const { cfg, isDefault } = await readConfig(companyId);
+  const normalized = normalizeConfig({ [table]: cfg?.[table] ?? {} });
+  return { config: normalized[table] ?? {}, isDefault };
+}
+
+export async function saveCustomRelation(table, column, relation, companyId = 0) {
+  return writeRelation(table, column, relation, companyId);
+}
+
+export async function updateCustomRelationAtIndex(
+  table,
+  column,
+  index,
+  relation,
+  companyId = 0,
+) {
+  if (!Number.isInteger(index) || index < 0) {
+    throw new Error('index must be a non-negative integer');
+  }
+  return writeRelation(table, column, relation, companyId, { index });
+}
+
+export async function updateCustomRelationMatching(
+  table,
+  column,
+  match,
+  relation,
+  companyId = 0,
+) {
+  if (!match || typeof match !== 'object') {
+    throw new Error('match criteria is required');
+  }
+  return writeRelation(table, column, relation, companyId, { match });
+}
+
+export async function removeCustomRelation(table, column, companyId = 0) {
+  return removeRelation(table, column, companyId);
+}
+
+export async function removeCustomRelationAtIndex(
+  table,
+  column,
+  index,
+  companyId = 0,
+) {
+  if (!Number.isInteger(index) || index < 0) {
+    throw new Error('index must be a non-negative integer');
+  }
+  return removeRelation(table, column, companyId, { index });
+}
+
+export async function removeCustomRelationMatching(
+  table,
+  column,
+  match,
+  companyId = 0,
+) {
+  if (!match || typeof match !== 'object') {
+    throw new Error('match criteria is required');
+  }
+  return removeRelation(table, column, companyId, { match });
 }
 
 export async function removeTableCustomRelations(table, companyId = 0) {


### PR DESCRIPTION
## Summary
- store custom table relations as arrays and add helpers to update or remove individual mappings
- update API endpoints and TableRelationsEditor to handle multiple custom relations per column
- expand service, controller, and component tests to cover multiple relations, secondary mappings, and targeted deletions

## Testing
- `npm test -- tests/services/tableRelationsConfig.test.js tests/controllers/tableController.test.js tests/components/tableRelationsEditor.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68cfbc116f3083319bf675e187a01ff8