### PR TITLE
Improve manual translation language detection

### DIFF
--- a/api-server/services/manualTranslations.js
+++ b/api-server/services/manualTranslations.js
@@ -18,6 +18,16 @@ async function listLangs(dir) {
   }
 }
 
+const cyrillicRegex = /[\u0400-\u04FF]/;
+const latinRegex = /[A-Za-z]/;
+
+function detectLang(str) {
+  if (typeof str !== 'string') return undefined;
+  if (cyrillicRegex.test(str)) return 'mn';
+  if (latinRegex.test(str)) return 'en';
+  return undefined;
+}
+
 export async function loadTranslations() {
   const langs = new Set([
     ...(await listLangs(localesDir)),
@@ -99,8 +109,13 @@ export async function loadTranslations() {
           const meta = metadata[k] || {};
           const localeEntry = ensureEntry(localeId, k, 'locale');
           const tooltipEntry = ensureEntry(tooltipId, k, 'tooltip');
-          if (localeEntry.values.en == null) localeEntry.values.en = v;
-          if (tooltipEntry.values.en == null) tooltipEntry.values.en = v;
+          const detectedLang = detectLang(v);
+          const targetLangs = detectedLang ? [detectedLang] : ['en'];
+          for (const langKey of targetLangs) {
+            langs.add(langKey);
+            if (localeEntry.values[langKey] == null) localeEntry.values[langKey] = v;
+            if (tooltipEntry.values[langKey] == null) tooltipEntry.values[langKey] = v;
+          }
           if (!localeEntry.module && meta.module) localeEntry.module = meta.module;
           if (!tooltipEntry.module && meta.module) tooltipEntry.module = meta.module;
           if (!localeEntry.context && meta.context) localeEntry.context = meta.context;

--- a/tests/services/manualTranslations.test.js
+++ b/tests/services/manualTranslations.test.js
@@ -5,12 +5,28 @@ import path from 'path';
 import { loadTranslations } from '../../api-server/services/manualTranslations.js';
 
 const exportedPath = path.join('config', '0', 'exportedtexts.json');
+const enLocalePath = path.join('src', 'erp.mgt.mn', 'locales', 'en.json');
+const mnLocalePath = path.join('src', 'erp.mgt.mn', 'locales', 'mn.json');
+const enTooltipPath = path.join(
+  'src',
+  'erp.mgt.mn',
+  'locales',
+  'tooltips',
+  'en.json',
+);
+const mnTooltipPath = path.join(
+  'src',
+  'erp.mgt.mn',
+  'locales',
+  'tooltips',
+  'mn.json',
+);
 
 function cleanup() {
   try { fs.unlinkSync(exportedPath); } catch {}
 }
 
-test('exported texts are merged into manual translations', async () => {
+test('exported texts are merged into manual translations', { concurrency: false }, async () => {
   cleanup();
   fs.mkdirSync(path.dirname(exportedPath), { recursive: true });
   fs.writeFileSync(
@@ -64,5 +80,105 @@ test('exported texts are merged into manual translations', async () => {
     assert.equal(plainLocale.context, '');
   } finally {
     cleanup();
+  }
+});
+
+test('exported texts detect languages and respect existing entries', { concurrency: false }, async () => {
+  cleanup();
+  fs.mkdirSync(path.dirname(exportedPath), { recursive: true });
+
+  const englishKey = 'manualTranslationsTest.english';
+  const mongolianKey = 'manualTranslationsTest.mongolian';
+  const conflictKey = 'manualTranslationsTest.conflict';
+
+  const originalEnLocale = fs.readFileSync(enLocalePath, 'utf8');
+  const originalMnLocale = fs.readFileSync(mnLocalePath, 'utf8');
+  const originalEnTooltip = fs.readFileSync(enTooltipPath, 'utf8');
+  const originalMnTooltip = fs.readFileSync(mnTooltipPath, 'utf8');
+
+  try {
+    const enLocale = JSON.parse(originalEnLocale);
+    const mnLocale = JSON.parse(originalMnLocale);
+    const enTooltip = JSON.parse(originalEnTooltip);
+    const mnTooltip = JSON.parse(originalMnTooltip);
+
+    enLocale[conflictKey] = 'Existing English Locale';
+    mnLocale[conflictKey] = 'Оригинал Монгол Locale';
+    enTooltip[conflictKey] = 'Existing English Tooltip';
+    mnTooltip[conflictKey] = 'Оригинал Монгол Tooltip';
+
+    for (const key of [englishKey, mongolianKey]) {
+      delete enLocale[key];
+      delete mnLocale[key];
+      delete enTooltip[key];
+      delete mnTooltip[key];
+    }
+
+    fs.writeFileSync(enLocalePath, JSON.stringify(enLocale, null, 2));
+    fs.writeFileSync(mnLocalePath, JSON.stringify(mnLocale, null, 2));
+    fs.writeFileSync(enTooltipPath, JSON.stringify(enTooltip, null, 2));
+    fs.writeFileSync(mnTooltipPath, JSON.stringify(mnTooltip, null, 2));
+
+    fs.writeFileSync(
+      exportedPath,
+      JSON.stringify(
+        {
+          translations: {
+            [englishKey]: 'Sample English Phrase',
+            [mongolianKey]: 'Санхүүгийн тайлан',
+            [conflictKey]: 'Should Not Override',
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const data = await loadTranslations();
+
+    const englishLocale = data.entries.find(
+      (e) => e.type === 'locale' && e.key === englishKey,
+    );
+    const englishTooltip = data.entries.find(
+      (e) => e.type === 'tooltip' && e.key === englishKey,
+    );
+    assert(englishLocale, 'english locale entry exists');
+    assert(englishTooltip, 'english tooltip entry exists');
+    assert.equal(englishLocale.values.en, 'Sample English Phrase');
+    assert.equal(englishTooltip.values.en, 'Sample English Phrase');
+    assert.equal(englishLocale.values.mn, '');
+    assert.equal(englishTooltip.values.mn, '');
+
+    const mongolianLocale = data.entries.find(
+      (e) => e.type === 'locale' && e.key === mongolianKey,
+    );
+    const mongolianTooltip = data.entries.find(
+      (e) => e.type === 'tooltip' && e.key === mongolianKey,
+    );
+    assert(mongolianLocale, 'mongolian locale entry exists');
+    assert(mongolianTooltip, 'mongolian tooltip entry exists');
+    assert.equal(mongolianLocale.values.mn, 'Санхүүгийн тайлан');
+    assert.equal(mongolianTooltip.values.mn, 'Санхүүгийн тайлан');
+    assert.equal(mongolianLocale.values.en, '');
+    assert.equal(mongolianTooltip.values.en, '');
+
+    const conflictLocale = data.entries.find(
+      (e) => e.type === 'locale' && e.key === conflictKey,
+    );
+    const conflictTooltip = data.entries.find(
+      (e) => e.type === 'tooltip' && e.key === conflictKey,
+    );
+    assert(conflictLocale, 'conflict locale entry exists');
+    assert(conflictTooltip, 'conflict tooltip entry exists');
+    assert.equal(conflictLocale.values.en, 'Existing English Locale');
+    assert.equal(conflictTooltip.values.en, 'Existing English Tooltip');
+    assert.equal(conflictLocale.values.mn, 'Оригинал Монгол Locale');
+    assert.equal(conflictTooltip.values.mn, 'Оригинал Монгол Tooltip');
+  } finally {
+    cleanup();
+    fs.writeFileSync(enLocalePath, originalEnLocale);
+    fs.writeFileSync(mnLocalePath, originalMnLocale);
+    fs.writeFileSync(enTooltipPath, originalEnTooltip);
+    fs.writeFileSync(mnTooltipPath, originalMnTooltip);
   }
 });


### PR DESCRIPTION
## Summary
- apply script language heuristics when importing exported texts so strings populate the appropriate locale or tooltip language without clobbering existing values
- extend the manualTranslations service test suite to cover English and Mongolian exports while ensuring prior locale and tooltip data is preserved

## Testing
- node --test tests/services/manualTranslations.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d00e5a75b48331833bd360dd55c76f