### PR TITLE
Ensure manual translation loader includes supported locales

### DIFF
--- a/api-server/services/manualTranslations.js
+++ b/api-server/services/manualTranslations.js
@@ -9,6 +9,7 @@ const projectRoot = path.resolve(__dirname, '../../');
 
 const localesDir = path.join(projectRoot, 'src', 'erp.mgt.mn', 'locales');
 const tooltipDir = path.join(localesDir, 'tooltips');
+const SUPPORTED_LANGS = ['en', 'mn', 'ja', 'ko', 'zh', 'es', 'de', 'fr', 'ru'];
 const LOCALE_FILE_LABEL = 'Locale file';
 const TOOLTIP_FILE_LABEL = 'Tooltip file';
 const MANUAL_ENTRY_LABEL = 'Manual entry';
@@ -187,6 +188,9 @@ export async function loadTranslations() {
     ...(await listLangs(localesDir)),
     ...(await listLangs(tooltipDir)),
   ]);
+  for (const lang of SUPPORTED_LANGS) {
+    seedLangs.add(lang);
+  }
 
   const langs = new Set(seedLangs);
 


### PR DESCRIPTION
## Summary
- define the supported ERP language list within the manual translation loader
- seed the loader's language set with all supported locales so responses include empty columns when files are missing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4f8788c34833199e55e5bc666a154