### PR TITLE
Allow report builder code tab to list all procedures

### DIFF
--- a/api-server/routes/report_builder.js
+++ b/api-server/routes/report_builder.js
@@ -98,6 +98,8 @@ router.get('/procedures', requireAuth, async (req, res, next) => {
   try {
     const companyId = Number(req.query.companyId ?? req.user.companyId);
     const prefix = req.query.prefix || '';
+    const includeAllRaw = (req.query.includeAll || '').toString().toLowerCase();
+    const includeAll = ['1', 'true', 'yes'].includes(includeAllRaw);
 
     const session =
       req.session || (await getEmploymentSession(req.user.empid, companyId));
@@ -108,7 +110,7 @@ router.get('/procedures', requireAuth, async (req, res, next) => {
     }
 
     let names = await listReportProcedures(prefix);
-    if (!isAdmin) {
+    if (!isAdmin && !includeAll) {
       names = names.filter((n) => {
         const parts = n.split('_');
         return parts[1] === '0' || parts[1] === String(companyId);


### PR DESCRIPTION
## Summary
- remove tenant-only filtering so the Code development tab shows the complete stored procedure list and display labels without the report prefix
- allow the procedures API to honour an includeAll flag so Code development can bypass the company filter
- extend ReportBuilder tests to cover the new label formatting and the refreshed, unfiltered procedure reload behaviour

## Testing
- `npm test -- tests/pages/ReportBuilder.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d4b11d73108331aa626c666904933d