### PR TITLE
Reorder allParamsProvided memo before dependent hooks

### DIFF
--- a/src/erp.mgt.mn/pages/Reports.jsx
+++ b/src/erp.mgt.mn/pages/Reports.jsx
@@ -245,27 +245,6 @@ export default function Reports() {
     lockInfoMeta.tableName,
   ]);
 
-  useEffect(() => {
-    if (!approvalContext) return;
-    if (approvalContext.proposed_data?.procedure !== selectedProc) return;
-    if (!allParamsProvided) return;
-    if (hasLoadedApprovalResult) return;
-    runReport();
-    setHasLoadedApprovalResult(true);
-  }, [
-    approvalContext,
-    selectedProc,
-    allParamsProvided,
-    hasLoadedApprovalResult,
-    runReport,
-  ]);
-
-  useEffect(() => {
-    if (!approvalContext) {
-      setHasLoadedApprovalResult(false);
-    }
-  }, [approvalContext]);
-
   const autoParams = useMemo(() => {
     return procParams.map((p) => {
       const name = p.toLowerCase();
@@ -290,6 +269,27 @@ export default function Reports() {
     () => finalParams.every((v) => v !== null && v !== ''),
     [finalParams],
   );
+
+  useEffect(() => {
+    if (!approvalContext) return;
+    if (approvalContext.proposed_data?.procedure !== selectedProc) return;
+    if (!allParamsProvided) return;
+    if (hasLoadedApprovalResult) return;
+    runReport();
+    setHasLoadedApprovalResult(true);
+  }, [
+    approvalContext,
+    selectedProc,
+    allParamsProvided,
+    hasLoadedApprovalResult,
+    runReport,
+  ]);
+
+  useEffect(() => {
+    if (!approvalContext) {
+      setHasLoadedApprovalResult(false);
+    }
+  }, [approvalContext]);
 
   const normalizedTransactionsForRequest = useCallback(
     (transactions) => {


### PR DESCRIPTION
## Summary
- move the `allParamsProvided` memo so it is initialized before effects and callbacks that depend on it in the reports page

## Testing
- npm run test *(fails: existing seedTenantTables and users trigger tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e01798f16c8331a1e9688f95d00c8c