### PR TITLE
Handle JSON-encoded composite row ids

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -959,8 +959,15 @@ const TableManager = forwardRef(function TableManager({
   function getRowId(row) {
     const keys = getKeyFields();
     if (keys.length === 0) return undefined;
-    const idVal = keys.length === 1 ? row[keys[0]] : keys.map((k) => row[k]).join('-');
-    return idVal;
+    if (keys.length === 1) {
+      return row[keys[0]];
+    }
+    try {
+      return JSON.stringify(keys.map((k) => row[k]));
+    } catch (err) {
+      console.error('Failed to build composite row id', err);
+      return keys.map((k) => row[k]).join('-');
+    }
   }
 
   function getImageFolder(row) {


### PR DESCRIPTION
## Summary
- serialize composite primary keys in the table manager with JSON to avoid delimiter collisions
- decode JSON-encoded composite identifiers in database helpers while retaining the legacy hyphen fallback
- add controller API tests that exercise GET/PUT/DELETE flows with composite key values containing hyphens and dates

## Testing
- node --test tests/controllers/tableController.test.js
- npm test *(fails: existing seedTenantTables suite expects different mocked queries)*

------
https://chatgpt.com/codex/tasks/task_e_68dca957ee2c833185355d5d569ad165