### PR TITLE
Add temporary transaction request workflow for subordinate users

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -89,6 +89,7 @@ function parseEntry(raw = {}) {
       : [],
     moduleLabel: typeof raw.moduleLabel === 'string' ? raw.moduleLabel : '',
     procedures: arrify(raw.procedures || raw.procedure),
+    allowTemporaryTransactions: Boolean(raw.allowTemporaryTransactions),
   };
 }
 
@@ -203,6 +204,7 @@ export async function setFormConfig(
     detectFields = [],
     detectField = '',
     procedures = [],
+    allowTemporaryTransactions = false,
   } = config || {};
   const uid = arrify(userIdFields.length ? userIdFields : userIdField ? [userIdField] : []);
   const bid = arrify(
@@ -252,6 +254,7 @@ export async function setFormConfig(
     allowedBranches: ab,
     allowedDepartments: ad,
     procedures: arrify(procedures),
+    allowTemporaryTransactions: Boolean(allowTemporaryTransactions),
   };
   if (editableFields !== undefined) {
     cfg[table][name].editableFields = arrify(editableFields);

--- a/config/0/transactionForms.json
+++ b/config/0/transactionForms.json
@@ -47,6 +47,7 @@
         "or_o_barimt": "0",
         "company_id": ""
       },
+      "allowTemporaryTransactions": true,
       "tooltips": {
         "or_g_id": "tooltip.organization",
         "or_date": "tooltip.date"

--- a/docs/transaction-form-config.md
+++ b/docs/transaction-form-config.md
@@ -49,6 +49,9 @@ speed up loading when the images are viewed.
 - **moduleLabel** – optional label for the parent module
 - **allowedBranches** – restrict usage to these branch IDs
 - **allowedDepartments** – restrict usage to these department IDs
+- **allowTemporaryTransactions** – allow subordinate users to submit the form as
+  a temporary transaction request that requires senior approval before it is
+  written to the live table
 
 The form displays header fields (system filled values) separately from other
 fields. When printing, the `printEmpField` and `printCustField` lists control


### PR DESCRIPTION
## Summary
- add an `allowTemporaryTransactions` flag to transaction form configs and documentation
- extend pending request handling with a `temporary_insert` workflow that inserts approved drafts
- update the TableManager UI so subordinates can request temporary transactions and see pending statuses

## Testing
- npm test -- --test-name-pattern=pendingRequest

------
https://chatgpt.com/codex/tasks/task_e_68e015146ee8833192911237e2f6367b