### PR TITLE
Handle provider-only updates for manual translation metadata

### DIFF
--- a/api-server/services/manualTranslations.js
+++ b/api-server/services/manualTranslations.js
@@ -392,6 +392,19 @@ export async function saveTranslation({
   const fileOrigin = FILE_ORIGIN_BY_TYPE[type] || FILE_ORIGIN_BY_TYPE.locale;
   const updatedLanguages = new Set();
 
+  for (const [lang, label] of Object.entries(incomingTranslatedBy)) {
+    if (Object.prototype.hasOwnProperty.call(values, lang)) continue;
+    const requestedMeta = rawIncomingMeta[lang] || parseTranslatedByLabel(label);
+    const providerCode = requestedMeta.provider || '';
+    if (!providerCode) continue;
+    const existingMeta = parseTranslatedByLabel(existingTranslatedBy[lang]);
+    const origin = requestedMeta.origin || existingMeta.origin || fileOrigin;
+    const combinedLabel = composeTranslatedByLabel(origin, providerCode);
+    if (!combinedLabel || combinedLabel === existingTranslatedBy[lang]) continue;
+    incomingTranslatedBy[lang] = combinedLabel;
+    updatedLanguages.add(lang);
+  }
+
   for (const [lang, val] of Object.entries(values)) {
     const dir = type === 'tooltip' ? tooltipDir : localesDir;
     const file = path.join(dir, `${lang}.json`);


### PR DESCRIPTION
## Summary
- merge provider-only translatedBy updates with stored origins before saving translations
- default origin to existing metadata or file type when combining provider-only labels
- ensure languages updated without value changes persist the combined origin/provider label

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7af36805c8331834ab152f6471989