### PR TITLE
Enable Joyride spotlight clicks

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -709,6 +709,7 @@ export default function ERPLayout() {
             run={runTour}
             stepIndex={tourStepIndex}
             continuous
+            spotlightClicks
             scrollOffset={joyrideScrollOffset}
             scrollToFirstStep
             scrollToSteps


### PR DESCRIPTION
## Summary
- enable spotlight clicks on the Joyride tour within ERPLayout so focused elements can receive user interaction

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d649f216548331b07375f9dc292cf3