### PR TITLE
Pass POS totals metadata to RowFormModal

### DIFF
--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -1901,6 +1901,12 @@ export default function PosTransactionsPage() {
                   fc.footerFields && fc.footerFields.length > 0
                     ? fc.footerFields
                     : [];
+                const totalAmountFields = Array.isArray(fc.totalAmountFields)
+                  ? fc.totalAmountFields
+                  : [];
+                const totalCurrencyFields = Array.isArray(fc.totalCurrencyFields)
+                  ? fc.totalCurrencyFields
+                  : [];
                 const provided = Array.isArray(fc.editableFields)
                   ? fc.editableFields
                   : [];
@@ -1967,6 +1973,8 @@ export default function PosTransactionsPage() {
                       mainFields={mainFields}
                       footerFields={footerFields}
                       defaultValues={fc.defaultValues || {}}
+                      totalAmountFields={totalAmountFields}
+                      totalCurrencyFields={totalCurrencyFields}
                       table={t.table}
                       imagenameField={
                         memoFormConfigs[t.table]?.imagenameField || []


### PR DESCRIPTION
## Summary
- ensure POS RowFormModal instances receive total amount and currency field metadata from their form configurations
- forward the totals configuration so InlineTransactionTable can render summed footers and row counts

## Testing
- node --test tests/components/inlineTransactionTableMetadata.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d50375544c8331a4181c316c8feb2c