### PR TITLE
Support named POS transaction layouts

### DIFF
--- a/api-server/routes/pos_txn_post.js
+++ b/api-server/routes/pos_txn_post.js
@@ -7,10 +7,10 @@ const router = express.Router();
 router.post('/', requireAuth, async (req, res, next) => {
   try {
     const companyId = Number(req.query.companyId ?? req.user.companyId);
-    const { data, session } = req.body;
+    const { name, data, session } = req.body;
     if (!data) return res.status(400).json({ message: 'invalid data' });
     const info = { ...(session || {}), userId: req.user.id };
-    const id = await postPosTransaction(data, info, companyId);
+    const id = await postPosTransaction(name, data, info, companyId);
     res.json({ id });
   } catch (err) {
     next(err);


### PR DESCRIPTION
## Summary
- pass the requested POS layout name from the transaction route into the service call
- load POS transaction configs by layout name and return a 400 error when the layout is missing
- add targeted service tests that exercise the POS_Modmarket and ONLINE_POS layouts and the missing layout error path

## Testing
- npm test -- tests/services/postPosTransaction.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d36ac602e083319c1e1a2205622845