### PR TITLE
Handle zero-date soft delete markers in tenant seeding

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -1432,7 +1432,15 @@ export async function seedTenantTables(
     if (softDeleteColumn) {
       const identifier = escapeIdentifier(softDeleteColumn);
       const normalizedIdentifier = `LOWER(${identifier})`;
-      const activeMarkers = ['0', 'n', 'no', 'false', 'f'];
+      const activeMarkers = [
+        '0',
+        'n',
+        'no',
+        'false',
+        'f',
+        '0000-00-00 00:00:00',
+        '0000-00-00',
+      ];
       const markerPlaceholders = activeMarkers.map(() => '?').join(', ');
       countSql += ` AND (${identifier} IS NULL OR ${identifier} IN (0,'')`;
       if (markerPlaceholders) {


### PR DESCRIPTION
## Summary
- treat zero-date timestamp strings as active markers when checking for existing tenant rows
- update the tenant seeding tests to expect the expanded marker list and cover the zero-date regression case

## Testing
- node --test tests/db/seedTenantTables.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d3bc697c1c8331834f2bab7ba8857d