### PR TITLE
Align code_chiglel identifier schema with unique constraint

### DIFF
--- a/db/mgtmn_erp_db.sql
+++ b/db/mgtmn_erp_db.sql
@@ -4268,7 +4268,8 @@ ALTER TABLE `code_cashier`
 -- Indexes for table `code_chiglel`
 --
 ALTER TABLE `code_chiglel`
-  ADD PRIMARY KEY (`id`);
+  ADD PRIMARY KEY (`id`),
+  ADD UNIQUE KEY `uniq_company_chig_id` (`company_id`,`chig_id`);
 
 --
 -- Indexes for table `code_department`

--- a/db/migrations/2025-10-30_code_identifier_columns.sql
+++ b/db/migrations/2025-10-30_code_identifier_columns.sql
@@ -1,12 +1,5 @@
--- Add identifier columns for hierarchical code tables
+-- Ensure code_chiglel identifiers use integer values and enforced uniqueness
 ALTER TABLE `code_chiglel`
-  ADD COLUMN `chig_id` varchar(50) DEFAULT NULL AFTER `id`,
+  MODIFY COLUMN `chig_id` int NOT NULL,
+  DROP INDEX `uniq_company_chig_id`,
   ADD UNIQUE KEY `uniq_company_chig_id` (`company_id`, `chig_id`);
-
-ALTER TABLE `code_torol`
-  ADD COLUMN `torol_id` varchar(50) DEFAULT NULL AFTER `id`,
-  ADD UNIQUE KEY `uniq_company_torol_id` (`company_id`, `torol_id`);
-
-ALTER TABLE `code_huvaari`
-  ADD COLUMN `baitsaagch_id` varchar(50) DEFAULT NULL AFTER `position_id`,
-  ADD UNIQUE KEY `uniq_company_baitsaagch_id` (`company_id`, `baitsaagch_id`);

--- a/db/migrations/archive/2025-10-30_code_identifier_columns.sql
+++ b/db/migrations/archive/2025-10-30_code_identifier_columns.sql
@@ -1,0 +1,12 @@
+-- Add identifier columns for hierarchical code tables
+ALTER TABLE `code_chiglel`
+  ADD COLUMN `chig_id` varchar(50) DEFAULT NULL AFTER `id`,
+  ADD UNIQUE KEY `uniq_company_chig_id` (`company_id`, `chig_id`);
+
+ALTER TABLE `code_torol`
+  ADD COLUMN `torol_id` varchar(50) DEFAULT NULL AFTER `id`,
+  ADD UNIQUE KEY `uniq_company_torol_id` (`company_id`, `torol_id`);
+
+ALTER TABLE `code_huvaari`
+  ADD COLUMN `baitsaagch_id` varchar(50) DEFAULT NULL AFTER `position_id`,
+  ADD UNIQUE KEY `uniq_company_baitsaagch_id` (`company_id`, `baitsaagch_id`);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -110,7 +110,7 @@ CREATE TABLE `code_cashier` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 CREATE TABLE `code_chiglel` (
   `id` int NOT NULL,
-  `chig_id` varchar(50) DEFAULT NULL,
+  `chig_id` int NOT NULL,
   `name` varchar(100) NOT NULL,
   `company_id` int NOT NULL DEFAULT '0',
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
## Summary
- add the `(company_id, chig_id)` unique key to the production dump so it mirrors the schema
- update the baseline schema to define `chig_id` as an integer column with the same key
- archive the original identifier migration and replace it with one that enforces the integer column and unique key

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfc39bdbf48331acd18859810c72ee