### PR TITLE
Fetch full rows before editing

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1114,32 +1114,116 @@ const TableManager = forwardRef(function TableManager({
     setShowForm(true);
   }
 
-  async function openEdit(row) {
-    if (getRowId(row) === undefined) {
+  async function hydrateRowForEdit(row) {
+    const id = getRowId(row);
+    if (id === undefined) {
       addToast(
         t('cannot_edit_without_pk', 'Cannot edit rows without a primary key'),
         'error',
       );
-      return;
+      return null;
     }
-    await ensureColumnMeta();
-    setEditing(row);
-    setGridRows([row]);
+
+    const meta = await ensureColumnMeta();
+    const cols = Array.isArray(meta) && meta.length > 0 ? meta : columnMeta;
+    const caseMap = { ...columnCaseMap };
+    cols.forEach((c) => {
+      if (c?.name) {
+        caseMap[c.name.toLowerCase()] = c.name;
+      }
+    });
+
+    const recordUrl = `/api/tables/${encodeURIComponent(table)}/${encodeURIComponent(
+      id,
+    )}`;
+    let payload;
+    try {
+      const res = await fetch(recordUrl, { credentials: 'include' });
+      if (!res.ok) {
+        addToast(
+          t('failed_load_record_for_edit', 'Failed to load record for editing'),
+          'error',
+        );
+        return null;
+      }
+      try {
+        payload = await res.json();
+      } catch (err) {
+        console.error('Failed to parse record payload for edit', err);
+        addToast(
+          t('failed_load_record_for_edit', 'Failed to load record for editing'),
+          'error',
+        );
+        return null;
+      }
+    } catch (err) {
+      console.error('Failed to fetch record for edit', err);
+      addToast(
+        t('failed_load_record_for_edit', 'Failed to load record for editing'),
+        'error',
+      );
+      return null;
+    }
+
+    let fetchedRow = null;
+    if (payload && typeof payload === 'object') {
+      if (Array.isArray(payload.rows) && payload.rows.length > 0) {
+        fetchedRow = payload.rows[0];
+      } else if (payload.row && typeof payload.row === 'object') {
+        fetchedRow = payload.row;
+      } else {
+        fetchedRow = payload;
+      }
+    }
+
+    if (!fetchedRow || typeof fetchedRow !== 'object') {
+      addToast(
+        t('failed_load_record_for_edit', 'Failed to load record for editing'),
+        'error',
+      );
+      return null;
+    }
+
+    const merged = { ...row };
+    Object.entries(fetchedRow).forEach(([key, value]) => {
+      if (typeof key === 'string') {
+        const normalizedKey = caseMap[key.toLowerCase()] || key;
+        merged[normalizedKey] = value;
+      } else {
+        merged[key] = value;
+      }
+    });
+
+    (Array.isArray(formColumns) ? formColumns : []).forEach((col) => {
+      const lower = typeof col === 'string' ? col.toLowerCase() : col;
+      const normalizedKey =
+        typeof lower === 'string' ? caseMap[lower] || col : col;
+      if (
+        typeof normalizedKey === 'string' &&
+        merged[normalizedKey] === undefined &&
+        fetchedRow[normalizedKey] !== undefined
+      ) {
+        merged[normalizedKey] = fetchedRow[normalizedKey];
+      }
+    });
+
+    return merged;
+  }
+
+  async function openEdit(row) {
+    const hydrated = await hydrateRowForEdit(row);
+    if (!hydrated) return;
+    setEditing(hydrated);
+    setGridRows([hydrated]);
     setIsAdding(false);
     setShowForm(true);
   }
 
   async function openRequestEdit(row) {
-    if (getRowId(row) === undefined) {
-      addToast(
-        t('cannot_edit_without_pk', 'Cannot edit rows without a primary key'),
-        'error',
-      );
-      return;
-    }
-    await ensureColumnMeta();
-    setEditing(row);
-    setGridRows([row]);
+    const hydrated = await hydrateRowForEdit(row);
+    if (!hydrated) return;
+    setEditing(hydrated);
+    setGridRows([hydrated]);
     setIsAdding(false);
     setRequestType('edit');
     setShowForm(true);
@@ -1147,6 +1231,8 @@ const TableManager = forwardRef(function TableManager({
 
   useImperativeHandle(ref, () => ({
     openAdd: buttonPerms['New transaction'] ? openAdd : () => {},
+    openEdit,
+    openRequestEdit,
   }));
 
   async function openDetail(row) {

--- a/tests/components/tableManagerEditHydration.test.js
+++ b/tests/components/tableManagerEditHydration.test.js
@@ -1,0 +1,153 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const jsDocument = {
+  createElement: () => ({
+    style: {},
+    appendChild: () => {},
+    remove: () => {},
+    removeChild: () => {},
+  }),
+};
+
+global.document = jsDocument;
+
+global.window = {
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  confirm: () => true,
+};
+
+let React;
+let act;
+let createRoot;
+let haveReact = true;
+try {
+  const reactMod = await import('react');
+  React = reactMod.default || reactMod;
+  ({ act } = await import('react-dom/test-utils'));
+  ({ createRoot } = await import('react-dom/client'));
+} catch {
+  haveReact = false;
+}
+
+if (!haveReact) {
+  test('TableManager hydrates edit rows with hidden fields', { skip: true }, () => {});
+} else {
+  test('TableManager hydrates edit rows with hidden fields', async (t) => {
+    const origFetch = global.fetch;
+    const fetchCalls = [];
+    const listRow = { id: 1, name: 'Listed value' };
+    global.fetch = async (url) => {
+      const target = typeof url === 'string' ? url : url?.url ?? '';
+      fetchCalls.push(target);
+      if (target === '/api/tables/test/columns') {
+        return {
+          ok: true,
+          json: async () => [
+            { name: 'id', key: 'PRI', type: 'int' },
+            { name: 'name', type: 'varchar' },
+            { name: 'hidden_field', type: 'varchar' },
+          ],
+        };
+      }
+      if (target === '/api/tables/test/relations') {
+        return { ok: true, json: async () => [] };
+      }
+      if (target.startsWith('/api/tables/test?')) {
+        return { ok: true, json: async () => ({ rows: [listRow], count: 1 }) };
+      }
+      if (target === '/api/tables/test/1') {
+        return {
+          ok: true,
+          json: async () => ({
+            id: 1,
+            name: 'Listed value',
+            hidden_field: 'Secret value',
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    };
+
+    const toasts = [];
+    const captured = { row: null, rows: null };
+    const RowFormModalMock = (props) => {
+      captured.row = props.row;
+      captured.rows = props.rows;
+      return null;
+    };
+
+    try {
+      const { default: TableManager } = await t.mock.import(
+        '../../src/erp.mgt.mn/components/TableManager.jsx',
+        {
+          '../context/AuthContext.jsx': {
+            AuthContext: React.createContext({}),
+          },
+          '../context/ToastContext.jsx': {
+            useToast: () => ({
+              addToast: (message, type) => {
+                toasts.push({ message, type });
+              },
+            }),
+          },
+          './RowFormModal.jsx': { default: RowFormModalMock },
+          './CascadeDeleteModal.jsx': { default: () => null },
+          './RowDetailModal.jsx': { default: () => null },
+          './RowImageViewModal.jsx': { default: () => null },
+          './RowImageUploadModal.jsx': { default: () => null },
+          './ImageSearchModal.jsx': { default: () => null },
+          './Modal.jsx': { default: () => null },
+          './CustomDatePicker.jsx': { default: () => null },
+          '../hooks/useGeneralConfig.js': { default: () => ({}) },
+          '../utils/formatTimestamp.js': { default: () => '2024-01-01 00:00:00' },
+          '../utils/buildImageName.js': { default: () => ({}) },
+          '../utils/slugify.js': { default: () => '' },
+          '../utils/apiBase.js': { API_BASE: '' },
+          'react-i18next': {
+            useTranslation: () => ({ t: (k, fallback) => fallback ?? k }),
+          },
+        },
+      );
+
+      const ref = React.createRef();
+      const container = document.createElement('div');
+      const root = createRoot(container);
+      await act(async () => {
+        root.render(
+          React.createElement(TableManager, {
+            table: 'test',
+            ref,
+            formConfig: {
+              visibleFields: ['id', 'name'],
+              mainFields: ['id', 'name', 'hidden_field'],
+            },
+          }),
+        );
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      assert.ok(ref.current, 'ref should be populated');
+      await act(async () => {
+        await ref.current.openEdit(listRow);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      assert.ok(
+        fetchCalls.includes('/api/tables/test/1'),
+        'should request full record when editing',
+      );
+      assert.equal(toasts.length, 0, 'should not emit toasts on successful hydration');
+      assert.equal(captured.row?.hidden_field, 'Secret value');
+      assert.equal(captured.rows?.[0]?.hidden_field, 'Secret value');
+
+      await act(async () => {
+        root.unmount();
+      });
+    } finally {
+      global.fetch = origFetch;
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- hydrate TableManager edit flow by fetching the complete record before opening the modal
- normalize fetched payloads via column casing and guard against request failures with toasts
- add regression coverage that ensures edit forms receive fields hidden from the list view

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d63d759e7483318cf2a1881b7f8fa5