### PR TITLE
Fix relation config memo dependencies

### DIFF
--- a/src/erp.mgt.mn/components/InlineTransactionTable.jsx
+++ b/src/erp.mgt.mn/components/InlineTransactionTable.jsx
@@ -152,6 +152,10 @@ function InlineTransactionTable(
     });
     return map;
   }, [relationConfigsKey, columnCaseMapKey]);
+  const relationConfigMapKey = React.useMemo(
+    () => JSON.stringify(relationConfigMap || {}),
+    [relationConfigMap],
+  );
 
   const displayIndex = React.useMemo(() => {
     const index = {};

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -170,6 +170,10 @@ const RowFormModal = function RowFormModal({
     });
     return map;
   }, [relationConfigsKey, columnCaseMapKey]);
+  const relationConfigMapKey = React.useMemo(
+    () => JSON.stringify(relationConfigMap || {}),
+    [relationConfigMap],
+  );
 
   const displayIndex = React.useMemo(() => {
     const index = {};
@@ -293,10 +297,6 @@ const RowFormModal = function RowFormModal({
     if (match === undefined) return undefined;
     return rowObj[match];
   }, []);
-  const relationConfigMapKey = React.useMemo(
-    () => JSON.stringify(relationConfigMap || {}),
-    [relationConfigMap],
-  );
   const viewSourceMapKey = React.useMemo(
     () => JSON.stringify(viewSourceMap || {}),
     [viewSourceMap],


### PR DESCRIPTION
## Summary
- memoize the serialized relation config map in InlineTransactionTable before dependent hooks run
- move the relation config map key memo in RowFormModal so dependent hooks no longer reference it before initialization

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc94bf7eb88331bb909b41824723f6