### PR TITLE
Handle Mongolian translation retries during manual review

### DIFF
--- a/src/erp.mgt.mn/pages/ManualTranslationsTab.jsx
+++ b/src/erp.mgt.mn/pages/ManualTranslationsTab.jsx
@@ -447,19 +447,29 @@ export default function ManualTranslationsTab() {
           }
         }
 
-        if (swapped && attemptedMnTranslation && !mnTranslationSucceeded) {
-          const previousMn = normalizeBaseLanguageValue(entry.values.mn);
-          if (previousMn) {
-            entry.values.mn = '';
-            changed = true;
-          } else {
-            entry.values.mn = '';
+        if (attemptedMnTranslation && !mnTranslationSucceeded) {
+          const mnAnalysisAfter = analyzeBaseLanguage(entry.values.mn);
+          if (mnAnalysisAfter.language !== 'mn') {
+            const previousMnRaw = entry.values.mn;
+            const normalizedMn = normalizeBaseLanguageValue(previousMnRaw);
+            if (previousMnRaw !== '' || normalizedMn) {
+              entry.values.mn = '';
+              if (
+                normalizedMn ||
+                (typeof previousMnRaw === 'string' && previousMnRaw !== '')
+              ) {
+                changed = true;
+              }
+            }
           }
           manualReviewIndexes.add(issue.index);
         }
       }
 
-      const finalResult = changed ? validateBaseLanguages(correctedEntries) : initial;
+      const shouldRevalidate = changed || manualReviewIndexes.size > 0;
+      const finalResult = shouldRevalidate
+        ? validateBaseLanguages(correctedEntries)
+        : initial;
 
       return {
         correctedEntries: changed ? correctedEntries : entriesToCheck,

--- a/tests/pages/ManualTranslationsTab.languageValidation.test.js
+++ b/tests/pages/ManualTranslationsTab.languageValidation.test.js
@@ -269,7 +269,7 @@ if (typeof mock.import !== 'function') {
   );
 
   test(
-    'ManualTranslationsTab completeAll sanitizes swapped base languages when translation needs retry',
+    'ManualTranslationsTab completeAll sanitizes Mongolian base when translation needs retry',
     async () => {
       const translateMock = mock.fn(async (lang) => {
         if (lang === 'mn') return { text: '', needsRetry: true };
@@ -326,7 +326,7 @@ if (typeof mock.import !== 'function') {
                   type: 'locale',
                   module: 'module',
                   context: 'ctx',
-                  values: { en: 'Сайн байна уу', mn: 'Hello there' },
+                  values: { en: 'Hello there', mn: 'Hello there' },
                 },
               ];
             }
@@ -385,6 +385,10 @@ if (typeof mock.import !== 'function') {
         assert(
           toasts.some((t) => t.type === 'warning' && /manual review/i.test(t.message)),
           'warning toast for manual review was not shown',
+        );
+        assert(
+          !toasts.some((t) => /English\/Mongolian/i.test(t.message)),
+          'base language mismatch toast should not be shown',
         );
         assert(translateMock.mock.callCount() >= 2);
         const entryState = states[1][0];


### PR DESCRIPTION
## Summary
- extend the Mongolian base-language fallback so failed translations clear invalid text, revalidate entries, and always mark rows for manual review
- trigger a follow-up validation pass whenever manual review cleanup occurs
- update the manual translations tab test to cover Mongolian translation retries without aborting completion

## Testing
- npm test -- tests/pages/ManualTranslationsTab.languageValidation.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d001e61ee083319d9314dabf87e25e