### PR TITLE
Ensure active tab keeps URL in sync

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -1176,6 +1176,13 @@ function MainWindow({ title }) {
     setTabContent(location.pathname, outlet);
   }, [location.pathname, setTabContent]);
 
+  useEffect(() => {
+    if (!activeKey || activeKey === location.pathname) return;
+    if (typeof activeKey !== 'string') return;
+    if (!activeKey.startsWith('/')) return;
+    navigate(activeKey);
+  }, [activeKey, location.pathname, navigate]);
+
   function handleSwitch(key) {
     switchTab(key);
     if (key.startsWith('/')) navigate(key);
@@ -1338,7 +1345,7 @@ function MainWindow({ title }) {
               <button
                 onClick={(e) => {
                   e.stopPropagation();
-                  closeTab(t.key);
+                  closeTab(t.key, navigate);
                 }}
                 style={styles.closeBtn}
               >

--- a/src/erp.mgt.mn/context/TabContext.jsx
+++ b/src/erp.mgt.mn/context/TabContext.jsx
@@ -42,23 +42,44 @@ export function TabProvider({ children }) {
     window.__activeTabKey = key;
   }, []);
 
-  const closeTab = useCallback((key) => {
-    if (key === '/') return;
-    trackSetState('TabProvider.setTabs');
-    setTabs((t) => t.filter((tab) => tab.key !== key));
-    trackSetState('TabProvider.setCache');
-    setCache((c) => {
-      const n = { ...c };
-      delete n[key];
-      return n;
-    });
-    trackSetState('TabProvider.setActiveKey');
-    setActiveKey((k) => {
-      if (k !== key) return k;
-      const remaining = tabs.filter((t) => t.key !== key);
-      return remaining[0]?.key || null;
-    });
-  }, [tabs]);
+  const closeTab = useCallback(
+    (key, onNavigate) => {
+      if (key === '/') return;
+      trackSetState('TabProvider.setTabs');
+      setTabs((t) => t.filter((tab) => tab.key !== key));
+      trackSetState('TabProvider.setCache');
+      setCache((c) => {
+        const n = { ...c };
+        delete n[key];
+        return n;
+      });
+      let nextActiveKey = null;
+      let shouldNavigate = false;
+      trackSetState('TabProvider.setActiveKey');
+      setActiveKey((current) => {
+        if (current !== key) {
+          nextActiveKey = current;
+          return current;
+        }
+        const remaining = tabs.filter((t) => t.key !== key);
+        const fallback = remaining[0]?.key || null;
+        nextActiveKey = fallback;
+        shouldNavigate = true;
+        return fallback;
+      });
+      window.__activeTabKey = nextActiveKey || 'global';
+      if (
+        shouldNavigate &&
+        typeof onNavigate === 'function' &&
+        nextActiveKey &&
+        typeof nextActiveKey === 'string' &&
+        nextActiveKey.startsWith('/')
+      ) {
+        onNavigate(nextActiveKey);
+      }
+    },
+    [tabs],
+  );
 
   const setTabContent = useCallback((key, content) => {
     trackSetState('TabProvider.setCache');


### PR DESCRIPTION
## Summary
- keep the router location aligned with the active tab by navigating whenever the active tab key changes
- allow the tab context to trigger navigation when closing the active tab so the location always matches the visible content

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d77883e8e88331aec83c2c62205af0