### PR TITLE
Disable Joyride beacon for tour

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -650,6 +650,7 @@ export default function ERPLayout() {
             showBackButton
             showProgress
             disableOverlayClose
+            disableBeacon
             disableKeyboardNavigation={false}
             callback={handleTourCallback}
             locale={{


### PR DESCRIPTION
## Summary
- disable the Joyride beacon so the tour tooltip opens immediately after selecting "View tour"

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d63d4766a483319d59ed0d4b47586f