### PR TITLE
Enable AI-backed English translations and retain provider info

### DIFF
--- a/src/erp.mgt.mn/pages/ManualTranslationsTab.jsx
+++ b/src/erp.mgt.mn/pages/ManualTranslationsTab.jsx
@@ -11,11 +11,14 @@ const RATE_LIMIT_MAX_DELAY = 5000;
 
 const TRANSLATOR_LABELS = {
   ai: 'OpenAI',
+  openai: 'OpenAI',
   'locale-file': 'Locale file',
   'cache-node': 'Server cache',
   'cache-localStorage': 'LocalStorage cache',
   'cache-indexedDB': 'IndexedDB cache',
   base: 'Base value',
+  google: 'Google',
+  'google-translate': 'Google Translate',
   'fallback-error': 'Fallback (error)',
   'fallback-missing': 'Fallback (missing)',
   'fallback-validation': 'Fallback (validation)',


### PR DESCRIPTION
## Summary
- normalize translation responses so provider metadata is retained and include detected source language when requesting English output
- store translation records with their provider in browser, IndexedDB, and server caches to ensure cached lookups still attribute the provider
- extend manual translation labels so OpenAI and Google attributions surface in the UI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4dccfcd248331a9aadf8d1c68e478