### PR TITLE
Fix relation config memo usage in transaction components

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -153,6 +153,11 @@ function InlineTransactionTable(
     return map;
   }, [relationConfigsKey, columnCaseMapKey]);
 
+  const relationConfigMapKey = React.useMemo(
+    () => JSON.stringify(relationConfigMap || {}),
+    [relationConfigMap],
+  );
+
   const displayIndex = React.useMemo(() => {
     const index = {};
     Object.entries(tableDisplayFields || {}).forEach(([tbl, cfg]) => {

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -171,6 +171,11 @@ const RowFormModal = function RowFormModal({
     return map;
   }, [relationConfigsKey, columnCaseMapKey]);
 
+  const relationConfigMapKey = React.useMemo(
+    () => JSON.stringify(relationConfigMap || {}),
+    [relationConfigMap],
+  );
+
   const displayIndex = React.useMemo(() => {
     const index = {};
     Object.entries(tableDisplayFields || {}).forEach(([tbl, cfg]) => {
@@ -258,10 +263,6 @@ const RowFormModal = function RowFormModal({
     if (match === undefined) return undefined;
     return rowObj[match];
   }, []);
-  const relationConfigMapKey = React.useMemo(
-    () => JSON.stringify(relationConfigMap || {}),
-    [relationConfigMap],
-  );
   const viewSourceMapKey = React.useMemo(
     () => JSON.stringify(viewSourceMap || {}),
     [viewSourceMap],


### PR DESCRIPTION
## Summary
- memoize the relation config map key in InlineTransactionTable so dependent hooks see stable identity
- move the relation config map key memo in RowFormModal so dependent hooks do not reference it before declaration

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68db5e6414448331bd0f4d128bc146f3