### PR TITLE
Relax manual translations limiter and add rate-limit backoff

### DIFF
--- a/api-server/routes/manual_translations.js
+++ b/api-server/routes/manual_translations.js
@@ -1,61 +1,62 @@
 import express from 'express';
 import { requireAuth } from '../middlewares/auth.js';
-import rateLimit from 'express-rate-limit';
 import {
   loadTranslations,
   saveTranslation,
   deleteTranslation,
 } from '../services/manualTranslations.js';
+import { createManualTranslationsLimiter } from './manual_translationsLimiter.js';
 
-// Set up rate limiter: max 100 requests per 15 minutes per IP
-const limiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // Limit each IP to 100 requests per windowMs
-  standardHeaders: true, // Return rate limit info in the RateLimit-* headers
-  legacyHeaders: false, // Disable the X-RateLimit-* headers
-});
+export function createManualTranslationsRouter({ limiter: limiterOptions } = {}) {
+  const router = express.Router();
+  router.use(requireAuth);
+  const limiter = createManualTranslationsLimiter(limiterOptions);
+  router.use(limiter);
 
-const router = express.Router();
-
-router.get('/', limiter, requireAuth, async (req, res, next) => {
-  try {
-    const data = await loadTranslations();
-    res.json(data);
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.post('/', limiter, requireAuth, async (req, res, next) => {
-  try {
-    await saveTranslation(req.body || {});
-    res.sendStatus(204);
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.post('/bulk', limiter, requireAuth, async (req, res, next) => {
-  try {
-    const entries = Array.isArray(req.body) ? req.body : [];
-    for (const entry of entries) {
-      await saveTranslation(entry || {});
+  router.get('/', async (req, res, next) => {
+    try {
+      const data = await loadTranslations();
+      res.json(data);
+    } catch (err) {
+      next(err);
     }
-    res.sendStatus(204);
-  } catch (err) {
-    next(err);
-  }
-});
+  });
 
-router.delete('/', limiter, requireAuth, async (req, res, next) => {
-  try {
-    const { key, type = 'locale' } = req.query;
-    if (!key) return res.status(400).json({ error: 'key required' });
-    await deleteTranslation(key, type);
-    res.sendStatus(204);
-  } catch (err) {
-    next(err);
-  }
-});
+  router.post('/', async (req, res, next) => {
+    try {
+      await saveTranslation(req.body || {});
+      res.sendStatus(204);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.post('/bulk', async (req, res, next) => {
+    try {
+      const entries = Array.isArray(req.body) ? req.body : [];
+      for (const entry of entries) {
+        await saveTranslation(entry || {});
+      }
+      res.sendStatus(204);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.delete('/', async (req, res, next) => {
+    try {
+      const { key, type = 'locale' } = req.query;
+      if (!key) return res.status(400).json({ error: 'key required' });
+      await deleteTranslation(key, type);
+      res.sendStatus(204);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}
+
+const router = createManualTranslationsRouter();
 
 export default router;

--- a/api-server/routes/manual_translationsLimiter.js
+++ b/api-server/routes/manual_translationsLimiter.js
@@ -1,0 +1,82 @@
+let rateLimit;
+
+try {
+  const mod = await import('express-rate-limit');
+  rateLimit = mod.default ?? mod;
+} catch {
+  rateLimit = (options = {}) => {
+    const windowMs = options.windowMs ?? 60 * 1000;
+    const max = options.max ?? 5;
+    const skipSuccessful = options.skipSuccessfulRequests ?? false;
+    const keyGenerator = options.keyGenerator ?? ((req) => req.ip);
+    const statusCode = options.statusCode ?? 429;
+    const message = options.message ?? 'Too many requests';
+    const store = new Map();
+
+    function resolveLimit(req, res) {
+      return typeof max === 'function' ? max(req, res) : max;
+    }
+
+    return (req, res, next) => {
+      const key = keyGenerator(req, res);
+      const now = Date.now();
+      let entry = store.get(key);
+      if (!entry || now - entry.start >= windowMs) {
+        entry = { count: 0, start: now };
+        store.set(key, entry);
+      }
+
+      const limit = resolveLimit(req, res);
+      if (entry.count >= limit) {
+        if (typeof res.status === 'function') res.status(statusCode);
+        if (typeof res.json === 'function') {
+          res.json(message);
+        } else if (typeof res.send === 'function') {
+          res.send(message);
+        } else if (typeof res.end === 'function') {
+          res.end();
+        }
+        return;
+      }
+
+      entry.count += 1;
+      if (skipSuccessful && typeof res.on === 'function') {
+        res.once('finish', () => {
+          if (res.statusCode < 400 && entry.count > 0) {
+            entry.count -= 1;
+          }
+        });
+      }
+
+      next();
+    };
+  };
+}
+
+export function createManualTranslationsLimiter(options = {}) {
+  const {
+    windowMs = 15 * 60 * 1000,
+    max = (req) => (req.user ? 600 : 100),
+    standardHeaders = true,
+    legacyHeaders = false,
+    skipSuccessfulRequests = true,
+    keyGenerator = (req) => {
+      if (req.user?.id) {
+        const company = req.user.companyId ?? 'global';
+        return `user:${req.user.id}:company:${company}`;
+      }
+      return req.ip;
+    },
+    ...rest
+  } = options;
+
+  return rateLimit({
+    windowMs,
+    max,
+    standardHeaders,
+    legacyHeaders,
+    skipSuccessfulRequests,
+    keyGenerator,
+    ...rest,
+  });
+}

--- a/tests/pages/ManualTranslationsTab.rateLimit.test.js
+++ b/tests/pages/ManualTranslationsTab.rateLimit.test.js
@@ -3,82 +3,230 @@ import assert from 'node:assert/strict';
 
 if (typeof mock.import !== 'function') {
   test('ManualTranslationsTab halts on rate limit and shows one toast', { skip: true }, () => {});
+  test(
+    'ManualTranslationsTab backs off API reloads after hitting rate limit',
+    { skip: true },
+    () => {},
+  );
 } else {
   test('ManualTranslationsTab halts on rate limit and shows one toast', async () => {
-  const toasts = [];
-  globalThis.window = {
-    dispatchEvent: (ev) => {
-      if (ev.type === 'toast') toasts.push(ev.detail);
-    },
-    addEventListener: () => {},
-    location: { hash: '' },
-  };
-  globalThis.CustomEvent = function (type, opts) {
-    return { type, ...opts };
-  };
+    const toasts = [];
+    globalThis.window = {
+      dispatchEvent: (ev) => {
+        if (ev.type === 'toast') toasts.push(ev.detail);
+      },
+      addEventListener: () => {},
+      location: { hash: '' },
+    };
+    globalThis.CustomEvent = function (type, opts) {
+      return { type, ...opts };
+    };
 
-  const states = [];
-  let completeHandler;
-  const reactMock = {
-    useState(initial) {
-      const idx = states.length;
-      let value = initial;
-      if (idx === 0) value = ['en', 'mn'];
-      if (idx === 1) {
-        value = [
-          { key: 'k1', type: 'locale', values: { en: 'Hello', mn: '' } },
-          { key: 'k2', type: 'locale', values: { en: 'World', mn: '' } },
+    const states = [];
+    let completeHandler;
+    const reactMock = {
+      useState(initial) {
+        const idx = states.length;
+        let value = initial;
+        if (idx === 0) value = ['en', 'mn'];
+        if (idx === 1) {
+          value = [
+            { key: 'k1', type: 'locale', values: { en: 'Hello', mn: '' } },
+            { key: 'k2', type: 'locale', values: { en: 'World', mn: '' } },
+          ];
+        }
+        states.push(value);
+        return [
+          value,
+          (v) => {
+            states[idx] = typeof v === 'function' ? v(states[idx]) : v;
+          },
         ];
-      }
-      states.push(value);
-      return [value, (v) => (states[idx] = v)];
-    },
-    useEffect() {},
-    useContext() {
-      return { t: (_k, d) => d };
-    },
-    useRef(initial) {
-      return { current: initial };
-    },
-    createElement(type, props, ...children) {
-      if (typeof type === 'function') {
-        return type({ ...props, children });
-      }
-      const text = children.flat ? children.flat().join('') : children.join('');
-      if (type === 'button' && text.includes('Complete translations')) {
-        completeHandler = props.onClick;
-      }
-      return null;
-    },
-  };
+      },
+      useEffect() {},
+      useContext() {
+        return { t: (_k, d) => d };
+      },
+      useRef(initial) {
+        return { current: initial };
+      },
+      useCallback(fn) {
+        return fn;
+      },
+      createElement(type, props, ...children) {
+        if (typeof type === 'function') {
+          return type({ ...props, children });
+        }
+        const text = children.flat ? children.flat().join('') : children.join('');
+        if (type === 'button' && text.includes('Complete translations')) {
+          completeHandler = props.onClick;
+        }
+        return null;
+      },
+    };
 
-  const translateMock = mock.fn(async () => {
-    const err = new Error('rate limited');
-    err.rateLimited = true;
-    throw err;
+    const translateMock = mock.fn(async () => {
+      const err = new Error('rate limited');
+      err.rateLimited = true;
+      throw err;
+    });
+
+    const { default: ManualTranslationsTab } = await mock.import(
+      '../../src/erp.mgt.mn/pages/ManualTranslationsTab.jsx',
+      {
+        react: {
+          default: reactMock,
+          useState: reactMock.useState,
+          useEffect: reactMock.useEffect,
+          useContext: reactMock.useContext,
+          useRef: reactMock.useRef,
+          useCallback: reactMock.useCallback,
+          createElement: reactMock.createElement,
+        },
+        '../context/I18nContext.jsx': { default: {} },
+        '../utils/translateWithCache.js': { default: translateMock },
+      },
+    );
+
+    reactMock.createElement(ManualTranslationsTab, {});
+
+    await completeHandler();
+
+    assert.equal(translateMock.mock.callCount(), 1);
+    assert.equal(toasts.length, 1);
   });
 
-  const { default: ManualTranslationsTab } = await mock.import(
-    '../../src/erp.mgt.mn/pages/ManualTranslationsTab.jsx',
-    {
-      react: {
-        default: reactMock,
-        useState: reactMock.useState,
-        useEffect: reactMock.useEffect,
-        useContext: reactMock.useContext,
-        useRef: reactMock.useRef,
-        createElement: reactMock.createElement,
+  test('ManualTranslationsTab backs off API reloads after hitting rate limit', async () => {
+    const toasts = [];
+    const fetchCalls = [];
+    const scheduledTimeouts = [];
+    const originalFetch = global.fetch;
+    const originalWindow = global.window;
+    const originalCustomEvent = global.CustomEvent;
+    const originalSetTimeout = global.setTimeout;
+    const originalClearTimeout = global.clearTimeout;
+
+    const translateMock = mock.fn(async () => ({ text: 'OK', needsRetry: false }));
+
+    global.fetch = mock.fn(async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      if (url === '/api/manual_translations') {
+        return { status: 429, ok: false, json: async () => ({}) };
+      }
+      if (url === '/api/manual_translations/bulk') {
+        return { status: 204, ok: true, json: async () => ({}) };
+      }
+      return { status: 404, ok: false, json: async () => ({}) };
+    });
+
+    global.window = {
+      dispatchEvent: (ev) => {
+        if (ev.type === 'toast') toasts.push(ev.detail);
       },
-      '../context/I18nContext.jsx': { default: {} },
-      '../utils/translateWithCache.js': { default: translateMock },
-    },
-  );
+      addEventListener: () => {},
+      location: { hash: '' },
+    };
+    global.CustomEvent = function (type, opts) {
+      return { type, ...opts };
+    };
 
-  reactMock.createElement(ManualTranslationsTab, {});
+    global.setTimeout = (fn, delay, ...args) => {
+      if (delay === 200) {
+        fn(...args);
+        return { immediate: true, delay };
+      }
+      const handle = { fn, delay, args };
+      scheduledTimeouts.push(handle);
+      return handle;
+    };
+    global.clearTimeout = (handle) => {
+      const idx = scheduledTimeouts.indexOf(handle);
+      if (idx >= 0) scheduledTimeouts.splice(idx, 1);
+    };
 
-  await completeHandler();
+    const states = [];
+    let completeHandler;
+    const reactMock = {
+      useState(initial) {
+        const idx = states.length;
+        let value = initial;
+        if (idx === 0) value = ['en', 'mn'];
+        if (idx === 1) {
+          value = [{ key: 'k1', type: 'locale', values: { en: 'Hello', mn: '' } }];
+        }
+        states.push(value);
+        return [
+          value,
+          (v) => {
+            states[idx] = typeof v === 'function' ? v(states[idx]) : v;
+          },
+        ];
+      },
+      useEffect(effect) {
+        effect();
+      },
+      useContext() {
+        return { t: (_k, d) => d };
+      },
+      useRef(initial) {
+        return { current: initial };
+      },
+      useCallback(fn) {
+        return fn;
+      },
+      createElement(type, props, ...children) {
+        if (typeof type === 'function') {
+          return type({ ...props, children });
+        }
+        const text = children.flat ? children.flat().join('') : children.join('');
+        if (type === 'button' && text.includes('Complete translations')) {
+          completeHandler = props.onClick;
+        }
+        return null;
+      },
+    };
 
-  assert.equal(translateMock.mock.callCount(), 1);
-  assert.equal(toasts.length, 1);
+    try {
+      const { default: ManualTranslationsTab } = await mock.import(
+        '../../src/erp.mgt.mn/pages/ManualTranslationsTab.jsx',
+        {
+          react: {
+            default: reactMock,
+            useState: reactMock.useState,
+            useEffect: reactMock.useEffect,
+            useContext: reactMock.useContext,
+            useRef: reactMock.useRef,
+            useCallback: reactMock.useCallback,
+            createElement: reactMock.createElement,
+          },
+          '../context/I18nContext.jsx': { default: {} },
+          '../context/ToastContext.jsx': {
+            useToast: () => ({ addToast: () => {} }),
+          },
+          '../utils/translateWithCache.js': { default: translateMock },
+        },
+      );
+
+      reactMock.createElement(ManualTranslationsTab, {});
+
+      await completeHandler();
+
+      const manualFetches = fetchCalls.filter((c) => c.url === '/api/manual_translations');
+      const bulkFetches = fetchCalls.filter((c) => c.url === '/api/manual_translations/bulk');
+
+      assert.equal(manualFetches.length, 1, 'should only fetch manual translations once');
+      assert.equal(bulkFetches.length, 1, 'should post translated batch once');
+      assert.equal(scheduledTimeouts.length, 1, 'should schedule a single retry');
+      assert.equal(toasts.length, 1, 'should only show one rate limit toast');
+      assert.equal(translateMock.mock.callCount(), 1, 'translates a single missing value');
+    } finally {
+      global.fetch = originalFetch;
+      if (originalWindow === undefined) delete global.window;
+      else global.window = originalWindow;
+      if (originalCustomEvent === undefined) delete global.CustomEvent;
+      else global.CustomEvent = originalCustomEvent;
+      global.setTimeout = originalSetTimeout;
+      global.clearTimeout = originalClearTimeout;
+    }
   });
 }

--- a/tests/pages/ManualTranslationsTab.test.js
+++ b/tests/pages/ManualTranslationsTab.test.js
@@ -12,7 +12,12 @@ if (typeof mock.import !== 'function') {
       useState(initial) {
         const idx = states.length;
         states.push(initial);
-        return [states[idx], (v) => (states[idx] = v)];
+        return [
+          states[idx],
+          (v) => {
+            states[idx] = typeof v === 'function' ? v(states[idx]) : v;
+          },
+        ];
       },
       useEffect() {},
       useContext() {
@@ -20,6 +25,9 @@ if (typeof mock.import !== 'function') {
       },
       useRef(initial) {
         return { current: initial };
+      },
+      useCallback(fn) {
+        return fn;
       },
       createElement(type, props, ...children) {
         if (typeof type === 'function') {
@@ -46,6 +54,7 @@ if (typeof mock.import !== 'function') {
           useEffect: reactMock.useEffect,
           useContext: reactMock.useContext,
           useRef: reactMock.useRef,
+          useCallback: reactMock.useCallback,
           createElement: reactMock.createElement,
         },
         '../context/I18nContext.jsx': { default: {} },

--- a/tests/routes/manual_translations.limiter.test.js
+++ b/tests/routes/manual_translations.limiter.test.js
@@ -1,0 +1,88 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { createManualTranslationsLimiter } from '../../api-server/routes/manual_translationsLimiter.js';
+
+function createResponse() {
+  const res = new EventEmitter();
+  res.statusCode = 200;
+  res.headersSent = false;
+  res.status = function (code) {
+    this.statusCode = code;
+    return this;
+  };
+  res.setHeader = () => {};
+  res.json = function (body) {
+    this.body = body;
+    this.headersSent = true;
+    this.emit('finish');
+    return this;
+  };
+  res.send = res.json;
+  res.end = function () {
+    this.headersSent = true;
+    this.emit('finish');
+  };
+  return res;
+}
+
+function runLimiter(limiter, req, res) {
+  return new Promise((resolve) => {
+    let nextCalled = false;
+    let settled = false;
+    const finish = () => {
+      if (!settled) {
+        settled = true;
+        resolve({ nextCalled, statusCode: res.statusCode });
+      }
+    };
+    res.on('finish', finish);
+    limiter(req, res, () => {
+      nextCalled = true;
+      if (!res.headersSent) {
+        res.emit('finish');
+      }
+    });
+  });
+}
+
+await test('manual translations limiter skips successful requests by default', async () => {
+  const limiter = createManualTranslationsLimiter({ windowMs: 1000, max: 1 });
+  const req = { ip: '127.0.0.1', user: { id: 'user-1', companyId: 'co-1' } };
+
+  const res1 = createResponse();
+  const result1 = await runLimiter(limiter, req, res1);
+  assert.equal(result1.statusCode, 200);
+  assert.equal(result1.nextCalled, true);
+
+  const res2 = createResponse();
+  const result2 = await runLimiter(limiter, req, res2);
+  assert.equal(result2.statusCode, 200);
+  assert.equal(result2.nextCalled, true);
+});
+
+await test('manual translations limiter tracks counts per authenticated user', async () => {
+  const limiter = createManualTranslationsLimiter({
+    windowMs: 1000,
+    max: 2,
+    skipSuccessfulRequests: false,
+  });
+
+  const makeReq = (id) => ({ ip: '192.168.0.1', user: { id, companyId: 'co-7' } });
+
+  const first = await runLimiter(limiter, makeReq('user-a'), createResponse());
+  assert.equal(first.statusCode, 200);
+  assert.equal(first.nextCalled, true);
+
+  const second = await runLimiter(limiter, makeReq('user-a'), createResponse());
+  assert.equal(second.statusCode, 200);
+  assert.equal(second.nextCalled, true);
+
+  const third = await runLimiter(limiter, makeReq('user-a'), createResponse());
+  assert.equal(third.statusCode, 429);
+  assert.equal(third.nextCalled, false);
+
+  const other = await runLimiter(limiter, makeReq('user-b'), createResponse());
+  assert.equal(other.statusCode, 200);
+  assert.equal(other.nextCalled, true);
+});


### PR DESCRIPTION
## Summary
- apply authentication before the manual translations limiter and scope the limiter per user via a shared helper with a fallback implementation
- debounce manual translations reloads and bulk saves so the UI backs off after rate limiting and avoids redundant refreshes
- cover limiter behavior and client backoff with dedicated tests for the manual translations tab

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfd7c460508331aacdfc21e7e64d3a