### PR TITLE
Derive default tour page key from location

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -22,6 +22,7 @@ import ErrorBoundary from "../components/ErrorBoundary.jsx";
 import { useToast } from "../context/ToastContext.jsx";
 import { API_BASE } from "../utils/apiBase.js";
 import TourBuilder from "./tours/TourBuilder.jsx";
+import derivePageKey from "../utils/derivePageKey.js";
 
 export const TourContext = React.createContext({
   startTour: () => false,
@@ -979,6 +980,8 @@ function MainWindow({ title }) {
   const generalConfig = useGeneralConfig();
   const badgePaths = hasNew ? new Set(['/', '/requests']) : new Set();
 
+  const derivedPageKey = useMemo(() => derivePageKey(location.pathname), [location.pathname]);
+
   // Store rendered outlet by path once the route changes. Avoid tracking
   // the `outlet` object itself to prevent endless updates caused by React
   // creating a new element on every render.
@@ -1035,12 +1038,16 @@ function MainWindow({ title }) {
 
   const handleCreateTour = useCallback(() => {
     if (!canManageTours) return;
-    openTourBuilder?.({
+    const builderState = {
       mode: 'create',
       pageKey: tourInfo?.pageKey || null,
       path: tourInfo?.path || location.pathname,
-    });
-  }, [canManageTours, location.pathname, openTourBuilder, tourInfo]);
+    };
+    if (!tourInfo?.pageKey) {
+      builderState.derivedPageKey = derivedPageKey;
+    }
+    openTourBuilder?.(builderState);
+  }, [canManageTours, derivedPageKey, location.pathname, openTourBuilder, tourInfo]);
 
   const handleEditTour = useCallback(() => {
     if (!canManageTours || !hasTour || !tourInfo) return;

--- a/src/erp.mgt.mn/utils/derivePageKey.js
+++ b/src/erp.mgt.mn/utils/derivePageKey.js
@@ -1,0 +1,27 @@
+export default function derivePageKey(inputPath) {
+  if (typeof inputPath !== 'string') {
+    return 'home';
+  }
+
+  const normalized = inputPath.trim();
+  if (!normalized) {
+    return 'home';
+  }
+
+  const cleaned = normalized.replace(/^[#\/]+|[#\/]+$/g, '');
+  if (!cleaned) {
+    return 'home';
+  }
+
+  const segments = cleaned
+    .split(/[\/]+/)
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+    .map((segment) => segment.replace(/[^a-zA-Z0-9_-]+/g, '-'))
+    .map((segment) => segment.replace(/-+/g, '-'))
+    .map((segment) => segment.toLowerCase())
+    .filter(Boolean);
+
+  const joined = segments.join('-');
+  return joined || 'home';
+}


### PR DESCRIPTION
## Summary
- derive a default tour page key from the current route and pass it to the tour builder when creating new tours
- initialize the tour builder with the derived key unless the user provides one and keep it unless the user edits the field
- share a helper that normalizes route paths into stable page keys

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d63e12ecb8833188b8311f02815610