### PR TITLE
Ensure dynamic transaction forms evaluate virtual fields

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1091,7 +1091,7 @@ const TableManager = forwardRef(function TableManager({
         generatedEvaluators[key] = evaluator;
       }
     });
-    const initialRows = [{ ...baseRow }];
+    const initialRows = [{ ...baseRow, _saved: false }];
     if (Object.keys(generatedEvaluators).length > 0) {
       const { changed } = applyGeneratedColumnEvaluators({
         targetRows: initialRows,


### PR DESCRIPTION
## Summary
- evaluate generated column formulas inside the dynamic transaction form so virtual fields refresh as related inputs change
- propagate generated updates back to the table manager and mark newly added rows as editable defaults

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d613d5b65083318facffc036d9303e