### PR TITLE
Add API endpoint for fetching single table rows

### DIFF
--- a/api-server/routes/tables.js
+++ b/api-server/routes/tables.js
@@ -2,6 +2,7 @@ import express from 'express';
 import {
   getTables,
   getTableRows,
+  getTableRow,
   getTableRelations,
   listCustomTableRelations,
   saveCustomTableRelation,
@@ -34,6 +35,7 @@ router.get('/:table/relations', requireAuth, getTableRelations);
 router.get('/:table/columns', requireAuth, getTableColumnsMeta);
 router.put('/:table/labels', requireAuth, saveColumnLabels);
 router.get('/:table/:id/references', requireAuth, getRowReferences);
+router.get('/:table/:id', requireAuth, getTableRow);
 router.put('/:table/:id', requireAuth, updateRow);
 router.delete('/:table/:id', requireAuth, deleteRow);
 router.post('/:table', requireAuth, addRow);


### PR DESCRIPTION
## Summary
- add a GET /tables/:table/:id route so edit hydration resolves through the API
- implement controller logic to fetch a row via listTableRows with company scoping and JSON response
- extend table controller tests to cover success, 404, and validation cases for the new endpoint

## Testing
- npm test -- tests/controllers/tableController.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d6537dc5e48331b608c76201da9114