### PR TITLE
Fix TableManager tenant filter fallback when editing rows

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1271,8 +1271,6 @@ const TableManager = forwardRef(function TableManager({
         const rowCompanyId = normalizedRow[companyKey];
         if (rowCompanyId != null && rowCompanyId !== '') {
           params.set('company_id', rowCompanyId);
-        } else if (company != null) {
-          params.set('company_id', company);
         }
       }
       if (hasTenantKey(tenantInfo, 'branch_id', localCaseMap)) {
@@ -1280,8 +1278,6 @@ const TableManager = forwardRef(function TableManager({
         const rowBranchId = normalizedRow[branchKey];
         if (rowBranchId != null && rowBranchId !== '') {
           params.set('branch_id', rowBranchId);
-        } else if (branch != null) {
-          params.set('branch_id', branch);
         }
       }
       if (hasTenantKey(tenantInfo, 'department_id', localCaseMap)) {
@@ -1289,8 +1285,6 @@ const TableManager = forwardRef(function TableManager({
         const rowDepartmentId = normalizedRow[departmentKey];
         if (rowDepartmentId != null && rowDepartmentId !== '') {
           params.set('department_id', rowDepartmentId);
-        } else if (department != null) {
-          params.set('department_id', department);
         }
       }
     }
@@ -1386,8 +1380,6 @@ const TableManager = forwardRef(function TableManager({
             const rowCompanyId = normalizedRow[companyKey];
             if (rowCompanyId != null && rowCompanyId !== '') {
               params.set('company_id', rowCompanyId);
-            } else if (company != null) {
-              params.set('company_id', company);
             }
           }
           if (hasTenantKey(tenantInfo, 'branch_id', localCaseMap)) {
@@ -1395,8 +1387,6 @@ const TableManager = forwardRef(function TableManager({
             const rowBranchId = normalizedRow[branchKey];
             if (rowBranchId != null && rowBranchId !== '') {
               params.set('branch_id', rowBranchId);
-            } else if (branch != null) {
-              params.set('branch_id', branch);
             }
           }
           if (hasTenantKey(tenantInfo, 'department_id', localCaseMap)) {
@@ -1404,8 +1394,6 @@ const TableManager = forwardRef(function TableManager({
             const rowDepartmentId = normalizedRow[departmentKey];
             if (rowDepartmentId != null && rowDepartmentId !== '') {
               params.set('department_id', rowDepartmentId);
-            } else if (department != null) {
-              params.set('department_id', department);
             }
           }
         }

--- a/tests/components/tableManagerEditHydration.test.js
+++ b/tests/components/tableManagerEditHydration.test.js
@@ -361,6 +361,172 @@ if (!haveReact) {
     }
   });
 
+  test('TableManager skips tenant filters when row values are empty', async (t) => {
+    const prevWindow = global.window;
+    const prevDocument = global.document;
+    const prevNavigator = global.navigator;
+
+    const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+      url: 'http://localhost',
+    });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.navigator = dom.window.navigator;
+    dom.window.confirm = () => true;
+    dom.window.scrollTo = () => {};
+
+    const toasts = [];
+    const modalProps = [];
+    const detailCalls = [];
+
+    const origFetch = global.fetch;
+    global.fetch = async (input) => {
+      const url = typeof input === 'string' ? input : input?.url || '';
+      if (url === '/api/tables/test/columns') {
+        return {
+          ok: true,
+          json: async () => [
+            { name: 'id', key: 'PRI' },
+            { name: 'name' },
+            { name: 'company_id' },
+            { name: 'branch_id' },
+          ],
+        };
+      }
+      if (url === '/api/tables/test/relations') {
+        return { ok: true, json: async () => [] };
+      }
+      if (url.startsWith('/api/display_fields?')) {
+        return { ok: true, json: async () => ({ displayFields: [] }) };
+      }
+      if (url.startsWith('/api/proc_triggers')) {
+        return { ok: true, json: async () => [] };
+      }
+      if (url === '/api/tenant_tables/test') {
+        return { ok: true, json: async () => ({ tenantKeys: ['company_id', 'branch_id'] }) };
+      }
+      if (url.startsWith('/api/tables/test?')) {
+        return {
+          ok: true,
+          json: async () => ({
+            rows: [
+              { id: 1, company_id: null, branch_id: null, name: 'Row 1' },
+            ],
+            count: 1,
+          }),
+        };
+      }
+      if (url === '/api/tables/test/1') {
+        detailCalls.push(url);
+        return {
+          ok: true,
+          json: async () => ({ id: 1, name: 'Row 1', company_id: 1, branch_id: 2 }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    };
+
+    const RowFormModalStub = (props) => {
+      modalProps.push({ ...props });
+      return null;
+    };
+
+    const { default: TableManager } = await t.mock.import(
+      '../../src/erp.mgt.mn/components/TableManager.jsx',
+      {
+        '../context/AuthContext.jsx': {
+          AuthContext: React.createContext({
+            company: 5,
+            branch: 6,
+            session: {},
+          }),
+        },
+        '../context/ToastContext.jsx': {
+          useToast: () => ({
+            addToast: (...args) => {
+              toasts.push(args);
+            },
+          }),
+        },
+        './RowFormModal.jsx': { default: RowFormModalStub },
+        './CascadeDeleteModal.jsx': { default: () => null },
+        './RowDetailModal.jsx': { default: () => null },
+        './RowImageViewModal.jsx': { default: () => null },
+        './RowImageUploadModal.jsx': { default: () => null },
+        './ImageSearchModal.jsx': { default: () => null },
+        './Modal.jsx': { default: () => null },
+        './CustomDatePicker.jsx': { default: () => null },
+        '../hooks/useGeneralConfig.js': { default: () => ({}) },
+        '../utils/formatTimestamp.js': { default: () => '2024-01-01 00:00:00' },
+        '../utils/buildImageName.js': { default: () => ({}) },
+        '../utils/slugify.js': { default: () => '' },
+        '../utils/apiBase.js': { API_BASE: '' },
+        '../utils/normalizeDateInput.js': { default: (v) => v },
+      },
+    );
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          React.createElement(TableManager, {
+            table: 'test',
+            buttonPerms: { 'Edit transaction': true },
+          }),
+        );
+      });
+
+      for (let i = 0; i < 10; i += 1) {
+        if (container.querySelectorAll('button').length > 0) break;
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+
+      const editButton = Array.from(container.querySelectorAll('button')).find((btn) =>
+        (btn.textContent || '').includes('Edit'),
+      );
+      assert.ok(editButton, 'expected edit button to be rendered');
+
+      await act(async () => {
+        editButton.dispatchEvent(
+          new dom.window.MouseEvent('click', { bubbles: true, cancelable: true }),
+        );
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      for (let i = 0; i < 10; i += 1) {
+        const last = modalProps.at(-1);
+        if (last?.visible) break;
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+
+      const lastProps = modalProps.at(-1);
+      assert.ok(lastProps?.visible, 'expected modal to be visible');
+      assert.equal(lastProps.row?.company_id, 1);
+      assert.equal(lastProps.rows?.[0]?.branch_id, 2);
+      assert.equal(toasts.length, 0, 'expected no error toasts');
+      assert.ok(detailCalls.length >= 1, 'expected detail fetch to be called');
+
+      const detailUrl = detailCalls.at(-1);
+      assert.ok(!detailUrl.includes('?'), 'expected tenant filters to be omitted');
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+
+      global.fetch = origFetch;
+      global.window = prevWindow;
+      global.document = prevDocument;
+      global.navigator = prevNavigator;
+      dom.window.close();
+    }
+  });
+
   test('TableManager maps underscored tenant keys to camel case columns', async (t) => {
     const prevWindow = global.window;
     const prevDocument = global.document;


### PR DESCRIPTION
## Summary
- stop TableManager from injecting session tenant defaults when editing or viewing rows
- allow edit and detail requests to omit tenant filters when the grid row lacks values
- add a regression test to ensure empty tenant fields no longer append mismatched filters

## Testing
- npm test -- tests/components/tableManagerEditHydration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dff78cdd808331bb60f3184af33208