### PR TITLE
Hide audit columns and skip serialization

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1369,7 +1369,9 @@ const TableManager = forwardRef(function TableManager({
     const cleaned = {};
     const skipFields = new Set([...autoCols, ...generatedCols, 'id']);
     Object.entries(merged).forEach(([k, v]) => {
+      const lower = k.toLowerCase();
       if (skipFields.has(k) || k.startsWith('_')) return;
+      if (auditFieldSet.has(lower) && !(editSet?.has(lower))) return;
       if (v !== '') {
         cleaned[k] =
           typeof v === 'string' ? normalizeDateInput(v, placeholders[k]) : v;
@@ -1633,7 +1635,9 @@ const TableManager = forwardRef(function TableManager({
       const cleaned = {};
       const skipFields = new Set([...autoCols, ...generatedCols, 'id']);
       Object.entries(row).forEach(([k, v]) => {
+        const lower = k.toLowerCase();
         if (skipFields.has(k) || k.startsWith('_')) return;
+        if (auditFieldSet.has(lower) && !(editSet?.has(lower))) return;
         if (v !== '') cleaned[k] = v;
       });
       const res = await fetch(`${API_BASE}/pending_request`, {
@@ -1804,8 +1808,53 @@ const TableManager = forwardRef(function TableManager({
   columnMeta.forEach((c) => {
     labels[c.name] = c.label || c.name;
   });
-  const hiddenColumns = ['password', 'created_by', 'created_at'];
-  let columns = ordered.filter((c) => !hiddenColumns.includes(c));
+  const auditFieldSet = useMemo(() => {
+    const base = [
+      'created_by',
+      'created_at',
+      'updated_by',
+      'updated_at',
+      'deleted_by',
+      'deleted_at',
+      'is_deleted',
+    ];
+    const set = new Set(base.map((name) => name.toLowerCase()));
+    columnMeta.forEach((c) => {
+      const name = (c.name || '').toLowerCase();
+      if (!name) return;
+      const rawType = (
+        c.type ||
+        c.columnType ||
+        c.dataType ||
+        c.DATA_TYPE ||
+        ''
+      ).toLowerCase();
+      if (
+        /tinyint\(1\)|boolean|bool|bit\(1\)/.test(rawType) &&
+        name.includes('deleted')
+      ) {
+        set.add(name);
+      }
+    });
+    return set;
+  }, [columnMeta]);
+  const hiddenColumnSet = useMemo(() => {
+    const set = new Set(auditFieldSet);
+    set.add('password');
+    return set;
+  }, [auditFieldSet]);
+  let columns = ordered.filter((c) => !hiddenColumnSet.has(c.toLowerCase()));
+  const provided = Array.isArray(formConfig?.editableFields)
+    ? formConfig.editableFields
+    : [];
+  const defaults = Array.isArray(formConfig?.editableDefaultFields)
+    ? formConfig.editableDefaultFields
+    : [];
+  const editVals = Array.from(new Set([...defaults, ...provided]));
+  const editSet =
+    editVals.length > 0
+      ? new Set(editVals.map((f) => f.toLowerCase()))
+      : null;
   const placeholders = useMemo(() => {
     const map = {};
     columnMeta.forEach((c) => {
@@ -1867,9 +1916,12 @@ const TableManager = forwardRef(function TableManager({
   if (columnMeta.length === 0 && autoCols.size === 0 && allColumns.includes('id')) {
     autoCols.add('id');
   }
-  let formColumns = ordered.filter(
-    (c) => !autoCols.has(c) && c !== 'created_at' && c !== 'created_by'
-  );
+  let formColumns = ordered.filter((c) => {
+    if (autoCols.has(c)) return false;
+    const lower = c.toLowerCase();
+    if (auditFieldSet.has(lower) && !(editSet?.has(lower))) return false;
+    return true;
+  });
 
   const lockedDefaults = Object.entries(formConfig?.defaultValues || {})
     .filter(
@@ -1890,14 +1942,6 @@ const TableManager = forwardRef(function TableManager({
     if (!formColumns.includes(f) && allColumns.includes(f)) formColumns.push(f);
   });
 
-  const provided = Array.isArray(formConfig?.editableFields)
-    ? formConfig.editableFields
-    : [];
-  const defaults = Array.isArray(formConfig?.editableDefaultFields)
-    ? formConfig.editableDefaultFields
-    : [];
-  const editVals = Array.from(new Set([...defaults, ...provided]));
-  const editSet = editVals.length > 0 ? new Set(editVals.map((f) => f.toLowerCase())) : null;
   let disabledFields = editSet
     ? formColumns.filter((c) => !editSet.has(c.toLowerCase()))
     : [];

--- a/tests/components/timestampDisplay.test.js
+++ b/tests/components/timestampDisplay.test.js
@@ -86,6 +86,120 @@ if (!haveReact) {
     global.fetch = origFetch;
   });
 
+  test('TableManager hides audit columns from grid headers', async (t) => {
+    const origFetch = global.fetch;
+    global.fetch = async (url) => {
+      if (url === '/api/tables/test/columns') {
+        return {
+          ok: true,
+          json: async () => [
+            { name: 'id', type: 'int' },
+            { name: 'name', type: 'varchar' },
+            { name: 'created_at', type: 'timestamp' },
+            { name: 'created_by', type: 'int' },
+            { name: 'updated_at', type: 'timestamp' },
+            { name: 'updated_by', type: 'int' },
+            { name: 'deleted_at', type: 'timestamp' },
+            { name: 'deleted_by', type: 'int' },
+            { name: 'is_deleted', type: 'tinyint(1)' },
+          ],
+        };
+      }
+      if (url === '/api/tables/test/relations') {
+        return { ok: true, json: async () => [] };
+      }
+      if (url.startsWith('/api/display_fields?')) {
+        return { ok: true, json: async () => ({ displayFields: [] }) };
+      }
+      if (url.startsWith('/api/proc_triggers')) {
+        return { ok: true, json: async () => [] };
+      }
+      if (url.startsWith('/api/tables/test?')) {
+        return {
+          ok: true,
+          json: async () => ({
+            rows: [
+              {
+                id: 1,
+                name: 'Example',
+                created_at: '2024-05-01 12:34:56',
+                created_by: 10,
+                updated_at: '2024-05-02 08:00:00',
+                updated_by: 11,
+                deleted_at: null,
+                deleted_by: null,
+                is_deleted: 0,
+              },
+            ],
+            count: 1,
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    };
+
+    const { default: TableManager } = await t.mock.import(
+      '../../src/erp.mgt.mn/components/TableManager.jsx',
+      {
+        '../context/AuthContext.jsx': {
+          AuthContext: React.createContext({ company: 1 }),
+        },
+        '../context/ToastContext.jsx': {
+          useToast: () => ({ addToast: () => {} }),
+        },
+        './RowFormModal.jsx': { default: () => null },
+        './CascadeDeleteModal.jsx': { default: () => null },
+        './RowDetailModal.jsx': { default: () => null },
+        './RowImageViewModal.jsx': { default: () => null },
+        './RowImageUploadModal.jsx': { default: () => null },
+        './ImageSearchModal.jsx': { default: () => null },
+        './Modal.jsx': { default: () => null },
+        './CustomDatePicker.jsx': { default: () => null },
+        '../hooks/useGeneralConfig.js': { default: () => ({}) },
+        '../utils/formatTimestamp.js': { default: () => '2024-05-01 12:34:56' },
+        '../utils/buildImageName.js': { default: () => ({}) },
+        '../utils/slugify.js': { default: () => '' },
+        '../utils/apiBase.js': { API_BASE: '' },
+        '../utils/normalizeDateInput.js': {
+          default: (v, f) => (f === 'YYYY-MM-DD' ? v.slice(0, 10) : v),
+        },
+      },
+    );
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    try {
+      await act(async () => {
+        root.render(React.createElement(TableManager, { table: 'test' }));
+      });
+      for (let i = 0; i < 5; i += 1) {
+        if ((container.textContent || '').includes('Action')) break;
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      const headers =
+        typeof container.querySelectorAll === 'function'
+          ? Array.from(container.querySelectorAll('th')).map(
+              (th) => th.textContent || '',
+            )
+          : [container.textContent || ''];
+      assert.ok(headers.some((text) => text.toLowerCase().includes('name')));
+      ['created_at', 'created_by', 'updated_at', 'updated_by', 'deleted_at', 'deleted_by', 'is_deleted'].forEach(
+        (field) => {
+          assert.ok(
+            headers.every(
+              (text) => !text || !text.toLowerCase().includes(field),
+            ),
+            `expected header to hide ${field}`,
+          );
+        },
+      );
+    } finally {
+      root.unmount();
+      global.fetch = origFetch;
+    }
+  });
+
   test('RowFormModal uses YYYY-MM-DD placeholder for date fields', async (t) => {
     const { default: RowFormModal } = await t.mock.import(
       '../../src/erp.mgt.mn/components/RowFormModal.jsx',


### PR DESCRIPTION
## Summary
- hide audit and soft-delete columns from the table headers by default while still allowing explicit config overrides
- prevent audit fields from being serialized back to the API unless they are marked editable
- add a UI test that asserts audit columns no longer appear in the rendered grid headers

## Testing
- npm test -- tests/components/timestampDisplay.test.js *(skipped: React packages unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d35b077d9c833188a9bf2f5e329d24