### PR TITLE
Ensure exported texts leave tooltips empty

### DIFF
--- a/api-server/services/manualTranslations.js
+++ b/api-server/services/manualTranslations.js
@@ -166,7 +166,19 @@ export async function loadTranslations() {
               ? detectedLang
               : initialLangKey;
           if (localeEntry.values[langKey] == null) localeEntry.values[langKey] = v;
-          if (tooltipEntry.values[langKey] == null) tooltipEntry.values[langKey] = v;
+
+          const tooltipSources = [meta.tooltip, meta.tooltipValue, meta.tooltipText];
+          const tooltipContent = tooltipSources.find(
+            (value) => typeof value === 'string' && value.trim(),
+          );
+
+          if (tooltipContent) {
+            if (tooltipEntry.values[langKey] == null) {
+              tooltipEntry.values[langKey] = tooltipContent;
+            }
+          } else if (tooltipEntry.values[langKey] == null) {
+            tooltipEntry.values[langKey] = '';
+          }
           if (!localeEntry.module && meta.module) localeEntry.module = meta.module;
           if (!tooltipEntry.module && meta.module) tooltipEntry.module = meta.module;
           if (!localeEntry.context && meta.context) localeEntry.context = meta.context;

--- a/tests/services/manualTranslations.test.js
+++ b/tests/services/manualTranslations.test.js
@@ -75,7 +75,7 @@ test('exported texts are merged into manual translations', { concurrency: false 
     assert(nestedLocale, 'nested locale entry exists');
     assert(nestedTooltip, 'nested tooltip entry exists');
     assert.equal(nestedLocale.values.en, 'Bar');
-    assert.equal(nestedTooltip.values.en, 'Bar');
+    assert.equal(nestedTooltip.values.en, '');
     assert.equal(nestedLocale.module, 'pages/NestedPage');
     assert.equal(nestedLocale.context, 'label');
     assert.equal(nestedLocale.page, 'NestedPage');
@@ -154,7 +154,7 @@ test('exported texts detect languages and respect existing entries', { concurren
     assert(englishLocale, 'english locale entry exists');
     assert(englishTooltip, 'english tooltip entry exists');
     assert.equal(englishLocale.values.en, 'Sample English Phrase');
-    assert.equal(englishTooltip.values.en, 'Sample English Phrase');
+    assert.equal(englishTooltip.values.en, '');
     assert.equal(englishLocale.values.mn, '');
     assert.equal(englishTooltip.values.mn, '');
 
@@ -167,7 +167,7 @@ test('exported texts detect languages and respect existing entries', { concurren
     assert(mongolianLocale, 'mongolian locale entry exists');
     assert(mongolianTooltip, 'mongolian tooltip entry exists');
     assert.equal(mongolianLocale.values.mn, 'Санхүүгийн тайлан');
-    assert.equal(mongolianTooltip.values.mn, 'Санхүүгийн тайлан');
+    assert.equal(mongolianTooltip.values.mn, '');
     assert.equal(mongolianLocale.values.en, '');
     assert.equal(mongolianTooltip.values.en, '');
 


### PR DESCRIPTION
## Summary
- stop copying exported locale text into tooltip values when loading manual translations, while still capturing tooltip metadata
- allow optional real tooltip content from metadata and default empty strings so tooltip generation can fill them later
- update manual translation service tests to expect blank tooltip values for newly exported entries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4fdf0f6fc8331b58e54b36fd4cd8b