### PR TITLE
Trigger generated column recalculation when evaluators load

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -1064,6 +1064,9 @@ function InlineTransactionTable(
     });
     return map;
   }, [tableColumnsKey, columnCaseMapKey]);
+  const hasGeneratedColumnsRef = useRef(
+    Object.keys(generatedColumnEvaluators).length > 0,
+  );
 
   const mainFieldSet = React.useMemo(() => {
     const set = new Set();
@@ -1173,6 +1176,16 @@ function InlineTransactionTable(
     },
     [applyGeneratedColumns, onRowsChange],
   );
+
+  useEffect(() => {
+    const hasGeneratedColumns = Object.keys(generatedColumnEvaluators).length > 0;
+    const prevHasGeneratedColumns = hasGeneratedColumnsRef.current;
+    hasGeneratedColumnsRef.current = hasGeneratedColumns;
+    if (prevHasGeneratedColumns || !hasGeneratedColumns) return;
+    const currentRows = rowsRef.current;
+    if (!Array.isArray(currentRows) || currentRows.length === 0) return;
+    commitRowsUpdate((prev) => prev);
+  }, [generatedColumnEvaluators, commitRowsUpdate]);
 
   const placeholders = React.useMemo(() => {
     const map = {};


### PR DESCRIPTION
## Summary
- reprocess inline transaction rows when generated column evaluators become available so stored fields populate immediately

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d51eb5c32c8331899e8924188613c5