### PR TITLE
Preserve POS multi-table metadata in transport

### DIFF
--- a/api-server/services/postPosTransaction.js
+++ b/api-server/services/postPosTransaction.js
@@ -6,6 +6,8 @@ import { getConfigPath } from '../utils/configPaths.js';
 const masterForeignKeyCache = new Map();
 const masterTableColumnsCache = new Map();
 
+const arrayIndexPattern = /^(0|[1-9]\d*)$/;
+
 const SESSION_KEY_MAP = new Map([
   ['employee_id', 'emp_id'],
   ['employeeid', 'emp_id'],
@@ -95,6 +97,29 @@ function setValue(target, field, value) {
   }
 }
 
+function extractArrayMetadata(value) {
+  if (!value || typeof value !== 'object') return null;
+  const metadata = {};
+  let hasMetadata = false;
+  for (const key of Object.keys(value)) {
+    if (key === 'rows' || key === 'meta') continue;
+    if (arrayIndexPattern.test(key)) continue;
+    metadata[key] = value[key];
+    hasMetadata = true;
+  }
+  return hasMetadata ? metadata : null;
+}
+
+function assignArrayMetadata(target, source) {
+  if (!Array.isArray(target) || !source || typeof source !== 'object') {
+    return target;
+  }
+  const metadata = extractArrayMetadata(source);
+  if (!metadata) return target;
+  Object.assign(target, metadata);
+  return target;
+}
+
 function sumCellValue(source, field) {
   if (Array.isArray(source)) {
     let sum = 0;
@@ -160,6 +185,12 @@ export function propagateCalcFields(cfg, data) {
         const { table, field } = cell || {};
         if (!table || !field) continue;
         const source = data[table];
+        const direct = getValue(source, field);
+        if (direct !== undefined) {
+          computedValue = direct;
+          hasComputedValue = true;
+          break;
+        }
         if (Array.isArray(source)) {
           for (const row of source) {
             if (!row || typeof row !== 'object') continue;
@@ -190,6 +221,7 @@ export function propagateCalcFields(cfg, data) {
       if (!target) continue;
 
       if (agg === 'SUM' && Array.isArray(target)) {
+        setValue(target, field, computedValue);
         continue;
       }
 
@@ -198,6 +230,7 @@ export function propagateCalcFields(cfg, data) {
           if (!row || typeof row !== 'object') continue;
           setValue(row, field, computedValue);
         }
+        setValue(target, field, computedValue);
       } else if (isPlainObject(target)) {
         setValue(target, field, computedValue);
       }
@@ -326,13 +359,24 @@ function normalizeSingleEntry(value) {
 }
 
 function normalizeMultiEntry(value) {
+  let rows = [];
+  let metadata = null;
   if (Array.isArray(value)) {
-    return value.filter((item) => isPlainObject(item)).map((item) => ({ ...item }));
+    rows = value.filter((item) => isPlainObject(item)).map((item) => ({ ...item }));
+    metadata = extractArrayMetadata(value);
+  } else if (isPlainObject(value)) {
+    if (Array.isArray(value.rows)) {
+      rows = value.rows
+        .filter((item) => isPlainObject(item))
+        .map((item) => ({ ...item }));
+      metadata = extractArrayMetadata(value.meta || {});
+    } else {
+      rows = [{ ...value }];
+    }
   }
-  if (isPlainObject(value)) {
-    return [{ ...value }];
-  }
-  return [];
+  const normalized = Array.isArray(rows) ? rows : [];
+  if (!metadata) return normalized;
+  return assignArrayMetadata(normalized, metadata);
 }
 
 function inferExpectedFieldType(info) {
@@ -413,7 +457,11 @@ export function validateConfiguredFields(cfg, data, tableTypeMap = new Map()) {
 
     let rows;
     if (Array.isArray(tableData)) {
+      const metadata = extractArrayMetadata(tableData);
       rows = tableData.map((row, index) => ({ row, index }));
+      if (metadata && Object.keys(metadata).length > 0) {
+        rows.push({ row: metadata, index: 'meta' });
+      }
     } else if (isPlainObject(tableData)) {
       rows = [{ row: tableData, index: null }];
     } else {


### PR DESCRIPTION
## Summary
- capture multi-table metadata in the POS UI when saving pending work or posting transactions and restore it when loading data
- serialize multi-entry payloads as `{ rows, meta }` objects and update server-side handlers to normalize, propagate, and validate metadata-aware arrays
- ensure calc field propagation writes metadata values while keeping validation aware of header/footer fields

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d517ff2f8883318c001b90599569f0