### PR TITLE
Allow add modal for non-transaction tables

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -198,6 +198,12 @@ const TableManager = forwardRef(function TableManager({
   const [imagesRow, setImagesRow] = useState(null);
   const [uploadRow, setUploadRow] = useState(null);
   const [ctxMenu, setCtxMenu] = useState(null); // { x, y, value }
+
+  const tableName = typeof table === 'string' ? table : String(table ?? '');
+  const isTransactionTable = tableName.toLowerCase().startsWith('transactions');
+  const canAddRows = isTransactionTable
+    ? Boolean(buttonPerms?.['New transaction'])
+    : true;
   const [searchTerm, setSearchTerm] = useState('');
   const [searchImages, setSearchImages] = useState([]);
   const [searchPage, setSearchPage] = useState(1);
@@ -1290,11 +1296,11 @@ const TableManager = forwardRef(function TableManager({
   useImperativeHandle(
     ref,
     () => ({
-      openAdd: buttonPerms['New transaction'] ? openAdd : () => {},
+      openAdd: canAddRows ? openAdd : () => {},
       openEdit,
       openRequestEdit,
     }),
-    [buttonPerms, openAdd, openEdit, openRequestEdit],
+    [canAddRows, openAdd, openEdit, openRequestEdit],
   );
 
   async function openDetail(row) {
@@ -2172,7 +2178,7 @@ const TableManager = forwardRef(function TableManager({
           textAlign: 'left',
         }}
       >
-        {buttonPerms['New transaction'] && (
+        {canAddRows && (
           <TooltipWrapper title={t('add_row', { ns: 'tooltip', defaultValue: 'Add new row' })}>
             <button onClick={openAdd} style={{ marginRight: '0.5rem' }}>
               {addLabel}

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -69,6 +69,12 @@ export default function FinanceTransactions({ moduleKey = 'finance_transactions'
   const prevSessionRef = useRef({});
   const prevConfigRef = useRef(null);
 
+  const tableName = typeof table === 'string' ? table : String(table ?? '');
+  const isTransactionTable = tableName.toLowerCase().startsWith('transactions');
+  const canAddRows = isTransactionTable
+    ? Boolean(buttonPerms?.['New transaction'])
+    : true;
+
   const procMap = useHeaderMappings(
     config?.procedures
       ? [...config.procedures, selectedProc].filter(Boolean)
@@ -575,7 +581,7 @@ useEffect(() => {
       {table && config && (
         <>
           <div style={{ marginBottom: '0.5rem' }}>
-            {buttonPerms['New transaction'] && (
+            {canAddRows && (
               <button
                 onClick={() => tableRef.current?.openAdd()}
                 style={{ marginRight: '0.5rem' }}


### PR DESCRIPTION
## Summary
- derive a transaction-aware `canAddRows` flag in TableManager so non-transaction tables always keep their add modal
- reuse `canAddRows` for the built-in add button and imperative handle to prevent accidental blocking
- align FinanceTransactions' external add button with the shared `canAddRows` rules

## Testing
- node --test tests/components/tableManagerAddModeDisabledFields.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d7bca886548331b5e05d64457c668a