### PR TITLE
Add tour routes to API server

### DIFF
--- a/api-server/server.js
+++ b/api-server/server.js
@@ -51,6 +51,7 @@ import pendingRequestRoutes from "./routes/pending_request.js";
 import activityLogRoutes from "./routes/user_activity_log.js";
 import userSettingsRoutes from "./routes/user_settings.js";
 import translationRoutes from "./routes/translations.js";
+import tourRoutes from "./routes/tours.js";
 import manualTranslationsRoutes from "./routes/manual_translations.js";
 
 // Polyfill for __dirname in ES modules
@@ -150,6 +151,7 @@ app.use("/api/procedures", requireAuth, procedureRoutes);
 app.use("/api/proc_triggers", requireAuth, procTriggerRoutes);
 app.use("/api/report_procedures", reportProcedureRoutes);
 app.use("/api/report_access", reportAccessRoutes);
+app.use("/api/tours", tourRoutes);
 app.use("/api/report_builder", reportBuilderRoutes);
 app.use("/api/transactions", requireAuth, transactionRoutes);
 app.use("/api/transaction_images", transactionImageRoutes);


### PR DESCRIPTION
## Summary
- import the tours router into the API server entry point
- expose the /api/tours route without an extra auth wrapper so it mirrors app.js

## Testing
- npm run serve *(fails: missing dependencies such as dotenv are unavailable in the execution environment)*


------
https://chatgpt.com/codex/tasks/task_e_68d63341fbcc8331b60c536ffab5b849