### PR TITLE
Allow procedure triggers to update non-grid columns

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -563,6 +563,13 @@ const RowFormModal = function RowFormModal({
     mainFields.length > 0
       ? columns.filter((c) => mainSet.has(c))
       : columns.filter((c) => !headerSet.has(c) && !footerSet.has(c));
+  const allSectionFields = Array.from(
+    new Set([
+      ...headerCols,
+      ...mainCols,
+      ...footerCols,
+    ].filter(Boolean)),
+  );
 
   const inputFontSize = Math.max(10, labelFontSize);
   const formGridClass = fitted ? 'grid' : 'grid gap-2';
@@ -1368,6 +1375,7 @@ const RowFormModal = function RowFormModal({
           <InlineTransactionTable
             ref={useGrid ? tableRef : undefined}
             fields={cols}
+            allFields={allSectionFields}
             relations={relations}
             relationConfigs={relationConfigMap}
             relationData={relationData}


### PR DESCRIPTION
## Summary
- merge all configured column sections into a writable set for InlineTransactionTable and expose it via a new prop
- ensure procedure trigger results update any mapped columns on the row, using case-insensitive lookups
- pass the full column list from RowFormModal and add a regression test that verifies header fields populate after a trigger

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3db9d53f883319e1c35eee79b14fc