### PR TITLE
Normalize tenant filter keys in table row handler

### DIFF
--- a/api-server/controllers/tableController.js
+++ b/api-server/controllers/tableController.js
@@ -36,6 +36,11 @@ try {
 }
 import { formatDateForDb } from '../utils/formatDate.js';
 
+let getTableRowByIdImpl = getTableRowById;
+export function __setGetTableRowByIdForTest(fn) {
+  getTableRowByIdImpl = typeof fn === 'function' ? fn : getTableRowById;
+}
+
 export async function getTables(req, res, next) {
   try {
     const tables = await listDatabaseTables();
@@ -144,13 +149,27 @@ export async function getTableRow(req, res, next) {
     const includeDeletedFlag =
       includeDeleted === '1' || includeDeleted === 'true';
     const tenantFilters = {};
+    const normalizeTenantKey = (key) => key.toLowerCase().replace(/_/g, '');
+    const tenantKeyMap = {
+      companyid: 'company_id',
+      branchid: 'branch_id',
+      departmentid: 'department_id',
+    };
     for (const key of ['company_id', 'branch_id', 'department_id']) {
       const value = rawQuery[key];
       if (value !== undefined && value !== '') {
         tenantFilters[key] = value;
       }
     }
-    const row = await getTableRowById(table, id, {
+    for (const [key, value] of Object.entries(rawQuery)) {
+      if (value === undefined || value === '') continue;
+      const normalized = normalizeTenantKey(key);
+      const snakeCaseKey = tenantKeyMap[normalized];
+      if (snakeCaseKey && tenantFilters[snakeCaseKey] === undefined) {
+        tenantFilters[snakeCaseKey] = value;
+      }
+    }
+    const row = await getTableRowByIdImpl(table, id, {
       tenantFilters,
       includeDeleted: includeDeletedFlag,
       defaultCompanyId: req.user?.companyId,

--- a/tests/api/tableController.test.js
+++ b/tests/api/tableController.test.js
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  getTableRow,
+  __setGetTableRowByIdForTest,
+} from '../../api-server/controllers/tableController.js';
+
+function createRes() {
+  return {
+    code: undefined,
+    body: undefined,
+    locals: {},
+    status(c) {
+      this.code = c;
+      return this;
+    },
+    json(b) {
+      this.body = b;
+    },
+    sendStatus(c) {
+      this.code = c;
+    },
+  };
+}
+
+test('GET /api/tables/:table/:id normalizes tenant filter keys', async () => {
+  let capturedOptions;
+  __setGetTableRowByIdForTest(async (table, id, options) => {
+    capturedOptions = options;
+    return { id };
+  });
+  const req = {
+    params: { table: 'foo', id: '123' },
+    query: { CompanyID: '77' },
+    user: { companyId: '11' },
+    on() {},
+  };
+  const res = createRes();
+  await getTableRow(req, res, () => {});
+  assert.ok(capturedOptions);
+  assert.equal(capturedOptions.tenantFilters.company_id, '77');
+  assert.deepEqual(res.body, { id: '123' });
+  __setGetTableRowByIdForTest(null);
+});


### PR DESCRIPTION
## Summary
- normalize tenant filter queries by mapping case-insensitive tenant keys to snake_case filters in the table row controller
- add a test hook to override the table row lookup during tests and verify normalization against the handler

## Testing
- npm test -- tests/api/tableController.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e00f0f9be08331b6b85cd1e0bf0280