### PR TITLE
Adjust Joyride tooltip to close on final step

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -214,6 +214,7 @@ function computeStepSignature(steps) {
 
 function JoyrideTooltip({
   index = 0,
+  size = 0,
   step,
   tooltipProps = {},
   helpers = {},
@@ -226,6 +227,7 @@ function JoyrideTooltip({
   const nextLabel = step?.locale?.next || 'Next';
   const endLabel =
     step?.locale?.last || step?.locale?.close || step?.locale?.skip || 'End tour';
+  const isLastStep = size > 0 && index >= size - 1;
 
   const {
     className: backClassName,
@@ -254,16 +256,6 @@ function JoyrideTooltip({
     }
   };
 
-  const handleNext = (event) => {
-    if (typeof primaryOnClick === 'function') {
-      primaryOnClick(event);
-      return;
-    }
-    if (typeof helpers.next === 'function') {
-      helpers.next(event);
-    }
-  };
-
   const handleEnd = (event) => {
     if (typeof skipOnClick === 'function') {
       skipOnClick(event);
@@ -271,6 +263,24 @@ function JoyrideTooltip({
     }
     if (typeof helpers.close === 'function') {
       helpers.close(true);
+    }
+  };
+
+  const handlePrimary = (event) => {
+    if (isLastStep) {
+      if (typeof primaryOnClick === 'function') {
+        primaryOnClick(event);
+        if (event?.defaultPrevented) return;
+      }
+      handleEnd(event);
+      return;
+    }
+    if (typeof primaryOnClick === 'function') {
+      primaryOnClick(event);
+      return;
+    }
+    if (typeof helpers.next === 'function') {
+      helpers.next(event);
     }
   };
 
@@ -345,19 +355,21 @@ function JoyrideTooltip({
         <button
           type="button"
           className={`react-joyride__tooltip-button react-joyride__tooltip-button--primary ${primaryClassName ?? ''}`.trim()}
-          onClick={handleNext}
+          onClick={handlePrimary}
           {...restPrimaryProps}
         >
-          {nextLabel}
+          {isLastStep ? endLabel : nextLabel}
         </button>
-        <button
-          type="button"
-          className={`react-joyride__tooltip-button react-joyride__tooltip-button--skip ${skipClassName ?? ''}`.trim()}
-          onClick={handleEnd}
-          {...restSkipProps}
-        >
-          {endLabel}
-        </button>
+        {isLastStep ? null : (
+          <button
+            type="button"
+            className={`react-joyride__tooltip-button react-joyride__tooltip-button--skip ${skipClassName ?? ''}`.trim()}
+            onClick={handleEnd}
+            {...restSkipProps}
+          >
+            {endLabel}
+          </button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow JoyrideTooltip to receive the Joyride size prop and detect the final step
- reuse the localized end label on the primary button when finishing a tour
- hide the redundant skip button on the last step so ending closes the tour immediately

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7bbf283108331bbc56342e65a78ff