### PR TITLE
Improve Mongolian language detection heuristics

### DIFF
--- a/tests/api/translationHelpers.mongolian.test.js
+++ b/tests/api/translationHelpers.mongolian.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { detectLang } from '../../api-server/utils/translationHelpers.js';
+
+test('detectLang identifies Mongolian Cyrillic without diacritic letters', () => {
+  assert.equal(detectLang('Сайн байна уу'), 'mn');
+  assert.equal(detectLang('Байгууллага'), 'mn');
+  assert.equal(detectLang('Боломж'), 'mn');
+  assert.equal(detectLang('Тодорхойлолт'), 'mn');
+  assert.equal(detectLang('Монгол Улс'), 'mn');
+});
+
+test('detectLang treats plain Russian Cyrillic as ru when Mongolian signals are absent', () => {
+  assert.equal(detectLang('Онлайн сервис'), 'ru');
+  assert.equal(detectLang('Добро пожаловать'), 'ru');
+  assert.equal(detectLang('Файл'), 'ru');
+});
+
+test('detectLang recognises Mongolian question and command phrases', () => {
+  assert.equal(detectLang('Та юу хийдэг вэ?'), 'mn');
+  assert.equal(detectLang('Холбоо барих'), 'mn');
+});


### PR DESCRIPTION
## Summary
- refine the Mongolian Cyrillic heuristic to require Mongolian-specific letters, phrases, or bigram combinations
- count strong Mongolian sequences before scoring bigram matches so plain Russian text falls back to ru
- add regression tests covering Mongolian phrases without diacritics and Russian phrases that should resolve to ru

## Testing
- npm test
- npm run generate:translations *(fails: missing OpenAI/Google API access, command aborted after repeated warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68d39a7d857c8331a7975e00248592ac