### PR TITLE
Blur tour targets after selection

### DIFF
--- a/src/erp.mgt.mn/components/tours/TourBuilder.jsx
+++ b/src/erp.mgt.mn/components/tours/TourBuilder.jsx
@@ -356,6 +356,14 @@ export default function TourBuilder({ state, onClose }) {
           ),
         );
       }
+      if (target && typeof target.blur === 'function') {
+        const blurTarget = () => target.blur();
+        if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+          window.requestAnimationFrame(blurTarget);
+        } else {
+          blurTarget();
+        }
+      }
       setPicking(false);
     };
 


### PR DESCRIPTION
## Summary
- blur picked tour targets after capturing their selectors so focus rings are cleared
- defer the blur with requestAnimationFrame when available to avoid interfering with React updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d78ade4b2c8331abcf394071fa6801