### PR TITLE
Allow auto-select dropdowns to accept free-form values

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -1521,11 +1521,10 @@ function InlineTransactionTable(
     if (!isEnter && !isForwardTab) return;
     e.preventDefault();
     const field = fields[colIdx];
-    const isLookupField =
+    const requiresExplicitMatch =
       !!relationConfigMap[field] ||
-      !!viewSourceMap[field] ||
-      !!autoSelectConfigs[field];
-    if (isLookupField && e.lookupMatched === false) {
+      !!viewSourceMap[field];
+    if (requiresExplicitMatch && e.lookupMatched === false) {
       const label = labels[field] || field;
       const message = `${label} талбарт тохирох утга олдсонгүй.`;
       setErrorMsg(message);

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -718,11 +718,10 @@ const RowFormModal = function RowFormModal({
   async function handleKeyDown(e, col) {
     if (e.key !== 'Enter') return;
     e.preventDefault();
-    const isLookupField =
+    const requiresExplicitMatch =
       !!relationConfigMap[col] ||
-      !!viewSourceMap[col] ||
-      !!autoSelectConfigs[col];
-    if (isLookupField && e.lookupMatched === false) {
+      !!viewSourceMap[col];
+    if (requiresExplicitMatch && e.lookupMatched === false) {
       setErrors((er) => ({ ...er, [col]: 'Тохирох утга олдсонгүй' }));
       const el = inputRefs.current[col];
       if (el) {

--- a/tests/components/rowFormModalAutoSelectFreeform.test.js
+++ b/tests/components/rowFormModalAutoSelectFreeform.test.js
@@ -1,0 +1,177 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+if (!global.document) {
+  global.document = { createElement: () => ({}) };
+} else if (!global.document.createElement) {
+  global.document.createElement = () => ({});
+}
+
+if (!global.window) {
+  global.window = {};
+}
+if (!global.window.addEventListener) global.window.addEventListener = () => {};
+if (!global.window.removeEventListener) global.window.removeEventListener = () => {};
+if (!global.window.dispatchEvent) global.window.dispatchEvent = () => {};
+if (!global.window.confirm) global.window.confirm = () => true;
+if (!global.window.alert) global.window.alert = () => {};
+if (!global.window.open)
+  global.window.open = () => ({ document: { write: () => {}, close: () => {} }, focus: () => {}, print: () => {} });
+if (!global.window.innerWidth) global.window.innerWidth = 1024;
+if (!global.window.matchMedia)
+  global.window.matchMedia = () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} });
+if (!global.ResizeObserver)
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+
+let React;
+let act;
+let createRoot;
+let haveReact = true;
+try {
+  const reactMod = await import('react');
+  React = reactMod.default || reactMod;
+  ({ act } = await import('react-dom/test-utils'));
+  ({ createRoot } = await import('react-dom/client'));
+} catch {
+  haveReact = false;
+}
+
+if (!haveReact) {
+  test('RowFormModal allows unmatched auto-select values', { skip: true }, () => {});
+} else {
+  const baseProps = {
+    visible: true,
+    onCancel: () => {},
+    onSubmit: () => {},
+    onChange: () => {},
+    onRowsChange: () => {},
+    columns: ['status'],
+    row: {},
+    rows: [],
+    relations: {},
+    relationConfigs: {},
+    relationData: {},
+    fieldTypeMap: { status: 'varchar' },
+    disabledFields: [],
+    labels: { status: 'Status' },
+    requiredFields: [],
+    defaultValues: {},
+    dateField: [],
+    inline: false,
+    useGrid: false,
+    fitted: false,
+    table: 'test',
+    imagenameField: [],
+    imageIdField: '',
+    scope: 'forms',
+    headerFields: [],
+    mainFields: ['status'],
+    footerFields: [],
+    userIdFields: [],
+    branchIdFields: [],
+    departmentIdFields: [],
+    companyIdFields: [],
+    printEmpField: [],
+    printCustField: [],
+    totalAmountFields: [],
+    totalCurrencyFields: [],
+    procTriggers: {},
+    columnCaseMap: { status: 'status' },
+    viewSource: {},
+    viewDisplays: {},
+    viewColumns: {},
+    loadView: () => {},
+    autoFillSession: false,
+    tableColumns: [],
+  };
+
+  test('RowFormModal allows unmatched auto-select values', async (t) => {
+    let keyDownHandler = null;
+    let observedValue = null;
+
+    const AsyncSearchSelectMock = (props) => {
+      observedValue = props.value;
+      keyDownHandler = props.onKeyDown;
+      if (props.inputRef) {
+        props.inputRef({
+          value: props.value ?? '',
+          focus: () => {},
+          select: () => {},
+          style: {},
+        });
+      }
+      return React.createElement('div', null);
+    };
+
+    const ModalMock = (props) => React.createElement('div', null, props.children);
+
+    const mocks = {
+      './AsyncSearchSelect.jsx': { default: AsyncSearchSelectMock },
+      './Modal.jsx': { default: ModalMock },
+      './InlineTransactionTable.jsx': { default: () => null },
+      './RowDetailModal.jsx': { default: () => null },
+      './TooltipWrapper.jsx': { default: ({ children }) => React.createElement(React.Fragment, null, children) },
+      'react-i18next': { useTranslation: () => ({ t: (key, fallback) => fallback || key }) },
+      '../context/AuthContext.jsx': { AuthContext: React.createContext({}) },
+      '../utils/formatTimestamp.js': { default: () => '2024-01-01 00:00:00' },
+      '../utils/normalizeDateInput.js': { default: (val) => val },
+      '../utils/callProcedure.js': { default: async () => ({}) },
+      '../utils/generatedColumns.js': {
+        applyGeneratedColumnEvaluators: () => ({ changed: false }),
+        createGeneratedColumnEvaluator: () => null,
+      },
+      '../hooks/useGeneralConfig.js': { default: () => ({ general: {} }) },
+      '../utils/apiBase.js': { API_BASE: '' },
+    };
+
+    const origFetch = global.fetch;
+    global.fetch = async () => ({
+      ok: true,
+      json: async () => ({ demo: { idField: 'status', displayFields: ['name'] } }),
+    });
+
+    let root;
+    try {
+      const mod = await t.mock.import('../../src/erp.mgt.mn/components/RowFormModal.jsx', mocks);
+      const RowFormModal = mod.default || mod;
+
+      const container = document.createElement('div');
+      root = createRoot(container);
+
+      await act(async () => {
+        root.render(React.createElement(RowFormModal, baseProps));
+      });
+
+      // Allow fetch promise and subsequent state updates to settle.
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      assert.ok(typeof keyDownHandler === 'function', 'AsyncSearchSelect should provide onKeyDown');
+      assert.equal(observedValue ?? '', '', 'Initial field value should be empty');
+
+      await act(async () => {
+        keyDownHandler({
+          key: 'Enter',
+          preventDefault: () => {},
+          target: {
+            value: 'Custom Value',
+            focus: () => {},
+            select: () => {},
+          },
+          lookupMatched: false,
+        });
+      });
+
+      assert.equal(observedValue, 'Custom Value');
+    } finally {
+      if (root) root.unmount();
+      global.fetch = origFetch;
+    }
+  });
+}
+


### PR DESCRIPTION
## Summary
- require lookup matches only for relation/view-backed form fields and allow suggested auto-select columns to accept free-form entries
- mirror the relaxed lookup guard in InlineTransactionTable so inferred dropdown cells keep user input
- add a regression test covering free-form entry on an auto-select-only column in RowFormModal

## Testing
- npm test -- --test-name-pattern="auto-select"

------
https://chatgpt.com/codex/tasks/task_e_68d7c198913c8331a7ff78ad5ca9e96c