### PR TITLE
Allow relation-driven defaults to stay editable

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -2231,11 +2231,23 @@ const TableManager = forwardRef(function TableManager({
   });
 
   const lockedDefaults = Object.entries(formConfig?.defaultValues || {})
-    .filter(
-      ([k, v]) =>
-        v !== undefined && v !== '' &&
-        !(formConfig?.editableDefaultFields || []).includes(k)
-    )
+    .filter(([rawKey, value]) => {
+      if (value === undefined || value === '') return false;
+      if ((formConfig?.editableDefaultFields || []).includes(rawKey)) return false;
+
+      const canonicalKey = resolveCanonicalKey(rawKey);
+      const relationKeyMatches = [rawKey, canonicalKey].filter(Boolean);
+      const hasRelationMetadata = relationKeyMatches.some((key) => {
+        if (key == null) return false;
+        return (
+          relationOpts[key] !== undefined ||
+          relationConfigs[key] !== undefined ||
+          viewSourceMap[key] !== undefined
+        );
+      });
+
+      return !hasRelationMetadata;
+    })
     .map(([k]) => k);
 
   const headerFields = formConfig?.headerFields || [];


### PR DESCRIPTION
## Summary
- skip locking default values on columns backed by relations or view sources so their dropdowns remain interactive

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dff57be9f88331adc4ea8ed5f8f1c5