### PR TITLE
Fix generated column pipeline initialization order

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -324,20 +324,6 @@ function InlineTransactionTable(
     [tableColumns],
   );
 
-  const generatedColumnPipeline = React.useMemo(
-    () =>
-      createGeneratedColumnPipeline({
-        tableColumns,
-        columnCaseMap,
-        mainFields: mainFieldSet,
-        metadataFields: metadataFieldSet,
-        equals: valuesEqual,
-      }),
-    [tableColumnsKey, columnCaseMapKey, mainFieldSet, metadataFieldSet],
-  );
-  const generatedColumnEvaluators = generatedColumnPipeline.evaluators;
-  const hasGeneratedColumnsRef = useRef(false);
-
   const mainFieldSet = React.useMemo(() => {
     const set = new Set();
     fields.forEach((f) => {
@@ -357,6 +343,20 @@ function InlineTransactionTable(
     });
     return set;
   }, [allFieldsKey, columnCaseMapKey, mainFieldSet]);
+
+  const generatedColumnPipeline = React.useMemo(
+    () =>
+      createGeneratedColumnPipeline({
+        tableColumns,
+        columnCaseMap,
+        mainFields: mainFieldSet,
+        metadataFields: metadataFieldSet,
+        equals: valuesEqual,
+      }),
+    [tableColumnsKey, columnCaseMapKey, mainFieldSet, metadataFieldSet],
+  );
+  const generatedColumnEvaluators = generatedColumnPipeline.evaluators;
+  const hasGeneratedColumnsRef = useRef(false);
 
   const applyGeneratedColumns = React.useCallback(
     (targetRows, indices = null) =>


### PR DESCRIPTION
## Summary
- ensure the generated column pipeline is memoized only after the field sets are initialized

## Testing
- not run (not feasible in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d783efdb308331a1b8347f04b3a49e