### PR TITLE
Preserve translation origin when editing manual translations

### DIFF
--- a/src/erp.mgt.mn/pages/ManualTranslationsTab.jsx
+++ b/src/erp.mgt.mn/pages/ManualTranslationsTab.jsx
@@ -560,7 +560,6 @@ export default function ManualTranslationsTab() {
       if (entry.translatedBySources) {
         entry.translatedBySources = {
           ...entry.translatedBySources,
-          [lang]: '',
         };
       }
       copy[index] = entry;


### PR DESCRIPTION
## Summary
- prevent manual translation edits from clearing existing origin metadata
- continue marking manual edits through the provider map only

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7a5b457308331990f61e149b655c7