### PR TITLE
Handle localized numeric strings in calc field sums

### DIFF
--- a/src/erp.mgt.mn/utils/syncCalcFields.js
+++ b/src/erp.mgt.mn/utils/syncCalcFields.js
@@ -26,6 +26,44 @@ function assignArrayMetadata(target, source) {
   return target;
 }
 
+function parseLocalizedNumber(value) {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const withoutGrouping = trimmed.replace(/[\s\u00A0]+/g, '');
+  if (!withoutGrouping) return null;
+
+  let normalized = withoutGrouping;
+
+  const hasComma = normalized.includes(',');
+  const hasDot = normalized.includes('.');
+  if (hasComma && hasDot) {
+    if (normalized.lastIndexOf(',') > normalized.lastIndexOf('.')) {
+      normalized = normalized.replace(/\./g, '').replace(/,/g, '.');
+    } else {
+      normalized = normalized.replace(/,/g, '');
+    }
+  } else if (hasComma) {
+    const commaCount = (normalized.match(/,/g) || []).length;
+    if (commaCount === 1) {
+      normalized = normalized.replace(',', '.');
+    } else {
+      normalized = normalized.replace(/,/g, '');
+    }
+  }
+
+  const num = Number(normalized);
+  return Number.isFinite(num) ? num : null;
+}
+
 function collectSectionFields(map, table) {
   const fields = new Set();
   if (!map || !table) return fields;
@@ -84,8 +122,8 @@ const CALC_FIELD_AGGREGATORS = {
           if (!isPlainObject(row)) continue;
           const raw = row[field];
           if (raw === undefined || raw === null) continue;
-          const num = Number(raw);
-          if (!Number.isFinite(num)) continue;
+          const num = parseLocalizedNumber(raw);
+          if (num === null) continue;
           sum += num;
           hasData = true;
         }
@@ -99,8 +137,8 @@ const CALC_FIELD_AGGREGATORS = {
         if (raw === undefined || raw === null) {
           return { sum: 0, hasValue: false };
         }
-        const num = Number(raw);
-        if (!Number.isFinite(num)) {
+        const num = parseLocalizedNumber(raw);
+        if (num === null) {
           return { sum: 0, hasValue: false };
         }
         return { sum: num, hasValue: true };


### PR DESCRIPTION
## Summary
- add a localized number parser so SUM aggregations can handle grouped spacing and comma decimals
- update the SUM aggregator to use the sanitized parser when summing array and object values
- extend the POS transactions tests to cover localized numeric strings syncing into master totals

## Testing
- node --test tests/pages/PosTransactions.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d7762088d883318770cddcd89169d4