### PR TITLE
Track translation providers in metadata

### DIFF
--- a/docs/manuals/manual-translation-sources.json
+++ b/docs/manuals/manual-translation-sources.json
@@ -1,0 +1,9 @@
+{
+  "locale:appName": {
+    "de": "ai",
+    "es": "google"
+  },
+  "tooltip:appName": {
+    "de": "google"
+  }
+}


### PR DESCRIPTION
## Summary
- capture translation provider codes when generating locale strings and tooltips and persist them to the manual translation metadata store
- add persistence helpers so the metadata map is normalized and written to docs/manuals/manual-translation-sources.json after translation runs
- seed docs/manuals/manual-translation-sources.json with example provider codes for appName so the manual translations API can surface "ai"/"google"

## Testing
- `node --input-type=module -e "import('./api-server/services/manualTranslations.js').then(async ({ loadTranslations }) => { const data = await loadTranslations(); const filtered = data.entries.filter((e) => e.key === 'appName'); console.log(JSON.stringify(filtered, null, 2)); });"`
- `npm run generate:translations` *(fails: missing OpenAI API key, aborts before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68d610f0f4ac8331b55d25325fba40e8