### PR TITLE
Ensure manual translation origins always populate

### DIFF
--- a/src/erp.mgt.mn/pages/ManualTranslationsTab.jsx
+++ b/src/erp.mgt.mn/pages/ManualTranslationsTab.jsx
@@ -290,8 +290,9 @@ export default function ManualTranslationsTab() {
               for (const lang of languagesList) {
                 if (values[lang] == null) values[lang] = '';
                 translatedBy[lang] = normalizeProvider(translatedBy[lang]);
-                const origin = normalizeOrigin(translatedBySources[lang]);
-                translatedBySources[lang] = origin;
+                const normalizedOrigin = normalizeOrigin(translatedBySources[lang]);
+                const fallbackOrigin = normalizeOrigin(entry.type) || toTrimmedString(entry.type);
+                translatedBySources[lang] = normalizedOrigin || fallbackOrigin || 'unknown';
               }
               return {
                 ...entry,


### PR DESCRIPTION
## Summary
- normalize manual translation origins by falling back to the entry type when missing
- guarantee each translated language retains a meaningful origin value

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7a52f7a948331a92e1b3540db26b7