### PR TITLE
Handle localized numbers when applying POS fields

### DIFF
--- a/src/erp.mgt.mn/utils/syncCalcFields.js
+++ b/src/erp.mgt.mn/utils/syncCalcFields.js
@@ -4,7 +4,7 @@ function isPlainObject(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-function parseLocalizedNumber(value) {
+export function parseLocalizedNumber(value) {
   if (typeof value === 'number') {
     return Number.isFinite(value) ? value : null;
   }

--- a/src/erp.mgt.mn/utils/transactionValues.js
+++ b/src/erp.mgt.mn/utils/transactionValues.js
@@ -3,7 +3,7 @@ import {
   applyGeneratedColumnEvaluators,
   valuesEqual,
 } from './generatedColumns.js';
-import { syncCalcFields } from './syncCalcFields.js';
+import { syncCalcFields, parseLocalizedNumber } from './syncCalcFields.js';
 
 const arrayIndexPattern = /^(0|[1-9]\d*)$/;
 
@@ -229,6 +229,11 @@ export function applyPosFields(vals, posFieldConfig) {
 
   let next = { ...vals };
 
+  const parseOrZero = (value) => {
+    const parsed = parseLocalizedNumber(value);
+    return parsed === null ? 0 : parsed;
+  };
+
   for (const pf of posFieldConfig) {
     const parts = Array.isArray(pf?.parts) ? pf.parts : [];
     if (parts.length < 2) continue;
@@ -245,15 +250,15 @@ export function applyPosFields(vals, posFieldConfig) {
       if (Array.isArray(data)) {
         if (p.agg === 'SUM' || p.agg === 'AVG') {
           const sum = data.reduce(
-            (sumAcc, row) => sumAcc + (Number(row?.[p.field]) || 0),
+            (sumAcc, row) => sumAcc + parseOrZero(row?.[p.field]),
             0,
           );
           num = p.agg === 'AVG' ? (data.length ? sum / data.length : 0) : sum;
         } else {
-          num = Number(data[0]?.[p.field]) || 0;
+          num = parseOrZero(data[0]?.[p.field]);
         }
       } else {
-        num = Number(data?.[p.field]) || 0;
+        num = parseOrZero(data?.[p.field]);
       }
 
       if (p.agg === '=' && !init) {


### PR DESCRIPTION
## Summary
- export the localized number parser so POS field helpers can reuse it
- use localized parsing when computing POS aggregates to avoid NaN results
- cover thin-space and comma decimal POS inputs to ensure payable and cashback stay aligned

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7cb823680833191a4b66cccd206e8