### PR TITLE
Track translation sources for manual translations

### DIFF
--- a/tests/services/manualTranslations.test.js
+++ b/tests/services/manualTranslations.test.js
@@ -56,6 +56,16 @@ test('exported texts are merged into manual translations', { concurrency: false 
   );
   try {
     const data = await loadTranslations();
+    assert(Array.isArray(data.languages), 'languages is an array');
+    for (const entry of data.entries) {
+      assert.equal(typeof entry.translatedBy, 'object', 'translatedBy is an object');
+      for (const lang of data.languages) {
+        assert(
+          Object.prototype.hasOwnProperty.call(entry.translatedBy, lang),
+          `translatedBy has key for ${lang}`,
+        );
+      }
+    }
     const localeFoo = data.entries.find((e) => e.type === 'locale' && e.key === 'foo');
     const tooltipFoo = data.entries.find((e) => e.type === 'tooltip' && e.key === 'foo');
     assert.equal(localeFoo, undefined);


### PR DESCRIPTION
## Summary
- persist a translatedBy map for manual translation entries and expose it from the manual translations API
- record and display friendly translator labels in the manual translations UI, including a new column and progress overlay updates
- assert that translatedBy metadata is returned for every entry in manual translation service tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4d64b99808331977027aaf658504d