### PR TITLE
Normalize cached translation sources

### DIFF
--- a/tests/utils/translateWithCache.test.js
+++ b/tests/utils/translateWithCache.test.js
@@ -1,0 +1,42 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createCacheRecord } from '../../src/erp.mgt.mn/utils/translateWithCache.js';
+
+describe('createCacheRecord', () => {
+  it('replaces cache-prefixed sources with the provided fallback', () => {
+    const record = createCacheRecord(
+      { text: 'Hello', source: 'cache-ai' },
+      'ai',
+    );
+    assert.ok(record);
+    assert.equal(record.source, 'ai');
+  });
+
+  it('normalizes legacy cache tags to the fallback provider', () => {
+    const record = createCacheRecord(
+      { text: 'Hello', source: 'cache-indexedDB' },
+      'ai',
+    );
+    assert.ok(record);
+    assert.equal(record.source, 'ai');
+  });
+
+  it('respects non-cache sources', () => {
+    const record = createCacheRecord(
+      { text: 'Hello', source: 'OpenAI' },
+      'ai',
+    );
+    assert.ok(record);
+    assert.equal(record.source, 'OpenAI');
+  });
+
+  it('supports alternate provider fallbacks', () => {
+    const record = createCacheRecord(
+      { text: 'Hello', source: 'cache-google' },
+      'google',
+    );
+    assert.ok(record);
+    assert.equal(record.source, 'google');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure cached translation records replace legacy cache source tags with the provided provider fallback
- export the cache normalization helper and cover cache source normalization with new unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d51ade06088331a94925a2417990f9