### PR TITLE
Skip blank trimmed values when syncing calc fields

### DIFF
--- a/src/erp.mgt.mn/utils/syncCalcFields.js
+++ b/src/erp.mgt.mn/utils/syncCalcFields.js
@@ -61,15 +61,22 @@ function collectSectionFields(map, table) {
 
 function pickFirstDefinedFieldValue(source, field) {
   if (!field) return undefined;
+
+  const hasMeaningfulValue = (value) => {
+    if (value === undefined || value === null) return false;
+    const str = typeof value === 'string' ? value : String(value);
+    return str.trim() !== '';
+  };
+
   if (Array.isArray(source)) {
     for (const row of source) {
       if (!isPlainObject(row)) continue;
       const val = row[field];
-      if (val !== undefined && val !== null) return val;
+      if (hasMeaningfulValue(val)) return val;
     }
   } else if (isPlainObject(source)) {
     const val = source[field];
-    if (val !== undefined && val !== null) return val;
+    if (hasMeaningfulValue(val)) return val;
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary
- update syncCalcFields helper to ignore values whose trimmed string is empty so later cells with data can be picked

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d632b1bc3c8331b00a5096c72c1f19