### PR TITLE
Add approval workflow to report viewer

### DIFF
--- a/src/erp.mgt.mn/components/ReportTable.jsx
+++ b/src/erp.mgt.mn/components/ReportTable.jsx
@@ -1,4 +1,10 @@
-import React, { useContext, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
 import useGeneralConfig, { updateCache } from '../hooks/useGeneralConfig.js';
 import useHeaderMappings from '../hooks/useHeaderMappings.js';
@@ -55,12 +61,44 @@ function isCountColumn(name) {
   return f === 'count' || f === 'count()' || f.startsWith('count(');
 }
 
+function normalizeTransactionKey(item, defaultTable) {
+  if (!item) return null;
+  if (typeof item === 'string') return item;
+  if (typeof item !== 'object') return null;
+  const tableValue =
+    item.table ?? item.tableName ?? item.sourceTable ?? defaultTable ?? '';
+  const recordValue =
+    item.recordId ?? item.record_id ?? item.id ?? item.transactionId;
+  if (recordValue === null || recordValue === undefined || recordValue === '') {
+    return null;
+  }
+  const recordId = String(recordValue);
+  if (tableValue) return `${String(tableValue)}::${recordId}`;
+  return recordId;
+}
+
+function deriveRowTransaction(row, { idField, tableField, tableName }) {
+  if (!row || !idField) return null;
+  const rawId = row[idField];
+  if (rawId === null || rawId === undefined || rawId === '') return null;
+  const recordId = String(rawId);
+  let table = tableName || null;
+  if (tableField && row[tableField] !== undefined && row[tableField] !== null) {
+    table = String(row[tableField]);
+  }
+  const key = table ? `${table}::${recordId}` : recordId;
+  return { key, table, recordId };
+}
+
 export default function ReportTable({
   procedure = '',
   params = {},
   rows = [],
   buttonPerms = {},
   fieldTypeMap = {},
+  lockInfo = null,
+  onTransactionsChange,
+  onTransactionMetadata,
 }) {
   const { user, branch, department } = useContext(AuthContext);
   const generalConfig = useGeneralConfig();
@@ -93,6 +131,83 @@ export default function ReportTable({
 
   const columns = rows && rows.length ? Object.keys(rows[0]) : [];
   const columnHeaderMap = useHeaderMappings(columns);
+
+  const derivedIdField = useMemo(() => {
+    if (lockInfo?.idField) return lockInfo.idField;
+    return (
+      columns.find((c) => {
+        const lower = String(c).toLowerCase();
+        return (
+          lower === 'id' ||
+          lower.endsWith('_id') ||
+          lower.endsWith('id') ||
+          lower.includes('transaction')
+        );
+      }) || null
+    );
+  }, [lockInfo?.idField, columns]);
+
+  const derivedTableField = useMemo(() => {
+    if (lockInfo?.tableField) return lockInfo.tableField;
+    return (
+      columns.find((c) => {
+        const lower = String(c).toLowerCase();
+        return lower === 'table' || lower === 'table_name' || lower.endsWith('table');
+      }) || null
+    );
+  }, [lockInfo?.tableField, columns]);
+
+  const transactionMeta = useMemo(
+    () => ({
+      idField: derivedIdField,
+      tableField: derivedTableField,
+      tableName: lockInfo?.tableName ?? null,
+    }),
+    [derivedIdField, derivedTableField, lockInfo?.tableName],
+  );
+
+  const pendingSet = useMemo(() => {
+    const set = new Set();
+    if (Array.isArray(lockInfo?.pending)) {
+      lockInfo.pending.forEach((item) => {
+        const key = normalizeTransactionKey(item, transactionMeta.tableName);
+        if (key) set.add(key);
+      });
+    }
+    return set;
+  }, [lockInfo?.pending, transactionMeta.tableName]);
+
+  const lockedSet = useMemo(() => {
+    const set = new Set();
+    if (Array.isArray(lockInfo?.locked)) {
+      lockInfo.locked.forEach((item) => {
+        const key = normalizeTransactionKey(item, transactionMeta.tableName);
+        if (key) set.add(key);
+      });
+    }
+    return set;
+  }, [lockInfo?.locked, transactionMeta.tableName]);
+
+  useEffect(() => {
+    if (typeof onTransactionMetadata === 'function') {
+      onTransactionMetadata(transactionMeta);
+    }
+  }, [transactionMeta, onTransactionMetadata]);
+
+  useEffect(() => {
+    if (typeof onTransactionsChange !== 'function') return;
+    if (!transactionMeta.idField) {
+      onTransactionsChange([]);
+      return;
+    }
+    const unique = new Map();
+    rows.forEach((row) => {
+      const tx = deriveRowTransaction(row, transactionMeta);
+      if (!tx) return;
+      unique.set(tx.key, { table: tx.table, recordId: tx.recordId });
+    });
+    onTransactionsChange(Array.from(unique.values()));
+  }, [rows, transactionMeta, onTransactionsChange]);
 
   const placeholders = useMemo(() => {
     const map = {};
@@ -248,173 +363,193 @@ export default function ReportTable({
     );
   }
 
-  function handleCellClick(col, value, row) {
-    const num = Number(String(value).replace(',', '.'));
-    if (!procedure || Number.isNaN(num) || num <= 0) return;
-    rowToast(`Procedure: ${procedure}`, 'info');
-    let displayValue = value;
-    if (placeholders[col]) {
-      displayValue = formatCellValue(value, placeholders[col]);
-    } else if (numericColumns.includes(col)) {
-      const parsed = Number(String(value).replace(',', '.'));
-      if (!Number.isNaN(parsed)) displayValue = parsed;
-    }
-    const firstField = columns[0];
+  const handleCellClick = useCallback(
+    (col, value, row) => {
+      const tx = deriveRowTransaction(row, transactionMeta);
+      const key = tx?.key;
+      if (key && (lockedSet.has(key) || pendingSet.has(key))) {
+        return;
+      }
+      const num = Number(String(value).replace(',', '.'));
+      if (!procedure || Number.isNaN(num) || num <= 0) return;
+      rowToast(`Procedure: ${procedure}`, 'info');
+      let displayValue = value;
+      if (placeholders[col]) {
+        displayValue = formatCellValue(value, placeholders[col]);
+      } else if (numericColumns.includes(col)) {
+        const parsed = Number(String(value).replace(',', '.'));
+        if (!Number.isNaN(parsed)) displayValue = parsed;
+      }
+      const firstField = columns[0];
 
-    let idx = 0;
-    let groupField = columns[idx];
-    let groupValue = row[groupField];
+      let idx = 0;
+      let groupField = columns[idx];
+      let groupValue = row[groupField];
 
-    while (
-      idx < columns.length - 1 &&
-      (groupField.toLowerCase() === 'modal' ||
-        String(groupValue).toLowerCase() === 'modal' ||
-        isCountColumn(groupField))
-    ) {
-      idx += 1;
-      groupField = columns[idx];
-      groupValue = row[groupField];
-    }
-
-    if (placeholders[groupField]) {
-      groupValue = formatCellValue(groupValue, placeholders[groupField]);
-    } else if (numericColumns.includes(groupField)) {
-      const parsed = Number(String(groupValue).replace(',', '.'));
-      if (!Number.isNaN(parsed)) groupValue = parsed;
-    }
-
-    const allConditions = [];
-    for (let i = 0; i < columns.length; i++) {
-      const field = columns[i];
-      const val = row[field];
-      if (
-        !field ||
-        val === undefined ||
-        val === null ||
-        val === '' ||
-        isCountColumn(field) ||
-        (i !== 0 &&
-          (field.toLowerCase() === 'modal' ||
-            String(val).toLowerCase() === 'modal'))
+      while (
+        idx < columns.length - 1 &&
+        (groupField.toLowerCase() === 'modal' ||
+          String(groupValue).toLowerCase() === 'modal' ||
+          isCountColumn(groupField))
       ) {
-        continue;
+        idx += 1;
+        groupField = columns[idx];
+        groupValue = row[groupField];
       }
-      let outVal = val;
-      if (placeholders[field]) {
-        outVal = formatCellValue(val, placeholders[field]);
-      } else if (numericColumns.includes(field)) {
-        const numVal = Number(String(val).replace(',', '.'));
-        if (!Number.isNaN(numVal)) outVal = numVal;
+
+      if (placeholders[groupField]) {
+        groupValue = formatCellValue(groupValue, placeholders[groupField]);
+      } else if (numericColumns.includes(groupField)) {
+        const parsed = Number(String(groupValue).replace(',', '.'));
+        if (!Number.isNaN(parsed)) groupValue = parsed;
       }
-      allConditions.push({ field, value: outVal });
-    }
-    const extraConditions = allConditions.filter(
-      (c) => c.field !== groupField && c.field !== col && c.field !== firstField,
-    );
-    let firstVal = row[firstField];
-    if (placeholders[firstField]) {
-      firstVal = formatCellValue(firstVal, placeholders[firstField]);
-    } else if (numericColumns.includes(firstField)) {
-      const num = Number(String(firstVal).replace(',', '.'));
-      if (!Number.isNaN(num)) firstVal = num;
-    }
-    if (
-      firstField &&
-      firstVal !== undefined &&
-      firstVal !== null &&
-      firstVal !== '' &&
-      !extraConditions.some((c) => c.field === firstField)
-    ) {
-      extraConditions.unshift({ field: firstField, value: firstVal });
-    }
-    const payload = {
-      name: procedure,
-      column: col,
+
+      const allConditions = [];
+      for (let i = 0; i < columns.length; i++) {
+        const field = columns[i];
+        const val = row[field];
+        if (
+          !field ||
+          val === undefined ||
+          val === null ||
+          val === '' ||
+          isCountColumn(field) ||
+          (i !== 0 &&
+            (field.toLowerCase() === 'modal' ||
+              String(val).toLowerCase() === 'modal'))
+        ) {
+          continue;
+        }
+        let outVal = val;
+        if (placeholders[field]) {
+          outVal = formatCellValue(val, placeholders[field]);
+        } else if (numericColumns.includes(field)) {
+          const numVal = Number(String(val).replace(',', '.'));
+          if (!Number.isNaN(numVal)) outVal = numVal;
+        }
+        allConditions.push({ field, value: outVal });
+      }
+      const extraConditions = allConditions.filter(
+        (c) => c.field !== groupField && c.field !== col && c.field !== firstField,
+      );
+      let firstVal = row[firstField];
+      if (placeholders[firstField]) {
+        firstVal = formatCellValue(firstVal, placeholders[firstField]);
+      } else if (numericColumns.includes(firstField)) {
+        const parsedFirst = Number(String(firstVal).replace(',', '.'));
+        if (!Number.isNaN(parsedFirst)) firstVal = parsedFirst;
+      }
+      if (
+        firstField &&
+        firstVal !== undefined &&
+        firstVal !== null &&
+        firstVal !== '' &&
+        !extraConditions.some((c) => c.field === firstField)
+      ) {
+        extraConditions.unshift({ field: firstField, value: firstVal });
+      }
+      const payload = {
+        name: procedure,
+        column: col,
+        params,
+        groupField,
+        groupValue,
+        extraConditions,
+        session: {
+          empid: user?.empid,
+          branch_id: branch,
+          department_id: department,
+        },
+      };
+      setTxnInfo({ loading: true, col, value, data: [], sql: '', displayFields: [] });
+      fetch('/api/procedures/raw', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(payload),
+      })
+        .then(async (res) => {
+          const data = await res.json().catch(() => ({}));
+          if (!res.ok) throw data;
+          return data;
+        })
+        .then((data) => {
+          let outRows = (data.rows || []).map((r) => {
+            const entries = Object.entries(r).filter(([k]) => !isCountColumn(k));
+            return Object.fromEntries(entries);
+          });
+          if (idx > 0 && firstField && !isCountColumn(firstField)) {
+            const replaceVal =
+              firstField.toLowerCase() === 'modal' ? groupValue : displayValue;
+            outRows = outRows.map((r) => ({ ...r, [firstField]: replaceVal }));
+          }
+          setTxnInfo({
+            loading: false,
+            col,
+            value,
+            data: outRows,
+            sql: data.sql || '',
+            displayFields: Array.isArray(data.displayFields)
+              ? data.displayFields
+              : [],
+          });
+          if (data.original) {
+            const preview =
+              data.original.length > 200
+                ? `${data.original.slice(0, 200)}…`
+                : data.original;
+            rowToast(
+              `Procedure SQL saved to ${data.file || ''}: ${preview}`,
+              'info',
+            );
+          } else {
+            rowToast('Procedure SQL not found', 'error');
+          }
+          if (data.sql && data.sql !== data.original) {
+            const preview =
+              data.sql.length > 200 ? `${data.sql.slice(0, 200)}…` : data.sql;
+            rowToast(
+              `Transformed SQL saved to ${data.file || ''}: ${preview}`,
+              'info',
+            );
+          } else {
+            rowToast('SQL transformation failed', 'error');
+          }
+          rowToast(
+            `Rows fetched: ${data.rows ? data.rows.length : 0}`,
+            data.rows && data.rows.length ? 'success' : 'error',
+          );
+        })
+        .catch((err) => {
+          const sql = err && typeof err === 'object' ? err.sql || '' : '';
+          const file = err && typeof err === 'object' ? err.file || '' : '';
+          setTxnInfo({ loading: false, col, value, data: [], sql, displayFields: [] });
+          if (sql) {
+            const preview = sql.length > 200 ? `${sql.slice(0, 200)}…` : sql;
+            rowToast(`SQL saved to ${file}: ${preview}`, 'info');
+          } else {
+            rowToast('No SQL generated', 'error');
+          }
+          rowToast(
+            err && err.message ? err.message : 'Row fetch failed',
+            'error',
+          );
+        });
+    },
+    [
+      branch,
+      columns,
+      department,
+      numericColumns,
       params,
-      groupField,
-      groupValue,
-      extraConditions,
-      session: {
-        empid: user?.empid,
-        branch_id: branch,
-        department_id: department,
-      },
-    };
-    setTxnInfo({ loading: true, col, value, data: [], sql: '', displayFields: [] });
-    fetch('/api/procedures/raw', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify(payload),
-    })
-      .then(async (res) => {
-        const data = await res.json().catch(() => ({}));
-        if (!res.ok) throw data;
-        return data;
-      })
-      .then((data) => {
-        let outRows = (data.rows || []).map((r) => {
-          const entries = Object.entries(r).filter(([k]) => !isCountColumn(k));
-          return Object.fromEntries(entries);
-        });
-        if (idx > 0 && firstField && !isCountColumn(firstField)) {
-          const replaceVal =
-            firstField.toLowerCase() === 'modal' ? groupValue : displayValue;
-          outRows = outRows.map((r) => ({ ...r, [firstField]: replaceVal }));
-        }
-        setTxnInfo({
-          loading: false,
-          col,
-          value,
-          data: outRows,
-          sql: data.sql || '',
-          displayFields: Array.isArray(data.displayFields)
-            ? data.displayFields
-            : [],
-        });
-        if (data.original) {
-          const preview =
-            data.original.length > 200
-              ? `${data.original.slice(0, 200)}…`
-              : data.original;
-          rowToast(
-            `Procedure SQL saved to ${data.file || ''}: ${preview}`,
-            'info',
-          );
-        } else {
-          rowToast('Procedure SQL not found', 'error');
-        }
-        if (data.sql && data.sql !== data.original) {
-          const preview =
-            data.sql.length > 200 ? `${data.sql.slice(0, 200)}…` : data.sql;
-          rowToast(
-            `Transformed SQL saved to ${data.file || ''}: ${preview}`,
-            'info',
-          );
-        } else {
-          rowToast('SQL transformation failed', 'error');
-        }
-        rowToast(
-          `Rows fetched: ${data.rows ? data.rows.length : 0}`,
-          data.rows && data.rows.length ? 'success' : 'error',
-        );
-      })
-      .catch((err) => {
-        const sql = err && typeof err === 'object' ? err.sql || '' : '';
-        const file = err && typeof err === 'object' ? err.file || '' : '';
-        setTxnInfo({ loading: false, col, value, data: [], sql, displayFields: [] });
-        if (sql) {
-          const preview = sql.length > 200 ? `${sql.slice(0, 200)}…` : sql;
-          rowToast(`SQL saved to ${file}: ${preview}`, 'info');
-        } else {
-          rowToast('No SQL generated', 'error');
-        }
-        rowToast(
-          err && err.message ? err.message : 'Row fetch failed',
-          'error',
-        );
-      });
-  }
+      placeholders,
+      procedure,
+      transactionMeta,
+      lockedSet,
+      pendingSet,
+      user?.empid,
+    ],
+  );
 
   function handleSaveFieldLabels() {
     const existing = generalConfig.general?.procFieldLabels || {};
@@ -552,37 +687,106 @@ export default function ReportTable({
             </tr>
           </thead>
           <tbody className="table-manager">
-            {pageRows.map((row, idx) => (
-              <tr key={idx}>
-                {columns.map((col) => {
-                  const w = columnWidths[col];
-                  const style = {
-                    padding: '0.5rem',
-                    border: '1px solid #d1d5db',
-                    textAlign: columnAlign[col],
-                  };
-                  if (w) {
-                    style.width = w;
-                    style.minWidth = w;
-                    style.maxWidth = MAX_WIDTH;
-                    style.whiteSpace = 'nowrap';
-                    style.overflow = 'hidden';
-                    style.textOverflow = 'ellipsis';
+            {pageRows.map((row, idx) => {
+              const tx = deriveRowTransaction(row, transactionMeta);
+              const key = tx?.key;
+              const isLockedRow = key ? lockedSet.has(key) : false;
+              const isPendingRow = key ? pendingSet.has(key) : false;
+              const rowStatus = isLockedRow ? 'locked' : isPendingRow ? 'pending' : null;
+              const rowTitle =
+                rowStatus === 'locked'
+                  ? 'This transaction has been locked by an approved report.'
+                  : rowStatus === 'pending'
+                  ? 'This transaction will be locked once the report is approved.'
+                  : undefined;
+              const rowStyle = rowStatus
+                ? {
+                    backgroundColor:
+                      rowStatus === 'locked' ? '#fee2e2' : '#fef3c7',
                   }
-                  return (
-                    <td
-                      key={col}
-                      style={{ ...style, cursor: row[col] ? 'pointer' : 'default' }}
-                      onClick={() => handleCellClick(col, row[col], row)}
-                    >
-                      {numericColumns.includes(col)
-                        ? formatNumber(row[col])
-                        : formatCellValue(row[col], placeholders[col])}
-                    </td>
-                  );
-                })}
-              </tr>
-            ))}
+                : undefined;
+              return (
+                <tr key={idx} style={rowStyle} title={rowTitle}>
+                  {columns.map((col, colIdx) => {
+                    const w = columnWidths[col];
+                    const style = {
+                      padding: '0.5rem',
+                      border: '1px solid #d1d5db',
+                      textAlign: columnAlign[col],
+                    };
+                    if (w) {
+                      style.width = w;
+                      style.minWidth = w;
+                      style.maxWidth = MAX_WIDTH;
+                      style.whiteSpace = 'nowrap';
+                      style.overflow = 'hidden';
+                      style.textOverflow = 'ellipsis';
+                    }
+                    const baseValue = numericColumns.includes(col)
+                      ? formatNumber(row[col])
+                      : formatCellValue(row[col], placeholders[col]);
+                    const badge = rowStatus
+                      ? (
+                          <span
+                            style={{
+                              display: 'inline-block',
+                              padding: '0.1rem 0.45rem',
+                              borderRadius: '9999px',
+                              backgroundColor:
+                                rowStatus === 'locked' ? '#b91c1c' : '#d97706',
+                              color: '#fff',
+                              fontSize: '0.65rem',
+                              textTransform: 'uppercase',
+                              letterSpacing: '0.05em',
+                            }}
+                          >
+                            {rowStatus === 'locked' ? 'Locked' : 'Pending'}
+                          </span>
+                        )
+                      : null;
+                    const showBadge = badge && colIdx === 0;
+                    const content = showBadge ? (
+                      <span
+                        style={{
+                          display: 'inline-flex',
+                          alignItems: 'center',
+                          gap: '0.4rem',
+                          maxWidth: '100%',
+                          overflow: 'hidden',
+                        }}
+                      >
+                        {badge}
+                        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                          {baseValue}
+                        </span>
+                      </span>
+                    ) : (
+                      baseValue
+                    );
+                    const disableClick = Boolean(rowStatus);
+                    return (
+                      <td
+                        key={col}
+                        style={{
+                          ...style,
+                          cursor:
+                            disableClick || row[col] === undefined || row[col] === null
+                              ? 'default'
+                              : 'pointer',
+                        }}
+                        onClick={() => {
+                          if (disableClick) return;
+                          handleCellClick(col, row[col], row);
+                        }}
+                        title={rowTitle}
+                      >
+                        {content}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
           </tbody>
           {numericColumns.length > 0 && (
             <tfoot>

--- a/src/erp.mgt.mn/pages/Reports.jsx
+++ b/src/erp.mgt.mn/pages/Reports.jsx
@@ -1,5 +1,12 @@
 // src/erp.mgt.mn/pages/Reports.jsx
-import React, { useContext, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { useToast } from '../context/ToastContext.jsx';
 import formatTimestamp from '../utils/formatTimestamp.js';
@@ -11,10 +18,11 @@ import useButtonPerms from '../hooks/useButtonPerms.js';
 import normalizeDateInput from '../utils/normalizeDateInput.js';
 
 export default function Reports() {
-  const { company, branch, department, user } = useContext(AuthContext);
+  const { company, branch, department, user, session } = useContext(AuthContext);
   const buttonPerms = useButtonPerms();
   const { addToast } = useToast();
   const generalConfig = useGeneralConfig();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [procedures, setProcedures] = useState([]);
   const [selectedProc, setSelectedProc] = useState('');
   const [procParams, setProcParams] = useState([]);
@@ -23,14 +31,77 @@ export default function Reports() {
   const [datePreset, setDatePreset] = useState('custom');
   const [result, setResult] = useState(null);
   const [manualParams, setManualParams] = useState({});
+  const [selectedTransactions, setSelectedTransactions] = useState([]);
+  const [lockInfo, setLockInfo] = useState(null);
+  const [pendingApproval, setPendingApproval] = useState(null);
+  const [requestingApproval, setRequestingApproval] = useState(false);
+  const [responding, setResponding] = useState(false);
+  const [approvalContext, setApprovalContext] = useState(null);
+  const [approvalLoading, setApprovalLoading] = useState(false);
+  const [approvalError, setApprovalError] = useState(null);
+  const [hasLoadedApprovalResult, setHasLoadedApprovalResult] = useState(false);
   const procNames = useMemo(() => procedures.map((p) => p.name), [procedures]);
   const procMap = useHeaderMappings(procNames);
 
-  function getLabel(name) {
-    return (
-      generalConfig.general?.procLabels?.[name] || procMap[name] || name
-    );
-  }
+  const approvalRequestId = searchParams.get('request_id');
+  const isSubordinate = Number(session?.senior_empid) > 0;
+  const isSenior = Boolean(user?.empid) && !isSubordinate;
+
+  const getLabel = useCallback(
+    (name) =>
+      generalConfig.general?.procLabels?.[name] || procMap[name] || name,
+    [generalConfig.general?.procLabels, procMap],
+  );
+
+  const lockInfoMeta = useMemo(
+    () => ({
+      idField: lockInfo?.idField ?? null,
+      tableField: lockInfo?.tableField ?? null,
+      tableName: lockInfo?.tableName ?? null,
+    }),
+    [lockInfo?.idField, lockInfo?.tableField, lockInfo?.tableName],
+  );
+
+  const approvalTransactions = useMemo(() => {
+    const raw = approvalContext?.proposed_data?.transactions;
+    if (!Array.isArray(raw)) return [];
+    return raw
+      .map((tx) => {
+        if (!tx || typeof tx !== 'object') return null;
+        const table =
+          tx.table || tx.tableName || tx.sourceTable || lockInfoMeta.tableName || null;
+        const recordValue =
+          tx.recordId ?? tx.record_id ?? tx.id ?? tx.transactionId;
+        if (
+          !table ||
+          recordValue === undefined ||
+          recordValue === null ||
+          recordValue === ''
+        ) {
+          return null;
+        }
+        return { table, recordId: String(recordValue) };
+      })
+      .filter(Boolean);
+  }, [approvalContext, lockInfoMeta.tableName]);
+
+  const handleTransactionsChange = useCallback((transactions) => {
+    setSelectedTransactions(transactions || []);
+  }, []);
+
+  const handleTransactionMetadata = useCallback((meta) => {
+    if (!meta) return;
+    setLockInfo((info) => {
+      const base = info || { pending: [], locked: [] };
+      return {
+        ...base,
+        idField: meta.idField ?? base.idField ?? null,
+        tableField: meta.tableField ?? base.tableField ?? null,
+        tableName:
+          meta.tableName !== undefined ? meta.tableName : base.tableName ?? null,
+      };
+    });
+  }, []);
 
   useEffect(() => {
     const prefix = generalConfig?.general?.reportProcPrefix || '';
@@ -83,6 +154,118 @@ export default function Reports() {
     setManualParams({});
   }, [selectedProc]);
 
+  useEffect(() => {
+    if (!isSenior || !approvalRequestId || !user?.empid) {
+      if (!approvalRequestId) {
+        setApprovalContext(null);
+        setApprovalError(null);
+        setApprovalLoading(false);
+      }
+      return;
+    }
+    let cancelled = false;
+    setApprovalLoading(true);
+    setApprovalError(null);
+    async function loadApprovalRequest() {
+      try {
+        const params = new URLSearchParams();
+        params.set('request_type', 'report_approval');
+        params.set('status', 'pending');
+        params.set('senior_empid', user.empid);
+        params.set('per_page', '50');
+        const res = await fetch(`/api/pending_request?${params.toString()}`, {
+          credentials: 'include',
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          throw new Error(data.message || 'Failed to load approval request');
+        }
+        const rows = Array.isArray(data.rows) ? data.rows : [];
+        const request = rows.find(
+          (row) => String(row.request_id) === String(approvalRequestId),
+        );
+        if (cancelled) return;
+        if (!request) {
+          setApprovalError('Approval request not found.');
+          setApprovalContext(null);
+          return;
+        }
+        setApprovalContext(request);
+        setPendingApproval(null);
+      } catch (err) {
+        if (cancelled) return;
+        setApprovalError(
+          err && err.message
+            ? err.message
+            : 'Failed to load approval request.',
+        );
+        setApprovalContext(null);
+      } finally {
+        if (!cancelled) setApprovalLoading(false);
+      }
+    }
+    loadApprovalRequest();
+    return () => {
+      cancelled = true;
+    };
+  }, [isSenior, approvalRequestId, user?.empid]);
+
+  useEffect(() => {
+    if (!approvalContext?.proposed_data) return;
+    const { procedure, parameters } = approvalContext.proposed_data;
+    if (procedure) {
+      setSelectedProc(procedure);
+      setDatePreset('custom');
+    }
+    if (parameters && typeof parameters === 'object') {
+      setManualParams(parameters);
+      Object.entries(parameters).forEach(([key, value]) => {
+        const lower = key.toLowerCase();
+        if (lower.includes('start') || lower.includes('from')) {
+          setStartDate(normalizeDateInput(String(value), 'YYYY-MM-DD'));
+        } else if (lower.includes('end') || lower.includes('to')) {
+          setEndDate(normalizeDateInput(String(value), 'YYYY-MM-DD'));
+        }
+      });
+    }
+    setSelectedTransactions(approvalTransactions);
+    setLockInfo((info) => ({
+      idField: info?.idField ?? lockInfoMeta.idField ?? null,
+      tableField: info?.tableField ?? lockInfoMeta.tableField ?? null,
+      tableName: info?.tableName ?? lockInfoMeta.tableName ?? null,
+      pending: approvalTransactions,
+      locked: [],
+    }));
+    setHasLoadedApprovalResult(false);
+  }, [
+    approvalContext,
+    approvalTransactions,
+    lockInfoMeta.idField,
+    lockInfoMeta.tableField,
+    lockInfoMeta.tableName,
+  ]);
+
+  useEffect(() => {
+    if (!approvalContext) return;
+    if (approvalContext.proposed_data?.procedure !== selectedProc) return;
+    if (!allParamsProvided) return;
+    if (hasLoadedApprovalResult) return;
+    runReport();
+    setHasLoadedApprovalResult(true);
+  }, [
+    approvalContext,
+    selectedProc,
+    allParamsProvided,
+    hasLoadedApprovalResult,
+    runReport,
+  ]);
+
+  useEffect(() => {
+    if (!approvalContext) {
+      setHasLoadedApprovalResult(false);
+    }
+  }, [approvalContext]);
+
   const autoParams = useMemo(() => {
     return procParams.map((p) => {
       const name = p.toLowerCase();
@@ -106,6 +289,181 @@ export default function Reports() {
   const allParamsProvided = useMemo(
     () => finalParams.every((v) => v !== null && v !== ''),
     [finalParams],
+  );
+
+  const normalizedTransactionsForRequest = useCallback(
+    (transactions) => {
+      if (!Array.isArray(transactions)) return [];
+      return transactions
+        .map((tx) => {
+          if (!tx || typeof tx !== 'object') return null;
+          const table = tx.table || lockInfoMeta.tableName || null;
+          const recordId = tx.recordId;
+          if (!table || !recordId) return null;
+          return { table, recordId };
+        })
+        .filter(Boolean);
+    },
+    [lockInfoMeta.tableName],
+  );
+
+  const handleRequestApproval = useCallback(async () => {
+    if (!result) {
+      addToast('Run the report before requesting approval', 'error');
+      return;
+    }
+    const normalizedTransactions = normalizedTransactionsForRequest(
+      selectedTransactions,
+    );
+    if (!normalizedTransactions.length) {
+      addToast('No transactions are available for approval', 'error');
+      return;
+    }
+    const reason = window.prompt('Enter a reason for this approval request');
+    if (reason === null) return;
+    const trimmedReason = reason.trim();
+    if (!trimmedReason) {
+      addToast('Approval reason is required', 'error');
+      return;
+    }
+
+    const payload = {
+      table_name: 'report_transaction_locks',
+      record_id: `${selectedProc}:${Date.now()}`,
+      request_type: 'report_approval',
+      request_reason: trimmedReason,
+      proposed_data: {
+        procedure: selectedProc,
+        parameters: result.params || {},
+        transactions: normalizedTransactions,
+      },
+    };
+
+    const previousLockInfo = lockInfo;
+    setLockInfo((info) => ({
+      idField: info?.idField ?? lockInfoMeta.idField ?? null,
+      tableField: info?.tableField ?? lockInfoMeta.tableField ?? null,
+      tableName: info?.tableName ?? lockInfoMeta.tableName ?? null,
+      locked: info?.locked || [],
+      pending: normalizedTransactions,
+    }));
+    setRequestingApproval(true);
+    try {
+      const res = await fetch('/api/pending_request', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.message || 'Failed to submit approval request');
+      }
+      setPendingApproval({
+        requestId: data.request_id,
+        procedure: selectedProc,
+        parameters: result.params || {},
+        transactions: normalizedTransactions,
+        reason: trimmedReason,
+      });
+      addToast('Approval request sent for review', 'success');
+    } catch (err) {
+      setLockInfo(previousLockInfo || null);
+      addToast(
+        err && err.message ? err.message : 'Failed to request approval',
+        'error',
+      );
+    } finally {
+      setRequestingApproval(false);
+    }
+  }, [
+    result,
+    normalizedTransactionsForRequest,
+    selectedTransactions,
+    addToast,
+    lockInfo,
+    lockInfoMeta.idField,
+    lockInfoMeta.tableField,
+    lockInfoMeta.tableName,
+    selectedProc,
+  ]);
+
+  const handleApprovalResponse = useCallback(
+    async (status) => {
+      if (!approvalContext?.request_id) return;
+      const promptText =
+        status === 'accepted'
+          ? 'Add approval notes'
+          : 'Provide a reason for declining this approval';
+      const notes = window.prompt(promptText);
+      if (notes === null) return;
+      const trimmed = notes.trim();
+      if (!trimmed) {
+        addToast('Response notes are required', 'error');
+        return;
+      }
+
+      const transactions = approvalTransactions;
+      const previousLockInfo = lockInfo;
+      setLockInfo((info) => ({
+        idField: info?.idField ?? lockInfoMeta.idField ?? null,
+        tableField: info?.tableField ?? lockInfoMeta.tableField ?? null,
+        tableName: info?.tableName ?? lockInfoMeta.tableName ?? null,
+        pending: [],
+        locked: status === 'accepted' ? transactions : [],
+      }));
+      setResponding(true);
+      try {
+        const res = await fetch(
+          `/api/pending_request/${approvalContext.request_id}/respond`,
+          {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({
+              status: status === 'accepted' ? 'accepted' : 'declined',
+              response_notes: trimmed,
+            }),
+          },
+        );
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          throw new Error(data.message || 'Failed to submit response');
+        }
+        addToast(
+          status === 'accepted'
+            ? 'Report approved successfully'
+            : 'Report approval declined',
+          'success',
+        );
+        setApprovalContext(null);
+        setPendingApproval(null);
+        setApprovalError(null);
+        setSearchParams((prev) => {
+          const next = new URLSearchParams(prev);
+          next.delete('request_id');
+          return next;
+        }, { replace: true });
+      } catch (err) {
+        setLockInfo(previousLockInfo || null);
+        addToast(
+          err && err.message ? err.message : 'Failed to submit response',
+          'error',
+        );
+      } finally {
+        setResponding(false);
+      }
+    },
+    [
+      approvalContext?.request_id,
+      approvalTransactions,
+      addToast,
+      lockInfo,
+      lockInfoMeta.idField,
+      lockInfoMeta.tableField,
+      lockInfoMeta.tableName,
+      setSearchParams,
+    ],
   );
 
   function handlePresetChange(e) {
@@ -156,7 +514,7 @@ export default function Reports() {
     setEndDate(normalizeDateInput(fmt(end), 'YYYY-MM-DD'));
   }
 
-  async function runReport() {
+  const runReport = useCallback(async () => {
     if (!selectedProc) return;
     if (!allParamsProvided) {
       addToast('Missing parameters', 'error');
@@ -200,7 +558,16 @@ export default function Reports() {
     } catch {
       addToast('Failed to run procedure', 'error');
     }
-  }
+  }, [
+    selectedProc,
+    allParamsProvided,
+    procParams,
+    finalParams,
+    getLabel,
+    addToast,
+    branch,
+    department,
+  ]);
 
   return (
     <div>
@@ -280,9 +647,119 @@ export default function Reports() {
               >
                 Run
               </button>
+              {isSubordinate && result && (
+                <button
+                  onClick={handleRequestApproval}
+                  style={{ marginLeft: '0.5rem' }}
+                  disabled={
+                    requestingApproval ||
+                    selectedTransactions.length === 0 ||
+                    approvalContext !== null ||
+                    !!pendingApproval
+                  }
+                >
+                  {requestingApproval ? 'Requesting…' : 'Request Approval'}
+                </button>
+              )}
+              {isSenior && approvalContext && (
+                <>
+                  <button
+                    onClick={() => handleApprovalResponse('accepted')}
+                    style={{ marginLeft: '0.5rem' }}
+                    disabled={responding}
+                  >
+                    {responding ? 'Submitting…' : 'Approve'}
+                  </button>
+                  <button
+                    onClick={() => handleApprovalResponse('declined')}
+                    style={{ marginLeft: '0.5rem' }}
+                    disabled={responding}
+                  >
+                    Decline
+                  </button>
+                </>
+              )}
             </div>
         )}
       </div>
+      {pendingApproval && (
+        <div
+          style={{
+            marginTop: '0.75rem',
+            padding: '0.75rem',
+            border: '1px solid #fcd34d',
+            borderRadius: '0.5rem',
+            background: '#fffbeb',
+          }}
+        >
+          Pending approval request #{pendingApproval.requestId} for{' '}
+          {getLabel(pendingApproval.procedure)} covering{' '}
+          {pendingApproval.transactions?.length ?? 0} transaction
+          {pendingApproval.transactions?.length === 1 ? '' : 's'}.
+        </div>
+      )}
+      {isSenior && approvalRequestId && (
+        <div
+          style={{
+            marginTop: '0.75rem',
+            padding: '0.75rem',
+            border: '1px solid #d1d5db',
+            borderRadius: '0.5rem',
+            background: '#f9fafb',
+          }}
+        >
+          {approvalLoading ? (
+            <div>Loading approval request…</div>
+          ) : approvalError ? (
+            <div style={{ color: '#b91c1c' }}>{approvalError}</div>
+          ) : approvalContext ? (
+            <div>
+              <h3 style={{ marginTop: 0 }}>
+                Approval request #{approvalContext.request_id}
+              </h3>
+              <p>
+                Requested by <strong>{approvalContext.emp_id}</strong> on{' '}
+                {approvalContext.created_at || approvalContext.created_at_fmt ||
+                  'N/A'}
+              </p>
+              <p>
+                Reason: {approvalContext.request_reason || 'No reason provided'}
+              </p>
+              <p>
+                Procedure: {getLabel(approvalContext.proposed_data?.procedure || '')}
+              </p>
+              {approvalContext.proposed_data?.parameters && (
+                <div style={{ marginTop: '0.5rem' }}>
+                  <strong>Parameters:</strong>
+                  <ul style={{ marginTop: '0.25rem', paddingLeft: '1.25rem' }}>
+                    {Object.entries(
+                      approvalContext.proposed_data.parameters,
+                    ).map(([key, value]) => (
+                      <li key={key}>
+                        {key}: {String(value)}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {approvalTransactions.length > 0 && (
+                <div style={{ marginTop: '0.5rem' }}>
+                  <strong>Transactions:</strong>
+                  <ul style={{ marginTop: '0.25rem', paddingLeft: '1.25rem' }}>
+                    {approvalTransactions.map((tx, idx) => (
+                      <li key={`${tx.table || 'table'}-${tx.recordId}-${idx}`}>
+                        {tx.table || 'Unknown table'} #{tx.recordId}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div>No approval context loaded.</div>
+          )}
+        </div>
+      )}
       {result && (
         <ReportTable
           procedure={result.name}
@@ -290,6 +767,9 @@ export default function Reports() {
           rows={result.rows}
           buttonPerms={buttonPerms}
           fieldTypeMap={result.fieldTypeMap}
+          lockInfo={lockInfo}
+          onTransactionsChange={handleTransactionsChange}
+          onTransactionMetadata={handleTransactionMetadata}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- add approval state management to the Reports page including request and responder flows
- show approval context details and wire report actions to the backend while surfacing lock metadata
- extend ReportTable to expose transaction identifiers and highlight rows affected by pending or active locks

## Testing
- npm run lint *(fails: script not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68e00f60a16c8331ae59de8d0eda2e7e