### PR TITLE
Fix conditional rendering syntax in TableManager

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -3094,7 +3094,7 @@ const TableManager = forwardRef(function TableManager({
                           </button>
                         </>
                       )}
-                      {!isTemporaryRow ? (
+                      {!isTemporaryRow && (
                         !isSubordinate ? (
                           <>
                             {buttonPerms['Edit transaction'] && (
@@ -3134,7 +3134,7 @@ const TableManager = forwardRef(function TableManager({
                             </button>
                           </>
                         )
-                      ) : null}
+                      )}
                       {isTemporaryRow && (
                         <div
                           style={{


### PR DESCRIPTION
## Summary
- resolve the syntax error in TableManager by simplifying the temporary row action conditional

## Testing
- npm run build:erp *(fails: missing @babel/parser dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e024f2112483318659b74f0c4845e1