### PR TITLE
Fix POS form table context for inline tables

### DIFF
--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -1967,12 +1967,12 @@ export default function PosTransactionsPage() {
                       mainFields={mainFields}
                       footerFields={footerFields}
                       defaultValues={fc.defaultValues || {}}
-                      table={config.masterTable}
+                      table={t.table}
                       imagenameField={
-                        memoFormConfigs[config.masterTable]?.imagenameField || []
+                        memoFormConfigs[t.table]?.imagenameField || []
                       }
                       imageIdField={
-                        memoFormConfigs[config.masterTable]?.imageIdField || ''
+                        memoFormConfigs[t.table]?.imageIdField || ''
                       }
                       relations={relationsMap[t.table] || {}}
                       relationConfigs={memoRelationConfigs[t.table] || {}}


### PR DESCRIPTION
## Summary
- set RowFormModal to pass each form's table name to InlineTransactionTable
- load per-table image field configuration alongside the updated table prop so inline grids pick up the correct metadata

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4fc476ec483318336e105181aa5f7