### PR TITLE
Fix duplicate array index regex declaration

### DIFF
--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -269,8 +269,6 @@ export function shouldLoadRelations(formConfig, cols = []) {
   return hasView || hasForeignKey(cols);
 }
 
-const arrayIndexPattern = /^(0|[1-9]\d*)$/;
-
 function copyArrayMetadata(target, source) {
   if (!Array.isArray(target) || !Array.isArray(source)) return;
   Object.keys(source).forEach((key) => {


### PR DESCRIPTION
## Summary
- remove the duplicate arrayIndexPattern declaration in PosTransactions so the shared helper defined at the top of the module is reused

## Testing
- npm run build:erp *(fails: missing @babel/parser dependency in scripts/extractTourOrder.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d23898849c8331b2d86be1cc6c24a4