### PR TITLE
Add table row retrieval endpoint

### DIFF
--- a/api-server/routes/tables.js
+++ b/api-server/routes/tables.js
@@ -12,6 +12,7 @@ import {
   addRow,
   deleteRow,
   getRowReferences,
+  getTableRow,
 } from '../controllers/tableController.js';
 import { requireAuth } from '../middlewares/auth.js';
 
@@ -34,6 +35,7 @@ router.get('/:table/relations', requireAuth, getTableRelations);
 router.get('/:table/columns', requireAuth, getTableColumnsMeta);
 router.put('/:table/labels', requireAuth, saveColumnLabels);
 router.get('/:table/:id/references', requireAuth, getRowReferences);
+router.get('/:table/:id', requireAuth, getTableRow);
 router.put('/:table/:id', requireAuth, updateRow);
 router.delete('/:table/:id', requireAuth, deleteRow);
 router.post('/:table', requireAuth, addRow);


### PR DESCRIPTION
## Summary
- add a database helper that fetches a table row by its primary key while respecting tenant filters and soft-delete scoping
- expose a new GET /api/tables/:table/:id handler that calls the helper and return 404s when rows are missing
- register the route and cover success and not-found behaviors with controller tests

## Testing
- npm test -- tests/controllers/tableController.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc8d2251588331b92f65c36d580dd6