### PR TITLE
Add users trigger and tighten created_at migration

### DIFF
--- a/README_MIGRATION.md
+++ b/README_MIGRATION.md
@@ -43,6 +43,7 @@ Two SQL utilities assist with default module permissions:
 * `db/migrations/2025-07-24_proc_fix.sql` – recreates `resolve_inventory_metadata` and `calculate_stock_per_branch` as read‑only procedures so triggers no longer attempt to update their source tables.
 * `db/migrations/2025-07-25_inventory_triggers.sql` – recreates inventory and expense triggers so they call the read‑only procedures without modifying their own tables.
 * `db/migrations/2025-09-02_standardize_audit_columns.sql` – normalizes `created_at`, `created_by`, `updated_at`, `updated_by`, and `deleted_at` across every base table and backfills existing rows with a fallback `created_by = 'system'`. Re-run this migration after pulling to align live databases with the schema.
+* `db/migrations/2025-09-05_users_created_trigger.sql` – recreates the `users_bi` trigger so inserts automatically fill any missing audit timestamps or actors for the `users` table.
 
 Run the script after applying the migration to initialize permissions for all roles.
 

--- a/db/migrations/2025-08-29_add_created_fields.sql
+++ b/db/migrations/2025-08-29_add_created_fields.sql
@@ -40,7 +40,11 @@ BEGIN
          AND TABLE_NAME = tbl
          AND COLUMN_NAME = 'created_at'
     ) THEN
-      SET @s = CONCAT('ALTER TABLE `', tbl, '` ADD COLUMN `created_at` TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP;');
+      SET @s = CONCAT(
+        'ALTER TABLE `',
+        tbl,
+        '` ADD COLUMN `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;'
+      );
       PREPARE stmt FROM @s;
       EXECUTE stmt;
       DEALLOCATE PREPARE stmt;

--- a/db/migrations/2025-09-05_users_created_trigger.sql
+++ b/db/migrations/2025-09-05_users_created_trigger.sql
@@ -1,0 +1,21 @@
+-- Ensure the users table automatically stamps audit metadata on insert
+DROP TRIGGER IF EXISTS users_bi;
+DELIMITER $$
+CREATE TRIGGER users_bi
+BEFORE INSERT ON users
+FOR EACH ROW
+BEGIN
+  IF NEW.created_at IS NULL THEN
+    SET NEW.created_at = NOW();
+  END IF;
+  IF NEW.created_by IS NULL OR NEW.created_by = '' THEN
+    SET NEW.created_by = CURRENT_USER();
+  END IF;
+  IF NEW.updated_at IS NULL THEN
+    SET NEW.updated_at = NOW();
+  END IF;
+  IF NEW.updated_by IS NULL OR NEW.updated_by = '' THEN
+    SET NEW.updated_by = NEW.created_by;
+  END IF;
+END$$
+DELIMITER ;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -2693,3 +2693,24 @@ ALTER TABLE `users`
 ALTER TABLE `user_level_permissions`
   ADD CONSTRAINT `user_level_permissions_ibfk_1` FOREIGN KEY (`userlevel_id`) REFERENCES `user_levels` (`userlevel_id`),
   ADD CONSTRAINT `user_level_permissions_ibfk_2` FOREIGN KEY (`company_id`) REFERENCES `companies` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+DROP TRIGGER IF EXISTS `users_bi`;
+DELIMITER $$
+CREATE TRIGGER `users_bi`
+BEFORE INSERT ON `users`
+FOR EACH ROW
+BEGIN
+  IF NEW.created_at IS NULL THEN
+    SET NEW.created_at = NOW();
+  END IF;
+  IF NEW.created_by IS NULL OR NEW.created_by = '' THEN
+    SET NEW.created_by = CURRENT_USER();
+  END IF;
+  IF NEW.updated_at IS NULL THEN
+    SET NEW.updated_at = NOW();
+  END IF;
+  IF NEW.updated_by IS NULL OR NEW.updated_by = '' THEN
+    SET NEW.updated_by = NEW.created_by;
+  END IF;
+END$$
+DELIMITER ;


### PR DESCRIPTION
## Summary
- ensure the created_at backfill migration adds a NOT NULL column with CURRENT_TIMESTAMP
- add a users_bi trigger migration and baseline schema entry so inserts stamp missing audit fields
- document the new trigger migration in the deployment README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d25ed0efe083318e239358d080a427