### PR TITLE
Purge tenant user-level permissions before company deletion

### DIFF
--- a/api-server/controllers/companyController.js
+++ b/api-server/controllers/companyController.js
@@ -3,6 +3,7 @@ import {
   insertTableRow,
   updateTableRow,
   deleteTableRowCascade,
+  deleteUserLevelPermissionsForCompany,
   getPrimaryKeyColumns,
   getEmploymentSession,
   getUserLevelActions,
@@ -156,6 +157,12 @@ export async function deleteCompanyHandler(req, res, next) {
       'companies',
       cascadeIdentifier,
       tenantCompanyId,
+      {
+        // Ensure tenant-specific permission rows are removed in the same
+        // transaction so they cannot block the cascade via FK constraints.
+        beforeDelete: (conn) =>
+          deleteUserLevelPermissionsForCompany(company.id, conn),
+      },
     );
     res.status(200).json({
       backup: backupMetadata || null,


### PR DESCRIPTION
## Summary
- add a database helper to remove `user_level_permissions` rows for a given company and let `deleteTableRowCascade` invoke optional pre-delete hooks
- invoke the helper from `deleteCompanyHandler` so permission records are purged within the same transaction as the cascade
- extend the company controller tests to cover seeded permission rows and update expectations for the additional delete

## Testing
- npm test -- tests/controllers/companyController.test.js
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfdb8eed148331b9dcd0faf3329308