### PR TITLE
Adjust extra spotlight positioning to viewport coordinates

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -1428,10 +1428,8 @@ export default function ERPLayout() {
     const updatePositions = () => {
       spotlightEntries.forEach(({ mask, outline, element, padding: paddingAmount }) => {
         const rect = element.getBoundingClientRect();
-        const scrollY = window.scrollY ?? window.pageYOffset ?? 0;
-        const scrollX = window.scrollX ?? window.pageXOffset ?? 0;
-        const top = scrollY + rect.top - paddingAmount;
-        const left = scrollX + rect.left - paddingAmount;
+        const top = rect.top - paddingAmount;
+        const left = rect.left - paddingAmount;
         const width = rect.width + paddingAmount * 2;
         const height = rect.height + paddingAmount * 2;
         const roundedTop = `${Math.floor(top)}px`;


### PR DESCRIPTION
## Summary
- update the extra spotlight helper to use viewport coordinates from getBoundingClientRect
- ensure mask and outline positioning remains in viewport space for fixed container spotlights

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7b875e6f08331a0d1f92c35feef2d