### PR TITLE
Add primary key ordinal metadata and composite key handling tests

### DIFF
--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -309,7 +309,14 @@ export async function deleteCustomTableRelation(req, res, next) {
 export async function getTableColumnsMeta(req, res, next) {
   try {
     const cols = await listTableColumnMeta(req.params.table);
-    res.json(cols);
+    const normalized = cols.map((col) => ({
+      ...col,
+      primaryKeyOrdinal:
+        col.primaryKeyOrdinal != null && Number.isFinite(Number(col.primaryKeyOrdinal))
+          ? Number(col.primaryKeyOrdinal)
+          : null,
+    }));
+    res.json(normalized);
   } catch (err) {
     next(err);
   }

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1012,9 +1012,25 @@ const TableManager = forwardRef(function TableManager({
   }
 
   function getKeyFields() {
-    const keys = columnMeta
+    const keyedColumns = columnMeta
       .filter((c) => c.key === 'PRI')
-      .map((c) => c.name);
+      .map((column, index) => {
+        const rawOrdinal = column?.primaryKeyOrdinal;
+        const numericOrdinal =
+          rawOrdinal != null && Number.isFinite(Number(rawOrdinal))
+            ? Number(rawOrdinal)
+            : null;
+        return { column, index, ordinal: numericOrdinal };
+      });
+    const keys = keyedColumns
+      .sort((a, b) => {
+        if (a.ordinal != null && b.ordinal != null) {
+          if (a.ordinal === b.ordinal) return a.index - b.index;
+          return a.ordinal - b.ordinal;
+        }
+        return a.index - b.index;
+      })
+      .map(({ column }) => column.name);
     let result = keys;
     if (result.length === 0) {
       if (columnMeta.some((c) => c.name === 'id')) result = ['id'];

--- a/tests/components/tableManagerEditHydration.test.js
+++ b/tests/components/tableManagerEditHydration.test.js
@@ -462,4 +462,180 @@ if (!haveReact) {
       dom.window.close();
     }
   });
+
+  test('TableManager handles composite PK ordinals and dashes when editing', async (t) => {
+    const prevWindow = global.window;
+    const prevDocument = global.document;
+    const prevNavigator = global.navigator;
+
+    const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+      url: 'http://localhost',
+    });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.navigator = dom.window.navigator;
+    dom.window.confirm = () => true;
+    dom.window.scrollTo = () => {};
+
+    const toasts = [];
+    const modalProps = [];
+    const detailCalls = [];
+    const invalidDetailCalls = [];
+
+    const origFetch = global.fetch;
+    global.fetch = async (input) => {
+      const url = typeof input === 'string' ? input : input?.url || '';
+      if (url === '/api/tables/test/columns') {
+        return {
+          ok: true,
+          json: async () => [
+            { name: 'order_code', key: 'PRI', primaryKeyOrdinal: 2 },
+            { name: 'region', key: 'PRI', primaryKeyOrdinal: 1 },
+            { name: 'description' },
+          ],
+        };
+      }
+      if (url === '/api/tables/test/relations') {
+        return { ok: true, json: async () => [] };
+      }
+      if (url.startsWith('/api/display_fields?')) {
+        return { ok: true, json: async () => ({ displayFields: [] }) };
+      }
+      if (url.startsWith('/api/proc_triggers')) {
+        return { ok: true, json: async () => [] };
+      }
+      if (url === '/api/tenant_tables/test') {
+        return { ok: true, json: async () => ({ is_shared: 1 }) };
+      }
+      if (url.startsWith('/api/tables/test?')) {
+        return {
+          ok: true,
+          json: async () => ({
+            rows: [
+              {
+                order_code: 'ABC-123',
+                region: 'MN',
+                description: 'Row 1',
+              },
+            ],
+            count: 1,
+          }),
+        };
+      }
+      if (url === '/api/tables/test/MN-ABC-123') {
+        detailCalls.push(url);
+        return {
+          ok: true,
+          json: async () => ({
+            order_code: 'ABC-123',
+            region: 'MN',
+            description: 'Detail row',
+          }),
+        };
+      }
+      if (url.startsWith('/api/tables/test/')) {
+        invalidDetailCalls.push(url);
+        return { ok: false, json: async () => ({}) };
+      }
+      return { ok: true, json: async () => ({}) };
+    };
+
+    const RowFormModalStub = (props) => {
+      modalProps.push({ ...props });
+      return null;
+    };
+
+    const { default: TableManager } = await t.mock.import(
+      '../../src/erp.mgt.mn/components/TableManager.jsx',
+      {
+        '../context/AuthContext.jsx': {
+          AuthContext: React.createContext({ company: 1, session: {} }),
+        },
+        '../context/ToastContext.jsx': {
+          useToast: () => ({
+            addToast: (...args) => {
+              toasts.push(args);
+            },
+          }),
+        },
+        './RowFormModal.jsx': { default: RowFormModalStub },
+        './CascadeDeleteModal.jsx': { default: () => null },
+        './RowDetailModal.jsx': { default: () => null },
+        './RowImageViewModal.jsx': { default: () => null },
+        './RowImageUploadModal.jsx': { default: () => null },
+        './ImageSearchModal.jsx': { default: () => null },
+        './Modal.jsx': { default: () => null },
+        './CustomDatePicker.jsx': { default: () => null },
+        '../hooks/useGeneralConfig.js': { default: () => ({}) },
+        '../utils/formatTimestamp.js': { default: () => '2024-01-01 00:00:00' },
+        '../utils/buildImageName.js': { default: () => ({}) },
+        '../utils/slugify.js': { default: () => '' },
+        '../utils/apiBase.js': { API_BASE: '' },
+        '../utils/normalizeDateInput.js': { default: (v) => v },
+      },
+    );
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          React.createElement(TableManager, {
+            table: 'test',
+            buttonPerms: { 'Edit transaction': true },
+          }),
+        );
+      });
+
+      for (let i = 0; i < 10; i += 1) {
+        if (container.querySelectorAll('button').length > 0) break;
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+
+      const editButton = Array.from(container.querySelectorAll('button')).find((btn) =>
+        (btn.textContent || '').includes('Edit'),
+      );
+      assert.ok(editButton, 'expected edit button to be rendered');
+
+      await act(async () => {
+        editButton.dispatchEvent(
+          new dom.window.MouseEvent('click', { bubbles: true, cancelable: true }),
+        );
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      for (let i = 0; i < 10; i += 1) {
+        const last = modalProps.at(-1);
+        if (last?.visible) break;
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+
+      const lastProps = modalProps.at(-1);
+      assert.ok(lastProps?.visible, 'expected modal to be visible');
+      assert.equal(lastProps.row?.order_code, 'ABC-123');
+      assert.equal(lastProps.rows?.[0]?.region, 'MN');
+      const errorToasts = toasts.filter(([, type]) => type === 'error');
+      assert.equal(errorToasts.length, 0, 'expected no error toasts');
+      assert.deepEqual(invalidDetailCalls, [], 'expected only sorted detail fetches');
+      assert.ok(
+        detailCalls.includes('/api/tables/test/MN-ABC-123'),
+        'expected detail fetch for encoded composite id',
+      );
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+
+      global.fetch = origFetch;
+      global.window = prevWindow;
+      global.document = prevDocument;
+      global.navigator = prevNavigator;
+      dom.window.close();
+    }
+  });
 }

--- a/tests/db/columnMeta.test.js
+++ b/tests/db/columnMeta.test.js
@@ -19,7 +19,15 @@ test('listTableColumnMeta uses header mappings when DB labels missing', async ()
   await fs.writeFile(filePath, JSON.stringify({ title: 'гарчиг' }));
   const restore = mockPool(async (sql) => {
     if (sql.includes('information_schema.COLUMNS')) {
-      return [[{ COLUMN_NAME: 'title', COLUMN_KEY: '', EXTRA: '' }]];
+      return [[
+        {
+          COLUMN_NAME: 'title',
+          COLUMN_KEY: '',
+          EXTRA: '',
+          PRIMARY_KEY_ORDINAL: null,
+          GENERATION_EXPRESSION: null,
+        },
+      ]];
     }
     if (sql.includes('table_column_labels')) {
       return [[]];
@@ -30,6 +38,60 @@ test('listTableColumnMeta uses header mappings when DB labels missing', async ()
   restore();
   await fs.writeFile(filePath, origContent);
   assert.deepEqual(meta, [
-    { name: 'title', key: '', extra: '', label: 'гарчиг', generationExpression: null },
+    {
+      name: 'title',
+      key: '',
+      extra: '',
+      label: 'гарчиг',
+      generationExpression: null,
+      primaryKeyOrdinal: null,
+    },
+  ]);
+});
+
+test('listTableColumnMeta includes primary key ordinal when available', async () => {
+  const restore = mockPool(async (sql) => {
+    if (sql.includes('information_schema.COLUMNS')) {
+      return [[
+        {
+          COLUMN_NAME: 'id',
+          COLUMN_KEY: 'PRI',
+          EXTRA: 'auto_increment',
+          PRIMARY_KEY_ORDINAL: 2,
+          GENERATION_EXPRESSION: null,
+        },
+        {
+          COLUMN_NAME: 'tenant_id',
+          COLUMN_KEY: 'PRI',
+          EXTRA: '',
+          PRIMARY_KEY_ORDINAL: '1',
+          GENERATION_EXPRESSION: null,
+        },
+      ]];
+    }
+    if (sql.includes('table_column_labels')) {
+      return [[]];
+    }
+    return [[]];
+  });
+  const meta = await db.listTableColumnMeta('tenants');
+  restore();
+  assert.deepEqual(meta, [
+    {
+      name: 'id',
+      key: 'PRI',
+      extra: 'auto_increment',
+      label: 'Нэгдсэн дугаар',
+      generationExpression: null,
+      primaryKeyOrdinal: 2,
+    },
+    {
+      name: 'tenant_id',
+      key: 'PRI',
+      extra: '',
+      label: 'tenant_id',
+      generationExpression: null,
+      primaryKeyOrdinal: 1,
+    },
   ]);
 });


### PR DESCRIPTION
## Summary
- include primary-key ordinal information when reading table column metadata and surface it through the table columns API
- sort TableManager primary-key fields by the ordinal to produce stable composite identifiers
- extend unit tests to cover the new metadata and confirm editing works with dashed composite keys

## Testing
- npm test -- tests/db/columnMeta.test.js tests/controllers/tableController.test.js tests/components/tableManagerEditHydration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc9a8ca2788331997ae914b43390e6