### PR TITLE
Ensure tenant params include snake case query keys

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -333,6 +333,21 @@ const TableManager = forwardRef(function TableManager({
     [normalizeTenantKey],
   );
 
+  const appendTenantParam = useCallback(
+    (params, tenantKey, caseMap, value) => {
+      if (!params || value == null || value === '') return;
+      const canonicalKey = resolveCanonicalKey(tenantKey, caseMap);
+      const snakeKey = sanitizeName(tenantKey);
+      if (snakeKey) {
+        params.set(snakeKey, value);
+      }
+      if (canonicalKey && canonicalKey !== snakeKey) {
+        params.set(canonicalKey, value);
+      }
+    },
+    [resolveCanonicalKey],
+  );
+
   const fieldTypeMap = useMemo(() => {
     const map = {};
     columnMeta.forEach((c) => {
@@ -1268,24 +1283,23 @@ const TableManager = forwardRef(function TableManager({
     if (tenantInfo && !(tenantInfo.isShared ?? tenantInfo.is_shared)) {
       if (hasTenantKey(tenantInfo, 'company_id', localCaseMap)) {
         const companyKey = resolveCanonicalKey('company_id', localCaseMap);
-        const rowCompanyId = normalizedRow[companyKey];
-        if (rowCompanyId != null && rowCompanyId !== '') {
-          params.set(companyKey, rowCompanyId);
-        }
+        const rowCompanyId =
+          companyKey != null ? normalizedRow[companyKey] : normalizedRow.company_id;
+        appendTenantParam(params, 'company_id', localCaseMap, rowCompanyId);
       }
       if (hasTenantKey(tenantInfo, 'branch_id', localCaseMap)) {
         const branchKey = resolveCanonicalKey('branch_id', localCaseMap);
-        const rowBranchId = normalizedRow[branchKey];
-        if (rowBranchId != null && rowBranchId !== '') {
-          params.set(branchKey, rowBranchId);
-        }
+        const rowBranchId =
+          branchKey != null ? normalizedRow[branchKey] : normalizedRow.branch_id;
+        appendTenantParam(params, 'branch_id', localCaseMap, rowBranchId);
       }
       if (hasTenantKey(tenantInfo, 'department_id', localCaseMap)) {
         const departmentKey = resolveCanonicalKey('department_id', localCaseMap);
-        const rowDepartmentId = normalizedRow[departmentKey];
-        if (rowDepartmentId != null && rowDepartmentId !== '') {
-          params.set(departmentKey, rowDepartmentId);
-        }
+        const rowDepartmentId =
+          departmentKey != null
+            ? normalizedRow[departmentKey]
+            : normalizedRow.department_id;
+        appendTenantParam(params, 'department_id', localCaseMap, rowDepartmentId);
       }
     }
 
@@ -1377,24 +1391,25 @@ const TableManager = forwardRef(function TableManager({
         if (tenantInfo && !(tenantInfo.isShared ?? tenantInfo.is_shared)) {
           if (hasTenantKey(tenantInfo, 'company_id', localCaseMap)) {
             const companyKey = resolveCanonicalKey('company_id', localCaseMap);
-            const rowCompanyId = normalizedRow[companyKey];
-            if (rowCompanyId != null && rowCompanyId !== '') {
-              params.set(companyKey, rowCompanyId);
-            }
+            const rowCompanyId =
+              companyKey != null
+                ? normalizedRow[companyKey]
+                : normalizedRow.company_id;
+            appendTenantParam(params, 'company_id', localCaseMap, rowCompanyId);
           }
           if (hasTenantKey(tenantInfo, 'branch_id', localCaseMap)) {
             const branchKey = resolveCanonicalKey('branch_id', localCaseMap);
-            const rowBranchId = normalizedRow[branchKey];
-            if (rowBranchId != null && rowBranchId !== '') {
-              params.set(branchKey, rowBranchId);
-            }
+            const rowBranchId =
+              branchKey != null ? normalizedRow[branchKey] : normalizedRow.branch_id;
+            appendTenantParam(params, 'branch_id', localCaseMap, rowBranchId);
           }
           if (hasTenantKey(tenantInfo, 'department_id', localCaseMap)) {
             const departmentKey = resolveCanonicalKey('department_id', localCaseMap);
-            const rowDepartmentId = normalizedRow[departmentKey];
-            if (rowDepartmentId != null && rowDepartmentId !== '') {
-              params.set(departmentKey, rowDepartmentId);
-            }
+            const rowDepartmentId =
+              departmentKey != null
+                ? normalizedRow[departmentKey]
+                : normalizedRow.department_id;
+            appendTenantParam(params, 'department_id', localCaseMap, rowDepartmentId);
           }
         }
         const url = `/api/tables/${encodeURIComponent(table)}/${encodeURIComponent(id)}/references${

--- a/tests/components/tableManagerEditHydration.test.js
+++ b/tests/components/tableManagerEditHydration.test.js
@@ -534,6 +534,9 @@ if (!haveReact) {
       assert.equal(parsed.searchParams.get('CompanyID'), '41');
       assert.equal(parsed.searchParams.get('BranchID'), '42');
       assert.equal(parsed.searchParams.get('DepartmentID'), '43');
+      assert.equal(parsed.searchParams.get('company_id'), '41');
+      assert.equal(parsed.searchParams.get('branch_id'), '42');
+      assert.equal(parsed.searchParams.get('department_id'), '43');
     } finally {
       await act(async () => {
         root.unmount();


### PR DESCRIPTION
## Summary
- add a reusable helper to append tenant filters with both canonical and snake_case keys
- update edit and detail URL builders to use the helper
- extend the camel-case tenant key test to assert snake_case parameters are emitted

## Testing
- npm test -- tests/components/tableManagerEditHydration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e00179bd588331a49c4ee358af2a31