### PR TITLE
Normalize edit payload keys before merging rows

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1201,7 +1201,24 @@ const TableManager = forwardRef(function TableManager({
       return;
     }
 
-    const mergedRow = { ...row, ...record };
+    const normalizeToCanonical = (source) => {
+      if (!source || typeof source !== 'object') return {};
+      const normalized = {};
+      for (const [rawKey, value] of Object.entries(source)) {
+        const canonicalKey =
+          columnCaseMap[String(rawKey).toLowerCase()] ?? rawKey;
+        normalized[canonicalKey] = value;
+      }
+      return normalized;
+    };
+
+    const normalizedRow = normalizeToCanonical(row);
+    const normalizedRecord = normalizeToCanonical(record);
+    const mergedRow = { ...normalizedRow };
+    for (const [key, value] of Object.entries(normalizedRecord)) {
+      mergedRow[key] = value;
+    }
+
     setEditing(mergedRow);
     setGridRows([mergedRow]);
     setIsAdding(false);


### PR DESCRIPTION
## Summary
- normalize edit payloads through the column case map before merging with existing rows
- ensure the normalized row is stored in editing state and grid rows so downstream consumers receive canonical keys

## Testing
- node --test tests/components/tableManagerEditHydration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68df7ca7d8c48331b514445934f6eb67