### PR TITLE
Handle hyphenated single-column row ids

### DIFF
--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -108,7 +108,7 @@ export async function getTableRow(req, res, next) {
       req.user?.companyId != null && hasCompanyId && !pkLower.includes('company_id');
     const flags = addCompanyFilter ? await getTenantTableFlags(table) : null;
 
-    const decodedParts = deserializeRowId(id);
+    const decodedParts = deserializeRowId(id, pkCols);
 
     if (pkCols.length === 1) {
       const col = pkCols[0];
@@ -359,7 +359,7 @@ export async function updateRow(req, res, next) {
     try {
       const pkCols = await getPrimaryKeyColumns(req.params.table);
       if (pkCols.length > 0) {
-        const parts = deserializeRowId(req.params.id);
+        const parts = deserializeRowId(req.params.id, pkCols);
         if (pkCols.some((_, index) => parts[index] === undefined)) {
           throw new Error('Row not found');
         }
@@ -437,7 +437,7 @@ export async function deleteRow(req, res, next) {
     try {
       const pkCols = await getPrimaryKeyColumns(table);
       if (pkCols.length > 0) {
-        const parts = deserializeRowId(id);
+        const parts = deserializeRowId(id, pkCols);
         if (pkCols.some((_, index) => parts[index] === undefined)) {
           throw new Error('Row not found');
         }

--- a/api-server/services/pendingRequest.js
+++ b/api-server/services/pendingRequest.js
@@ -65,7 +65,7 @@ export async function createRequest({
       if (pkCols.length === 1) {
         const col = pkCols[0];
         const where = col === 'id' ? 'id = ?' : `\`${col}\` = ?`;
-        const decoded = deserializeRowId(recordId);
+        const decoded = deserializeRowId(recordId, pkCols);
         const value = decoded[0] ?? recordId;
         const [r] = await conn.query(
           `SELECT * FROM ?? WHERE ${where} LIMIT 1`,
@@ -73,7 +73,7 @@ export async function createRequest({
         );
         currentRow = r[0] || null;
       } else if (pkCols.length > 1) {
-        const parts = deserializeRowId(recordId);
+        const parts = deserializeRowId(recordId, pkCols);
         if (pkCols.some((_, index) => parts[index] === undefined)) {
           currentRow = null;
         } else {
@@ -92,7 +92,7 @@ export async function createRequest({
       if (pkCols.length === 1) {
         const col = pkCols[0];
         const where = col === 'id' ? 'id = ?' : `\`${col}\` = ?`;
-        const decoded = deserializeRowId(recordId);
+        const decoded = deserializeRowId(recordId, pkCols);
         const value = decoded[0] ?? recordId;
         const [r] = await conn.query(
           `SELECT * FROM ?? WHERE ${where} LIMIT 1`,
@@ -100,7 +100,7 @@ export async function createRequest({
         );
         currentRow = r[0] || null;
       } else if (pkCols.length > 1) {
-        const parts = deserializeRowId(recordId);
+        const parts = deserializeRowId(recordId, pkCols);
         if (pkCols.some((_, index) => parts[index] === undefined)) {
           currentRow = null;
         } else {
@@ -262,7 +262,7 @@ export async function listRequests(filters) {
             if (pkCols.length === 1) {
               const col = pkCols[0];
               const whereClause = col === 'id' ? 'id = ?' : `\`${col}\` = ?`;
-              const decoded = deserializeRowId(row.record_id);
+              const decoded = deserializeRowId(row.record_id, pkCols);
               const value = decoded[0] ?? row.record_id;
               const [r] = await pool.query(
                 `SELECT * FROM ?? WHERE ${whereClause} LIMIT 1`,
@@ -270,7 +270,7 @@ export async function listRequests(filters) {
               );
               original = r[0] || null;
             } else if (pkCols.length > 1) {
-              const parts = deserializeRowId(row.record_id);
+              const parts = deserializeRowId(row.record_id, pkCols);
               if (pkCols.some((_, index) => parts[index] === undefined)) {
                 original = null;
               } else {

--- a/db/index.js
+++ b/db/index.js
@@ -4200,7 +4200,7 @@ export async function updateTableRow(
     return { [col]: id };
   }
 
-  const parts = deserializeRowId(id);
+  const parts = deserializeRowId(id, pkCols);
   let where = pkCols.map((c) => `\`${c}\` = ?`).join(' AND ');
   const whereParams = [...parts];
   if (addCompanyFilter) {
@@ -4328,7 +4328,7 @@ export async function deleteTableRow(
     return { [col]: id };
   }
 
-  const parts = deserializeRowId(id);
+  const parts = deserializeRowId(id, pkCols);
   let where = pkCols.map((c) => `\`${c}\` = ?`).join(' AND ');
   const whereParams = [...parts];
   if (addCompanyFilter) {
@@ -4389,7 +4389,7 @@ async function fetchTenantDefaultRow(tableName, rowId) {
     err.status = 400;
     throw err;
   }
-  const parts = deserializeRowId(rowId ?? '');
+  const parts = deserializeRowId(rowId ?? '', pkCols);
   if (parts.length !== pkCols.length || parts.some((part) => part === '')) {
     const err = new Error('Invalid row identifier');
     err.status = 400;
@@ -4490,7 +4490,7 @@ export async function deleteTenantDefaultRow(tableName, rowId, userId) {
 
 export async function listRowReferences(tableName, id, conn = pool) {
   const pkCols = await getPrimaryKeyColumns(tableName);
-  const parts = deserializeRowId(id);
+  const parts = deserializeRowId(id, pkCols);
   let targetRowLoaded = false;
   let targetRow;
 

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -102,9 +102,19 @@ function base64UrlEncode(value) {
   throw new Error('Unable to encode row id component');
 }
 
+const SIMPLE_ROW_ID = /^[A-Za-z0-9_]+$/;
+
 function serializeRowId(values) {
   if (!Array.isArray(values) || values.length === 0) return undefined;
-  if (values.length === 1) return values[0];
+  if (values.length === 1) {
+    const value = values[0];
+    if (value == null) return value;
+    const str = String(value);
+    if (str.startsWith(ROW_ID_PREFIX)) return str;
+    if (SIMPLE_ROW_ID.test(str)) return value;
+    const encoded = base64UrlEncode(str);
+    return `${ROW_ID_PREFIX}${encoded}`;
+  }
   const encodedParts = values.map((value) => base64UrlEncode(value));
   return `${ROW_ID_PREFIX}${encodedParts.join('.')}`;
 }


### PR DESCRIPTION
## Summary
- encode single-column row identifiers containing reserved delimiters using the existing base64 scheme so client links remain stable
- ensure deserializeRowId can decode the new format while preserving legacy single-column identifiers when splitting would lose data
- update server logic and controller tests to cover hyphenated primary keys and confirm edit flows hydrate the correct rows

## Testing
- node --test tests/controllers/tableController.test.js

------
https://chatgpt.com/codex/tasks/task_e_68db732cff408331b385c290aa8c8880