### PR TITLE
Prioritize tour lookup by normalized path

### DIFF
--- a/api-server/services/tours.js
+++ b/api-server/services/tours.js
@@ -136,18 +136,20 @@ export async function listTours(companyId) {
 
 export async function getTour({ pageKey, path }, companyId) {
   const tours = await readTours(companyId);
+  const normalizedPath = normalizePath(path);
+
+  if (normalizedPath) {
+    for (const [key, value] of Object.entries(tours)) {
+      if (normalizePath(value?.path) === normalizedPath) {
+        return toResponse(key, value);
+      }
+    }
+  }
+
   if (pageKey && tours[pageKey]) {
     return toResponse(pageKey, tours[pageKey]);
   }
 
-  const normalizedPath = normalizePath(path);
-  if (!normalizedPath) return null;
-
-  for (const [key, value] of Object.entries(tours)) {
-    if (normalizePath(value.path) === normalizedPath) {
-      return toResponse(key, value);
-    }
-  }
   return null;
 }
 

--- a/tests/services/tours.test.js
+++ b/tests/services/tours.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { getTour } from '../../api-server/services/tours.js';
+
+const COMPANY_ID = 'get-tour-tests';
+const DATA_DIR = path.join('api-server', 'data', COMPANY_ID);
+const TOURS_FILE = path.join(DATA_DIR, 'tours.json');
+
+async function writeToursFile(data) {
+  await fs.mkdir(DATA_DIR, { recursive: true });
+  await fs.writeFile(TOURS_FILE, JSON.stringify(data, null, 2));
+}
+
+test.after(async () => {
+  await fs.rm(DATA_DIR, { recursive: true, force: true });
+});
+
+test('getTour prefers path matches over pageKey matches', { concurrency: false }, async () => {
+  await writeToursFile({
+    sharedKey: {
+      path: '/shared-path',
+      steps: [
+        {
+          selector: '#shared',
+          content: 'Shared step',
+        },
+      ],
+    },
+    reports: {
+      path: '/reports/sales',
+      steps: [
+        {
+          selector: '#reports',
+          content: 'Reports step',
+        },
+      ],
+    },
+  });
+
+  const tour = await getTour(
+    {
+      pageKey: 'sharedKey',
+      path: '/reports/sales?filter=open#section-2',
+    },
+    COMPANY_ID,
+  );
+
+  assert.ok(tour, 'tour is returned');
+  assert.equal(tour.pageKey, 'reports');
+  assert.equal(tour.path, '/reports/sales');
+  assert.equal(tour.steps.length, 1);
+  assert.equal(tour.steps[0].selector, '#reports');
+});
+
+test('getTour falls back to pageKey when no path match exists', { concurrency: false }, async () => {
+  await writeToursFile({
+    sharedKey: {
+      path: '/shared-path',
+      steps: [
+        {
+          selector: '#shared',
+          content: 'Shared step',
+        },
+      ],
+    },
+  });
+
+  const tour = await getTour(
+    {
+      pageKey: 'sharedKey',
+      path: '/unknown-path',
+    },
+    COMPANY_ID,
+  );
+
+  assert.ok(tour, 'tour is returned');
+  assert.equal(tour.pageKey, 'sharedKey');
+  assert.equal(tour.path, '/shared-path');
+  assert.equal(tour.steps.length, 1);
+  assert.equal(tour.steps[0].selector, '#shared');
+});


### PR DESCRIPTION
## Summary
- prioritize normalized path matches when resolving tours before falling back to page keys
- add regression tests covering path-first lookups and page key fallback

## Testing
- npm test -- tests/services/tours.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d64202e5288331a7b81b759c7a8c80