### PR TITLE
Ensure multi-table metadata inherits branch/company ids

### DIFF
--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -655,6 +655,20 @@ export default function PosTransactionsPage() {
               tableChanged = true;
             }
           };
+          const maybeAssignArrayField = (fields, value) => {
+            if (!Array.isArray(fields) || fields.length === 0) return;
+            if (value === undefined || value === null) return;
+            fields.forEach((field) => {
+              if (!field) return;
+              const holder = tableChanged ? targetRows : currentRows;
+              const current = holder[field];
+              if (current !== undefined && current !== null && current !== '') {
+                return;
+              }
+              ensureClone();
+              targetRows[field] = value;
+            });
+          };
           currentRows.forEach((row, idx) => {
             const { updated, changed } = fillRecord(row, branchFields, companyFields);
             if (changed) {
@@ -677,6 +691,12 @@ export default function PosTransactionsPage() {
                 targetRows[key] = updated;
               }
             });
+          }
+          if (branchReady) {
+            maybeAssignArrayField(branchFields, branch);
+          }
+          if (companyReady) {
+            maybeAssignArrayField(companyFields, company);
           }
           if (tableChanged) {
             if (nextValues === currentValues) {


### PR DESCRIPTION
## Summary
- extend multi-table rehydration to set branch/company IDs on array metadata fields when values are empty
- clone multi-table arrays before mutating metadata or primitive properties to avoid mutating state in place

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4d8063c888331ae41c344bc63aceb