### PR TITLE
Wrap report builder panes in fragment

### DIFF
--- a/src/erp.mgt.mn/pages/ReportBuilder.jsx
+++ b/src/erp.mgt.mn/pages/ReportBuilder.jsx
@@ -3120,12 +3120,14 @@ function ReportBuilderInner() {
           </button>
         ))}
       </div>
-      <div style={{ display: activeTab === 'builder' ? 'block' : 'none' }}>
-        <ReportBuilderWorkspace key="builder" />
-      </div>
-      <div style={{ display: activeTab === 'code' ? 'block' : 'none' }}>
-        <ReportBuilderWorkspace key="code" />
-      </div>
+      <React.Fragment>
+        <div style={{ display: activeTab === 'builder' ? 'block' : 'none' }}>
+          <ReportBuilderWorkspace key="builder" />
+        </div>
+        <div style={{ display: activeTab === 'code' ? 'block' : 'none' }}>
+          <ReportBuilderWorkspace key="code" />
+        </div>
+      </React.Fragment>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the visual builder and code development tab panes in a React fragment to avoid returning multiple sibling nodes

## Testing
- node scripts/extractTourOrder.js && vite build --config vite.config.js *(fails: missing dependency @babel/parser)*

------
https://chatgpt.com/codex/tasks/task_e_68d4c3464a408331a7c31d3ec3a54440