### PR TITLE
Add end tour control to Joyride viewer

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -350,6 +350,15 @@ export default function ERPLayout() {
   const closeTourViewer = useCallback(() => {
     setTourViewerState(null);
   }, []);
+
+  const endTour = useCallback(() => {
+    setRunTour(false);
+    setTourSteps([]);
+    setTourStepIndex(0);
+    setCurrentTourPage("");
+    setCurrentTourPath("");
+    closeTourViewer();
+  }, [closeTourViewer]);
   useEffect(() => {
     const handler = () => setIsMobile(window.innerWidth < 768);
     window.addEventListener('resize', handler);
@@ -738,22 +747,16 @@ export default function ERPLayout() {
             const seen = { ...(userSettings?.toursSeen || {}), [currentTourPage]: true };
             updateUserSettings({ toursSeen: seen });
           }
-          setTourStepIndex(0);
-          setTourSteps([]);
-          setRunTour(false);
-          setCurrentTourPage('');
-          setCurrentTourPath('');
-          closeTourViewer();
+          endTour();
         }
       });
     },
     [
       addToast,
-      closeTourViewer,
       currentTourPage,
+      endTour,
       t,
       tourSteps,
-      setTourSteps,
       updateUserSettings,
       userSettings,
     ],
@@ -765,15 +768,10 @@ export default function ERPLayout() {
     if (normalizedLocationPath === currentTourPath) return;
     if (!(runTour || tourViewerState)) return;
 
-    setRunTour(false);
-    setTourSteps([]);
-    setTourStepIndex(0);
-    setCurrentTourPage('');
-    setCurrentTourPath('');
-    closeTourViewer();
+    endTour();
   }, [
-    closeTourViewer,
     currentTourPath,
+    endTour,
     location.pathname,
     normalizePath,
     runTour,
@@ -902,6 +900,7 @@ export default function ERPLayout() {
             runId: activeTourRunId,
           }}
           onClose={closeTourViewer}
+          onEndTour={endTour}
           onSelectStep={handleTourStepJump}
         />
       )}

--- a/src/erp.mgt.mn/components/tours/TourViewer.jsx
+++ b/src/erp.mgt.mn/components/tours/TourViewer.jsx
@@ -145,7 +145,7 @@ function normalizeSteps(steps) {
   }));
 }
 
-export default function TourViewer({ state, onClose, onSelectStep }) {
+export default function TourViewer({ state, onClose, onSelectStep, onEndTour }) {
   const steps = useMemo(() => normalizeSteps(state?.steps), [state?.steps]);
   const activeIndex = useMemo(() => {
     if (typeof state?.currentStepIndex !== "number") return null;
@@ -329,6 +329,11 @@ export default function TourViewer({ state, onClose, onSelectStep }) {
                 )}
               </div>
               <div style={headerActionsStyles}>
+                {typeof onEndTour === "function" && (
+                  <button type="button" onClick={onEndTour} style={actionButtonStyles}>
+                    End tour
+                  </button>
+                )}
                 <button type="button" onClick={toggleSide} style={actionButtonStyles}>
                   Dock {side === "right" ? "left" : "right"}
                 </button>


### PR DESCRIPTION
## Summary
- add an ERPLayout endTour handler that stops Joyride, clears steps, and closes the viewer
- pass the handler into TourViewer so the panel can end a tour manually
- render an End tour button in the TourViewer header that triggers the handler

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d782b5eb688331a1be403f605a11a0