### PR TITLE
Fix duplicate export of findCalcFieldMismatch

### DIFF
--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -17,7 +17,7 @@ import slugify from '../utils/slugify.js';
 import { debugLog } from '../utils/debug.js';
 import { syncCalcFields } from '../utils/syncCalcFields.js';
 
-export { syncCalcFields, findCalcFieldMismatch };
+export { syncCalcFields };
 
 function isPlainRecord(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value);


### PR DESCRIPTION
## Summary
- remove the duplicate export of `findCalcFieldMismatch` from the POS transactions page while keeping `syncCalcFields` exported

## Testing
- npm run build:erp *(fails: missing @babel/parser dependency in the build script environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d38f263340833195f3f8a5110df220