### PR TITLE
Fix manual translations import consolidation

### DIFF
--- a/api-server/services/manualTranslations.js
+++ b/api-server/services/manualTranslations.js
@@ -1,8 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { evaluateTranslationCandidate } from '../../utils/translationValidation.js';
-
 import {
   evaluateTranslationCandidate,
   summarizeHeuristic,


### PR DESCRIPTION
## Summary
- consolidate the manual translations service imports so both helpers load from a single declaration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfed7b958883318221c24a0f4596dd