### PR TITLE
Handle English fallback failures in manual translations

### DIFF
--- a/src/erp.mgt.mn/pages/ManualTranslationsTab.jsx
+++ b/src/erp.mgt.mn/pages/ManualTranslationsTab.jsx
@@ -354,6 +354,8 @@ export default function ManualTranslationsTab() {
         let swapped = false;
         let attemptedMnTranslation = false;
         let mnTranslationSucceeded = false;
+        let attemptedEnTranslation = false;
+        let enTranslationSucceeded = false;
 
         if (issue.issues.includes('baseFieldsSwapped')) {
           const previousEn = entry.values.en;
@@ -378,6 +380,7 @@ export default function ManualTranslationsTab() {
             }
 
             if (source && getEnLanguage() !== 'en') {
+              attemptedEnTranslation = true;
               try {
                 const translated = await translateWithCache(
                   'en',
@@ -388,6 +391,7 @@ export default function ManualTranslationsTab() {
                 if (translated?.text && !translated.needsRetry) {
                   entry.values.en = translated.text;
                   changed = true;
+                  enTranslationSucceeded = true;
                 }
               } catch {
                 // ignore translation errors; validation below will catch unresolved entries
@@ -422,6 +426,24 @@ export default function ManualTranslationsTab() {
                 // ignore translation errors; validation below will catch unresolved entries
               }
             }
+          }
+        }
+
+        if (attemptedEnTranslation && !enTranslationSucceeded) {
+          const enAnalysisAfter = analyzeBaseLanguage(entry.values.en);
+          if (enAnalysisAfter.language !== 'en') {
+            const previousEnRaw = entry.values.en;
+            const normalizedEn = normalizeBaseLanguageValue(previousEnRaw);
+            if (previousEnRaw !== '' || normalizedEn) {
+              entry.values.en = '';
+              if (
+                normalizedEn ||
+                (typeof previousEnRaw === 'string' && previousEnRaw !== '')
+              ) {
+                changed = true;
+              }
+            }
+            manualReviewIndexes.add(issue.index);
           }
         }
 

--- a/tests/pages/ManualTranslationsTab.languageValidation.test.js
+++ b/tests/pages/ManualTranslationsTab.languageValidation.test.js
@@ -409,6 +409,148 @@ if (typeof mock.import !== 'function') {
     },
   );
 
+  test(
+    'ManualTranslationsTab completeAll sanitizes English base when translation needs retry',
+    async () => {
+      const translateMock = mock.fn(async (lang) => {
+        if (lang === 'en') return { text: '', needsRetry: true };
+        return { text: '', needsRetry: false };
+      });
+      const toasts = [];
+      const addToast = (message, type) => {
+        toasts.push({ message, type });
+      };
+      const originalFetch = global.fetch;
+      const originalWindow = global.window;
+      const originalCustomEvent = global.CustomEvent;
+      const originalSetTimeout = global.setTimeout;
+      const originalClearTimeout = global.clearTimeout;
+      try {
+        global.fetch = mock.fn(async (url) => {
+          if (url === '/api/manual_translations/bulk') {
+            return { status: 204, ok: true, json: async () => ({}) };
+          }
+          return { status: 200, ok: true, json: async () => ({}) };
+        });
+        const dispatchedEvents = [];
+        global.window = {
+          dispatchEvent: (event) => {
+            dispatchedEvents.push(event);
+          },
+          addEventListener: () => {},
+          location: { hash: '' },
+        };
+        global.CustomEvent = function (type, detail) {
+          return { type, ...detail };
+        };
+        global.setTimeout = (fn, delay, ...args) => {
+          if (delay === 200) {
+            fn(...args);
+            return { immediate: true };
+          }
+          return originalSetTimeout(fn, delay, ...args);
+        };
+        global.clearTimeout = (handle) => {
+          if (!handle?.immediate) originalClearTimeout(handle);
+        };
+        const states = [];
+        let completeHandler;
+        const reactMock = {
+          useState(initial) {
+            const idx = states.length;
+            let value = initial;
+            if (idx === 0) value = ['en', 'mn'];
+            if (idx === 1) {
+              value = [
+                {
+                  key: 'needs-en-fix',
+                  type: 'locale',
+                  module: 'module',
+                  context: 'ctx',
+                  values: { en: 'Сайн байна уу', mn: 'Сайн байна уу' },
+                },
+              ];
+            }
+            states.push(value);
+            return [
+              value,
+              (next) => {
+                states[idx] = typeof next === 'function' ? next(states[idx]) : next;
+              },
+            ];
+          },
+          useEffect() {},
+          useContext() {
+            return { t: (_k, d) => d };
+          },
+          useRef(initial) {
+            return { current: initial };
+          },
+          useCallback(fn) {
+            return fn;
+          },
+          createElement(type, props, ...children) {
+            if (typeof type === 'function') {
+              return type({ ...props, children });
+            }
+            const text = children.flat ? children.flat().join('') : children.join('');
+            if (type === 'button' && text.includes('Complete translations')) {
+              completeHandler = props.onClick;
+            }
+            return null;
+          },
+        };
+
+        const { default: ManualTranslationsTab } = await mock.import(
+          '../../src/erp.mgt.mn/pages/ManualTranslationsTab.jsx',
+          {
+            react: {
+              default: reactMock,
+              useState: reactMock.useState,
+              useEffect: reactMock.useEffect,
+              useContext: reactMock.useContext,
+              useRef: reactMock.useRef,
+              useCallback: reactMock.useCallback,
+              createElement: reactMock.createElement,
+            },
+            '../context/I18nContext.jsx': { default: {} },
+            '../context/ToastContext.jsx': { useToast: () => ({ addToast }) },
+            '../utils/translateWithCache.js': { default: translateMock },
+          },
+        );
+
+        reactMock.createElement(ManualTranslationsTab, {});
+        await completeHandler();
+
+        assert.equal(toasts.filter((t) => t.type === 'error').length, 0);
+        assert(
+          toasts.some((t) => t.type === 'warning' && /manual review/i.test(t.message)),
+          'warning toast for manual review was not shown',
+        );
+        assert(translateMock.mock.callCount() >= 1);
+        const entryState = states[1][0];
+        assert.equal(entryState.values.en, '');
+        assert.equal(entryState.values.mn, 'Сайн байна уу');
+        assert.equal(global.fetch.mock.callCount(), 0);
+        assert(
+          dispatchedEvents.some(
+            (event) =>
+              event?.detail?.type === 'error' && /incomplete/i.test(event.detail.message),
+          ),
+          'incomplete toast event was not dispatched',
+        );
+      } finally {
+        global.fetch = originalFetch;
+        if (originalWindow === undefined) delete global.window;
+        else global.window = originalWindow;
+        if (originalCustomEvent === undefined) delete global.CustomEvent;
+        else global.CustomEvent = originalCustomEvent;
+        global.setTimeout = originalSetTimeout;
+        global.clearTimeout = originalClearTimeout;
+      }
+    },
+  );
+
   test('ManualTranslationsTab completeAll continues when base languages are valid', async () => {
     const translateMock = mock.fn(async () => ({ text: 'Hallo', needsRetry: false }));
     const toasts = [];


### PR DESCRIPTION
## Summary
- ensure `resolveBaseLanguages` clears invalid English values when translation fails and flags rows for manual review
- keep sanitized entries from reintroducing invalid English text while collecting manual review indexes
- extend manual translations tests to cover the English retry fallback path

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cffdc11b4c83319c64580fd7720857