### PR TITLE
Refactor report builder workspace to support dual tabs

### DIFF
--- a/src/erp.mgt.mn/pages/ReportBuilder.jsx
+++ b/src/erp.mgt.mn/pages/ReportBuilder.jsx
@@ -23,7 +23,7 @@ const OPERATORS = ['=', '>', '<', '>=', '<=', '<>'];
 const CALC_OPERATORS = ['+', '-', '*', '/'];
 const PAREN_OPTIONS = [0, 1, 2, 3];
 
-function ReportBuilderInner() {
+function ReportBuilderWorkspace() {
   const [tables, setTables] = useState([]); // list of table names
   const [tableFields, setTableFields] = useState({}); // { tableName: [field, ...] }
   const [fieldEnums, setFieldEnums] = useState({}); // { tableName: { field: [enum] } }
@@ -65,7 +65,6 @@ function ReportBuilderInner() {
 
   const [customParamName, setCustomParamName] = useState('');
   const [customParamType, setCustomParamType] = useState(PARAM_TYPES[0]);
-  const [activeTab, setActiveTab] = useState('builder');
   const { addToast } = useToast();
   const { company, permissions, session } = useContext(AuthContext);
   const { t: i18nextT } = useTranslation(['translation', 'tooltip']);
@@ -1777,65 +1776,24 @@ function ReportBuilderInner() {
 
   return (
     <div>
-      <h2>{t('reportBuilder.title', 'Report Builder')}</h2>
-      <div
-        style={{
-          display: 'flex',
-          gap: '0.5rem',
-          borderBottom: '1px solid #ccc',
-          marginBottom: '1rem',
-        }}
-      >
-        {[
-          { key: 'builder', label: t('reportBuilder.tabBuilder', 'Visual builder') },
-          { key: 'code', label: t('reportBuilder.tabCodeDevelopment', 'Code development') },
-        ].map((tab) => (
-          <button
-            key={tab.key}
-            onClick={() => setActiveTab(tab.key)}
-            style={{
-              padding: '0.5rem 1rem',
-              border: 'none',
-              borderBottom:
-                activeTab === tab.key ? '2px solid #000' : '2px solid transparent',
-              background: 'transparent',
-              cursor: 'pointer',
-              fontWeight: activeTab === tab.key ? 'bold' : 'normal',
-            }}
-          >
-            {tab.label}
-          </button>
-        ))}
+      <div style={{ marginBottom: '0.5rem' }}>
+        <button onClick={handleImport}>
+          {t('reportBuilder.importDefaults', 'Import Defaults')}
+        </button>
       </div>
 
-      {activeTab === 'builder' && (
-        <div style={{ marginBottom: '1rem' }}>
-          {t(
-            'reportBuilder.builderTabComingSoon',
-            'Visual builder tools coming soon.',
-          )}
-        </div>
-      )}
+      <section>
+        <h3>{t('reportBuilder.primaryTable', 'Primary Table')}</h3>
+        <select value={fromTable} onChange={(e) => setFromTable(e.target.value)}>
+          {tables.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </section>
 
-      <div style={{ display: activeTab === 'code' ? 'block' : 'none' }}>
-        <div style={{ marginBottom: '0.5rem' }}>
-          <button onClick={handleImport}>
-            {t('reportBuilder.importDefaults', 'Import Defaults')}
-          </button>
-        </div>
-
-        <section>
-          <h3>{t('reportBuilder.primaryTable', 'Primary Table')}</h3>
-          <select value={fromTable} onChange={(e) => setFromTable(e.target.value)}>
-            {tables.map((t) => (
-              <option key={t} value={t}>
-                {t}
-              </option>
-            ))}
-          </select>
-        </section>
-
-        <section>
+      <section>
           <h3>{t('reportBuilder.primaryTableFilters', 'Primary Table Filters')}</h3>
           {fromFilters.map((f, i) => (
             <div
@@ -3118,6 +3076,55 @@ function ReportBuilderInner() {
         {procSql && (
           <pre style={{ whiteSpace: 'pre-wrap', marginTop: '1rem' }}>{procSql}</pre>
         )}
+      </div>
+    </div>
+  );
+}
+
+
+function ReportBuilderInner() {
+  const [activeTab, setActiveTab] = useState('builder');
+  const { t: i18nextT } = useTranslation(['translation', 'tooltip']);
+  const { t: contextT } = useContext(I18nContext);
+  const t = i18nextT || contextT;
+
+  return (
+    <div>
+      <h2>{t('reportBuilder.title', 'Report Builder')}</h2>
+      <div
+        style={{
+          display: 'flex',
+          gap: '0.5rem',
+          borderBottom: '1px solid #ccc',
+          marginBottom: '1rem',
+        }}
+      >
+        {[
+          { key: 'builder', label: t('reportBuilder.tabBuilder', 'Visual builder') },
+          { key: 'code', label: t('reportBuilder.tabCodeDevelopment', 'Code development') },
+        ].map((tab) => (
+          <button
+            key={tab.key}
+            onClick={() => setActiveTab(tab.key)}
+            style={{
+              padding: '0.5rem 1rem',
+              border: 'none',
+              borderBottom:
+                activeTab === tab.key ? '2px solid #000' : '2px solid transparent',
+              background: 'transparent',
+              cursor: 'pointer',
+              fontWeight: activeTab === tab.key ? 'bold' : 'normal',
+            }}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div style={{ display: activeTab === 'builder' ? 'block' : 'none' }}>
+        <ReportBuilderWorkspace key="builder" />
+      </div>
+      <div style={{ display: activeTab === 'code' ? 'block' : 'none' }}>
+        <ReportBuilderWorkspace key="code" />
       </div>
     </div>
   );

--- a/tests/pages/ReportBuilder.test.js
+++ b/tests/pages/ReportBuilder.test.js
@@ -69,14 +69,14 @@ if (typeof mock.import !== 'function') {
     activateCodeTab?.();
 
     // selectedDbProcedure
-    states[28] = 'proc1';
-    states[29] = '';
-    states[30] = '';
+    states[66] = 'proc1';
+    states[67] = '';
+    states[68] = '';
 
     await loadConfigHandler();
 
     assert.equal(fetchUrl, '/api/report_builder/procedures/proc1');
-    assert.equal(states[4], 'abc');
+    assert.equal(states[42], 'abc');
     assert.deepEqual(addToastCalls, [
       { msg: 'Loaded config from embedded block', type: 'success' },
     ]);
@@ -151,12 +151,12 @@ if (typeof mock.import !== 'function') {
     activateCodeTab?.();
 
     // selectedReport
-    states[24] = 'cfg1';
+    states[62] = 'cfg1';
 
     await loadConfigHandler({});
 
     assert.equal(fetchUrl, '/api/report_builder/configs/cfg1');
-    assert.equal(states[4], 'abc');
+    assert.equal(states[42], 'abc');
 
     delete global.fetch;
   });
@@ -233,9 +233,9 @@ if (typeof mock.import !== 'function') {
     activateCodeTab?.();
 
     // selectedDbProcedure
-    states[28] = 'proc1';
-    states[29] = '';
-    states[30] = '';
+    states[66] = 'proc1';
+    states[67] = '';
+    states[68] = '';
 
     await loadConfigHandler();
 
@@ -243,7 +243,7 @@ if (typeof mock.import !== 'function') {
       '/api/report_builder/procedures/proc1',
       '/api/report_builder/procedures/proc1/config',
     ]);
-    assert.equal(states[4], 'abc');
+    assert.equal(states[42], 'abc');
     assert.deepEqual(addToastCalls, [
       { msg: 'Generated config from SQL', type: 'success' },
     ]);
@@ -317,9 +317,9 @@ if (typeof mock.import !== 'function') {
     activateCodeTab?.();
 
     // selectedDbProcedure
-    states[28] = 'proc1';
-    states[29] = '';
-    states[30] = '';
+    states[66] = 'proc1';
+    states[67] = '';
+    states[68] = '';
 
     await loadConfigHandler();
 


### PR DESCRIPTION
## Summary
- extract the report builder workflow into a reusable `ReportBuilderWorkspace` component and render an instance for each tab so Visual builder and Code development maintain separate state
- update the tab container to manage visibility of the two workspace instances while preserving existing fetch and workflow logic inside each workspace
- adjust the report builder tests to target the code tab state bundle after activating the tab and align state index references with the new component layout

## Testing
- npm test
- npm test -- tests/pages/ReportBuilder.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d4b829b0f0833181336a27fa9e8342