### PR TITLE
Ensure RowFormModal distinguishes add mode UI

### DIFF
--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -66,6 +66,7 @@ const RowFormModal = function RowFormModal({
   procTriggers = {},
   autoFillSession = true,
   tableColumns = [],
+  isAddMode = false,
 }) {
   const mounted = useRef(false);
   const renderCount = useRef(0);
@@ -224,7 +225,12 @@ const RowFormModal = function RowFormModal({
     [fieldTypeMap],
   );
   const columnsKey = React.useMemo(() => columns.join(','), [columns]);
-  const rowKey = React.useMemo(() => JSON.stringify(row || {}), [row]);
+  const hasExistingRow = !isAddMode && row && typeof row === 'object';
+  const currentRow = hasExistingRow ? row : null;
+  const rowKey = React.useMemo(
+    () => JSON.stringify(currentRow || {}),
+    [currentRow],
+  );
   const defaultValuesKey = React.useMemo(
     () => JSON.stringify(defaultValues || {}),
     [defaultValues],
@@ -259,9 +265,11 @@ const RowFormModal = function RowFormModal({
       } else if (typ === 'date' || typ === 'datetime') {
         placeholder = 'YYYY-MM-DD';
       }
-      const raw = row ? String(row[c] ?? '') : String(defaultValues[c] ?? '');
+      const raw = currentRow
+        ? String(currentRow[c] ?? '')
+        : String(defaultValues[c] ?? '');
       let val = normalizeDateInput(raw, placeholder);
-      const missing = !row || row[c] === undefined || row[c] === '';
+      const missing = !currentRow || currentRow[c] === undefined || currentRow[c] === '';
       if (missing && !val && dateField.includes(c)) {
         if (placeholder === 'YYYY-MM-DD') val = formatTimestamp(now).slice(0, 10);
         else if (placeholder === 'HH:MM:SS') val = formatTimestamp(now).slice(11, 19);
@@ -282,7 +290,7 @@ const RowFormModal = function RowFormModal({
   });
   const [extraVals, setExtraVals] = useState(() => {
     const extras = {};
-    Object.entries(row || {}).forEach(([k, v]) => {
+    Object.entries(currentRow || {}).forEach(([k, v]) => {
       if (!columns.includes(k)) {
         const typ = fieldTypeMap[k];
         let placeholder = '';
@@ -434,7 +442,7 @@ const RowFormModal = function RowFormModal({
     const map = {};
     const cols = new Set([
       ...columns,
-      ...Object.keys(row || {}),
+      ...Object.keys(currentRow || {}),
       ...Object.keys(defaultValues || {}),
     ]);
     cols.forEach((c) => {
@@ -450,16 +458,16 @@ const RowFormModal = function RowFormModal({
 
   useEffect(() => {
     const extras = {};
-    Object.entries(row || {}).forEach(([k, v]) => {
+    Object.entries(currentRow || {}).forEach(([k, v]) => {
       if (!columns.includes(k)) {
         extras[k] = normalizeDateInput(String(v ?? ''), placeholders[k]);
       }
     });
     setExtraVals(extras);
-  }, [row, columns, placeholders]);
+  }, [currentRow, columns, placeholders]);
 
   useEffect(() => {
-    if (table !== 'companies' || row) return;
+    if (table !== 'companies' || !isAddMode) return;
     fetch('/api/tenant_tables', { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : []))
       .then((data) => {
@@ -474,7 +482,7 @@ const RowFormModal = function RowFormModal({
         opts.forEach((o) => loadSeedRecords(o.tableName));
       })
       .catch(() => {});
-  }, [table, row]);
+  }, [table, isAddMode]);
 
   function toggleSeedTable(name) {
     setExtraVals((e) => {
@@ -610,9 +618,11 @@ const RowFormModal = function RowFormModal({
     if (!visible) return;
     const vals = {};
     columns.forEach((c) => {
-      const raw = row ? String(row[c] ?? '') : String(defaultValues[c] ?? '');
+      const raw = currentRow
+        ? String(currentRow[c] ?? '')
+        : String(defaultValues[c] ?? '');
       let v = normalizeDateInput(raw, placeholders[c]);
-      const missing = !row || row[c] === undefined || row[c] === '';
+      const missing = !currentRow || currentRow[c] === undefined || currentRow[c] === '';
       if (missing && !v && dateField.includes(c)) {
         const now = new Date();
         if (placeholders[c] === 'YYYY-MM-DD') v = formatTimestamp(now).slice(0, 10);
@@ -633,7 +643,7 @@ const RowFormModal = function RowFormModal({
     inputRefs.current = {};
     setErrors({});
     setFormValuesWithGenerated(() => vals, { notify: false });
-  }, [row, visible, user, company, branch, department, setFormValuesWithGenerated]);
+  }, [currentRow, visible, user, company, branch, department, setFormValuesWithGenerated]);
 
   function resizeInputs() {
     Object.values({ ...inputRefs.current, ...readonlyRefs.current }).forEach((el) => {
@@ -2046,7 +2056,7 @@ const RowFormModal = function RowFormModal({
     <>
       <Modal
         visible={visible}
-        title={row ? 'Мөр засах' : 'Мөр нэмэх'}
+        title={isAddMode ? 'Мөр нэмэх' : 'Мөр засах'}
         onClose={onCancel}
         width="70vw"
       >
@@ -2062,7 +2072,7 @@ const RowFormModal = function RowFormModal({
         {renderHeaderTable(headerCols)}
         {renderMainTable(mainCols)}
         {renderSection('Footer', footerCols)}
-        {table === 'companies' && !row && seedOptions.length > 0 && (
+        {table === 'companies' && isAddMode && seedOptions.length > 0 && (
           <div className="mt-4">
             <h3 className="font-semibold mb-2">Seed Tables</h3>
             <div className="space-y-2">
@@ -2099,20 +2109,24 @@ const RowFormModal = function RowFormModal({
           </div>
         )}
         <div className="mt-2 text-right space-x-2">
-          <button
-            type="button"
-            onClick={() => handlePrint('emp')}
-            className="px-3 py-1 bg-gray-200 rounded"
-          >
-            {t('printEmp', 'Print Emp')}
-          </button>
-          <button
-            type="button"
-            onClick={() => handlePrint('cust')}
-            className="px-3 py-1 bg-gray-200 rounded"
-          >
-            {t('printCust', 'Print Cust')}
-          </button>
+          {!isAddMode && (
+            <>
+              <button
+                type="button"
+                onClick={() => handlePrint('emp')}
+                className="px-3 py-1 bg-gray-200 rounded"
+              >
+                {t('printEmp', 'Print Emp')}
+              </button>
+              <button
+                type="button"
+                onClick={() => handlePrint('cust')}
+                className="px-3 py-1 bg-gray-200 rounded"
+              >
+                {t('printCust', 'Print Cust')}
+              </button>
+            </>
+          )}
           <button
             type="button"
             onClick={onCancel}

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -2806,6 +2806,7 @@ const TableManager = forwardRef(function TableManager({
         key={`rowform-${table}`}
         visible={showForm}
         useGrid
+        isAddMode={isAdding}
         onCancel={() => {
           setShowForm(false);
           setEditing(null);

--- a/tests/components/timestampDisplay.test.js
+++ b/tests/components/timestampDisplay.test.js
@@ -239,4 +239,69 @@ if (!haveReact) {
     assert.equal(input?.getAttribute('placeholder'), 'YYYY-MM-DD');
     root.unmount();
   });
+
+  test('RowFormModal add mode shows add title without edit chrome', async (t) => {
+    let modalTitle = null;
+    const origFetch = global.fetch;
+    global.fetch = async () => ({ ok: true, json: async () => ({}) });
+
+    const { default: RowFormModal } = await t.mock.import(
+      '../../src/erp.mgt.mn/components/RowFormModal.jsx',
+      {
+        './AsyncSearchSelect.jsx': { default: () => null },
+        './InlineTransactionTable.jsx': { default: () => null },
+        './RowDetailModal.jsx': { default: () => null },
+        './TooltipWrapper.jsx': { default: (p) => React.createElement('div', p) },
+        './Modal.jsx': {
+          default: ({ title, children }) => {
+            modalTitle = title;
+            return React.createElement('div', { 'data-testid': 'modal' }, children);
+          },
+        },
+        '../context/AuthContext.jsx': {
+          AuthContext: React.createContext({
+            user: {},
+            company: 1,
+            branch: 1,
+            department: 1,
+            userSettings: {},
+          }),
+        },
+        '../hooks/useGeneralConfig.js': { default: () => ({ forms: {}, general: {} }) },
+        '../utils/formatTimestamp.js': { default: () => '2024-05-01 12:34:56' },
+        '../utils/normalizeDateInput.js': { default: (v) => v },
+        '../utils/apiBase.js': { API_BASE: '' },
+        '../utils/callProcedure.js': { default: () => {} },
+        'react-i18next': { useTranslation: () => ({ t: (_k, d) => d || _k }) },
+      },
+    );
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    try {
+      await act(async () => {
+        root.render(
+          React.createElement(RowFormModal, {
+            visible: true,
+            onCancel: () => {},
+            onSubmit: () => {},
+            columns: ['id'],
+            row: { id: 42 },
+            defaultValues: { id: '42' },
+            fieldTypeMap: { id: 'text' },
+            isAddMode: true,
+            table: 'transactions',
+          }),
+        );
+      });
+
+      assert.equal(modalTitle, 'Мөр нэмэх');
+      const content = container.textContent || '';
+      assert.equal(content.includes('Print Emp'), false);
+      assert.equal(content.includes('Print Cust'), false);
+    } finally {
+      root.unmount();
+      global.fetch = origFetch;
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- pass an explicit add-mode flag from TableManager to RowFormModal
- use the new signal in RowFormModal to render add-mode specific defaults and hide edit-only controls
- add regression coverage that asserts the add-row modal shows the add title and no print buttons

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d61c9069bc8331bf984be78e45e429