### PR TITLE
Fix toast context usage order in TableManager

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -169,6 +169,11 @@ const TableManager = forwardRef(function TableManager({
   const [selectedRows, setSelectedRows] = useState(new Set());
   const [localRefresh, setLocalRefresh] = useState(0);
   const [procTriggers, setProcTriggers] = useState({});
+  const { user, company, branch, department, session } = useContext(AuthContext);
+  const generalConfig = useGeneralConfig();
+  const { addToast } = useToast();
+  const isSubordinate = Boolean(session?.senior_empid);
+  const canRequestStatus = isSubordinate;
   const columnCaseMap = useMemo(() => {
     const map = {};
     columnMeta.forEach((c) => {
@@ -353,11 +358,6 @@ const TableManager = forwardRef(function TableManager({
     () => Array.from(requestIdSet).sort().join(','),
     [requestIdSet],
   );
-  const { user, company, branch, department, session } = useContext(AuthContext);
-  const isSubordinate = Boolean(session?.senior_empid);
-  const generalConfig = useGeneralConfig();
-  const { addToast } = useToast();
-  const canRequestStatus = isSubordinate;
 
   function promptRequestReason() {
     return new Promise((resolve) => {


### PR DESCRIPTION
## Summary
- move the toast and authentication context hooks ahead of callbacks in TableManager
- ensure TableManager no longer references addToast (or related context values) before they are initialized, preventing runtime errors when loading finance transactions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dba59cc74083319132313ff22ef730