### PR TITLE
Add show tour buttons user preference

### DIFF
--- a/api-server/services/userSettings.js
+++ b/api-server/services/userSettings.js
@@ -23,7 +23,15 @@ export async function saveUserSettings(empid, settings, companyId = 0) {
   } catch {
     data = {};
   }
-  data[empid] = { ...(data[empid] || {}), ...settings };
+  const normalizedSettings = { ...(settings || {}) };
+  if (Object.prototype.hasOwnProperty.call(normalizedSettings, 'showTourButtons')) {
+    normalizedSettings.showTourButtons = Boolean(normalizedSettings.showTourButtons);
+  }
+
+  data[empid] = { ...(data[empid] || {}), ...normalizedSettings };
+  if (!Object.prototype.hasOwnProperty.call(data[empid], 'showTourButtons')) {
+    data[empid].showTourButtons = true;
+  }
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, JSON.stringify(data, null, 2));
   return data[empid];

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -719,10 +719,15 @@ function MainWindow({ title }) {
     return Boolean(value);
   }, []);
 
-  const showTourButtons = toBooleanFlag(
+  const showTourButtonsConfig = toBooleanFlag(
     generalConfig?.general?.showTourButtons,
     true,
   );
+  const showTourButtonsPreference = toBooleanFlag(
+    userSettings?.showTourButtons,
+    true,
+  );
+  const showTourButtons = showTourButtonsConfig && showTourButtonsPreference;
 
   const configBuilderToggle =
     generalConfig?.general?.tourBuilderEnabled ??

--- a/src/erp.mgt.mn/locales/de.json
+++ b/src/erp.mgt.mn/locales/de.json
@@ -506,7 +506,7 @@
   "settings_change_password": "Passwort ändern",
   "settings_company_licenses": "Unternehmenslizenzen",
   "settings_enable_tooltips": "Tooltips aktivieren",
-  "show_tour_buttons": "Tour-Schaltflächen anzeigen",
+  "settings_show_tour_buttons": "Tour-Schaltflächen anzeigen",
   "settings_forms_management": "Formularverwaltung",
   "settings_modules": "Module",
   "settings_report_management": "Berichtsverwaltung",

--- a/src/erp.mgt.mn/locales/en.json
+++ b/src/erp.mgt.mn/locales/en.json
@@ -664,7 +664,7 @@
   "settings_company_licenses": "Company Licenses",
   "settings_enable_tooltips": "Enable tooltips",
   "settings_enable_tours": "Show page guide",
-  "show_tour_buttons": "Show tour buttons",
+  "settings_show_tour_buttons": "Show tour buttons",
   "settings_fetch_error": "Error fetching settings:",
   "settings_fetch_failed": "Failed to fetch settings",
   "settings_forms_management": "Forms Management",

--- a/src/erp.mgt.mn/locales/es.json
+++ b/src/erp.mgt.mn/locales/es.json
@@ -660,7 +660,7 @@
   "settings_company_licenses": "Licencias de empresa",
   "settings_enable_tooltips": "Habilitar tooltips",
   "settings_enable_tours": "Mostrar guía de página",
-  "show_tour_buttons": "Mostrar botones de tour",
+  "settings_show_tour_buttons": "Mostrar botones de tour",
   "settings_fetch_error": "Error al obtener la configuración:",
   "settings_fetch_failed": "Error al obtener configuraciones",
   "settings_forms_management": "Gestión de formularios",

--- a/src/erp.mgt.mn/locales/fr.json
+++ b/src/erp.mgt.mn/locales/fr.json
@@ -30,7 +30,7 @@
   "no_activity": "Aucune activité à afficher.",
   "plans_coming_soon": "Contenu des plans à venir.",
   "settings_enable_tooltips": "Activer les info-bulles",
-  "show_tour_buttons": "Afficher les boutons du guide",
+  "settings_show_tour_buttons": "Afficher les boutons du guide",
   "delete_related_records": "Delete Related Records?",
   "ai_suggestions": "AI Suggestions",
   "no_suggestions": "No suggestions.",

--- a/src/erp.mgt.mn/locales/ja.json
+++ b/src/erp.mgt.mn/locales/ja.json
@@ -660,7 +660,7 @@
   "settings_company_licenses": "会社ライセンス",
   "settings_enable_tooltips": "ツールチップを有効にする",
   "settings_enable_tours": "ページガイドを表示",
-  "show_tour_buttons": "ツアーボタンを表示",
+  "settings_show_tour_buttons": "ツアーボタンを表示",
   "settings_fetch_error": "設定の取得エラー：",
   "settings_fetch_failed": "設定の取得に失敗しました",
   "settings_forms_management": "フォーム管理",

--- a/src/erp.mgt.mn/locales/ko.json
+++ b/src/erp.mgt.mn/locales/ko.json
@@ -660,7 +660,7 @@
   "settings_company_licenses": "회사 라이선스",
   "settings_enable_tooltips": "툴팁 활성화",
   "settings_enable_tours": "페이지 안내 표시",
-  "show_tour_buttons": "투어 버튼 표시",
+  "settings_show_tour_buttons": "투어 버튼 표시",
   "settings_fetch_error": "설정 가져오기 오류",
   "settings_fetch_failed": "설정을 가져오지 못했습니다",
   "settings_forms_management": "양식 관리",

--- a/src/erp.mgt.mn/locales/mn.json
+++ b/src/erp.mgt.mn/locales/mn.json
@@ -664,7 +664,7 @@
   "settings_company_licenses": "Компанийн лицензүүд",
   "settings_enable_tooltips": "Тайлбарыг идэвхжүүлэх",
   "settings_enable_tours": "Хуудсыг зааварчилгаа",
-  "show_tour_buttons": "Турын товчийг харуулах",
+  "settings_show_tour_buttons": "Турын товчийг харуулах",
   "settings_fetch_error": "Тохиргоо татахад алдаа гарлаа:",
   "settings_fetch_failed": "Тохиргоо татах амжилтгүй",
   "settings_forms_management": "Маягтын удирдлага",

--- a/src/erp.mgt.mn/locales/ru.json
+++ b/src/erp.mgt.mn/locales/ru.json
@@ -30,7 +30,7 @@
   "no_activity": "Нет активности для отображения.",
   "plans_coming_soon": "Содержание планов скоро появится.",
   "settings_enable_tooltips": "Включить подсказки",
-  "show_tour_buttons": "Показывать кнопки тура",
+  "settings_show_tour_buttons": "Показывать кнопки тура",
   "delete_related_records": "Delete Related Records?",
   "ai_suggestions": "AI Suggestions",
   "no_suggestions": "No suggestions.",

--- a/src/erp.mgt.mn/locales/tooltips/de.json
+++ b/src/erp.mgt.mn/locales/tooltips/de.json
@@ -15,6 +15,6 @@
   "reports": "Reports",
   "user_level_actions": "User level actions",
   "edit_delete_request": "Edit or delete request",
-  "show_tour_buttons": "Tour-Schaltflächen in der Fensterkopfzeile ein- oder ausblenden.",
+  "settings_show_tour_buttons": "Tour-Schaltflächen in der Fensterkopfzeile ein- oder ausblenden.",
   "system_settings": "System settings"
 }

--- a/src/erp.mgt.mn/locales/tooltips/en.json
+++ b/src/erp.mgt.mn/locales/tooltips/en.json
@@ -525,6 +525,6 @@
   "reports": "Reports",
   "user_level_actions": "User level actions",
   "edit_delete_request": "Edit or delete request",
-  "show_tour_buttons": "Show or hide the tour action buttons in the window header.",
+  "settings_show_tour_buttons": "Show or hide the tour action buttons in the window header.",
   "system_settings": "System settings"
 }

--- a/src/erp.mgt.mn/locales/tooltips/es.json
+++ b/src/erp.mgt.mn/locales/tooltips/es.json
@@ -468,6 +468,6 @@
   "assembly_price": "Assembly price",
   "reports": "Reports",
   "edit_delete_request": "Edit or delete request",
-  "show_tour_buttons": "Mostrar u ocultar los botones de tour en el encabezado de la ventana.",
+  "settings_show_tour_buttons": "Mostrar u ocultar los botones de tour en el encabezado de la ventana.",
   "system_settings": "System settings"
 }

--- a/src/erp.mgt.mn/locales/tooltips/fr.json
+++ b/src/erp.mgt.mn/locales/tooltips/fr.json
@@ -15,6 +15,6 @@
   "reports": "Reports",
   "user_level_actions": "User level actions",
   "edit_delete_request": "Edit or delete request",
-  "show_tour_buttons": "Afficher ou masquer les boutons du guide dans l'en-tête de la fenêtre.",
+  "settings_show_tour_buttons": "Afficher ou masquer les boutons du guide dans l'en-tête de la fenêtre.",
   "system_settings": "System settings"
 }

--- a/src/erp.mgt.mn/locales/tooltips/ja.json
+++ b/src/erp.mgt.mn/locales/tooltips/ja.json
@@ -789,6 +789,6 @@
   "assembly_price": "Assembly price",
   "reports": "Reports",
   "edit_delete_request": "Edit or delete request",
-  "show_tour_buttons": "ウィンドウヘッダーにツアーボタンを表示するか非表示にします。",
+  "settings_show_tour_buttons": "ウィンドウヘッダーにツアーボタンを表示するか非表示にします。",
   "system_settings": "System settings"
 }

--- a/src/erp.mgt.mn/locales/tooltips/ko.json
+++ b/src/erp.mgt.mn/locales/tooltips/ko.json
@@ -784,6 +784,6 @@
   "assembly_price": "Assembly price",
   "reports": "Reports",
   "edit_delete_request": "Edit or delete request",
-  "show_tour_buttons": "창 헤더의 투어 버튼을 표시하거나 숨깁니다.",
+  "settings_show_tour_buttons": "창 헤더의 투어 버튼을 표시하거나 숨깁니다.",
   "system_settings": "System settings"
 }

--- a/src/erp.mgt.mn/locales/tooltips/mn.json
+++ b/src/erp.mgt.mn/locales/tooltips/mn.json
@@ -250,6 +250,6 @@
   "assembly_price": "Assembly price",
   "reports": "Reports",
   "edit_delete_request": "Edit or delete request",
-  "show_tour_buttons": "Цонхны толгой хэсэгт байрлах турын товчнуудыг харуулах эсвэл нуух.",
+  "settings_show_tour_buttons": "Цонхны толгой хэсэгт байрлах турын товчнуудыг харуулах эсвэл нуух.",
   "system_settings": "System settings"
 }

--- a/src/erp.mgt.mn/locales/tooltips/ru.json
+++ b/src/erp.mgt.mn/locales/tooltips/ru.json
@@ -22,6 +22,6 @@
   "reports": "Reports",
   "user_level_actions": "User level actions",
   "edit_delete_request": "Edit or delete request",
-  "show_tour_buttons": "Показывать или скрывать кнопки тура в заголовке окна.",
+  "settings_show_tour_buttons": "Показывать или скрывать кнопки тура в заголовке окна.",
   "system_settings": "System settings"
 }

--- a/src/erp.mgt.mn/locales/tooltips/zh.json
+++ b/src/erp.mgt.mn/locales/tooltips/zh.json
@@ -788,6 +788,6 @@
   "assembly_price": "Assembly price",
   "reports": "Reports",
   "edit_delete_request": "Edit or delete request",
-  "show_tour_buttons": "在窗口标题中显示或隐藏导览按钮。",
+  "settings_show_tour_buttons": "在窗口标题中显示或隐藏导览按钮。",
   "system_settings": "System settings"
 }

--- a/src/erp.mgt.mn/locales/zh.json
+++ b/src/erp.mgt.mn/locales/zh.json
@@ -660,7 +660,7 @@
   "settings_company_licenses": "公司许可证",
   "settings_enable_tooltips": "启用提示",
   "settings_enable_tours": "显示页面指南",
-  "show_tour_buttons": "显示导览按钮",
+  "settings_show_tour_buttons": "显示导览按钮",
   "settings_fetch_error": "获取设置时出错",
   "settings_fetch_failed": "获取设置失败",
   "settings_forms_management": "表单管理",

--- a/src/erp.mgt.mn/pages/UserSettings.jsx
+++ b/src/erp.mgt.mn/pages/UserSettings.jsx
@@ -70,6 +70,7 @@ function UserManualTab() {
   const { t } = useTranslation(['translation', 'tooltip']);
   const { userSettings, updateUserSettings } = useAuth();
   const toursEnabled = userSettings.settings_enable_tours ?? false;
+  const showTourButtons = userSettings.showTourButtons ?? true;
   return (
     <div>
       <TooltipWrapper
@@ -88,6 +89,24 @@ function UserManualTab() {
             }
           />{' '}
           {t('settings_enable_tours', 'Show page guide')}
+        </label>
+      </TooltipWrapper>
+      <TooltipWrapper
+        title={t('settings_show_tour_buttons', {
+          ns: 'tooltip',
+          defaultValue: 'Show tour buttons in the header',
+        })}
+      >
+        <label htmlFor="show-tour-buttons-toggle">
+          <input
+            id="show-tour-buttons-toggle"
+            type="checkbox"
+            checked={showTourButtons}
+            onChange={(e) =>
+              updateUserSettings({ showTourButtons: e.target.checked })
+            }
+          />{' '}
+          {t('settings_show_tour_buttons', 'Show tour buttons')}
         </label>
       </TooltipWrapper>
     </div>


### PR DESCRIPTION
## Summary
- normalize and persist a showTourButtons preference when saving user settings
- add a translated toggle on the User Settings manual tab so users can control the tour buttons
- combine the general configuration flag with the user preference before rendering the tour action buttons

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d625c142848331ba34d53764ce1c69