### PR TITLE
Add configurable tour button visibility

### DIFF
--- a/api-server/services/generalConfig.js
+++ b/api-server/services/generalConfig.js
@@ -27,6 +27,7 @@ const defaults = {
     imageToastEnabled: false,
     debugLoggingEnabled: false,
     editLabelsEnabled: false,
+    showTourButtons: true,
     showReportParams: false,
     requestPollingEnabled: false,
     requestPollingIntervalSeconds: 30,
@@ -42,45 +43,45 @@ const defaults = {
   },
 };
 
-  async function readConfig(companyId = 0) {
-    const { path: filePath, isDefault } = await getConfigPath(
-      'generalConfig.json',
-      companyId,
-    );
+async function readConfig(companyId = 0) {
+  const { path: filePath, isDefault } = await getConfigPath(
+    'generalConfig.json',
+    companyId,
+  );
 
-    try {
-      const data = await fs.readFile(filePath, 'utf8');
-      const parsed = JSON.parse(data);
-      let result;
-      if (parsed.forms || parsed.pos || parsed.general || parsed.images) {
-        const { imageStorage, ...restGeneral } = parsed.general || {};
-        const images = parsed.images || imageStorage || {};
-        result = {
-          ...defaults,
-          ...parsed,
-          general: {
-            ...defaults.general,
-            ...restGeneral,
-          },
-          images: {
-            ...defaults.images,
-            ...images,
-          },
-        };
-      } else {
-        // migrate older flat structure to new nested layout
-        result = {
-          forms: { ...defaults.forms, ...parsed },
-          pos: { ...defaults.pos },
-          general: { ...defaults.general },
-          images: { ...defaults.images },
-        };
-      }
-      return { config: result, isDefault };
-    } catch {
-      return { config: { ...defaults }, isDefault: true };
+  try {
+    const data = await fs.readFile(filePath, 'utf8');
+    const parsed = JSON.parse(data);
+    let result;
+    if (parsed.forms || parsed.pos || parsed.general || parsed.images) {
+      const { imageStorage, ...restGeneral } = parsed.general || {};
+      const images = parsed.images || imageStorage || {};
+      result = {
+        ...defaults,
+        ...parsed,
+        general: {
+          ...defaults.general,
+          ...restGeneral,
+        },
+        images: {
+          ...defaults.images,
+          ...images,
+        },
+      };
+    } else {
+      // migrate older flat structure to new nested layout
+      result = {
+        forms: { ...defaults.forms, ...parsed },
+        pos: { ...defaults.pos },
+        general: { ...defaults.general },
+        images: { ...defaults.images },
+      };
     }
+    return { config: result, isDefault };
+  } catch {
+    return { config: { ...defaults }, isDefault: true };
   }
+}
 
 async function writeConfig(cfg, companyId = 0) {
   const filePath = tenantConfigPath('generalConfig.json', companyId);
@@ -98,6 +99,9 @@ export async function updateGeneralConfig(updates = {}, companyId = 0) {
   if (updates.pos) Object.assign(cfg.pos, updates.pos);
   if (updates.general) {
     Object.assign(cfg.general, updates.general);
+  }
+  if (!Object.prototype.hasOwnProperty.call(cfg.general, 'showTourButtons')) {
+    cfg.general.showTourButtons = defaults.general.showTourButtons;
   }
   if (updates.images) {
     Object.assign(cfg.images, updates.images);

--- a/config/0/generalConfig.json
+++ b/config/0/generalConfig.json
@@ -23,6 +23,7 @@
     "imageToastEnabled": false,
     "debugLoggingEnabled": false,
     "editLabelsEnabled": true,
+    "showTourButtons": true,
     "showReportParams": false,
     "requestPollingEnabled": false,
     "requestPollingIntervalSeconds": 30,

--- a/docs/general-configuration.md
+++ b/docs/general-configuration.md
@@ -37,10 +37,13 @@ up to `boxMaxWidth`/`boxMaxHeight` as text is entered and wrap when necessary.
 The **POS** section provides the same options specifically for POS transactions.
 Here `boxWidth` defines the initial grid box width of a POS transaction.
 
-The **General** section hosts feature toggles. `requestPollingEnabled` controls
-whether the client falls back to periodic API polling when a Socket.IO
-connection cannot be established. `requestPollingIntervalSeconds` sets the
-polling cadence (default 30&nbsp;seconds).
+The **General** section hosts feature toggles. `showTourButtons` controls
+whether the tour action group is displayed in the ERP window header. Toggle it
+off to hide the Create/Edit/View tour buttons across the application. Other
+options include `requestPollingEnabled`, which determines whether the client
+falls back to periodic API polling when a Socket.IO connection cannot be
+established, and `requestPollingIntervalSeconds`, which sets the polling
+cadence (default 30&nbsp;seconds).
 
 The **Images** tab exposes `basePath`, `cleanupDays` and an `ignoreOnSearch` list.
 `basePath` sets the root directory for uploaded transaction images. The default

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -719,6 +719,11 @@ function MainWindow({ title }) {
     return Boolean(value);
   }, []);
 
+  const showTourButtons = toBooleanFlag(
+    generalConfig?.general?.showTourButtons,
+    true,
+  );
+
   const configBuilderToggle =
     generalConfig?.general?.tourBuilderEnabled ??
     generalConfig?.general?.enableTourBuilder ??
@@ -772,41 +777,43 @@ function MainWindow({ title }) {
       <div style={styles.windowHeader}>
         <div style={styles.windowHeaderLeft}>
           <span>{title}</span>
-          <div style={styles.tourButtonGroup}>
-            <button
-              type="button"
-              onClick={handleCreateTour}
-              disabled={!canManageTours}
-              style={{
-                ...styles.tourButton,
-                ...(canManageTours ? null : styles.tourButtonDisabled),
-              }}
-            >
-              {t('tour_create', 'Create tour')}
-            </button>
-            <button
-              type="button"
-              onClick={handleEditTour}
-              disabled={!canManageTours || !hasTour}
-              style={{
-                ...styles.tourButton,
-                ...(canManageTours && hasTour ? null : styles.tourButtonDisabled),
-              }}
-            >
-              {t('tour_edit', 'Edit tour')}
-            </button>
-            <button
-              type="button"
-              onClick={handleViewTour}
-              disabled={!hasTour}
-              style={{
-                ...styles.tourButton,
-                ...(hasTour ? null : styles.tourButtonDisabled),
-              }}
-            >
-              {t('tour_view', 'View tour')}
-            </button>
-          </div>
+          {showTourButtons && (
+            <div style={styles.tourButtonGroup}>
+              <button
+                type="button"
+                onClick={handleCreateTour}
+                disabled={!canManageTours}
+                style={{
+                  ...styles.tourButton,
+                  ...(canManageTours ? null : styles.tourButtonDisabled),
+                }}
+              >
+                {t('tour_create', 'Create tour')}
+              </button>
+              <button
+                type="button"
+                onClick={handleEditTour}
+                disabled={!canManageTours || !hasTour}
+                style={{
+                  ...styles.tourButton,
+                  ...(canManageTours && hasTour ? null : styles.tourButtonDisabled),
+                }}
+              >
+                {t('tour_edit', 'Edit tour')}
+              </button>
+              <button
+                type="button"
+                onClick={handleViewTour}
+                disabled={!hasTour}
+                style={{
+                  ...styles.tourButton,
+                  ...(hasTour ? null : styles.tourButtonDisabled),
+                }}
+              >
+                {t('tour_view', 'View tour')}
+              </button>
+            </div>
+          )}
         </div>
         <div>
           <button style={styles.windowHeaderBtn}>–</button>

--- a/src/erp.mgt.mn/locales/de.json
+++ b/src/erp.mgt.mn/locales/de.json
@@ -506,6 +506,7 @@
   "settings_change_password": "Passwort ändern",
   "settings_company_licenses": "Unternehmenslizenzen",
   "settings_enable_tooltips": "Tooltips aktivieren",
+  "show_tour_buttons": "Tour-Schaltflächen anzeigen",
   "settings_forms_management": "Formularverwaltung",
   "settings_modules": "Module",
   "settings_report_management": "Berichtsverwaltung",

--- a/src/erp.mgt.mn/locales/en.json
+++ b/src/erp.mgt.mn/locales/en.json
@@ -664,6 +664,7 @@
   "settings_company_licenses": "Company Licenses",
   "settings_enable_tooltips": "Enable tooltips",
   "settings_enable_tours": "Show page guide",
+  "show_tour_buttons": "Show tour buttons",
   "settings_fetch_error": "Error fetching settings:",
   "settings_fetch_failed": "Failed to fetch settings",
   "settings_forms_management": "Forms Management",

--- a/src/erp.mgt.mn/locales/es.json
+++ b/src/erp.mgt.mn/locales/es.json
@@ -660,6 +660,7 @@
   "settings_company_licenses": "Licencias de empresa",
   "settings_enable_tooltips": "Habilitar tooltips",
   "settings_enable_tours": "Mostrar guía de página",
+  "show_tour_buttons": "Mostrar botones de tour",
   "settings_fetch_error": "Error al obtener la configuración:",
   "settings_fetch_failed": "Error al obtener configuraciones",
   "settings_forms_management": "Gestión de formularios",

--- a/src/erp.mgt.mn/locales/fr.json
+++ b/src/erp.mgt.mn/locales/fr.json
@@ -30,6 +30,7 @@
   "no_activity": "Aucune activité à afficher.",
   "plans_coming_soon": "Contenu des plans à venir.",
   "settings_enable_tooltips": "Activer les info-bulles",
+  "show_tour_buttons": "Afficher les boutons du guide",
   "delete_related_records": "Delete Related Records?",
   "ai_suggestions": "AI Suggestions",
   "no_suggestions": "No suggestions.",

--- a/src/erp.mgt.mn/locales/ja.json
+++ b/src/erp.mgt.mn/locales/ja.json
@@ -660,6 +660,7 @@
   "settings_company_licenses": "会社ライセンス",
   "settings_enable_tooltips": "ツールチップを有効にする",
   "settings_enable_tours": "ページガイドを表示",
+  "show_tour_buttons": "ツアーボタンを表示",
   "settings_fetch_error": "設定の取得エラー：",
   "settings_fetch_failed": "設定の取得に失敗しました",
   "settings_forms_management": "フォーム管理",

--- a/src/erp.mgt.mn/locales/ko.json
+++ b/src/erp.mgt.mn/locales/ko.json
@@ -660,6 +660,7 @@
   "settings_company_licenses": "회사 라이선스",
   "settings_enable_tooltips": "툴팁 활성화",
   "settings_enable_tours": "페이지 안내 표시",
+  "show_tour_buttons": "투어 버튼 표시",
   "settings_fetch_error": "설정 가져오기 오류",
   "settings_fetch_failed": "설정을 가져오지 못했습니다",
   "settings_forms_management": "양식 관리",

--- a/src/erp.mgt.mn/locales/mn.json
+++ b/src/erp.mgt.mn/locales/mn.json
@@ -664,6 +664,7 @@
   "settings_company_licenses": "Компанийн лицензүүд",
   "settings_enable_tooltips": "Тайлбарыг идэвхжүүлэх",
   "settings_enable_tours": "Хуудсыг зааварчилгаа",
+  "show_tour_buttons": "Турын товчийг харуулах",
   "settings_fetch_error": "Тохиргоо татахад алдаа гарлаа:",
   "settings_fetch_failed": "Тохиргоо татах амжилтгүй",
   "settings_forms_management": "Маягтын удирдлага",

--- a/src/erp.mgt.mn/locales/ru.json
+++ b/src/erp.mgt.mn/locales/ru.json
@@ -30,6 +30,7 @@
   "no_activity": "Нет активности для отображения.",
   "plans_coming_soon": "Содержание планов скоро появится.",
   "settings_enable_tooltips": "Включить подсказки",
+  "show_tour_buttons": "Показывать кнопки тура",
   "delete_related_records": "Delete Related Records?",
   "ai_suggestions": "AI Suggestions",
   "no_suggestions": "No suggestions.",

--- a/src/erp.mgt.mn/locales/tooltips/de.json
+++ b/src/erp.mgt.mn/locales/tooltips/de.json
@@ -15,5 +15,6 @@
   "reports": "Reports",
   "user_level_actions": "User level actions",
   "edit_delete_request": "Edit or delete request",
+  "show_tour_buttons": "Tour-Schaltflächen in der Fensterkopfzeile ein- oder ausblenden.",
   "system_settings": "System settings"
 }

--- a/src/erp.mgt.mn/locales/tooltips/en.json
+++ b/src/erp.mgt.mn/locales/tooltips/en.json
@@ -525,5 +525,6 @@
   "reports": "Reports",
   "user_level_actions": "User level actions",
   "edit_delete_request": "Edit or delete request",
+  "show_tour_buttons": "Show or hide the tour action buttons in the window header.",
   "system_settings": "System settings"
 }

--- a/src/erp.mgt.mn/locales/tooltips/es.json
+++ b/src/erp.mgt.mn/locales/tooltips/es.json
@@ -468,5 +468,6 @@
   "assembly_price": "Assembly price",
   "reports": "Reports",
   "edit_delete_request": "Edit or delete request",
+  "show_tour_buttons": "Mostrar u ocultar los botones de tour en el encabezado de la ventana.",
   "system_settings": "System settings"
 }

--- a/src/erp.mgt.mn/locales/tooltips/fr.json
+++ b/src/erp.mgt.mn/locales/tooltips/fr.json
@@ -15,5 +15,6 @@
   "reports": "Reports",
   "user_level_actions": "User level actions",
   "edit_delete_request": "Edit or delete request",
+  "show_tour_buttons": "Afficher ou masquer les boutons du guide dans l'en-tête de la fenêtre.",
   "system_settings": "System settings"
 }

--- a/src/erp.mgt.mn/locales/tooltips/ja.json
+++ b/src/erp.mgt.mn/locales/tooltips/ja.json
@@ -789,5 +789,6 @@
   "assembly_price": "Assembly price",
   "reports": "Reports",
   "edit_delete_request": "Edit or delete request",
+  "show_tour_buttons": "ウィンドウヘッダーにツアーボタンを表示するか非表示にします。",
   "system_settings": "System settings"
 }

--- a/src/erp.mgt.mn/locales/tooltips/ko.json
+++ b/src/erp.mgt.mn/locales/tooltips/ko.json
@@ -784,5 +784,6 @@
   "assembly_price": "Assembly price",
   "reports": "Reports",
   "edit_delete_request": "Edit or delete request",
+  "show_tour_buttons": "창 헤더의 투어 버튼을 표시하거나 숨깁니다.",
   "system_settings": "System settings"
 }

--- a/src/erp.mgt.mn/locales/tooltips/mn.json
+++ b/src/erp.mgt.mn/locales/tooltips/mn.json
@@ -250,5 +250,6 @@
   "assembly_price": "Assembly price",
   "reports": "Reports",
   "edit_delete_request": "Edit or delete request",
+  "show_tour_buttons": "Цонхны толгой хэсэгт байрлах турын товчнуудыг харуулах эсвэл нуух.",
   "system_settings": "System settings"
 }

--- a/src/erp.mgt.mn/locales/tooltips/ru.json
+++ b/src/erp.mgt.mn/locales/tooltips/ru.json
@@ -22,5 +22,6 @@
   "reports": "Reports",
   "user_level_actions": "User level actions",
   "edit_delete_request": "Edit or delete request",
+  "show_tour_buttons": "Показывать или скрывать кнопки тура в заголовке окна.",
   "system_settings": "System settings"
 }

--- a/src/erp.mgt.mn/locales/tooltips/zh.json
+++ b/src/erp.mgt.mn/locales/tooltips/zh.json
@@ -788,5 +788,6 @@
   "assembly_price": "Assembly price",
   "reports": "Reports",
   "edit_delete_request": "Edit or delete request",
+  "show_tour_buttons": "在窗口标题中显示或隐藏导览按钮。",
   "system_settings": "System settings"
 }

--- a/src/erp.mgt.mn/locales/zh.json
+++ b/src/erp.mgt.mn/locales/zh.json
@@ -660,6 +660,7 @@
   "settings_company_licenses": "公司许可证",
   "settings_enable_tooltips": "启用提示",
   "settings_enable_tours": "显示页面指南",
+  "show_tour_buttons": "显示导览按钮",
   "settings_fetch_error": "获取设置时出错",
   "settings_fetch_failed": "获取设置失败",
   "settings_forms_management": "表单管理",

--- a/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
+++ b/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
@@ -515,6 +515,24 @@ export default function GeneralConfiguration() {
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
             <TooltipWrapper
+              title={t(
+                'tooltip:show_tour_buttons',
+                'Display tour action buttons in the window header',
+              )}
+            >
+              <label>
+                {t('show_tour_buttons', 'Show tour buttons')}{' '}
+                <input
+                  name="showTourButtons"
+                  type="checkbox"
+                  checked={active.showTourButtons ?? true}
+                  onChange={handleChange}
+                />
+              </label>
+            </TooltipWrapper>
+          </div>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <TooltipWrapper
               title={t('show_report_params', {
                 ns: 'tooltip',
                 defaultValue: 'Display report parameters',


### PR DESCRIPTION
## Summary
- add a configurable `showTourButtons` flag to general configuration defaults on both server and client
- surface the new setting in the General Configuration page with localized label and tooltip strings
- respect the flag in the ERP layout so the tour action group is hidden automatically when disabled
- ensure the server persists the `showTourButtons` default when updating tenant configuration and document the new toggle in the General Configuration guide
- update the tour toggle tooltip call so its default string is captured by the hardcoded text export

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d61da12ca083318cd62742ef06feca