### PR TITLE
Move tenant cleanup after cascade during company deletion

### DIFF
--- a/api-server/controllers/companyController.js
+++ b/api-server/controllers/companyController.js
@@ -163,6 +163,11 @@ export async function deleteCompanyHandler(req, res, next) {
         // transaction so they cannot block the cascade via FK constraints.
         beforeDelete: async (conn) => {
           await deleteUserLevelPermissionsForCompany(company.id, conn);
+        },
+        // Remove branch-scoped tables after the cascade so any FK-bound
+        // records (e.g. tbl_discount, transactions_pos) have already been
+        // purged with their parents.
+        afterDelete: async (conn) => {
           await deleteUnprotectedTenantTableRowsForCompany(company, conn);
         },
       },

--- a/db/index.js
+++ b/db/index.js
@@ -4346,13 +4346,16 @@ export async function deleteTableRowCascade(
   options = {},
 ) {
   const conn = await pool.getConnection();
-  const { beforeDelete } = options ?? {};
+  const { beforeDelete, afterDelete } = options ?? {};
   try {
     await conn.beginTransaction();
     if (typeof beforeDelete === 'function') {
       await beforeDelete(conn);
     }
     await deleteCascade(conn, tableName, id, new Set(), companyId);
+    if (typeof afterDelete === 'function') {
+      await afterDelete(conn);
+    }
     await conn.commit();
   } catch (err) {
     await conn.rollback();


### PR DESCRIPTION
## Summary
- add an `afterDelete` hook to `deleteTableRowCascade` so follow-up work can run on the same connection before commit
- keep permission cleanup in the pre-delete hook but run tenant table purges after the cascade in `deleteCompanyHandler`
- extend controller tests to cover discount/POS cascades and verify branch cleanup happens post-cascade

## Testing
- npm test -- tests/controllers/companyController.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cff74ba410833181062f601ee3678b