### PR TITLE
Add report approval workflow with transaction locking

### DIFF
--- a/api-server/services/reportApprovals.js
+++ b/api-server/services/reportApprovals.js
@@ -1,0 +1,43 @@
+import {
+  lockTransactionsForReport,
+  activateReportTransactionLocks,
+  releaseReportTransactionLocks,
+  listLockedTransactions,
+  recordReportApproval,
+} from '../../db/index.js';
+
+export async function createReportApprovalLocks(
+  { companyId, requestId, transactions, createdBy },
+  conn,
+) {
+  return lockTransactionsForReport(
+    { companyId, requestId, transactions, createdBy },
+    conn,
+  );
+}
+
+export async function finalizeReportApprovalRequest(
+  { companyId, requestId, procedure, parameters, approvedBy, transactions },
+  conn,
+) {
+  await recordReportApproval(
+    {
+      companyId,
+      requestId,
+      procedureName: procedure,
+      parameters,
+      approvedBy,
+    },
+    conn,
+  );
+  await activateReportTransactionLocks({ requestId, finalizedBy: approvedBy }, conn);
+  return Array.isArray(transactions) ? transactions : [];
+}
+
+export async function releaseReportApprovalLocks({ requestId }, conn) {
+  await releaseReportTransactionLocks({ requestId }, conn);
+}
+
+export async function listLockedTransactionsForTable({ tableName, companyId } = {}) {
+  return listLockedTransactions({ tableName, companyId });
+}

--- a/tests/api/pendingRequest.test.js
+++ b/tests/api/pendingRequest.test.js
@@ -51,11 +51,14 @@ await test('direct senior can decline request', async () => {
   assert.ok(upd, 'should update status to declined');
 });
 
-await test('respondRequest returns requester and status', async () => {
+await test('respondRequest returns requester metadata', async () => {
   const { restore } = setupRequest();
   const result = await service.respondRequest(1, 's1', 'accepted', 'yes');
   restore();
-  assert.deepEqual(result, { requester: 'E1', status: 'accepted' });
+  assert.equal(result.requester, 'E1');
+  assert.equal(result.status, 'accepted');
+  assert.equal(result.requestType, 'edit');
+  assert.deepEqual(result.lockedTransactions, []);
 });
 
 await test('listRequests normalizes empids in filters', async () => {


### PR DESCRIPTION
## Summary
- add a report_approval pending-request workflow that validates payload metadata, records approvals, and manages provisional locks
- introduce database helpers and a report approval service to persist approvals and lock/unlock referenced transactions
- surface transaction lock status in listTransactions, enforce locks during updates/deletes, and extend pending request responses and notifications with lock details

## Testing
- npm test *(fails: multiple existing seedTenantTables and usersTrigger suites as shown in output)*

------
https://chatgpt.com/codex/tasks/task_e_68e008de9ad88331a4c90d7ec440d198