### PR TITLE
Fix spotlight overlay mask transparency

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -1787,8 +1787,11 @@ export default function ERPLayout() {
         document.body?.clientHeight || 0,
       );
 
+      const maskId = "tour-spotlight-mask";
       const svgParts = [
         `<svg xmlns="http://www.w3.org/2000/svg" width="${viewportWidth}" height="${viewportHeight}" viewBox="0 0 ${viewportWidth} ${viewportHeight}" preserveAspectRatio="none">`,
+        `<defs>`,
+        `<mask id="${maskId}" maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse" mask-type="alpha">`,
         `<rect x="0" y="0" width="${viewportWidth}" height="${viewportHeight}" fill="white" />`,
       ];
       let hasVisibleRect = false;
@@ -1807,12 +1810,16 @@ export default function ERPLayout() {
         const widthValue = Math.max(0, Math.ceil(expandedWidth));
         const heightValue = Math.max(0, Math.ceil(expandedHeight));
         svgParts.push(
-          `<rect x="${x}" y="${y}" width="${widthValue}" height="${heightValue}" rx="12" ry="12" fill="black" />`,
+          `<rect x="${x}" y="${y}" width="${widthValue}" height="${heightValue}" rx="12" ry="12" fill="white" fill-opacity="0" />`,
         );
         hasVisibleRect = true;
       });
 
       if (hasVisibleRect) {
+        svgParts.push(`</mask>`, `</defs>`);
+        svgParts.push(
+          `<rect x="0" y="0" width="${viewportWidth}" height="${viewportHeight}" fill="white" mask="url(#${maskId})" />`,
+        );
         const svg = `${svgParts.join("")}</svg>`;
         const encoded = `url("data:image/svg+xml,${encodeURIComponent(svg)}")`;
         overlayElement.style.backgroundColor = "rgba(15, 23, 42, 0.65)";


### PR DESCRIPTION
## Summary
- ensure the tour overlay mask uses alpha transparency for spotlight cut-outs
- preserve the dimmed backdrop while revealing highlighted controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7ce03b82c8331843adab2bc0c8701