### PR TITLE
Handle missing tour targets with fallback selectors

### DIFF
--- a/src/erp.mgt.mn/utils/findVisibleTourStep.js
+++ b/src/erp.mgt.mn/utils/findVisibleTourStep.js
@@ -3,6 +3,87 @@ export function defaultQuerySelector(selector) {
   return document.querySelector(selector);
 }
 
+function normalizeSelectorList(list) {
+  if (!Array.isArray(list)) return [];
+  return list
+    .map((value) => (typeof value === "string" ? value.trim() : ""))
+    .filter(Boolean);
+}
+
+function findExistingSelector(selectors, querySelector) {
+  for (let idx = 0; idx < selectors.length; idx += 1) {
+    const selector = selectors[idx];
+    try {
+      if (querySelector(selector)) {
+        return selector;
+      }
+    } catch (err) {
+      // Ignore invalid selectors while searching for a visible fallback.
+    }
+  }
+  return "";
+}
+
+function stripLastSelectorSegment(selector) {
+  let current = typeof selector === "string" ? selector.trim() : "";
+  if (!current) return "";
+
+  // Remove trailing combinators to simplify subsequent splitting.
+  current = current.replace(/[>+~]\s*$/, "").trim();
+  if (!current) return "";
+
+  const lastSpace = current.lastIndexOf(" ");
+  const lastChild = current.lastIndexOf(">");
+  const lastAdjacent = current.lastIndexOf("+");
+  const lastGeneral = current.lastIndexOf("~");
+  const lastIndex = Math.max(lastSpace, lastChild, lastAdjacent, lastGeneral);
+
+  if (lastIndex === -1) {
+    return "";
+  }
+
+  const shortened = current.slice(0, lastIndex).trim();
+  return shortened.replace(/[>+~]\s*$/, "").trim();
+}
+
+export function findVisibleFallbackSelector(
+  step,
+  querySelector = defaultQuerySelector,
+) {
+  if (!step || typeof step !== "object") return "";
+
+  const highlightSelectors = normalizeSelectorList(step.highlightSelectors);
+  const additionalSelectors = normalizeSelectorList(step.selectors);
+  const selectorPool = [...highlightSelectors, ...additionalSelectors];
+
+  const resolvedSelector = findExistingSelector(selectorPool, querySelector);
+  if (resolvedSelector) {
+    return resolvedSelector;
+  }
+
+  const baseSelector =
+    typeof step.target === "string" && step.target.trim()
+      ? step.target.trim()
+      : typeof step.selector === "string" && step.selector.trim()
+        ? step.selector.trim()
+        : "";
+
+  let parentSelector = baseSelector;
+  while (parentSelector) {
+    parentSelector = stripLastSelectorSegment(parentSelector);
+    if (!parentSelector) break;
+    try {
+      if (querySelector(parentSelector)) {
+        return parentSelector;
+      }
+    } catch (err) {
+      // Ignore invalid selectors and continue searching upward.
+    }
+  }
+
+  return "";
+}
+
 export function findLastVisibleTourStepIndex(
   steps,
   startIndex,

--- a/tests/findLastVisibleTourStepIndex.test.js
+++ b/tests/findLastVisibleTourStepIndex.test.js
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { findLastVisibleTourStepIndex } from "../src/erp.mgt.mn/utils/findVisibleTourStep.js";
+import {
+  findLastVisibleTourStepIndex,
+  findVisibleFallbackSelector,
+} from "../src/erp.mgt.mn/utils/findVisibleTourStep.js";
 
 test("findLastVisibleTourStepIndex returns previous visible step", () => {
   const steps = [
@@ -45,4 +48,28 @@ test("findLastVisibleTourStepIndex returns -1 when nothing visible", () => {
   const result = findLastVisibleTourStepIndex(steps, 1, query);
 
   assert.equal(result, -1);
+});
+
+test("findVisibleFallbackSelector returns first visible highlight selector", () => {
+  const step = {
+    target: "#missing",
+    highlightSelectors: ["#missing", "#fallback", "#other"],
+  };
+  const query = (selector) => selector === "#fallback";
+
+  const result = findVisibleFallbackSelector(step, query);
+
+  assert.equal(result, "#fallback");
+});
+
+test("findVisibleFallbackSelector falls back to parent selector", () => {
+  const step = {
+    target: "#alpha .bravo .charlie",
+    highlightSelectors: ["#alpha .bravo .charlie"],
+  };
+  const query = (selector) => selector === "#alpha .bravo";
+
+  const result = findVisibleFallbackSelector(step, query);
+
+  assert.equal(result, "#alpha .bravo");
 });


### PR DESCRIPTION
## Summary
- add a utility to resolve the first visible selector or fall back to a parent when tour targets are hidden
- update ERPLayout to swap hidden tour targets to a visible fallback, show an expansion hint, and restore the original selector once it reappears
- cover the new helper with unit tests to validate selector resolution and parent fallback logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7a9d6b37883319536e08b3f8dce07