### PR TITLE
Fix translation origin fallback

### DIFF
--- a/src/erp.mgt.mn/pages/ManualTranslationsTab.jsx
+++ b/src/erp.mgt.mn/pages/ManualTranslationsTab.jsx
@@ -1179,7 +1179,7 @@ export default function ManualTranslationsTab() {
                     <div style={getProviderGridStyle(languages.length)}>
                       {languages.map((l) => {
                         const provider = entry.translatedBy?.[l];
-                        const origin = entry.translatedBySources?.[l] ?? entry.type;
+                        const origin = entry.translatedBySources?.[l] || entry.type;
                         const displayLabel = formatTranslationSource(origin, provider);
                         return (
                           <div key={l} style={{ color: displayLabel ? '#111827' : '#6b7280' }}>


### PR DESCRIPTION
## Summary
- ensure the translation origin falls back to the entry type when a source is blank

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7a77dc2ec83318c0f899564b32aba