### PR TITLE
Fix POS generated column metadata fallback

### DIFF
--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -1296,7 +1296,11 @@ export default function PosTransactionsPage() {
       columns.forEach((col) => {
         if (!col || typeof col !== 'object') return;
         const rawName = col.name;
-        const expr = col.generationExpression ?? col.GENERATION_EXPRESSION;
+        const expr =
+          col.generationExpression ??
+          col.GENERATION_EXPRESSION ??
+          col.generation_expression ??
+          null;
         if (!rawName || !expr) return;
         const mapped = caseMap[String(rawName).toLowerCase()] || rawName;
         if (typeof mapped !== 'string') return;


### PR DESCRIPTION
## Summary
- include lowercase `generation_expression` values when building POS generated column evaluators
- add a unit test that exercises the metadata fallback and verifies evaluators are applied

## Testing
- npm test -- tests/pages/PosTransactions.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d632a033008331814e0c421fb7fadf