### PR TITLE
Propagate trigger outputs to header metadata

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -567,6 +567,7 @@ function InlineTransactionTable(
     if (!rowData || typeof rowData !== 'object') return;
     setRows((r) => {
       if (!Array.isArray(r)) return r;
+      const arrayUpdates = new Map();
       const next = r.map((row, i) => {
         if (i !== rowIdx) return row;
         const baseRow = row && typeof row === 'object' ? row : {};
@@ -589,12 +590,17 @@ function InlineTransactionTable(
             updated[mappedKey] = rawValue;
             keyLookup[lower] = mappedKey;
           }
+          arrayUpdates.set(mappedKey, rawValue);
         });
         return updated;
       });
-      assignArrayMetadata(next, r);
-      onRowsChange(next);
-      return next;
+      const withMetadata = assignArrayMetadata(next, r);
+      arrayUpdates.forEach((value, key) => {
+        if (!key && key !== 0) return;
+        withMetadata[key] = value;
+      });
+      onRowsChange(withMetadata);
+      return withMetadata;
     });
   }
 

--- a/tests/components/inlineTransactionTableMetadata.test.js
+++ b/tests/components/inlineTransactionTableMetadata.test.js
@@ -412,6 +412,14 @@ if (typeof mock?.import !== 'function') {
       assert.ok(tableRef.current, 'table ref should be populated');
       const rows = tableRef.current.getRows();
       assert.equal(rows[0].HeaderField, 'HDR-001');
+      assert.equal(rows.HeaderField, 'HDR-001');
+
+      assert.ok(onRowsChange.mock.callCount() > 0, 'onRowsChange should be called');
+      const lastCall = onRowsChange.mock.calls[onRowsChange.mock.calls.length - 1];
+      assert.ok(lastCall, 'onRowsChange should record the latest call');
+      const [changedRows] = lastCall.arguments;
+      assert.ok(changedRows, 'onRowsChange should provide rows data');
+      assert.equal(changedRows.HeaderField, 'HDR-001');
     } finally {
       global.fetch = originalFetch;
     }


### PR DESCRIPTION
## Summary
- update `applyProcedureResult` to collect trigger outputs and write them onto the rows metadata object
- ensure metadata cloning happens before overlaying new procedure values and notify listeners with the merged result
- extend the inline transaction table metadata test to cover header trigger outputs reaching the UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d3ea7890288331a98598eda15747dd