### PR TITLE
feat: handle branch aware tenant cleanup

### DIFF
--- a/tests/controllers/companyController.test.js
+++ b/tests/controllers/companyController.test.js
@@ -75,6 +75,8 @@ function setupCompanyDeletionWithBranchTables({
     transactionsDeleted: false,
     discountDeleted: false,
     branchesDeleted: false,
+    branchIdsLoaded: false,
+    branchIds: [],
   };
   const companyRow = {
     id: companyId,
@@ -129,12 +131,35 @@ function setupCompanyDeletionWithBranchTables({
     }
     if (
       sql.includes('FROM tenant_tables tt') &&
-      sql.includes('information_schema.KEY_COLUMN_USAGE')
+      sql.includes('information_schema.KEY_COLUMN_USAGE') &&
+      sql.includes("REFERENCED_TABLE_NAME IN ('companies', 'code_branches')")
     ) {
       return [[
-        { table_name: 'tbl_discount', column_name: 'company_id' },
-        { table_name: 'code_branches', column_name: 'company_id' },
+        {
+          table_name: 'tbl_discount',
+          column_name: 'company_id',
+          referenced_table: 'companies',
+          referenced_column: 'id',
+        },
+        {
+          table_name: 'tbl_discount',
+          column_name: 'branch_id',
+          referenced_table: 'code_branches',
+          referenced_column: 'branch_id',
+        },
+        {
+          table_name: 'code_branches',
+          column_name: 'company_id',
+          referenced_table: 'companies',
+          referenced_column: 'id',
+        },
       ]];
+    }
+    if (
+      sql.includes('FROM tenant_tables tt') &&
+      sql.includes('information_schema.COLUMNS')
+    ) {
+      return [[]];
     }
     if (
       sql.includes('SELECT TABLE_NAME, REFERENCED_TABLE_NAME') &&
@@ -191,6 +216,11 @@ function setupCompanyDeletionWithBranchTables({
       params?.[0] === 'transactions_pos'
     ) {
       return [[transactionRow]];
+    }
+    if (sql.startsWith('SELECT branch_id FROM code_branches WHERE')) {
+      state.branchIdsLoaded = true;
+      state.branchIds = [701, 702];
+      return [[{ branch_id: 701 }, { branch_id: 702 }]];
     }
     if (
       sql.startsWith('DELETE FROM ?? WHERE') &&
@@ -670,7 +700,14 @@ test('deleteCompanyHandler purges tenant tables without FK to companies', async 
     }
     if (
       sql.includes('FROM tenant_tables tt') &&
-      sql.includes('information_schema.KEY_COLUMN_USAGE')
+      sql.includes('information_schema.KEY_COLUMN_USAGE') &&
+      sql.includes("REFERENCED_TABLE_NAME IN ('companies', 'code_branches')")
+    ) {
+      return [[]];
+    }
+    if (
+      sql.includes('FROM tenant_tables tt') &&
+      sql.includes('information_schema.COLUMNS')
     ) {
       return [[{ table_name: 'tbl_employee', column_name: 'company_id' }]];
     }
@@ -759,6 +796,7 @@ test('DELETE /api/companies/:id succeeds when discount and POS rows exist', asyn
   assert.equal(state.transactionsDeleted, true);
   assert.equal(state.discountDeleted, true);
   assert.equal(state.branchesDeleted, true);
+  assert.equal(state.branchIdsLoaded, true);
 });
 
 test('deleteCompanyHandler clears branch tables after cascading dependent rows', async () => {
@@ -807,6 +845,13 @@ test('deleteCompanyHandler clears branch tables after cascading dependent rows',
   assert.equal(state.transactionsDeleted, true);
   assert.equal(state.discountDeleted, true);
   assert.equal(state.branchesDeleted, true);
+  assert.equal(state.branchIdsLoaded, true);
+  const discountParams = calls[discountDeleteIndex]?.params || [];
+  const discountValues = discountParams.slice(1).map((p) => Number(p));
+  assert.ok(
+    discountValues.includes(701),
+    'expected branch id 701 in tbl_discount cleanup',
+  );
 });
 
 test('deleteCompanyHandler cascades through employment and users tables', async () => {


### PR DESCRIPTION
## Summary
- extend tenant table purge to collect company and branch foreign key metadata
- load branch ids for company and delete branch-scoped tables alongside company scoped data
- update company deletion tests to exercise branch-aware cleanup paths and assert branch metadata is used

## Testing
- npm test -- tests/controllers/companyController.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cfff21a6b483319328768c9b52597e