### PR TITLE
Expand POS session field detection

### DIFF
--- a/tests/pages/PosTransactions.test.js
+++ b/tests/pages/PosTransactions.test.js
@@ -64,4 +64,90 @@ if (typeof mock.import !== 'function') {
     );
     assert.strictEqual(secondPass, populated);
   });
+
+  test('session field extraction includes grouped calc fields', async () => {
+    const {
+      extractSessionFieldsFromConfig,
+      applySessionIdToTables,
+    } = await mock.import('../../src/erp.mgt.mn/pages/PosTransactions.jsx', {});
+
+    const config = {
+      calcFields: [
+        {
+          cells: [
+            { table: 'transactions', field: 'pos_session_id' },
+            { table: 'transactions_inventory', field: 'bmtr_pid' },
+            { table: 'transactions_inventory', field: 'bmtr_session_id' },
+          ],
+        },
+        {
+          cells: [{ table: 'transactions_inventory', field: 'non_session_calc' }],
+        },
+      ],
+      posFields: [
+        {
+          parts: [
+            { table: 'transactions', field: 'pos_session_id' },
+            { table: 'transactions_payments', field: 'pos_session_id' },
+            { table: 'transactions_inventory', field: 'non_session_field' },
+          ],
+        },
+      ],
+    };
+
+    const sessionFields = extractSessionFieldsFromConfig(config);
+    assert.deepEqual(sessionFields, [
+      { table: 'transactions', field: 'pos_session_id' },
+      { table: 'transactions_inventory', field: 'bmtr_pid' },
+      { table: 'transactions_inventory', field: 'bmtr_session_id' },
+      { table: 'transactions_payments', field: 'pos_session_id' },
+    ]);
+    assert.equal(
+      sessionFields.some((sf) => sf.field === 'non_session_calc'),
+      false,
+    );
+    assert.equal(
+      sessionFields.some((sf) => sf.field === 'non_session_field'),
+      false,
+    );
+    const uniqueKeys = new Set(
+      sessionFields.map((sf) => `${sf.table}:${sf.field}`),
+    );
+    assert.equal(uniqueKeys.size, sessionFields.length);
+
+    const sessionFieldsByTable = sessionFields.reduce((acc, sf) => {
+      if (!acc[sf.table]) acc[sf.table] = [];
+      acc[sf.table].push(sf.field);
+      return acc;
+    }, {});
+    const tableTypeMap = {
+      transactions: 'single',
+      transactions_inventory: 'multi',
+      transactions_payments: 'multi',
+    };
+    const initialValues = {
+      transactions: { name: 'New Txn' },
+      transactions_inventory: [
+        { item: 'A' },
+        { item: 'B', bmtr_pid: 'legacy', bmtr_session_id: 'legacy' },
+      ],
+      transactions_payments: [{ amount: 10 }],
+    };
+    const sid = 'session-123';
+
+    const populated = applySessionIdToTables(
+      initialValues,
+      sid,
+      sessionFieldsByTable,
+      tableTypeMap,
+    );
+
+    assert.equal(populated.transactions.pos_session_id, sid);
+    assert.equal(populated.transactions_inventory[0].bmtr_pid, sid);
+    assert.equal(populated.transactions_inventory[0].bmtr_session_id, sid);
+    assert.equal(populated.transactions_inventory[1].bmtr_pid, sid);
+    assert.equal(populated.transactions_inventory[1].bmtr_session_id, sid);
+    assert.equal(initialValues.transactions_inventory[1].bmtr_pid, 'legacy');
+    assert.equal(populated.transactions_payments[0].pos_session_id, sid);
+  });
 }


### PR DESCRIPTION
## Summary
- add a reusable helper that extracts session-related fields (including grouped calc-field entries) with deduped, sorted output
- ensure the POS Transactions page populates its session fields via the helper so indirectly mapped columns receive the session id
- add a regression test confirming grouped calc-field entries fill related detail rows when a new session id is applied

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d35b976bd88331a9563412eb354e47