### PR TITLE
Expose candidate key metadata for table columns

### DIFF
--- a/tests/controllers/tableController.test.js
+++ b/tests/controllers/tableController.test.js
@@ -57,6 +57,12 @@ test('getTableColumnsMeta returns metadata with primary key ordinals', async () 
         },
       ]];
     }
+    if (text.includes("INDEX_NAME = 'PRIMARY'")) {
+      return [[
+        { COLUMN_NAME: 'code', SEQ_IN_INDEX: 1 },
+        { COLUMN_NAME: 'tenant_id', SEQ_IN_INDEX: 2 },
+      ]];
+    }
     if (text.includes('table_column_labels')) {
       return [[]];
     }
@@ -83,6 +89,7 @@ test('getTableColumnsMeta returns metadata with primary key ordinals', async () 
       label: 'tenant_id',
       generationExpression: null,
       primaryKeyOrdinal: 2,
+      candidateKeyOrdinal: 2,
     },
     {
       name: 'code',
@@ -91,6 +98,7 @@ test('getTableColumnsMeta returns metadata with primary key ordinals', async () 
       label: 'code',
       generationExpression: null,
       primaryKeyOrdinal: 1,
+      candidateKeyOrdinal: 1,
     },
     {
       name: 'description',
@@ -99,6 +107,7 @@ test('getTableColumnsMeta returns metadata with primary key ordinals', async () 
       label: 'Тайлбар',
       generationExpression: null,
       primaryKeyOrdinal: null,
+      candidateKeyOrdinal: null,
     },
   ]);
 });


### PR DESCRIPTION
## Summary
- surface candidate key ordinals from getPrimaryKeyColumns in the table columns metadata response
- teach TableManager to consume candidate key ordinals before falling back to legacy heuristics
- cover the new metadata flow with controller and UI tests, including unique-index backed editing

## Testing
- node --test tests/controllers/tableController.test.js tests/components/tableManagerEditHydration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dfb22730248331becd421c23af8d8c