### PR TITLE
Allow triggers to map wrapped output variables

### DIFF
--- a/api-server/services/procTriggers.js
+++ b/api-server/services/procTriggers.js
@@ -6,10 +6,12 @@ function stripQuotes(value = '') {
 
 function normalizeAssignmentToken(raw) {
   const cleaned = stripQuotes(String(raw || '').trim());
-  if (!cleaned || cleaned.startsWith('$')) return '';
-  const withoutMarkers = cleaned.replace(/^[^A-Za-z0-9_]+/, '');
-  if (!withoutMarkers || /[^A-Za-z0-9_]/.test(withoutMarkers)) return '';
-  return withoutMarkers.toLowerCase();
+  if (!cleaned) return '';
+  const match = cleaned.match(/[@:$]([A-Za-z0-9_]+)/);
+  if (match) return match[1].toLowerCase();
+  if (cleaned.startsWith('$')) return '';
+  const bare = cleaned.match(/[A-Za-z_][A-Za-z0-9_]*/);
+  return bare ? bare[0].toLowerCase() : '';
 }
 
 function normalizeParamToken(raw) {


### PR DESCRIPTION
## Summary
- adjust assignment token normalization to capture the first identifier even when wrapped in functions
- cover function-wrapped output variables in the proc trigger parsing tests so aliases reach runProcTrigger

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d35795fba8833181a521585b677a13