### PR TITLE
Guard auto-select lookups against local tables

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -168,16 +168,19 @@ function InlineTransactionTable(
   }, [tableDisplayFieldsKey]);
 
   // Only columns present in columnCaseMap are evaluated, preventing cross-table false positives.
+  const normalizedTableName =
+    typeof tableName === 'string' ? tableName.toLowerCase() : '';
+
   const autoSelectConfigs = React.useMemo(() => {
     const map = {};
     Object.entries(columnCaseMap || {}).forEach(([lower, key]) => {
       const cfg = displayIndex[lower];
-      if (cfg) {
-        map[key] = cfg;
-      }
+      if (!cfg) return;
+      if (cfg.table && cfg.table.toLowerCase() === normalizedTableName) return;
+      map[key] = cfg;
     });
     return map;
-  }, [columnCaseMapKey, displayIndex]);
+  }, [columnCaseMapKey, displayIndex, normalizedTableName]);
 
   const combinedViewSource = React.useMemo(() => {
     const map = { ...viewSourceMap };

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -189,16 +189,18 @@ const RowFormModal = function RowFormModal({
   }, [tableDisplayFieldsKey]);
 
   // Only columns present in columnCaseMap are evaluated, preventing cross-table false positives.
+  const normalizedTableName = typeof table === 'string' ? table.toLowerCase() : '';
+
   const autoSelectConfigs = React.useMemo(() => {
     const map = {};
     Object.entries(columnCaseMap || {}).forEach(([lower, key]) => {
       const cfg = displayIndex[lower];
-      if (cfg) {
-        map[key] = cfg;
-      }
+      if (!cfg) return;
+      if (cfg.table && cfg.table.toLowerCase() === normalizedTableName) return;
+      map[key] = cfg;
     });
     return map;
-  }, [columnCaseMapKey, displayIndex]);
+  }, [columnCaseMapKey, displayIndex, normalizedTableName]);
   const getRowValueCaseInsensitive = useCallback((rowObj, key) => {
     if (!rowObj || !key) return undefined;
     const lowerKey = key.toLowerCase();

--- a/tests/components/rowFormModalAutoSelectFreeform.test.js
+++ b/tests/components/rowFormModalAutoSelectFreeform.test.js
@@ -42,6 +42,7 @@ try {
 
 if (!haveReact) {
   test('RowFormModal allows unmatched auto-select values', { skip: true }, () => {});
+  test('RowFormModal renders primary key field as text input for owning table', { skip: true }, () => {});
 } else {
   const baseProps = {
     visible: true,
@@ -92,8 +93,10 @@ if (!haveReact) {
   test('RowFormModal allows unmatched auto-select values', async (t) => {
     let keyDownHandler = null;
     let observedValue = null;
+    let callCount = 0;
 
     const AsyncSearchSelectMock = (props) => {
+      callCount += 1;
       observedValue = props.value;
       keyDownHandler = props.onKeyDown;
       if (props.inputRef) {
@@ -153,6 +156,7 @@ if (!haveReact) {
 
       assert.ok(typeof keyDownHandler === 'function', 'AsyncSearchSelect should provide onKeyDown');
       assert.equal(observedValue ?? '', '', 'Initial field value should be empty');
+      assert.ok(callCount >= 1, 'AsyncSearchSelect should render for foreign tables');
 
       await act(async () => {
         keyDownHandler({
@@ -168,6 +172,68 @@ if (!haveReact) {
       });
 
       assert.equal(observedValue, 'Custom Value');
+    } finally {
+      if (root) root.unmount();
+      global.fetch = origFetch;
+    }
+  });
+
+  test('RowFormModal renders primary key field as text input for owning table', async (t) => {
+    let callCount = 0;
+
+    const AsyncSearchSelectMock = () => {
+      callCount += 1;
+      return React.createElement('div', null);
+    };
+
+    const ModalMock = (props) => React.createElement('div', null, props.children);
+
+    const mocks = {
+      './AsyncSearchSelect.jsx': { default: AsyncSearchSelectMock },
+      './Modal.jsx': { default: ModalMock },
+      './InlineTransactionTable.jsx': { default: () => null },
+      './RowDetailModal.jsx': { default: () => null },
+      './TooltipWrapper.jsx': { default: ({ children }) => React.createElement(React.Fragment, null, children) },
+      'react-i18next': { useTranslation: () => ({ t: (key, fallback) => fallback || key }) },
+      '../context/AuthContext.jsx': { AuthContext: React.createContext({}) },
+      '../utils/formatTimestamp.js': { default: () => '2024-01-01 00:00:00' },
+      '../utils/normalizeDateInput.js': { default: (val) => val },
+      '../utils/callProcedure.js': { default: async () => ({}) },
+      '../utils/generatedColumns.js': {
+        applyGeneratedColumnEvaluators: () => ({ changed: false }),
+        createGeneratedColumnEvaluator: () => null,
+      },
+      '../hooks/useGeneralConfig.js': { default: () => ({ general: {} }) },
+      '../utils/apiBase.js': { API_BASE: '' },
+    };
+
+    const origFetch = global.fetch;
+    global.fetch = async () => ({
+      ok: true,
+      json: async () => ({ test: { idField: 'status', displayFields: ['name'] } }),
+    });
+
+    let root;
+    try {
+      const mod = await t.mock.import('../../src/erp.mgt.mn/components/RowFormModal.jsx', mocks);
+      const RowFormModal = mod.default || mod;
+
+      const container = document.createElement('div');
+      root = createRoot(container);
+
+      await act(async () => {
+        root.render(React.createElement(RowFormModal, baseProps));
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      assert.equal(
+        callCount,
+        0,
+        'AsyncSearchSelect should not render for columns belonging to the owning table',
+      );
     } finally {
       if (root) root.unmount();
       global.fetch = origFetch;


### PR DESCRIPTION
## Summary
- filter auto-generated lookup configs so InlineTransactionTable and RowFormModal skip relations pointing to the owning table
- keep foreign table relations using async dropdowns while local primary keys stay free-text inputs
- add regression coverage verifying the owning table column renders as text when auto-select metadata resolves locally

## Testing
- npm test -- --test-name-pattern="RowFormModal"

------
https://chatgpt.com/codex/tasks/task_e_68d7ca57aa3c8331a11be0ac7c570eff