### PR TITLE
Load POS form metadata for hidden tables

### DIFF
--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -1060,20 +1060,27 @@ export default function PosTransactionsPage() {
 
       await Promise.all(
         tables.map(async (tbl, idx) => {
-          const form = forms[idx];
-          if (!tbl || !form || !visibleTables.has(tbl)) return;
+          if (!tbl) return;
 
+          const form = forms[idx];
           let cfg = null;
-          try {
-            const res = await fetch(
-              `/api/transaction_forms?table=${encodeURIComponent(tbl)}&name=${encodeURIComponent(form)}`,
-              { credentials: 'include' },
-            );
-            cfg = res.ok ? await res.json().catch(() => null) : null;
-          } catch {
-            cfg = null;
+          if (form) {
+            try {
+              const res = await fetch(
+                `/api/transaction_forms?table=${encodeURIComponent(tbl)}&name=${encodeURIComponent(form)}`,
+                { credentials: 'include' },
+              );
+              cfg = res.ok ? await res.json().catch(() => null) : null;
+            } catch {
+              cfg = null;
+            }
           }
-          fcMap[tbl] = cfg || {};
+
+          if (form) {
+            fcMap[tbl] = cfg || {};
+          } else if (!(tbl in fcMap)) {
+            fcMap[tbl] = {};
+          }
 
           if (!loadedTablesRef.current.has(tbl)) {
             try {


### PR DESCRIPTION
## Summary
- remove the visible-table guard when loading POS table metadata so hidden tables still fetch their form configs
- always populate the form config map for every configured table while reusing existing column and relation loading logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4ed4e87d88331a72e3bc80f72c132