### PR TITLE
Restore dynamic transaction edit row behavior

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1140,79 +1140,32 @@ const TableManager = forwardRef(function TableManager({
     setShowForm(true);
   }
 
-  async function hydrateRowForEdit(row, id) {
-    const meta = await ensureColumnMeta();
-    let caseMap = columnCaseMap;
-    if ((!caseMap || Object.keys(caseMap).length === 0) && Array.isArray(meta)) {
-      caseMap = {};
-      meta.forEach((c) => {
-        if (c?.name) caseMap[c.name.toLowerCase()] = c.name;
-      });
-    }
-    const map = caseMap || {};
-    try {
-      const apiId = formatRowIdForApi(id);
-      const res = await fetch(
-        `/api/tables/${encodeURIComponent(table)}/${encodeURIComponent(apiId)}`,
-        { credentials: 'include' },
-      );
-      if (!res.ok) {
-        throw new Error(`Failed to load row: ${res.status}`);
-      }
-      const data = await res.json();
-      if (!data || typeof data !== 'object' || Array.isArray(data)) {
-        throw new Error('Invalid row response');
-      }
-      const normalized = {};
-      Object.entries(data).forEach(([key, value]) => {
-        if (typeof key !== 'string') return;
-        const mapped = map[key.toLowerCase()] || key;
-        normalized[mapped] = value;
-      });
-      return { ...row, ...normalized };
-    } catch (err) {
-      if (typeof window !== 'undefined' && window?.erpDebug) {
-        console.error('Failed to hydrate row for edit', err);
-      }
-      addToast(
-        t('failed_load_table_row', 'Failed to load table row'),
-        'error',
-      );
-      return null;
-    }
-  }
-
   async function openEdit(row) {
-    const id = getRowId(row);
-    if (id === undefined) {
+    if (getRowId(row) === undefined) {
       addToast(
         t('cannot_edit_without_pk', 'Cannot edit rows without a primary key'),
         'error',
       );
       return;
     }
-    const hydrated = await hydrateRowForEdit(row, id);
-    if (!hydrated) return;
-    setEditing(hydrated);
-    setGridRows([hydrated]);
+    await ensureColumnMeta();
+    setEditing(row);
+    setGridRows([row]);
     setIsAdding(false);
-    setRequestType(null);
     setShowForm(true);
   }
 
   async function openRequestEdit(row) {
-    const id = getRowId(row);
-    if (id === undefined) {
+    if (getRowId(row) === undefined) {
       addToast(
         t('cannot_edit_without_pk', 'Cannot edit rows without a primary key'),
         'error',
       );
       return;
     }
-    const hydrated = await hydrateRowForEdit(row, id);
-    if (!hydrated) return;
-    setEditing(hydrated);
-    setGridRows([hydrated]);
+    await ensureColumnMeta();
+    setEditing(row);
+    setGridRows([row]);
     setIsAdding(false);
     setRequestType('edit');
     setShowForm(true);


### PR DESCRIPTION
## Summary
- restore the dynamic transaction edit row handler to the version from 5f858cb160c0e0200d99ebc49e3fcaefee9ab8e4 so edits no longer re-fetch rows

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68db8e98c2948331aeb975e8d8b4299a