### PR TITLE
Refactor TableManager submission helpers

### DIFF
--- a/src/erp.mgt.mn/components/tableManagerSubmissions.js
+++ b/src/erp.mgt.mn/components/tableManagerSubmissions.js
@@ -1,0 +1,281 @@
+export function buildTableQuery({ table, page, perPage, company, columns, sort, filters }) {
+  const params = new URLSearchParams({ page, perPage });
+  if (company != null && columns?.has('company_id')) params.set('company_id', company);
+  if (sort?.column) {
+    params.set('sort', sort.column);
+    params.set('dir', sort.dir);
+  }
+  Object.entries(filters || {}).forEach(([key, value]) => {
+    if (value) params.set(key, value);
+  });
+  return `/api/tables/${encodeURIComponent(table)}?${params.toString()}`;
+}
+
+export async function fetchLatestTableRows(options) {
+  const { fetchImpl = fetch } = options;
+  const url = buildTableQuery(options);
+  const response = await fetchImpl(url, { credentials: 'include' });
+  return response.json();
+}
+
+export async function submitEditRequest(
+  cleaned,
+  {
+    promptRequestReason,
+    addToast,
+    t,
+    table,
+    editing,
+    setShowForm,
+    setEditing,
+    setIsAdding,
+    setGridRows,
+    setRequestType,
+    getRowId,
+    API_BASE: apiBase,
+    fetchImpl = fetch,
+  },
+) {
+  const reason = await promptRequestReason();
+  if (!reason || !reason.trim()) {
+    addToast(
+      t('request_reason_required', 'Request reason is required'),
+      'error',
+    );
+    return false;
+  }
+  try {
+    const res = await fetchImpl(`${apiBase}/pending_request`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({
+        table_name: table,
+        record_id: getRowId(editing),
+        request_type: 'edit',
+        request_reason: reason,
+        proposed_data: cleaned,
+      }),
+    });
+    if (res.ok) {
+      addToast(t('edit_request_submitted', 'Edit request submitted'), 'success');
+      setShowForm(false);
+      setEditing(null);
+      setIsAdding(false);
+      setGridRows([]);
+      setRequestType(null);
+      return true;
+    }
+    if (res.status === 409) {
+      addToast(
+        t('similar_request_pending', 'A similar request is already pending'),
+        'error',
+      );
+      return false;
+    }
+    addToast(t('edit_request_failed', 'Edit request failed'), 'error');
+    return false;
+  } catch {
+    addToast(t('edit_request_failed', 'Edit request failed'), 'error');
+    return false;
+  }
+}
+
+export async function submitNewRow(
+  cleaned,
+  {
+    columns,
+    user,
+    formatTimestamp: formatTs,
+    fetchImpl = fetch,
+    table,
+    page,
+    perPage,
+    company,
+    sort,
+    filters,
+    setRows,
+    setCount,
+    logRowsMemory: logMemory,
+    setSelectedRows,
+    setShowForm,
+    setEditing,
+    setIsAdding,
+    setGridRows,
+    addToast,
+    openAdd,
+    formConfig,
+    merged,
+    buildImageName: buildName,
+    columnCaseMap,
+    getRowId,
+    getImageFolder,
+    oldImageName,
+  },
+) {
+  const payload = { ...cleaned };
+  if (columns?.has('created_by')) payload.created_by = user?.empid;
+  if (columns?.has('created_at')) payload.created_at = formatTs(new Date());
+  const url = `/api/tables/${encodeURIComponent(table)}`;
+  try {
+    const res = await fetchImpl(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(payload),
+    });
+    const savedRow = res.ok ? await res.json().catch(() => ({})) : {};
+    if (!res.ok) {
+      let message = 'Хадгалахад алдаа гарлаа';
+      try {
+        const data = await res.json();
+        if (data && data.message) message += `: ${data.message}`;
+      } catch {
+        // ignore
+      }
+      addToast(message, 'error');
+      return false;
+    }
+
+    const data = await fetchLatestTableRows({
+      fetchImpl,
+      table,
+      page,
+      perPage,
+      company,
+      columns,
+      sort,
+      filters,
+    });
+    const rows = data.rows || [];
+    setRows(rows);
+    setCount(data.total ?? data.count ?? 0);
+    logMemory(rows);
+    setSelectedRows(new Set());
+    setShowForm(false);
+    setEditing(null);
+    setIsAdding(false);
+    setGridRows([]);
+
+    if ((formConfig?.imagenameField || []).length) {
+      const inserted = rows.find(
+        (r) => String(getRowId(r)) === String(savedRow.id),
+      );
+      const rowForName =
+        inserted || {
+          ...merged,
+          [formConfig.imageIdField]: savedRow?.[formConfig.imageIdField],
+        };
+      const nameFields = Array.from(
+        new Set(
+          (formConfig?.imagenameField || [])
+            .concat(formConfig?.imageIdField || '')
+            .filter(Boolean),
+        ),
+      );
+      const { name: newImageName } = buildName(
+        rowForName,
+        nameFields,
+        columnCaseMap,
+      );
+      const folder = getImageFolder(rowForName);
+      if (
+        oldImageName &&
+        newImageName &&
+        (oldImageName !== newImageName || folder !== table)
+      ) {
+        const renameUrl =
+          `/api/transaction_images/${table}/${encodeURIComponent(oldImageName)}` +
+          `/rename/${encodeURIComponent(newImageName)}?folder=${encodeURIComponent(folder)}`;
+        await fetchImpl(renameUrl, { method: 'POST', credentials: 'include' });
+        const verifyUrl =
+          `/api/transaction_images/${table}/${encodeURIComponent(newImageName)}?folder=${encodeURIComponent(folder)}`;
+        const res2 = await fetchImpl(verifyUrl, { credentials: 'include' });
+        const imgs = res2.ok ? await res2.json().catch(() => []) : [];
+        if (!Array.isArray(imgs) || imgs.length === 0) {
+          await fetchImpl(renameUrl, { method: 'POST', credentials: 'include' });
+        }
+      }
+    }
+
+    addToast('Шинэ гүйлгээ хадгалагдлаа', 'success');
+    setTimeout(() => openAdd(), 0);
+    return true;
+  } catch (err) {
+    console.error('Save failed', err);
+    return false;
+  }
+}
+
+export async function submitUpdate(
+  cleaned,
+  {
+    fetchImpl = fetch,
+    table,
+    editing,
+    getRowId,
+    page,
+    perPage,
+    company,
+    columns,
+    sort,
+    filters,
+    setRows,
+    setCount,
+    logRowsMemory: logMemory,
+    setSelectedRows,
+    setShowForm,
+    setEditing,
+    setIsAdding,
+    setGridRows,
+    addToast,
+  },
+) {
+  const url = `/api/tables/${encodeURIComponent(table)}/${encodeURIComponent(
+    getRowId(editing),
+  )}`;
+  try {
+    const res = await fetchImpl(url, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(cleaned),
+    });
+    if (!res.ok) {
+      let message = 'Хадгалахад алдаа гарлаа';
+      try {
+        const data = await res.json();
+        if (data && data.message) message += `: ${data.message}`;
+      } catch {
+        // ignore
+      }
+      addToast(message, 'error');
+      return false;
+    }
+
+    const data = await fetchLatestTableRows({
+      fetchImpl,
+      table,
+      page,
+      perPage,
+      company,
+      columns,
+      sort,
+      filters,
+    });
+    const rows = data.rows || [];
+    setRows(rows);
+    setCount(data.total ?? data.count ?? 0);
+    logMemory(rows);
+    setSelectedRows(new Set());
+    setShowForm(false);
+    setEditing(null);
+    setIsAdding(false);
+    setGridRows([]);
+    addToast('Хадгалагдлаа', 'success');
+    return true;
+  } catch (err) {
+    console.error('Save failed', err);
+    return false;
+  }
+}

--- a/tests/components/tableManagerSubmitHelpers.test.js
+++ b/tests/components/tableManagerSubmitHelpers.test.js
@@ -1,0 +1,284 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+function createState(initial = {}) {
+  return { ...initial };
+}
+
+test('submitEditRequest submits payload and resets state on success', async () => {
+  const { submitEditRequest } = await import(
+    '../../src/erp.mgt.mn/components/tableManagerSubmissions.js',
+  );
+
+  const cleaned = { field: 'value' };
+  const states = createState({
+    showForm: true,
+    editing: { id: 7 },
+    isAdding: true,
+    gridRows: [1],
+    requestType: 'edit',
+  });
+
+  const toasts = [];
+  const fetchCalls = [];
+
+  const result = await submitEditRequest(cleaned, {
+    promptRequestReason: async () => 'Because',
+    addToast: (message, type) => toasts.push({ message, type }),
+    t: (_key, fallback) => fallback,
+    table: 'finance',
+    editing: states.editing,
+    setShowForm: (value) => {
+      states.showForm = value;
+    },
+    setEditing: (value) => {
+      states.editing = value;
+    },
+    setIsAdding: (value) => {
+      states.isAdding = value;
+    },
+    setGridRows: (value) => {
+      states.gridRows = value;
+    },
+    setRequestType: (value) => {
+      states.requestType = value;
+    },
+    getRowId: (row) => row.id,
+    API_BASE: '/api',
+    fetchImpl: async (url, init) => {
+      fetchCalls.push({ url, init });
+      return { ok: true, status: 200 };
+    },
+  });
+
+  assert.equal(result, true);
+  assert.equal(fetchCalls.length, 1);
+  assert.equal(fetchCalls[0].url, '/api/pending_request');
+  assert.deepEqual(JSON.parse(fetchCalls[0].init.body), {
+    table_name: 'finance',
+    record_id: 7,
+    request_type: 'edit',
+    request_reason: 'Because',
+    proposed_data: cleaned,
+  });
+  assert.equal(states.showForm, false);
+  assert.equal(states.editing, null);
+  assert.equal(states.isAdding, false);
+  assert.deepEqual(states.gridRows, []);
+  assert.equal(states.requestType, null);
+  assert.deepEqual(toasts, [
+    { message: 'Edit request submitted', type: 'success' },
+  ]);
+});
+
+test('submitNewRow posts payload with created fields and refreshes data', async () => {
+  const { submitNewRow } = await import(
+    '../../src/erp.mgt.mn/components/tableManagerSubmissions.js',
+  );
+
+  const cleaned = { amount: 100 };
+  const states = createState({
+    showForm: true,
+    editing: { id: 5 },
+    isAdding: true,
+    gridRows: [{ id: 1 }],
+    selectedRows: new Set([1]),
+    openAddCount: 0,
+    rows: [],
+    count: 0,
+    loggedRows: null,
+    toasts: [],
+  });
+
+  const toasts = [];
+  const fetchCalls = [];
+  let fetchStep = 0;
+  const fetchImpl = async (url, init = {}) => {
+    fetchCalls.push({ url, init });
+    if (fetchStep === 0) {
+      fetchStep += 1;
+      assert.equal(init.method, 'POST');
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 10 }),
+      };
+    }
+    fetchStep += 1;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ rows: [{ id: 10 }], total: 1 }),
+    };
+  };
+
+  const result = await submitNewRow(cleaned, {
+    columns: new Set(['created_by', 'created_at', 'company_id']),
+    user: { empid: 'EMP001' },
+    formatTimestamp: () => '2024-01-02 03:04:05',
+    fetchImpl,
+    table: 'finance records',
+    page: 2,
+    perPage: 25,
+    company: 11,
+    sort: { column: 'amount', dir: 'asc' },
+    filters: { status: 'pending', empty: '' },
+    setRows: (rows) => {
+      states.rows = rows;
+    },
+    setCount: (count) => {
+      states.count = count;
+    },
+    logRowsMemory: (rows) => {
+      states.loggedRows = rows;
+    },
+    setSelectedRows: (value) => {
+      states.selectedRows = value;
+    },
+    setShowForm: (value) => {
+      states.showForm = value;
+    },
+    setEditing: (value) => {
+      states.editing = value;
+    },
+    setIsAdding: (value) => {
+      states.isAdding = value;
+    },
+    setGridRows: (value) => {
+      states.gridRows = value;
+    },
+    addToast: (message, type) => {
+      toasts.push({ message, type });
+    },
+    openAdd: () => {
+      states.openAddCount += 1;
+    },
+    formConfig: {},
+    merged: { amount: 100 },
+    buildImageName: () => ({ name: '' }),
+    columnCaseMap: {},
+    getRowId: (row) => row.id,
+    getImageFolder: () => 'finance',
+    oldImageName: '',
+  });
+
+  assert.equal(result, true);
+  assert.equal(fetchCalls.length, 2);
+  assert.equal(
+    fetchCalls[0].url,
+    '/api/tables/finance%20records',
+  );
+  assert.deepEqual(JSON.parse(fetchCalls[0].init.body), {
+    amount: 100,
+    created_by: 'EMP001',
+    created_at: '2024-01-02 03:04:05',
+  });
+  assert.match(fetchCalls[1].url, /\?page=2&perPage=25/);
+  assert.deepEqual(states.rows, [{ id: 10 }]);
+  assert.equal(states.count, 1);
+  assert.deepEqual(states.loggedRows, [{ id: 10 }]);
+  assert.equal(states.showForm, false);
+  assert.equal(states.editing, null);
+  assert.equal(states.isAdding, false);
+  assert.deepEqual(states.gridRows, []);
+  assert.deepEqual([...states.selectedRows], []);
+  assert.deepEqual(toasts, [
+    { message: 'Шинэ гүйлгээ хадгалагдлаа', type: 'success' },
+  ]);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(states.openAddCount, 1);
+});
+
+test('submitUpdate updates payload and refreshes data', async () => {
+  const { submitUpdate } = await import(
+    '../../src/erp.mgt.mn/components/tableManagerSubmissions.js',
+  );
+
+  const cleaned = { amount: 150 };
+  const states = createState({
+    showForm: true,
+    editing: { id: 20 },
+    isAdding: true,
+    gridRows: [{ id: 20 }],
+    rows: [],
+    count: 0,
+    loggedRows: null,
+    selectedRows: new Set([20]),
+  });
+
+  const toasts = [];
+  const fetchCalls = [];
+  let fetchStep = 0;
+  const fetchImpl = async (url, init = {}) => {
+    fetchCalls.push({ url, init });
+    if (fetchStep === 0) {
+      fetchStep += 1;
+      assert.equal(init.method, 'PUT');
+      return { ok: true, status: 200 };
+    }
+    fetchStep += 1;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ rows: [{ id: 20, amount: 150 }], total: 1 }),
+    };
+  };
+
+  const result = await submitUpdate(cleaned, {
+    fetchImpl,
+    table: 'finance',
+    editing: states.editing,
+    getRowId: (row) => row.id,
+    page: 1,
+    perPage: 10,
+    company: null,
+    columns: new Set(),
+    sort: { column: 'amount', dir: 'desc' },
+    filters: { status: 'approved' },
+    setRows: (rows) => {
+      states.rows = rows;
+    },
+    setCount: (count) => {
+      states.count = count;
+    },
+    logRowsMemory: (rows) => {
+      states.loggedRows = rows;
+    },
+    setSelectedRows: (value) => {
+      states.selectedRows = value;
+    },
+    setShowForm: (value) => {
+      states.showForm = value;
+    },
+    setEditing: (value) => {
+      states.editing = value;
+    },
+    setIsAdding: (value) => {
+      states.isAdding = value;
+    },
+    setGridRows: (value) => {
+      states.gridRows = value;
+    },
+    addToast: (message, type) => {
+      toasts.push({ message, type });
+    },
+  });
+
+  assert.equal(result, true);
+  assert.equal(fetchCalls.length, 2);
+  assert.equal(
+    fetchCalls[0].url,
+    '/api/tables/finance/20',
+  );
+  assert.deepEqual(JSON.parse(fetchCalls[0].init.body), cleaned);
+  assert.match(fetchCalls[1].url, /sort=amount&dir=desc/);
+  assert.deepEqual(states.rows, [{ id: 20, amount: 150 }]);
+  assert.equal(states.count, 1);
+  assert.deepEqual(states.loggedRows, [{ id: 20, amount: 150 }]);
+  assert.equal(states.showForm, false);
+  assert.equal(states.editing, null);
+  assert.equal(states.isAdding, false);
+  assert.deepEqual(states.gridRows, []);
+  assert.deepEqual([...states.selectedRows], []);
+  assert.deepEqual(toasts, [{ message: 'Хадгалагдлаа', type: 'success' }]);
+});


### PR DESCRIPTION
## Summary
- extract TableManager submission flows into dedicated helper functions
- reuse the helpers from TableManager to reduce duplication across request, add, and update paths
- add unit tests covering each helper to ensure the new structure matches prior behavior

## Testing
- `node --test tests/components/tableManagerSubmitHelpers.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d64bddb9888331b79bec636b53ba02