### PR TITLE
Enable OpenAI API when key is present

### DIFF
--- a/api-server/services/generalConfig.js
+++ b/api-server/services/generalConfig.js
@@ -18,7 +18,7 @@ const defaults = {
     boxMaxHeight: 150,
   },
   general: {
-    aiApiEnabled: false,
+    aiApiEnabled: Boolean(process.env.OPENAI_API_KEY),
     aiInventoryApiEnabled: false,
     triggerToastEnabled: true,
     procToastEnabled: true,

--- a/config/0/generalConfig.json
+++ b/config/0/generalConfig.json
@@ -14,7 +14,7 @@
     "boxMaxHeight": 150
   },
   "general": {
-    "aiApiEnabled": false,
+    "aiApiEnabled": true,
     "aiInventoryApiEnabled": false,
     "triggerToastEnabled": false,
     "procToastEnabled": false,

--- a/docs/general-configuration.md
+++ b/docs/general-configuration.md
@@ -20,7 +20,7 @@
     "boxMaxHeight": 150
   },
   "general": {
-    "aiApiEnabled": false,
+    "aiApiEnabled": true,
     "requestPollingEnabled": false,
     "requestPollingIntervalSeconds": 30
   },
@@ -37,7 +37,9 @@ up to `boxMaxWidth`/`boxMaxHeight` as text is entered and wrap when necessary.
 The **POS** section provides the same options specifically for POS transactions.
 Here `boxWidth` defines the initial grid box width of a POS transaction.
 
-The **General** section hosts feature toggles. `requestPollingEnabled` controls
+The **General** section hosts feature toggles. When an `OPENAI_API_KEY` is set
+in the environment, `aiApiEnabled` now defaults to `true` so OpenAI endpoints
+are only exposed when they can be used. `requestPollingEnabled` controls
 whether the client falls back to periodic API polling when a Socket.IO
 connection cannot be established. `requestPollingIntervalSeconds` sets the
 polling cadence (default 30&nbsp;seconds).


### PR DESCRIPTION
## Summary
- enable the general configuration default for `aiApiEnabled` when an `OPENAI_API_KEY` is available so OpenAI endpoints automatically expose themselves for new tenants
- update the company 0 configuration to leave the OpenAI API enabled by default
- document the new OpenAI flag behaviour in the general configuration guide

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d49e1102248331bbcedfd9fd0ac94f