### PR TITLE
Restore transaction forms all mode payload

### DIFF
--- a/api-server/routes/transaction_forms.js
+++ b/api-server/routes/transaction_forms.js
@@ -3,6 +3,7 @@ import {
   getFormConfig,
   getConfigsByTable,
   listTransactionNames,
+  listAllTransactionConfigs,
   setFormConfig,
   deleteFormConfig,
   findTableByProcedure,
@@ -14,11 +15,15 @@ const router = express.Router();
 router.get('/', requireAuth, async (req, res, next) => {
   try {
     const companyId = Number(req.query.companyId ?? req.user.companyId);
-    const { table, name, moduleKey, branchId, departmentId, proc } = req.query;
+    const { table, name, moduleKey, branchId, departmentId, proc, mode } =
+      req.query;
     if (proc) {
       const { table: tbl, isDefault } = await findTableByProcedure(proc, companyId);
       if (tbl) res.json({ table: tbl, isDefault });
       else res.status(404).json({ message: 'Table not found', isDefault });
+    } else if (mode === 'all') {
+      const { tables, isDefault } = await listAllTransactionConfigs(companyId);
+      res.json({ tables, isDefault });
     } else if (table && name) {
       const { config, isDefault } = await getFormConfig(table, name, companyId);
       res.json({ ...config, isDefault });

--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -2,18 +2,18 @@ import fs from 'fs/promises';
 import path from 'path';
 import { tenantConfigPath, getConfigPath } from '../utils/configPaths.js';
 
-  async function readConfig(companyId = 0) {
-    const { path: filePath, isDefault } = await getConfigPath(
-      'transactionForms.json',
-      companyId,
-    );
-    try {
-      const data = await fs.readFile(filePath, 'utf8');
-      return { cfg: JSON.parse(data), isDefault };
-    } catch {
-      return { cfg: {}, isDefault: true };
-    }
+async function readConfig(companyId = 0) {
+  const { path: filePath, isDefault } = await getConfigPath(
+    'transactionForms.json',
+    companyId,
+  );
+  try {
+    const data = await fs.readFile(filePath, 'utf8');
+    return { cfg: JSON.parse(data), isDefault };
+  } catch {
+    return { cfg: {}, isDefault: true };
   }
+}
 
 async function writeConfig(cfg, companyId = 0) {
   const filePath = tenantConfigPath('transactionForms.json', companyId);
@@ -159,6 +159,20 @@ export async function listTransactionNames(
     }
   }
   return { names: result, isDefault };
+}
+
+export async function listAllTransactionConfigs(companyId = 0) {
+  const { cfg, isDefault } = await readConfig(companyId);
+  const tables = {};
+  for (const [table, names] of Object.entries(cfg)) {
+    if (!names || typeof names !== 'object') continue;
+    const parsed = {};
+    for (const [name, info] of Object.entries(names)) {
+      parsed[name] = { ...parseEntry(info), table, name };
+    }
+    tables[table] = parsed;
+  }
+  return { tables, isDefault };
 }
 
 export async function setFormConfig(

--- a/docs/transaction-form-config.md
+++ b/docs/transaction-form-config.md
@@ -93,8 +93,10 @@ Example snippet:
 Clients can retrieve a list of transaction names via `/api/transaction_forms`.
 Each entry includes the underlying table, `moduleKey` slug and the full
 configuration parsed from the file.  This allows the front‑end to populate
-forms without issuing additional requests or duplicating any parsing logic.
-To obtain a configuration for a specific transaction use
+forms without issuing additional requests or duplicating any parsing logic. Use
+`/api/transaction_forms?mode=all` to receive the complete configuration grouped
+by table, with each form containing its parsed fields alongside the table and
+form name metadata.  To obtain a configuration for a specific transaction use
 `/api/transaction_forms?table=tbl&name=transaction`. New configurations are
 posted with `{ table, name, config }` in the request body and can be removed via
 `DELETE /api/transaction_forms?table=tbl&name=transaction`.

--- a/src/erp.mgt.mn/pages/UserManualExport.jsx
+++ b/src/erp.mgt.mn/pages/UserManualExport.jsx
@@ -25,14 +25,34 @@ export default function UserManualExport() {
   useEffect(() => {
     async function loadFormDescs() {
       try {
-        const res = await fetch('/api/transaction_forms', {
+        const res = await fetch('/api/transaction_forms?mode=all', {
           credentials: 'include',
         });
         if (!res.ok) return;
-        const txForms = await res.json();
+        const apiData = await res.json().catch(() => null);
+        if (!apiData || typeof apiData !== 'object') return;
+        let txForms = apiData.tables || apiData.config || null;
+        if (!txForms) {
+          const { isDefault: _unused, ...rest } = apiData;
+          const grouped = {};
+          let groupedCount = 0;
+          Object.entries(rest || {}).forEach(([key, value]) => {
+            if (!value || typeof value !== 'object') return;
+            const tbl = value.table;
+            if (!tbl) return;
+            if (!grouped[tbl]) grouped[tbl] = {};
+            grouped[tbl][key] = value;
+            groupedCount += 1;
+          });
+          txForms = groupedCount > 0 ? grouped : rest;
+        }
         const bMap = {}, rMap = {}, reqMap = {};
         Object.values(txForms || {}).forEach((forms) => {
-          Object.entries(forms || {}).forEach(([_, cfg]) => {
+          const entries = Array.isArray(forms)
+            ? forms.map((f) => [typeof f === 'string' ? f : f.key, f])
+            : Object.entries(forms || {});
+          entries.forEach(([, cfg]) => {
+            if (!cfg || typeof cfg !== 'object') return;
             if (Array.isArray(cfg.buttons)) {
               cfg.buttons.forEach((b) => {
                 const bKey = typeof b === 'string' ? b : b.key;
@@ -298,10 +318,29 @@ export default function UserManualExport() {
 
         let tfData;
         try {
-          const tfRes = await fetch("/api/transaction_forms", {
+          const tfRes = await fetch("/api/transaction_forms?mode=all", {
             credentials: "include",
           });
-          if (tfRes.ok) tfData = await tfRes.json();
+          if (tfRes.ok) {
+            const apiData = await tfRes.json().catch(() => null);
+            if (apiData && typeof apiData === "object") {
+              tfData = apiData.tables || apiData.config || null;
+              if (!tfData) {
+                const { isDefault: _unused, ...rest } = apiData;
+                const grouped = {};
+                let groupedCount = 0;
+                Object.entries(rest || {}).forEach(([key, value]) => {
+                  if (!value || typeof value !== "object") return;
+                  const tbl = value.table;
+                  if (!tbl) return;
+                  if (!grouped[tbl]) grouped[tbl] = {};
+                  grouped[tbl][key] = value;
+                  groupedCount += 1;
+                });
+                tfData = groupedCount > 0 ? grouped : rest;
+              }
+            }
+          }
         } catch (e) {
           // ignore, will fall back to local config
         }


### PR DESCRIPTION
## Summary
- include table/name metadata when exporting all transaction form configs and return it directly from the API
- update the user manual export to consume the grouped all-mode payload while retaining legacy fallbacks for old responses
- document the /api/transaction_forms?mode=all option for retrieving the entire configuration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db91de96548331a2b11a6372af7dc5