### PR TITLE
Improve TableManager metadata normalization

### DIFF
--- a/tests/components/tableManagerEditHydration.test.js
+++ b/tests/components/tableManagerEditHydration.test.js
@@ -741,6 +741,216 @@ if (!haveReact) {
     }
   });
 
+  test(
+    'TableManager applies freshly fetched metadata when deriving tenant params',
+    async (t) => {
+      const prevWindow = global.window;
+      const prevDocument = global.document;
+      const prevNavigator = global.navigator;
+
+      const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+        url: 'http://localhost',
+      });
+      global.window = dom.window;
+      global.document = dom.window.document;
+      global.navigator = dom.window.navigator;
+      dom.window.confirm = () => true;
+      dom.window.scrollTo = () => {};
+
+      const toasts = [];
+      const modalProps = [];
+      const detailCalls = [];
+
+      const origFetch = global.fetch;
+      const fetchCalls = [];
+      global.fetch = async (input, init) => {
+        const url = typeof input === 'string' ? input : input?.url || '';
+        fetchCalls.push(url);
+        if (url === '/api/tables/test/columns') {
+          return {
+            ok: true,
+            json: async () => [
+              { name: 'ID', key: 'PRI' },
+              { name: 'CompanyID' },
+              { name: 'BranchID' },
+              { name: 'DepartmentID' },
+              { name: 'SecretValue' },
+            ],
+          };
+        }
+        if (url === '/api/tables/test/relations') {
+          return { ok: true, json: async () => [] };
+        }
+        if (url.startsWith('/api/display_fields?')) {
+          return { ok: true, json: async () => ({ displayFields: [] }) };
+        }
+        if (url.startsWith('/api/proc_triggers')) {
+          return { ok: true, json: async () => [] };
+        }
+        if (url === '/api/tenant_tables/test') {
+          return {
+            ok: true,
+            json: async () => ({ tenantKeys: ['company_id', 'branch_id', 'department_id'] }),
+          };
+        }
+        if (url.startsWith('/api/tables/test?')) {
+          return {
+            ok: true,
+            json: async () => ({
+              rows: [
+                {
+                  ID: 1,
+                  CompanyID: 77,
+                  BranchID: 66,
+                  DepartmentID: 55,
+                  SecretValue: 'grid-secret',
+                },
+              ],
+              count: 1,
+            }),
+          };
+        }
+        if (url.startsWith('/api/tables/test/1')) {
+          detailCalls.push(url);
+          return {
+            ok: true,
+            json: async () => ({
+              ID: 1,
+              CompanyID: 99,
+              BranchID: 88,
+              DepartmentID: 77,
+              SecretValue: 'detail-secret',
+            }),
+          };
+        }
+        return { ok: true, json: async () => ({}) };
+      };
+
+      const RowFormModalStub = (props) => {
+        modalProps.push({ ...props });
+        return null;
+      };
+
+      const { default: TableManager } = await t.mock.import(
+        '../../src/erp.mgt.mn/components/TableManager.jsx',
+        {
+          '../context/AuthContext.jsx': {
+            AuthContext: React.createContext({
+              company: 1,
+              branch: 2,
+              department: 3,
+              session: {},
+            }),
+          },
+          '../context/ToastContext.jsx': {
+            useToast: () => ({
+              addToast: (...args) => {
+                toasts.push(args);
+              },
+            }),
+          },
+          './RowFormModal.jsx': { default: RowFormModalStub },
+          './CascadeDeleteModal.jsx': { default: () => null },
+          './RowDetailModal.jsx': { default: () => null },
+          './RowImageViewModal.jsx': { default: () => null },
+          './RowImageUploadModal.jsx': { default: () => null },
+          './ImageSearchModal.jsx': { default: () => null },
+          './Modal.jsx': { default: () => null },
+          './CustomDatePicker.jsx': { default: () => null },
+          '../hooks/useGeneralConfig.js': { default: () => ({}) },
+          '../utils/formatTimestamp.js': { default: () => '2024-01-01 00:00:00' },
+          '../utils/buildImageName.js': { default: () => ({}) },
+          '../utils/slugify.js': { default: () => '' },
+          '../utils/apiBase.js': { API_BASE: '' },
+          '../utils/normalizeDateInput.js': { default: (v) => v },
+        },
+      );
+
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const root = createRoot(container);
+
+      try {
+        await act(async () => {
+          root.render(
+            React.createElement(TableManager, {
+              table: 'test',
+              buttonPerms: { 'Edit transaction': true },
+            }),
+          );
+        });
+
+        for (let i = 0; i < 10; i += 1) {
+          if (container.querySelectorAll('button').length > 0) break;
+          // eslint-disable-next-line no-await-in-loop
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+
+        const editButton = Array.from(container.querySelectorAll('button')).find((btn) =>
+          (btn.textContent || '').includes('Edit'),
+        );
+        assert.ok(editButton, 'expected edit button to be rendered');
+
+        await act(async () => {
+          editButton.dispatchEvent(
+            new dom.window.MouseEvent('click', { bubbles: true, cancelable: true }),
+          );
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        for (let i = 0; i < 10; i += 1) {
+          const last = modalProps.at(-1);
+          if (last?.visible) break;
+          // eslint-disable-next-line no-await-in-loop
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+
+        const lastProps = modalProps.at(-1);
+        assert.ok(lastProps?.visible, 'expected modal to be visible');
+        assert.equal(lastProps.row?.CompanyID, 99);
+        assert.equal(lastProps.row?.BranchID, 88);
+        assert.equal(lastProps.row?.DepartmentID, 77);
+        assert.equal(lastProps.rows?.[0]?.SecretValue, 'detail-secret');
+        assert.equal(toasts.length, 0, 'expected no error toasts');
+        assert.ok(detailCalls.length >= 1, 'expected detail fetch to be called');
+
+        const detailUrl = detailCalls.at(-1);
+        assert.ok(detailUrl.includes('?'), 'expected tenant keys to be appended');
+        const parsed = new URL(detailUrl, 'http://localhost');
+        assert.equal(
+          parsed.searchParams.get('company_id'),
+          '77',
+          'expected company_id from row to be used before metadata state updates',
+        );
+        assert.equal(
+          parsed.searchParams.get('branch_id'),
+          '66',
+          'expected branch_id from row to be used before metadata state updates',
+        );
+        assert.equal(
+          parsed.searchParams.get('department_id'),
+          '55',
+          'expected department_id from row to be used before metadata state updates',
+        );
+        assert.ok(
+          fetchCalls.includes('/api/tables/test/columns'),
+          'expected metadata fetch to occur during edit initialization',
+        );
+      } finally {
+        await act(async () => {
+          root.unmount();
+        });
+        container.remove();
+
+        global.fetch = origFetch;
+        global.window = prevWindow;
+        global.document = prevDocument;
+        global.navigator = prevNavigator;
+        dom.window.close();
+      }
+    },
+  );
+
   test('TableManager handles PK casing differences when editing', async (t) => {
     const prevWindow = global.window;
     const prevDocument = global.document;


### PR DESCRIPTION
## Summary
- extract column case map helpers for reuse across runtime paths
- allow canonical key utilities to accept custom case maps and use fresh metadata during edit/detail flows
- add coverage for the fresh metadata edit path to ensure tenant params favor row values

## Testing
- node --test tests/components/tableManagerEditHydration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dff355e22c83319c8cfc28bd5fc3b2