### PR TITLE
Add translation validation guardrails and shared heuristics

### DIFF
--- a/api-server/routes/openai.js
+++ b/api-server/routes/openai.js
@@ -1,6 +1,10 @@
 import express from 'express';
 import multer from 'multer';
-import { getResponse, getResponseWithFile } from '../utils/openaiClient.js';
+import {
+  getResponse,
+  getResponseWithFile,
+  validateTranslation,
+} from '../utils/openaiClient.js';
 
 const upload = multer({ storage: multer.memoryStorage() });
 
@@ -20,6 +24,25 @@ router.post('/', upload.single('file'), async (req, res, next) => {
       response = await getResponse(prompt);
     }
     res.json({ response });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/validate', async (req, res, next) => {
+  try {
+    const { candidate, base, lang, metadata } = req.body || {};
+    if (!candidate || !String(candidate).trim()) {
+      res.json({
+        valid: false,
+        reason: 'empty',
+        needsRetry: false,
+        strategy: 'heuristic',
+      });
+      return;
+    }
+    const result = await validateTranslation({ candidate, base, lang, metadata });
+    res.json(result);
   } catch (err) {
     next(err);
   }

--- a/api-server/utils/openaiClient.js
+++ b/api-server/utils/openaiClient.js
@@ -1,5 +1,10 @@
 import dotenv from 'dotenv';
 import OpenAI from 'openai';
+import {
+  evaluateTranslationCandidate,
+  buildValidationPrompt,
+  summarizeHeuristic,
+} from '../../utils/translationValidation.js';
 
 dotenv.config();
 
@@ -44,4 +49,107 @@ export async function getResponseWithFile(prompt, fileBuffer, mimeType) {
   });
 
   return completion.choices[0].message.content.trim();
+}
+
+function parseValidationResponse(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    const match = raw.match(/\{[\s\S]*\}/);
+    if (match) {
+      try {
+        return JSON.parse(match[0]);
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+export async function validateTranslation({ candidate, base, lang, metadata }) {
+  const heuristics = evaluateTranslationCandidate({
+    candidate,
+    base,
+    lang,
+    metadata,
+  });
+  const summary = summarizeHeuristic(heuristics);
+  const response = {
+    valid: false,
+    reason: '',
+    needsRetry: false,
+    strategy: 'heuristic',
+    languageConfidence: null,
+    heuristics,
+    summary,
+  };
+
+  if (heuristics.status === 'fail') {
+    return {
+      ...response,
+      reason: heuristics.reasons[0] || 'failed_heuristics',
+    };
+  }
+
+  if (!client) {
+    return {
+      ...response,
+      valid: heuristics.status === 'pass',
+      reason:
+        heuristics.status === 'pass'
+          ? ''
+          : heuristics.reasons[0] || 'validation_unavailable',
+      needsRetry: heuristics.status !== 'pass',
+      strategy: 'offline',
+    };
+  }
+
+  if (heuristics.status === 'pass') {
+    return {
+      ...response,
+      valid: true,
+      reason: '',
+      needsRetry: false,
+    };
+  }
+
+  const prompt = buildValidationPrompt({ candidate, base, lang, metadata });
+  try {
+    const raw = await getResponse(prompt);
+    const parsed = parseValidationResponse(raw);
+    if (!parsed) {
+      return {
+        ...response,
+        reason: 'invalid_validator_response',
+        needsRetry: true,
+        strategy: 'llm',
+      };
+    }
+    return {
+      ...response,
+      valid: Boolean(parsed.valid),
+      reason: parsed.reason || '',
+      needsRetry: parsed.valid ? false : true,
+      strategy: 'llm',
+      languageConfidence:
+        typeof parsed.languageConfidence === 'number'
+          ? parsed.languageConfidence
+          : null,
+    };
+  } catch (err) {
+    if (err?.response?.status === 429 || err?.rateLimited) {
+      const rateErr = new Error('rate limited');
+      rateErr.rateLimited = true;
+      throw rateErr;
+    }
+    console.error('LLM validation request failed', err);
+    return {
+      ...response,
+      reason: 'validation_error',
+      needsRetry: true,
+      strategy: 'llm-error',
+    };
+  }
 }

--- a/scripts/generateManuals.js
+++ b/scripts/generateManuals.js
@@ -36,11 +36,17 @@ function moduleSlug(key) {
   return key.replace(/_/g, '-');
 }
 
+async function translateLabel(lang, key, fallback, metadata) {
+  const result = await translateWithCache(lang, key, fallback, metadata);
+  if (!result) return fallback ?? '';
+  return result.text ?? (fallback ?? '');
+}
+
 async function loadLabels(lang = 'en') {
   const headerMap = await loadJSON(path.join(configDir, 'headerMappings.json'));
   const translate = async (key) => {
     const fallback = headerMap[key];
-    return translateWithCache(lang, key, fallback);
+    return translateLabel(lang, key, fallback);
   };
   return translate;
 }
@@ -109,35 +115,35 @@ async function generateManualForModule(module, translate, configs, options) {
     md += `## ${fTitle}\n`;
     if (formCfg.visibleFields?.length) {
       const vis = await Promise.all(formCfg.visibleFields.map((f) => translate(f)));
-      md += `- ${await translateWithCache(lang, 'visible', 'Visible')}: ${vis.join(', ')}\n`;
+      md += `- ${await translateLabel(lang, 'visible', 'Visible')}: ${vis.join(', ')}\n`;
     }
     if (formCfg.requiredFields?.length) {
       const req = await Promise.all(formCfg.requiredFields.map((f) => translate(f)));
-      md += `- ${await translateWithCache(lang, 'required', 'Required')}: ${req.join(', ')}\n`;
+      md += `- ${await translateLabel(lang, 'required', 'Required')}: ${req.join(', ')}\n`;
     }
     if (formCfg.defaultValues && Object.keys(formCfg.defaultValues).length) {
       const defsArr = await Promise.all(
         Object.entries(formCfg.defaultValues).map(async ([k, v]) => `${await translate(k)}=${v}`),
       );
-      md += `- ${await translateWithCache(lang, 'defaults', 'Defaults')}: ${defsArr.join(', ')}\n`;
+      md += `- ${await translateLabel(lang, 'defaults', 'Defaults')}: ${defsArr.join(', ')}\n`;
     }
     if (formCfg.conditions && Object.keys(formCfg.conditions).length) {
-      md += `- ${await translateWithCache(lang, 'conditions', 'Conditions')}: ${JSON.stringify(formCfg.conditions)}\n`;
+      md += `- ${await translateLabel(lang, 'conditions', 'Conditions')}: ${JSON.stringify(formCfg.conditions)}\n`;
     }
     md += '\n';
   }
 
   const tableCfg = configs.tableDisplayFields[module.module_key];
   if (tableCfg) {
-    md += `### ${await translateWithCache(lang, 'tableDisplay', 'Table Display')}\n`;
-    md += `- ${await translateWithCache(lang, 'idField', 'ID Field')}: ${await translate(tableCfg.idField)}\n`;
+    md += `### ${await translateLabel(lang, 'tableDisplay', 'Table Display')}\n`;
+    md += `- ${await translateLabel(lang, 'idField', 'ID Field')}: ${await translate(tableCfg.idField)}\n`;
     const display = await Promise.all(tableCfg.displayFields.map((f) => translate(f)));
-    md += `- ${await translateWithCache(lang, 'displayFields', 'Display Fields')}: ${display.join(', ')}\n`;
+    md += `- ${await translateLabel(lang, 'displayFields', 'Display Fields')}: ${display.join(', ')}\n`;
     if (tableCfg.tooltips) {
       const tipsArr = await Promise.all(
         Object.entries(tableCfg.tooltips).map(async ([k, v]) => `${await translate(k)}: ${await translate(v)}`),
       );
-      md += `- ${await translateWithCache(lang, 'tooltips', 'Tooltips')}: ${tipsArr.join(', ')}\n`;
+      md += `- ${await translateLabel(lang, 'tooltips', 'Tooltips')}: ${tipsArr.join(', ')}\n`;
     }
     md += '\n';
   }

--- a/src/erp.mgt.mn/pages/UserManualExport.jsx
+++ b/src/erp.mgt.mn/pages/UserManualExport.jsx
@@ -380,15 +380,21 @@ export default function UserManualExport() {
     return <p>{t("accessDenied", "Access denied", { lng: lang })}</p>;
   }
 
+  const translateLabel = async (key, fallback, meta) => {
+    const result = await translateWithCache(lang, key, fallback, meta);
+    if (!result) return fallback ?? "";
+    return result.text ?? (fallback ?? "");
+  };
+
   async function translate(key) {
     if (!key) return "";
     if (headerMap[key]) return headerMap[key];
-    return translateWithCache(lang, key);
+    return translateLabel(key);
   }
 
   async function buildMarkdown() {
-    let md = `# ${await translateWithCache(lang, "userManual", "User Manual")}\n\n`;
-    md += `## ${await translateWithCache(lang, "forms", "Forms")}\n`;
+    let md = `# ${await translateLabel("userManual", "User Manual")}\n\n`;
+    md += `## ${await translateLabel("forms", "Forms")}\n`;
     for (const [mKey, mod] of Object.entries(manual)) {
       if (!mod.forms.length) continue;
       md += `### ${await translate(mKey)}\n`;
@@ -398,7 +404,7 @@ export default function UserManualExport() {
         const rf = form.fields?.requiredFields || [];
         if (rf.length) {
           const rfNames = await Promise.all(rf.map((r) => translate(r)));
-          md += `${await translateWithCache(lang, "requiredFields", "Required Fields")}: ${rfNames.join(", ")}\n`;
+          md += `${await translateLabel("requiredFields", "Required Fields")}: ${rfNames.join(", ")}\n`;
         }
         const actions = [];
         (form.buttons || []).forEach((b) =>
@@ -414,11 +420,11 @@ export default function UserManualExport() {
       }
     }
 
-    md += `\n## ${await translateWithCache(lang, "reports", "Reports")}\n`;
+    md += `\n## ${await translateLabel("reports", "Reports")}\n`;
     for (const [mKey, mod] of Object.entries(manual)) {
       if (!mod.reports.length) continue;
       md += `### ${await translate(mKey)}\n`;
-      md += `| ${await translateWithCache(lang, "reportName", "Report Name")} | ${await translateWithCache(lang, "identifier", "Identifier")} | ${await translateWithCache(lang, "description", "Description")} |\n`;
+      md += `| ${await translateLabel("reportName", "Report Name")} | ${await translateLabel("identifier", "Identifier")} | ${await translateLabel("description", "Description")} |\n`;
       md += `| --- | --- | --- |\n`;
       for (const r of mod.reports) {
           const k = typeof r === "string" ? r : r.key;
@@ -432,19 +438,19 @@ export default function UserManualExport() {
             })();
           if (!rDesc) {
             const sentenceDefault = `The ${reportName} report provides a comprehensive overview of the associated data set, presenting information in a structured and readable manner for further analysis.`;
-            rDesc = await translateWithCache(lang, "reportPurposeDetail", sentenceDefault);
+            rDesc = await translateLabel("reportPurposeDetail", sentenceDefault);
           }
           md += `| ${reportName} | ${k} | ${rDesc} |\n`;
       }
     }
 
-    md += `\n## ${await translateWithCache(lang, "settings", "Settings")}\n`;
+    md += `\n## ${await translateLabel("settings", "Settings")}\n`;
     for (const [mKey, mod] of Object.entries(manual)) {
       if (!mod.buttons.length && !mod.functions.length) continue;
       md += `### ${await translate(mKey)}\n`;
       if (mod.buttons.length) {
-        md += `#### ${await translateWithCache(lang, "buttons", "Buttons")}\n`;
-        md += `| ${await translateWithCache(lang, "buttonName", "Button Name")} | ${await translateWithCache(lang, "identifier", "Identifier")} | ${await translateWithCache(lang, "description", "Description")} |\n`;
+        md += `#### ${await translateLabel("buttons", "Buttons")}\n`;
+        md += `| ${await translateLabel("buttonName", "Button Name")} | ${await translateLabel("identifier", "Identifier")} | ${await translateLabel("description", "Description")} |\n`;
         md += `| --- | --- | --- |\n`;
         for (const b of mod.buttons) {
           const bName = await translate(b);
@@ -461,26 +467,26 @@ export default function UserManualExport() {
             sentenceDefault = `The ${bName} button allows administrators to execute the ${bName} operation. Requires: ${rfNames.join(", ")}.`;
           }
           if (!bDesc) {
-            bDesc = await translateWithCache(lang, "settingsButtonDetail", sentenceDefault);
+            bDesc = await translateLabel("settingsButtonDetail", sentenceDefault);
           }
           md += `| ${bName} | ${b} | ${bDesc} |\n`;
         }
       }
       if (mod.functions.length) {
-        md += `\n#### ${await translateWithCache(lang, "functions", "Functions")}\n`;
-        md += `| ${await translateWithCache(lang, "functionName", "Function Name")} | ${await translateWithCache(lang, "identifier", "Identifier")} | ${await translateWithCache(lang, "description", "Description")} |\n`;
+        md += `\n#### ${await translateLabel("functions", "Functions")}\n`;
+        md += `| ${await translateLabel("functionName", "Function Name")} | ${await translateLabel("identifier", "Identifier")} | ${await translateLabel("description", "Description")} |\n`;
         md += `| --- | --- | --- |\n`;
         for (const fn of mod.functions) {
           const fnName = await translate(fn);
           const sentenceDefault = `The ${fnName} function performs the ${fnName} process, leveraging the active settings to modify how the application operates.`;
-          const sentence = await translateWithCache(lang, "settingsFunctionDetail", sentenceDefault);
+          const sentence = await translateLabel("settingsFunctionDetail", sentenceDefault);
           md += `| ${fnName} | ${fn} | ${sentence} |\n`;
         }
       }
     }
 
-    md += `\n## ${await translateWithCache(lang, "quickReference", "Quick Reference")}\n`;
-    md += `| ${await translateWithCache(lang, "userLevel", "User Level")} | ${await translateWithCache(lang, "modules", "Modules")} | ${await translateWithCache(lang, "forms", "Forms")} | ${await translateWithCache(lang, "reports", "Reports")} | ${await translateWithCache(lang, "buttons", "Buttons")} | ${await translateWithCache(lang, "functions", "Functions")} |\n`;
+    md += `\n## ${await translateLabel("quickReference", "Quick Reference")}\n`;
+    md += `| ${await translateLabel("userLevel", "User Level")} | ${await translateLabel("modules", "Modules")} | ${await translateLabel("forms", "Forms")} | ${await translateLabel("reports", "Reports")} | ${await translateLabel("buttons", "Buttons")} | ${await translateLabel("functions", "Functions")} |\n`;
     md += `| --- | --- | --- | --- | --- | --- |\n`;
     const lvl = { id: session?.user_level };
     const acts = levelActions[lvl.id] || {};

--- a/src/erp.mgt.mn/utils/translateWithCache.js
+++ b/src/erp.mgt.mn/utils/translateWithCache.js
@@ -1,3 +1,9 @@
+import {
+  evaluateTranslationCandidate,
+  buildValidationPrompt,
+  summarizeHeuristic,
+} from '../../../utils/translationValidation.js';
+
 let nodeCache;
 let nodeCachePath;
 const localeCache = {};
@@ -26,7 +32,8 @@ function buildPrompt(text, lang, metadata) {
   if (metadata.context) parts.push(`Context: ${metadata.context}`);
   if (metadata.key) parts.push(`Key: ${metadata.key}`);
   parts.push(`Text: ${textStr}`);
-  return `Translate the following text to ${lang}.\n${parts.join(', ')}`;
+  return `Translate the following text to ${lang}.
+${parts.join(', ')}`;
 }
 
 function buildCacheKeyParts(lang, base, metadata) {
@@ -183,29 +190,233 @@ function describe(key) {
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
+function createResult(text, options = {}) {
+  const rendered = typeof text === 'string' ? text : String(text ?? '');
+  const baseText = options.base ?? rendered;
+  return {
+    text: rendered,
+    base: typeof baseText === 'string' ? baseText : String(baseText ?? ''),
+    source: options.source || 'unknown',
+    fromCache: Boolean(options.fromCache),
+    candidate: options.candidate ?? null,
+    validation: options.validation ?? null,
+    needsRetry: Boolean(options.needsRetry),
+  };
+}
+
+function parseValidationText(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    const match = raw.match(/\{[\s\S]*\}/);
+    if (match) {
+      try {
+        return JSON.parse(match[0]);
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+async function requestValidationViaEndpoint(payload) {
+  if (typeof fetch !== 'function') return null;
+  try {
+    const res = await fetch('/api/openai/validate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      skipErrorToast: true,
+      skipLoader: true,
+    });
+    if (res.status === 404) {
+      return { ok: false, status: 404 };
+    }
+    if (res.status === 429) {
+      const err = new Error('rate limited');
+      err.rateLimited = true;
+      throw err;
+    }
+    if (!res.ok) {
+      return { ok: false, status: res.status };
+    }
+    const data = await res.json();
+    return { ok: true, ...data };
+  } catch (err) {
+    if (err.rateLimited) throw err;
+    console.error('Validation endpoint request failed', err);
+    return { ok: false, error: err };
+  }
+}
+
+async function requestValidationViaPrompt(payload) {
+  if (aiDisabled || typeof fetch !== 'function') return null;
+  try {
+    const prompt = buildValidationPrompt(payload);
+    const res = await fetch('/api/openai', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt }),
+      skipErrorToast: true,
+      skipLoader: true,
+    });
+    if (res.status === 404) {
+      aiDisabled = true;
+      return null;
+    }
+    if (res.status === 429) {
+      const err = new Error('rate limited');
+      err.rateLimited = true;
+      throw err;
+    }
+    if (!res.ok) return null;
+    const data = await res.json();
+    const parsed = parseValidationText(data.response?.trim());
+    if (!parsed) return null;
+    return {
+      ok: true,
+      valid: Boolean(parsed.valid),
+      reason: parsed.reason || '',
+      needsRetry: parsed.valid ? false : true,
+      languageConfidence: typeof parsed.languageConfidence === 'number'
+        ? parsed.languageConfidence
+        : null,
+      source: 'prompt',
+    };
+  } catch (err) {
+    if (err.rateLimited) throw err;
+    console.error('Validation prompt request failed', err);
+    return null;
+  }
+}
+
+export async function validateAITranslation(candidate, base, lang, metadata) {
+  const heuristics = evaluateTranslationCandidate({
+    candidate,
+    base,
+    lang,
+    metadata,
+  });
+  const summary = summarizeHeuristic(heuristics);
+  const result = {
+    valid: false,
+    reason: '',
+    needsRetry: false,
+    heuristics,
+    summary,
+    attemptedRemote: false,
+    remoteSource: null,
+    languageConfidence: null,
+  };
+
+  if (heuristics.status === 'fail') {
+    return {
+      ...result,
+      reason: heuristics.reasons[0] || 'failed_heuristics',
+      needsRetry: false,
+    };
+  }
+
+  if (heuristics.status === 'pass') {
+    return {
+      ...result,
+      valid: true,
+    };
+  }
+
+  const payload = { candidate, base, lang, metadata };
+  const viaEndpoint = await requestValidationViaEndpoint(payload);
+  if (viaEndpoint?.ok) {
+    return {
+      ...result,
+      valid: Boolean(viaEndpoint.valid),
+      reason: viaEndpoint.reason || '',
+      needsRetry:
+        typeof viaEndpoint.needsRetry === 'boolean'
+          ? viaEndpoint.needsRetry
+          : !viaEndpoint.valid,
+      attemptedRemote: true,
+      remoteSource: viaEndpoint.strategy || viaEndpoint.source || 'api',
+      languageConfidence: viaEndpoint.languageConfidence ?? null,
+    };
+  }
+
+  if (viaEndpoint && viaEndpoint.status === 404) {
+    const viaPrompt = await requestValidationViaPrompt(payload);
+    if (viaPrompt?.ok) {
+      return {
+        ...result,
+        valid: Boolean(viaPrompt.valid),
+        reason: viaPrompt.reason || '',
+        needsRetry: Boolean(viaPrompt.needsRetry),
+        attemptedRemote: true,
+        remoteSource: viaPrompt.source,
+        languageConfidence: viaPrompt.languageConfidence,
+      };
+    }
+  }
+
+  return {
+    ...result,
+    reason:
+      heuristics.reasons[0] ||
+      (viaEndpoint?.status ? `validation_http_${viaEndpoint.status}` : 'validation_unavailable'),
+    needsRetry: true,
+    attemptedRemote: Boolean(viaEndpoint),
+    remoteSource: viaEndpoint?.status ? `status_${viaEndpoint.status}` : null,
+  };
+}
+
 export default async function translateWithCache(lang, key, fallback, metadata) {
   const locales = await loadLocale(lang);
-  if (locales[key]) return locales[key];
-
   const enLocales = await loadLocale('en');
   const baseCandidate = enLocales[key] || fallback || describe(key);
-  const base = typeof baseCandidate === 'string' ? baseCandidate : String(baseCandidate ?? '');
-  if (lang === 'en') return base;
+  const base =
+    typeof baseCandidate === 'string' ? baseCandidate : String(baseCandidate ?? '');
 
+  if (lang === 'en') {
+    return createResult(base, { base, source: 'base', fromCache: true });
+  }
+
+  const direct = locales[key];
   const normalizedMetadata = normalizeMetadata(metadata);
-  const { primary: cacheKey, all: cacheKeys } = buildCacheKeyParts(lang, base, normalizedMetadata);
+  if (direct) {
+    return createResult(direct, {
+      base,
+      source: 'locale-file',
+      fromCache: true,
+    });
+  }
+
+  const { primary: cacheKey, all: cacheKeys } = buildCacheKeyParts(
+    lang,
+    base,
+    normalizedMetadata,
+  );
 
   let cached;
   for (const cacheId of cacheKeys) {
     cached = getLS(cacheId);
-    if (cached) return cached;
+    if (cached) {
+      return createResult(cached, {
+        base,
+        source: 'cache-localStorage',
+        fromCache: true,
+      });
+    }
   }
 
   for (const cacheId of cacheKeys) {
     cached = await idbGet(cacheId);
     if (cached) {
       if (!getLS(cacheId)) setLS(cacheId, cached);
-      return cached;
+      return createResult(cached, {
+        base,
+        source: 'cache-indexedDB',
+        fromCache: true,
+      });
     }
   }
 
@@ -214,7 +425,11 @@ export default async function translateWithCache(lang, key, fallback, metadata) 
     const value = cacheStore[cacheId];
     if (value) {
       if (!getLS(cacheId)) setLS(cacheId, value);
-      return value;
+      return createResult(value, {
+        base,
+        source: 'cache-node',
+        fromCache: true,
+      });
     }
   }
 
@@ -223,13 +438,66 @@ export default async function translateWithCache(lang, key, fallback, metadata) 
     translated = await requestTranslation(base, lang, normalizedMetadata);
   } catch (err) {
     if (err.rateLimited) throw err;
-    return base;
+    return createResult(base, {
+      base,
+      source: 'fallback-error',
+      needsRetry: true,
+      validation: {
+        valid: false,
+        reason: 'request_failed',
+        error: err.message,
+      },
+    });
   }
-  if (!translated) return base;
+
+  if (!translated) {
+    return createResult(base, {
+      base,
+      source: 'fallback-missing',
+      needsRetry: true,
+      validation: {
+        valid: false,
+        reason: 'no_translation',
+      },
+    });
+  }
+
+  let validation;
+  try {
+    validation = await validateAITranslation(translated, base, lang, normalizedMetadata);
+  } catch (err) {
+    if (err.rateLimited) throw err;
+    validation = {
+      valid: false,
+      needsRetry: true,
+      reason: 'validation_error',
+    };
+  }
+
+  if (!validation?.valid) {
+    return createResult(base, {
+      base,
+      source: 'fallback-validation',
+      needsRetry: true,
+      validation,
+      candidate: translated,
+    });
+  }
 
   setLS(cacheKey, translated);
   await idbSet(cacheKey, translated);
   cacheStore[cacheKey] = translated;
   await saveNodeCache();
-  return translated;
+
+  return createResult(translated, {
+    base,
+    source: 'ai',
+    fromCache: false,
+    validation: {
+      ...validation,
+      needsRetry: Boolean(validation.needsRetry),
+    },
+    needsRetry: Boolean(validation.needsRetry),
+    candidate: translated,
+  });
 }

--- a/tests/pages/ManualTranslationsTab.test.js
+++ b/tests/pages/ManualTranslationsTab.test.js
@@ -49,7 +49,9 @@ if (typeof mock.import !== 'function') {
           createElement: reactMock.createElement,
         },
         '../context/I18nContext.jsx': { default: {} },
-        '../utils/translateWithCache.js': { default: async () => '' },
+        '../utils/translateWithCache.js': {
+          default: async () => ({ text: '', needsRetry: false }),
+        },
       },
     );
 

--- a/utils/translationValidation.js
+++ b/utils/translationValidation.js
@@ -1,0 +1,398 @@
+const englishStopWords = new Set([
+  "a",
+  "about",
+  "above",
+  "across",
+  "after",
+  "again",
+  "against",
+  "all",
+  "almost",
+  "along",
+  "already",
+  "also",
+  "although",
+  "always",
+  "among",
+  "an",
+  "and",
+  "another",
+  "any",
+  "anyone",
+  "anything",
+  "are",
+  "around",
+  "as",
+  "at",
+  "away",
+  "back",
+  "because",
+  "been",
+  "before",
+  "being",
+  "below",
+  "between",
+  "both",
+  "but",
+  "by",
+  "can",
+  "cannot",
+  "come",
+  "could",
+  "day",
+  "did",
+  "do",
+  "does",
+  "done",
+  "down",
+  "during",
+  "each",
+  "either",
+  "else",
+  "even",
+  "ever",
+  "every",
+  "few",
+  "first",
+  "for",
+  "from",
+  "get",
+  "give",
+  "go",
+  "good",
+  "had",
+  "has",
+  "have",
+  "having",
+  "he",
+  "her",
+  "here",
+  "hers",
+  "herself",
+  "him",
+  "himself",
+  "his",
+  "how",
+  "however",
+  "if",
+  "in",
+  "into",
+  "is",
+  "it",
+  "its",
+  "itself",
+  "just",
+  "keep",
+  "know",
+  "last",
+  "less",
+  "let",
+  "like",
+  "long",
+  "look",
+  "made",
+  "make",
+  "many",
+  "may",
+  "me",
+  "might",
+  "more",
+  "most",
+  "much",
+  "must",
+  "my",
+  "myself",
+  "near",
+  "need",
+  "never",
+  "new",
+  "no",
+  "not",
+  "now",
+  "of",
+  "off",
+  "often",
+  "on",
+  "once",
+  "one",
+  "only",
+  "onto",
+  "or",
+  "other",
+  "our",
+  "ours",
+  "ourselves",
+  "out",
+  "over",
+  "own",
+  "people",
+  "perhaps",
+  "put",
+  "really",
+  "right",
+  "said",
+  "same",
+  "see",
+  "should",
+  "since",
+  "so",
+  "some",
+  "someone",
+  "something",
+  "still",
+  "such",
+  "sure",
+  "take",
+  "than",
+  "that",
+  "the",
+  "their",
+  "theirs",
+  "them",
+  "themselves",
+  "then",
+  "there",
+  "therefore",
+  "these",
+  "they",
+  "thing",
+  "think",
+  "this",
+  "those",
+  "though",
+  "through",
+  "thus",
+  "to",
+  "too",
+  "under",
+  "until",
+  "up",
+  "upon",
+  "us",
+  "use",
+  "very",
+  "was",
+  "we",
+  "well",
+  "were",
+  "what",
+  "when",
+  "where",
+  "whether",
+  "which",
+  "while",
+  "who",
+  "whom",
+  "whose",
+  "why",
+  "will",
+  "with",
+  "within",
+  "without",
+  "would",
+  "yes",
+  "yet",
+  "you",
+  "your",
+  "yours",
+  "yourself",
+  "yourselves",
+]);
+
+const accentRegex = /[áéíóúüñçàèìòùâêîôûäëïöüãõåæœßÿčšžğışășț]/i;
+const placeholderRegex = /{{\s*[^}]+\s*}}|%[-+]?\d*(?:\.\d+)?[sdif]|\{\d+\}|\$\{[^}]+\}|:[a-zA-Z_][\w-]*|<[^>]+>/g;
+const asciiWordRegex = /^[a-z]+$/;
+const nonAsciiRegex = /[^\u0000-\u007F]/;
+
+export function normalizeText(text) {
+  if (typeof text !== "string") return String(text ?? "").trim();
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function extractPlaceholders(text) {
+  if (!text) return [];
+  const matches = text.match(placeholderRegex) || [];
+  return matches.map((m) => m.trim()).sort();
+}
+
+function tokenizeWords(text) {
+  if (!text) return [];
+  return (
+    text
+      .toLowerCase()
+      .match(/[a-záéíóúüñçàèìòùâêîôûäëïöüãõåæœßÿčšžğışășț]+/g) || []
+  );
+}
+
+function englishCoverage(words) {
+  if (!words.length) return { asciiCount: 0, englishMatches: 0, ratio: 0 };
+  let asciiCount = 0;
+  let englishMatches = 0;
+  for (const word of words) {
+    if (asciiWordRegex.test(word)) {
+      asciiCount += 1;
+      if (englishStopWords.has(word)) englishMatches += 1;
+    }
+  }
+  const ratio = asciiCount === 0 ? 0 : englishMatches / asciiCount;
+  return { asciiCount, englishMatches, ratio };
+}
+
+function collectMetadataTokens(metadata) {
+  if (!metadata || typeof metadata !== "object") return [];
+  const tokens = new Set();
+  for (const raw of [metadata?.module, metadata?.context, metadata?.key]) {
+    if (!raw || typeof raw !== "string") continue;
+    const pieces = raw
+      .toLowerCase()
+      .split(/[^a-z0-9áéíóúüñçàèìòùâêîôûäëïöüãõåæœßÿčšžğışășț]+/i)
+      .filter(Boolean);
+    pieces.forEach((piece) => tokens.add(piece));
+  }
+  return Array.from(tokens);
+}
+
+export function evaluateTranslationCandidate({
+  candidate,
+  base,
+  lang,
+  metadata,
+}) {
+  const normalizedCandidate = normalizeText(candidate);
+  const normalizedBase = normalizeText(base);
+  const result = {
+    normalizedCandidate,
+    normalizedBase,
+    placeholders: { missing: [], extra: [] },
+    english: { asciiCount: 0, englishMatches: 0, ratio: 0 },
+    metadataTokens: collectMetadataTokens(metadata),
+    status: "pass",
+    reasons: [],
+  };
+
+  if (!normalizedCandidate) {
+    result.status = "fail";
+    result.reasons.push("empty");
+    return result;
+  }
+
+  if (
+    normalizedBase &&
+    normalizedCandidate.toLowerCase() === normalizedBase.toLowerCase()
+  ) {
+    result.status = "fail";
+    result.reasons.push("identical_to_base");
+    return result;
+  }
+
+  const basePlaceholders = extractPlaceholders(normalizedBase);
+  const candidatePlaceholders = extractPlaceholders(normalizedCandidate);
+  if (basePlaceholders.length) {
+    const missing = basePlaceholders.filter(
+      (ph) => !candidatePlaceholders.includes(ph),
+    );
+    if (missing.length) {
+      result.placeholders.missing = missing;
+      result.status = "fail";
+      result.reasons.push(`missing_placeholders:${missing.join(',')}`);
+      return result;
+    }
+  }
+  if (candidatePlaceholders.length) {
+    const extras = candidatePlaceholders.filter(
+      (ph) => !basePlaceholders.includes(ph),
+    );
+    if (extras.length) {
+      result.placeholders.extra = extras;
+      result.reasons.push(`extra_placeholders:${extras.join(',')}`);
+      if (result.status !== "fail") result.status = "retry";
+    }
+  }
+
+  const words = tokenizeWords(normalizedCandidate);
+  result.english = englishCoverage(words);
+
+  if (normalizedBase.split(" ").length > 3 && words.length <= 1) {
+    result.status = "fail";
+    result.reasons.push("too_short_for_context");
+    return result;
+  }
+
+  if (lang && lang !== "en") {
+    if (result.english.ratio >= 0.75 && result.english.asciiCount > 0) {
+      result.status = "fail";
+      result.reasons.push("appears_english");
+      return result;
+    }
+    if (
+      result.status !== "fail" &&
+      result.english.ratio >= 0.4 &&
+      result.english.asciiCount > 2
+    ) {
+      result.status = "retry";
+      result.reasons.push("possibly_english");
+    }
+    const hasNonAscii = nonAsciiRegex.test(normalizedCandidate);
+    if (
+      result.status !== "fail" &&
+      !hasNonAscii &&
+      !accentRegex.test(normalizedCandidate) &&
+      result.english.asciiCount === 0
+    ) {
+      result.status = "retry";
+      result.reasons.push("no_language_signal");
+    }
+  }
+
+  if (result.status !== "fail" && result.metadataTokens.length) {
+    const lowerCandidate = normalizedCandidate.toLowerCase();
+    const hits = result.metadataTokens.filter((token) =>
+      lowerCandidate.includes(token),
+    );
+    if (!hits.length) {
+      result.status = result.status === "pass" ? "retry" : result.status;
+      result.reasons.push("metadata_not_reflected");
+    }
+  }
+
+  return result;
+}
+
+export function buildValidationPrompt({ candidate, base, lang, metadata }) {
+  const metaParts = [];
+  if (metadata && typeof metadata === "object") {
+    if (metadata.module) metaParts.push(`module: ${metadata.module}`);
+    if (metadata.context) metaParts.push(`context: ${metadata.context}`);
+    if (metadata.key) metaParts.push(`key: ${metadata.key}`);
+  }
+  const metaLine = metaParts.length ? metaParts.join(', ') : 'none provided';
+  return [
+    'You are a meticulous translation validator. Determine whether the proposed translation is a faithful rendering of the base text, uses the requested target language, respects placeholders, and fits the supplied module/context metadata.',
+    'Respond ONLY with JSON using the shape {"valid":boolean,"reason":string,"languageConfidence":number}. If invalid, explain why in "reason" in English. If valid, set reason to an empty string.',
+    `Base text: """${base ?? ''}"""`,
+    `Proposed translation: """${candidate ?? ''}"""`,
+    `Target language code: ${lang || 'unknown'}`,
+    `Metadata: ${metaLine}`,
+  ].join('\n');
+}
+
+export function summarizeHeuristic(result) {
+  if (!result) return '';
+  const parts = [];
+  if (result.reasons.length) parts.push(result.reasons.join('; '));
+  if (result.placeholders?.missing?.length) {
+    parts.push(`missing placeholders: ${result.placeholders.missing.join(', ')}`);
+  }
+  if (result.english) {
+    parts.push(
+      `englishRatio=${result.english.ratio.toFixed(2)} (ascii=${result.english.asciiCount})`,
+    );
+  }
+  return parts.join(' | ');
+}
+
+export default {
+  evaluateTranslationCandidate,
+  buildValidationPrompt,
+  summarizeHeuristic,
+};


### PR DESCRIPTION
## Summary
- add shared translation validation heuristics with metadata-aware placeholder checks
- update translateWithCache to return validation metadata, run server-side validator, and gate caching on successful checks
- expose an /api/openai/validate endpoint and adjust manual export/manual translation flows and CLI to consume the richer results

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfcede3fb88331a0ea7e802c6b9d3d