### PR TITLE
Fix TableManager row click handler syntax error

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -2990,8 +2990,8 @@ const TableManager = forwardRef(function TableManager({
                   if (r._temporaryStatus) e.stopPropagation();
                   return;
                 }
-                  openDetail(r);
-                }
+
+                openDetail(r);
               }}
               style={{
                 cursor: r._temporaryStatus ? 'default' : 'pointer',


### PR DESCRIPTION
## Summary
- correct the TableManager row click handler to call `openDetail` only after skipping temporary rows
- ensure the row style spread expression closes correctly to restore build output

## Testing
- npm run build:erp *(fails: missing @babel/parser dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e007543a1883319a16a58f74a727ae