### PR TITLE
Align code_huvaari identifier with huvaari_id

### DIFF
--- a/db/mgtmn_erp_db.sql
+++ b/db/mgtmn_erp_db.sql
@@ -4337,6 +4337,7 @@ ALTER TABLE `code_frequency`
 --
 ALTER TABLE `code_huvaari`
   ADD PRIMARY KEY (`id`),
+  ADD UNIQUE KEY `uniq_company_huvaari_id` (`company_id`,`huvaari_id`),
   ADD KEY `position_id` (`position_id`);
 
 --

--- a/db/migrations/2025-10-30_code_identifier_columns.sql
+++ b/db/migrations/2025-10-30_code_identifier_columns.sql
@@ -1,12 +1,40 @@
--- Add identifier columns for hierarchical code tables
+-- Standardize identifier columns for hierarchical code tables
 ALTER TABLE `code_chiglel`
-  ADD COLUMN `chig_id` varchar(50) DEFAULT NULL AFTER `id`,
+  ADD COLUMN IF NOT EXISTS `chig_id` varchar(50) DEFAULT NULL AFTER `id`;
+
+DROP INDEX IF EXISTS `uniq_company_chig_id` ON `code_chiglel`;
+ALTER TABLE `code_chiglel`
   ADD UNIQUE KEY `uniq_company_chig_id` (`company_id`, `chig_id`);
 
 ALTER TABLE `code_torol`
-  ADD COLUMN `torol_id` varchar(50) DEFAULT NULL AFTER `id`,
+  ADD COLUMN IF NOT EXISTS `torol_id` varchar(50) DEFAULT NULL AFTER `id`;
+
+DROP INDEX IF EXISTS `uniq_company_torol_id` ON `code_torol`;
+ALTER TABLE `code_torol`
   ADD UNIQUE KEY `uniq_company_torol_id` (`company_id`, `torol_id`);
 
+SET @huvaari_has_baitsaagch := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'code_huvaari'
+    AND COLUMN_NAME = 'baitsaagch_id'
+);
+
+SET @huvaari_stmt := IF(
+  @huvaari_has_baitsaagch > 0,
+  'ALTER TABLE `code_huvaari` CHANGE COLUMN `baitsaagch_id` `huvaari_id` INT NOT NULL AFTER `id`',
+  'ALTER TABLE `code_huvaari` ADD COLUMN IF NOT EXISTS `huvaari_id` INT NOT NULL AFTER `id`'
+);
+
+PREPARE stmt FROM @huvaari_stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
 ALTER TABLE `code_huvaari`
-  ADD COLUMN `baitsaagch_id` varchar(50) DEFAULT NULL AFTER `position_id`,
-  ADD UNIQUE KEY `uniq_company_baitsaagch_id` (`company_id`, `baitsaagch_id`);
+  MODIFY COLUMN `huvaari_id` INT NOT NULL AFTER `id`;
+
+DROP INDEX IF EXISTS `uniq_company_baitsaagch_id` ON `code_huvaari`;
+DROP INDEX IF EXISTS `uniq_company_huvaari_id` ON `code_huvaari`;
+ALTER TABLE `code_huvaari`
+  ADD UNIQUE KEY `uniq_company_huvaari_id` (`company_id`, `huvaari_id`);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -259,8 +259,8 @@ CREATE TABLE `code_frequency` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 CREATE TABLE `code_huvaari` (
   `id` int NOT NULL,
+  `huvaari_id` int NOT NULL,
   `position_id` int NOT NULL,
-  `baitsaagch_id` varchar(50) DEFAULT NULL,
   `name` varchar(100) NOT NULL,
   `company_id` int NOT NULL DEFAULT '0',
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -2263,7 +2263,7 @@ ALTER TABLE `code_frequency`
   ADD PRIMARY KEY (`company_id`, `id`);
 ALTER TABLE `code_huvaari`
   ADD PRIMARY KEY (`company_id`, `id`),
-  ADD UNIQUE KEY `uniq_company_baitsaagch_id` (`company_id`, `baitsaagch_id`),
+  ADD UNIQUE KEY `uniq_company_huvaari_id` (`company_id`, `huvaari_id`),
   ADD KEY `position_id` (`company_id`, `position_id`);
 ALTER TABLE `code_incometype`
   ADD PRIMARY KEY (`company_id`, `id`);


### PR DESCRIPTION
## Summary
- adopt `huvaari_id` as the canonical identifier for `code_huvaari` in both the production dump and baseline schema, including the tenant-scoped unique key
- update the identifier migration to create or convert the column to `huvaari_id` and rebuild the supporting unique indexes safely

## Testing
- not run (SQL-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dfc40612bc833182b1a687e2e6ebae