### PR TITLE
Expose tour builder toggles and ensure default access

### DIFF
--- a/api-server/services/generalConfig.js
+++ b/api-server/services/generalConfig.js
@@ -28,6 +28,7 @@ const defaults = {
     debugLoggingEnabled: false,
     editLabelsEnabled: false,
     showTourButtons: true,
+    tourBuilderEnabled: true,
     showReportParams: false,
     requestPollingEnabled: false,
     requestPollingIntervalSeconds: 30,
@@ -102,6 +103,9 @@ export async function updateGeneralConfig(updates = {}, companyId = 0) {
   }
   if (!Object.prototype.hasOwnProperty.call(cfg.general, 'showTourButtons')) {
     cfg.general.showTourButtons = defaults.general.showTourButtons;
+  }
+  if (!Object.prototype.hasOwnProperty.call(cfg.general, 'tourBuilderEnabled')) {
+    cfg.general.tourBuilderEnabled = defaults.general.tourBuilderEnabled;
   }
   if (updates.images) {
     Object.assign(cfg.images, updates.images);

--- a/api-server/services/userSettings.js
+++ b/api-server/services/userSettings.js
@@ -7,9 +7,18 @@ export async function getUserSettings(empid, companyId = 0) {
     const filePath = await resolveDataPath('userSettings.json', companyId);
     const data = await fs.readFile(filePath, 'utf8');
     const json = JSON.parse(data || '{}');
-    return json[empid] || {};
+    const settings = { ...(json[empid] || {}) };
+    if (!Object.prototype.hasOwnProperty.call(settings, 'showTourButtons')) {
+      settings.showTourButtons = true;
+    }
+    if (
+      !Object.prototype.hasOwnProperty.call(settings, 'settings_enable_tour_builder')
+    ) {
+      settings.settings_enable_tour_builder = true;
+    }
+    return settings;
   } catch {
-    return {};
+    return { showTourButtons: true, settings_enable_tour_builder: true };
   }
 }
 
@@ -27,10 +36,25 @@ export async function saveUserSettings(empid, settings, companyId = 0) {
   if (Object.prototype.hasOwnProperty.call(normalizedSettings, 'showTourButtons')) {
     normalizedSettings.showTourButtons = Boolean(normalizedSettings.showTourButtons);
   }
+  if (
+    Object.prototype.hasOwnProperty.call(
+      normalizedSettings,
+      'settings_enable_tour_builder',
+    )
+  ) {
+    normalizedSettings.settings_enable_tour_builder = Boolean(
+      normalizedSettings.settings_enable_tour_builder,
+    );
+  }
 
   data[empid] = { ...(data[empid] || {}), ...normalizedSettings };
   if (!Object.prototype.hasOwnProperty.call(data[empid], 'showTourButtons')) {
     data[empid].showTourButtons = true;
+  }
+  if (
+    !Object.prototype.hasOwnProperty.call(data[empid], 'settings_enable_tour_builder')
+  ) {
+    data[empid].settings_enable_tour_builder = true;
   }
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, JSON.stringify(data, null, 2));

--- a/config/0/generalConfig.json
+++ b/config/0/generalConfig.json
@@ -24,6 +24,7 @@
     "debugLoggingEnabled": false,
     "editLabelsEnabled": true,
     "showTourButtons": true,
+    "tourBuilderEnabled": true,
     "showReportParams": false,
     "requestPollingEnabled": false,
     "requestPollingIntervalSeconds": 30,

--- a/docs/general-configuration.md
+++ b/docs/general-configuration.md
@@ -39,8 +39,10 @@ Here `boxWidth` defines the initial grid box width of a POS transaction.
 
 The **General** section hosts feature toggles. `showTourButtons` controls
 whether the tour action group is displayed in the ERP window header. Toggle it
-off to hide the Create/Edit/View tour buttons across the application. Other
-options include `requestPollingEnabled`, which determines whether the client
+off to hide the Create/Edit/View tour buttons across the application.
+`tourBuilderEnabled` governs whether administrators with the `system_settings`
+permission can launch the tour builder to create or edit guides. Other options
+include `requestPollingEnabled`, which determines whether the client
 falls back to periodic API polling when a Socket.IO connection cannot be
 established, and `requestPollingIntervalSeconds`, which sets the polling
 cadence (default 30&nbsp;seconds).

--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -1028,8 +1028,8 @@ function MainWindow({ title }) {
 
   const canManageTours = Boolean(
     session?.permissions?.system_settings &&
-      toBooleanFlag(configBuilderToggle) &&
-      toBooleanFlag(userBuilderToggle),
+      toBooleanFlag(configBuilderToggle, true) &&
+      toBooleanFlag(userBuilderToggle, true),
   );
 
   const handleCreateTour = useCallback(() => {

--- a/src/erp.mgt.mn/locales/en.json
+++ b/src/erp.mgt.mn/locales/en.json
@@ -663,6 +663,7 @@
   "settings_change_password": "Change Password",
   "settings_company_licenses": "Company Licenses",
   "settings_enable_tooltips": "Enable tooltips",
+  "settings_enable_tour_builder": "Enable tour builder",
   "settings_enable_tours": "Show page guide",
   "settings_show_tour_buttons": "Show tour buttons",
   "settings_fetch_error": "Error fetching settings:",
@@ -830,5 +831,6 @@
   "close": "Close",
   "cancel": "Cancel",
   "prev": "Prev",
-  "next": "Next"
+  "next": "Next",
+  "tour_builder_enabled": "Enable tour builder"
 }

--- a/src/erp.mgt.mn/locales/tooltips/en.json
+++ b/src/erp.mgt.mn/locales/tooltips/en.json
@@ -525,6 +525,8 @@
   "reports": "Reports",
   "user_level_actions": "User level actions",
   "edit_delete_request": "Edit or delete request",
+  "settings_enable_tour_builder": "Allow this user to create or edit guided tours when they have sufficient permissions.",
   "settings_show_tour_buttons": "Show or hide the tour action buttons in the window header.",
+  "tour_builder_enabled": "Allow administrators with system settings access to launch the tour builder interface.",
   "system_settings": "System settings"
 }

--- a/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
+++ b/src/erp.mgt.mn/pages/GeneralConfiguration.jsx
@@ -533,6 +533,24 @@ export default function GeneralConfiguration() {
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
             <TooltipWrapper
+              title={t(
+                'tooltip:tour_builder_enabled',
+                'Allow administrators to create or edit guided tours',
+              )}
+            >
+              <label>
+                {t('tour_builder_enabled', 'Enable tour builder')}{' '}
+                <input
+                  name="tourBuilderEnabled"
+                  type="checkbox"
+                  checked={active.tourBuilderEnabled ?? true}
+                  onChange={handleChange}
+                />
+              </label>
+            </TooltipWrapper>
+          </div>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <TooltipWrapper
               title={t('show_report_params', {
                 ns: 'tooltip',
                 defaultValue: 'Display report parameters',

--- a/src/erp.mgt.mn/pages/UserSettings.jsx
+++ b/src/erp.mgt.mn/pages/UserSettings.jsx
@@ -69,6 +69,7 @@ function UserManualTab() {
   const { userSettings, updateUserSettings } = useAuth();
   const toursEnabled = userSettings.settings_enable_tours ?? false;
   const showTourButtons = userSettings.showTourButtons ?? true;
+  const tourBuilderEnabled = userSettings.settings_enable_tour_builder ?? true;
   return (
     <div>
       <TooltipWrapper
@@ -105,6 +106,26 @@ function UserManualTab() {
             }
           />{' '}
           {t('settings_show_tour_buttons', 'Show tour buttons')}
+        </label>
+      </TooltipWrapper>
+      <TooltipWrapper
+        title={t('settings_enable_tour_builder', {
+          ns: 'tooltip',
+          defaultValue: 'Allow creating or editing tours',
+        })}
+      >
+        <label htmlFor="enable-tour-builder-toggle">
+          <input
+            id="enable-tour-builder-toggle"
+            type="checkbox"
+            checked={tourBuilderEnabled}
+            onChange={(e) =>
+              updateUserSettings({
+                settings_enable_tour_builder: e.target.checked,
+              })
+            }
+          />{' '}
+          {t('settings_enable_tour_builder', 'Enable tour builder')}
         </label>
       </TooltipWrapper>
     </div>


### PR DESCRIPTION
## Summary
- ensure tour builder access defaults to enabled for system_settings users when no overrides are configured
- add persisted general configuration and user setting switches for managing the tour builder, including UI labels and docs
- update server defaults and documentation so new toggles load correctly for existing tenants

## Testing
- npm test *(fails: exported texts detect languages and respect existing entries – SyntaxError: Unexpected non-whitespace character after JSON at position 33870)*

------
https://chatgpt.com/codex/tasks/task_e_68d62f2a34208331b7affc40341b3905