### PR TITLE
Respect tooltip metadata in translation cache

### DIFF
--- a/src/erp.mgt.mn/pages/ManualTranslationsTab.jsx
+++ b/src/erp.mgt.mn/pages/ManualTranslationsTab.jsx
@@ -639,6 +639,7 @@ export default function ManualTranslationsTab() {
         context: newEntry.context,
         key: newEntry.key,
         page: newEntry.page,
+        type: newEntry.type,
       };
       const translateEntry = (targetLang, text) =>
         translateWithCache(targetLang, text, undefined, entryMetadata);


### PR DESCRIPTION
## Summary
- include the translation entry type when ManualTranslationsTab auto-completes values
- teach translateWithCache to read tooltip locale files and only short-circuit when a tooltip exists
- make tooltip translations fall back to AI/Google by including type in cache keys when files lack values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d509b0217c8331bf3400514e003638