### PR TITLE
Fix virtual columns initialization in dynamic transactions

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -1064,9 +1064,7 @@ function InlineTransactionTable(
     });
     return map;
   }, [tableColumnsKey, columnCaseMapKey]);
-  const hasGeneratedColumnsRef = useRef(
-    Object.keys(generatedColumnEvaluators).length > 0,
-  );
+  const hasGeneratedColumnsRef = useRef(false);
 
   const mainFieldSet = React.useMemo(() => {
     const set = new Set();
@@ -1181,7 +1179,7 @@ function InlineTransactionTable(
     const hasGeneratedColumns = Object.keys(generatedColumnEvaluators).length > 0;
     const prevHasGeneratedColumns = hasGeneratedColumnsRef.current;
     hasGeneratedColumnsRef.current = hasGeneratedColumns;
-    if (prevHasGeneratedColumns || !hasGeneratedColumns) return;
+    if (!hasGeneratedColumns || prevHasGeneratedColumns) return;
     const currentRows = rowsRef.current;
     if (!Array.isArray(currentRows) || currentRows.length === 0) return;
     commitRowsUpdate((prev) => prev);


### PR DESCRIPTION
## Summary
- ensure inline transaction tables always recompute generated column values when metadata is immediately available
- allow dynamic transaction forms to display virtual/generated field values correctly on initial render

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5f9dc85008331b281ee9d22440b5c