### PR TITLE
Include page metadata in translation exports

### DIFF
--- a/api-server/services/translationsExport.js
+++ b/api-server/services/translationsExport.js
@@ -9,15 +9,17 @@ import {
   sortObj,
 } from '../utils/translationHelpers.js';
 
-function ensureMeta(meta, key, module = '', context = '') {
+function ensureMeta(meta, key, module = '', context = '', page = '') {
   if (!key) return;
   const normalizedKey = String(key);
   const nextModule = module ?? '';
   const nextContext = context ?? '';
+  const nextPage = page ?? '';
   if (!meta[normalizedKey]) {
     meta[normalizedKey] = {
       module: nextModule,
       context: nextContext,
+      page: nextPage,
     };
     return;
   }
@@ -32,8 +34,12 @@ function ensureMeta(meta, key, module = '', context = '') {
   ) {
     entry.context = nextContext;
   }
+  if ((entry.page == null || entry.page === '') && nextPage) {
+    entry.page = nextPage;
+  }
   if (entry.module == null) entry.module = '';
   if (entry.context == null) entry.context = '';
+  if (entry.page == null) entry.page = '';
 }
 
 function collectObjectMeta(meta, obj, prefix = '', context = '') {
@@ -115,9 +121,9 @@ export async function exportTranslations(companyId = 0) {
   }
 
   const tPairs = collectPhrasesFromPages(path.resolve('src/erp.mgt.mn'));
-  for (const { key, text, module: sourceModule, context } of tPairs) {
+  for (const { key, text, module: sourceModule, context, page } of tPairs) {
     if (base[key] === undefined) base[key] = pickDefault(text);
-    ensureMeta(metadata, key, sourceModule, context || 'page');
+    ensureMeta(metadata, key, sourceModule, context || 'page', page);
   }
 
   try {
@@ -250,7 +256,11 @@ export async function exportTranslations(companyId = 0) {
   const sorted = sortObj(base);
   const sortedMeta = sortObj(
     Object.fromEntries(
-      Object.entries(metadata).map(([k, v]) => [k, { module: v.module ?? '', context: v.context ?? '' }]),
+      Object.entries(metadata).map(([k, v]) => [k, {
+        module: v.module ?? '',
+        context: v.context ?? '',
+        page: v.page ?? '',
+      }]),
     ),
   );
   const exportPath = tenantConfigPath('exportedtexts.json', 0);

--- a/tests/services/translationsExport.test.js
+++ b/tests/services/translationsExport.test.js
@@ -102,14 +102,19 @@ export default function Tmp() {
   assert.equal(translations['Test Label'], 'Test Label');
   assert.equal(meta['Test Button'].module, 'TmpTranslation');
   assert.equal(meta['Test Button'].context, 'button');
+  assert.equal(meta['Test Button'].page, '');
   assert.equal(meta['Test Option'].module, 'TmpTranslation');
   assert.equal(meta['Test Option'].context, 'option');
+  assert.equal(meta['Test Option'].page, '');
   assert.equal(meta['Test Label'].module, 'TmpTranslation');
   assert.equal(meta['Test Label'].context, 'label');
+  assert.equal(meta['Test Label'].page, '');
   assert.equal(meta.wrapped.module, 'TmpTranslation');
   assert.equal(meta.wrapped.context, 'translation_call');
+  assert.equal(meta.wrapped.page, '');
   assert.equal(meta['Wrapped Button'].module, 'TmpTranslation');
   assert.equal(meta['Wrapped Button'].context, 'translation_call');
+  assert.equal(meta['Wrapped Button'].page, '');
   await db.pool.end();
 });
 


### PR DESCRIPTION
## Summary
- derive human-readable page labels during phrase collection
- persist page values when exporting translation metadata
- extend tests to cover the new metadata fields

## Testing
- node --test tests/services/manualTranslations.test.js tests/services/translationsExport.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d4d37ce4ec833186e8aae8a3cea48d