### PR TITLE
feat: support request categories across pending workflows

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -27,7 +27,8 @@ undefined the client connects to the same origin as the page.
 ## Local storage keys
 
 Hooks that track notification counts store "seen" markers in `localStorage`
-using a key that includes the employee ID and ends with `-seen`, for example
-`${empid}-incoming-pending-seen`. These markers persist across logouts so that
-counts are retained between sessions. New hooks should follow the same naming
-pattern to maintain per-user tracking.
+using a key that includes the employee ID, an optional request-type scope, and
+ends with `-seen`, for example `${empid}-all-incoming-pending-seen` or
+`${empid}-report_approval-outgoing-accepted-seen`. These markers persist across
+logouts so that counts are retained between sessions. New hooks should follow
+the same naming pattern to maintain per-user tracking.

--- a/src/erp.mgt.mn/components/HeaderMenu.jsx
+++ b/src/erp.mgt.mn/components/HeaderMenu.jsx
@@ -15,7 +15,17 @@ export default function HeaderMenu({ onOpen }) {
   const generalConfig = useGeneralConfig();
   const items = filterHeaderModules(modules, perms, txnModules);
   const headerMap = useHeaderMappings(items.map((m) => m.module_key));
-  const { hasNew } = usePendingRequests();
+  const { hasNew, categories, order } = usePendingRequests();
+
+  const totalPendingIncoming = order.reduce((sum, key) => {
+    const pending = categories?.[key]?.incoming?.pending?.count || 0;
+    return sum + pending;
+  }, 0);
+  const totalNewIncoming = order.reduce((sum, key) => {
+    const entry = categories?.[key]?.incoming?.pending;
+    if (!entry?.hasNew) return sum;
+    return sum + (entry.newCount || 0);
+  }, 0);
 
   // Build a quick lookup map so we can resolve module paths
   const moduleMap = {};
@@ -52,6 +62,12 @@ export default function HeaderMenu({ onOpen }) {
           >
             {badgeKeys.has(m.module_key) && <span style={styles.badge} />}
             {label}
+            {m.module_key === 'requests' && totalPendingIncoming > 0 && (
+              <span style={styles.countBadge}>{totalPendingIncoming}</span>
+            )}
+            {m.module_key === 'requests' && totalNewIncoming > 0 && (
+              <span style={styles.newBadge}>+{totalNewIncoming}</span>
+            )}
           </button>
         );
       })}
@@ -68,7 +84,10 @@ const styles = {
     cursor: 'pointer',
     fontSize: '0.9rem',
     marginRight: '0.75rem',
-    position: 'relative'
+    position: 'relative',
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0.35rem',
   },
   badge: {
     background: 'red',
@@ -77,5 +96,19 @@ const styles = {
     height: '8px',
     display: 'inline-block',
     marginRight: '4px'
+  },
+  countBadge: {
+    background: '#1d4ed8',
+    color: '#fff',
+    borderRadius: '999px',
+    padding: '0 0.45rem',
+    fontSize: '0.75rem',
+  },
+  newBadge: {
+    background: '#dc2626',
+    color: '#fff',
+    borderRadius: '999px',
+    padding: '0 0.35rem',
+    fontSize: '0.7rem',
   }
 };

--- a/src/erp.mgt.mn/components/PendingRequestWidget.jsx
+++ b/src/erp.mgt.mn/components/PendingRequestWidget.jsx
@@ -5,31 +5,66 @@ import { usePendingRequests } from '../context/PendingRequestContext.jsx';
 
 export default function PendingRequestWidget() {
   const navigate = useNavigate();
-  const { incoming } = usePendingRequests();
+  const { categories, order, incoming } = usePendingRequests();
   const { t } = useTranslation();
-  const count = incoming.pending.count;
 
-  const badgeStyle = {
-    display: 'inline-block',
-    backgroundColor: 'red',
-    color: 'white',
-    borderRadius: '50%',
-    padding: '0.25rem 0.5rem',
-    minWidth: '1.5rem',
-    textAlign: 'center',
-    marginLeft: '0.5rem',
+  const totalPending = incoming?.pending?.count ?? 0;
+  const totalNew = incoming?.pending?.newCount ?? 0;
+
+  const headerBadgeStyle = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#1d4ed8',
+    color: '#fff',
+    borderRadius: '999px',
+    padding: '0.1rem 0.6rem',
+    fontSize: '0.75rem',
+    marginLeft: '0.4rem',
+  };
+
+  const newBadgeStyle = {
+    backgroundColor: '#dc2626',
+    color: '#fff',
+    borderRadius: '999px',
+    padding: '0 0.4rem',
+    fontSize: '0.7rem',
+    marginLeft: '0.35rem',
+  };
+
+  const categoryButtonStyle = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    width: '100%',
+    border: '1px solid #cbd5f5',
+    borderRadius: '0.5rem',
+    padding: '0.6rem 0.85rem',
+    background: '#fff',
+    cursor: 'pointer',
+    fontSize: '0.9rem',
+    fontWeight: 500,
+  };
+
+  const goToView = (key) => {
+    const category = categories?.[key];
+    category?.markSeen?.();
+    navigate(`/requests?tab=incoming&view=${key}`);
   };
 
   return (
     <div>
-      <h3>
+      <h3 style={{ display: 'flex', alignItems: 'center' }}>
         {t('pendingRequestWidget.incomingRequestsHeading', 'Incoming requests')}
-        {count > 0 && <span style={badgeStyle}>{count}</span>}
+        {totalPending > 0 && (
+          <span style={headerBadgeStyle}>{totalPending}</span>
+        )}
+        {totalNew > 0 && <span style={newBadgeStyle}>+{totalNew}</span>}
       </h3>
-      {count > 0 ? (
+      {totalPending > 0 ? (
         <p>
           {t('pendingRequestWidget.incomingRequestCount', {
-            count,
+            count: totalPending,
             defaultValue: '{{count}} incoming request',
             defaultValue_plural: '{{count}} incoming requests',
           })}
@@ -39,6 +74,33 @@ export default function PendingRequestWidget() {
           {t('pendingRequestWidget.noIncomingRequests', 'No incoming requests')}
         </p>
       )}
+      <div style={{ display: 'grid', gap: '0.5rem', margin: '0.75rem 0' }}>
+        {order.map((key) => {
+          const category = categories?.[key];
+          if (!category) return null;
+          const pendingEntry = category.incoming?.pending || {
+            count: 0,
+            hasNew: false,
+            newCount: 0,
+          };
+          return (
+            <button
+              type="button"
+              key={key}
+              onClick={() => goToView(key)}
+              style={categoryButtonStyle}
+            >
+              <span>{category.label}</span>
+              <span style={{ display: 'flex', alignItems: 'center', gap: '0.35rem' }}>
+                <span style={{ fontWeight: 600 }}>{pendingEntry.count}</span>
+                {pendingEntry.hasNew && pendingEntry.newCount > 0 ? (
+                  <span style={newBadgeStyle}>+{pendingEntry.newCount}</span>
+                ) : null}
+              </span>
+            </button>
+          );
+        })}
+      </div>
       <button onClick={() => navigate('/requests?tab=incoming')}>
         {t('requestWidget.viewRequestsButton', 'View requests')}
       </button>

--- a/src/erp.mgt.mn/context/PendingRequestContext.jsx
+++ b/src/erp.mgt.mn/context/PendingRequestContext.jsx
@@ -1,19 +1,46 @@
 import { createContext, useContext } from 'react';
 
-const defaultStatus = { count: 0, hasNew: false, newCount: 0 };
+export const REQUEST_CATEGORY_CONFIG = [
+  { key: 'changes', label: 'Change Requests', requestType: 'changes' },
+  {
+    key: 'report_approval',
+    label: 'Report Approvals',
+    requestType: 'report_approval',
+  },
+  {
+    key: 'temporary_insert',
+    label: 'Temporary Transactions',
+    requestType: 'temporary_insert',
+  },
+];
+
+function createDefaultStatuses() {
+  return {
+    pending: { count: 0, hasNew: false, newCount: 0 },
+    accepted: { count: 0, hasNew: false, newCount: 0 },
+    declined: { count: 0, hasNew: false, newCount: 0 },
+  };
+}
+
+const defaultCategories = REQUEST_CATEGORY_CONFIG.reduce((acc, config) => {
+  acc[config.key] = {
+    key: config.key,
+    label: config.label,
+    requestType: config.requestType,
+    incoming: createDefaultStatuses(),
+    outgoing: createDefaultStatuses(),
+    hasNew: false,
+    markSeen: () => {},
+  };
+  return acc;
+}, {});
 
 export const PendingRequestContext = createContext({
-  incoming: {
-    pending: defaultStatus,
-    accepted: defaultStatus,
-    declined: defaultStatus,
-  },
-  outgoing: {
-    pending: defaultStatus,
-    accepted: defaultStatus,
-    declined: defaultStatus,
-  },
+  categories: defaultCategories,
+  order: REQUEST_CATEGORY_CONFIG.map((c) => c.key),
   hasNew: false,
+  incoming: createDefaultStatuses(),
+  outgoing: createDefaultStatuses(),
   markSeen: () => {},
 });
 

--- a/src/erp.mgt.mn/pages/Requests.jsx
+++ b/src/erp.mgt.mn/pages/Requests.jsx
@@ -1,5 +1,5 @@
 // src/erp.mgt.mn/pages/Requests.jsx
-import React, { useEffect, useState, useRef, useMemo } from 'react';
+import React, { useEffect, useState, useRef, useMemo, useCallback } from 'react';
 import { diff } from 'jsondiffpatch';
 import { useAuth } from '../context/AuthContext.jsx';
 import { API_BASE } from '../utils/apiBase.js';
@@ -17,15 +17,94 @@ function ch(n) {
 
 const MAX_WIDTH = ch(40);
 
-function getAverageLength(values) {
-  const list = values
-    .filter((v) => v !== null && v !== undefined)
-    .map((v) =>
-      typeof v === 'object' ? JSON.stringify(v) : String(v),
-    )
-    .slice(0, 20);
-  if (list.length === 0) return 0;
-  return Math.round(list.reduce((s, v) => s + v.length, 0) / list.length);
+const REQUEST_TYPE_LABELS = {
+  changes: 'All change requests',
+  edit: 'Edit Request',
+  delete: 'Delete Request',
+  report_approval: 'Report Approval',
+  temporary_insert: 'Temporary Transaction',
+};
+
+const STATUS_LABELS = {
+  pending: 'Pending',
+  accepted: 'Accepted',
+  declined: 'Declined',
+};
+
+const VIEW_CONFIG = {
+  changes: {
+    key: 'changes',
+    label: 'Change Requests',
+    defaultRequestType: 'changes',
+    requestTypeOptions: ['changes', 'edit', 'delete'],
+    showRequesterFilter: true,
+    showTableFilter: true,
+    lockRequestType: false,
+    defaultPerPage: 5,
+    renderMode: 'diff',
+  },
+  report_approval: {
+    key: 'report_approval',
+    label: 'Report Approvals',
+    defaultRequestType: 'report_approval',
+    requestTypeOptions: ['report_approval'],
+    showRequesterFilter: true,
+    showTableFilter: false,
+    lockRequestType: true,
+    defaultPerPage: 5,
+    renderMode: 'report',
+  },
+  temporary_insert: {
+    key: 'temporary_insert',
+    label: 'Temporary Transactions',
+    defaultRequestType: 'temporary_insert',
+    requestTypeOptions: ['temporary_insert'],
+    showRequesterFilter: true,
+    showTableFilter: true,
+    lockRequestType: true,
+    defaultPerPage: 5,
+    renderMode: 'temporary',
+  },
+};
+
+function getRequestTypeOptions(config) {
+  return config.requestTypeOptions.map((value) => ({
+    value,
+    label: REQUEST_TYPE_LABELS[value] || value,
+  }));
+}
+
+function createViewState(config, { today, initialStatus }) {
+  const safeToday = today || formatTimestamp(new Date()).slice(0, 10);
+  const status = initialStatus ?? 'pending';
+  return {
+    filters: {
+      requestedEmpid: '',
+      tableName: '',
+      status,
+      dateFrom: safeToday,
+      dateTo: safeToday,
+      requestType: config.defaultRequestType,
+      dateField: 'created',
+    },
+    perPage: config.defaultPerPage ?? 5,
+    incoming: {
+      data: [],
+      loading: false,
+      error: null,
+      page: 1,
+      total: 0,
+      reloadKey: 0,
+    },
+    outgoing: {
+      data: [],
+      loading: false,
+      error: null,
+      page: 1,
+      total: 0,
+      reloadKey: 0,
+    },
+  };
 }
 
 function renderValue(val) {
@@ -58,8 +137,7 @@ function normalizeEmpId(id) {
 
 export default function RequestsPage() {
   const { user, session } = useAuth();
-  const { incoming: incomingCounts, outgoing: outgoingCounts, markSeen } =
-    usePendingRequests();
+  const { categories, order } = usePendingRequests();
 
   const seniorEmpId =
     session && user?.empid && !(Number(session.senior_empid) > 0)
@@ -69,45 +147,168 @@ export default function RequestsPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const initialTab = searchParams.get('tab');
   const initialStatus = searchParams.get('status');
+  const initialViewParam = searchParams.get('view');
 
-  // Always default to the user's own outgoing requests. Seniors can
-  // still switch to the incoming tab manually.
   const [activeTab, setActiveTab] = useState(
     initialTab === 'incoming' ? 'incoming' : 'outgoing',
   );
-  const [incomingRequests, setIncomingRequests] = useState([]);
-  const [outgoingRequests, setOutgoingRequests] = useState([]);
-  const [incomingLoading, setIncomingLoading] = useState(true);
-  const [outgoingLoading, setOutgoingLoading] = useState(false);
-  const [incomingError, setIncomingError] = useState(null);
-  const [outgoingError, setOutgoingError] = useState(null);
 
-  // filters
-  const [requestedEmpid, setRequestedEmpid] = useState('');
-  const [tableName, setTableName] = useState('');
-  const [status, setStatus] = useState(initialStatus || 'pending');
-  const [dateFrom, setDateFrom] = useState('');
-  const [dateTo, setDateTo] = useState('');
-  const [requestType, setRequestType] = useState('');
-  const [dateField, setDateField] = useState('created');
-  const [incomingReloadKey, setIncomingReloadKey] = useState(0);
-  const [outgoingReloadKey, setOutgoingReloadKey] = useState(0);
-  const [incomingPage, setIncomingPage] = useState(1);
-  const [outgoingPage, setOutgoingPage] = useState(1);
+  const availableViewKeys = useMemo(
+    () => order.filter((key) => categories?.[key] && VIEW_CONFIG[key]),
+    [order, categories],
+  );
 
-  const [perPage, setPerPage] = useState(2);
-  const [incomingTotal, setIncomingTotal] = useState(0);
-  const [outgoingTotal, setOutgoingTotal] = useState(0);
+  const defaultViewKey = useMemo(() => {
+    if (initialViewParam && availableViewKeys.includes(initialViewParam)) {
+      return initialViewParam;
+    }
+    if (availableViewKeys.length) return availableViewKeys[0];
+    return 'changes';
+  }, [initialViewParam, availableViewKeys]);
+
+  const [activeView, setActiveView] = useState(defaultViewKey);
+
+  const todayStr = useMemo(
+    () => formatTimestamp(new Date()).slice(0, 10),
+    [],
+  );
+
+  const [viewState, setViewState] = useState(() => {
+    const initial = {};
+    Object.values(VIEW_CONFIG).forEach((config) => {
+      initial[config.key] = createViewState(config, {
+        today: todayStr,
+        initialStatus: initialStatus || 'pending',
+      });
+    });
+    return initial;
+  });
+
+  useEffect(() => {
+    if (
+      availableViewKeys.length &&
+      !availableViewKeys.includes(activeView)
+    ) {
+      setActiveView(availableViewKeys[0]);
+    }
+  }, [availableViewKeys, activeView]);
+
+  useEffect(() => {
+    if (!viewState[activeView] && VIEW_CONFIG[activeView]) {
+      setViewState((prev) => ({
+        ...prev,
+        [activeView]: createViewState(VIEW_CONFIG[activeView], {
+          today: todayStr,
+          initialStatus: initialStatus || 'pending',
+        }),
+      }));
+    }
+  }, [activeView, initialStatus, todayStr, viewState]);
+
+  const updateFilters = useCallback((viewKey, changes) => {
+    setViewState((prev) => {
+      const current = prev[viewKey];
+      if (!current) return prev;
+      const nextFilters =
+        typeof changes === 'function'
+          ? changes(current.filters)
+          : { ...current.filters, ...changes };
+      let changed = false;
+      for (const key of Object.keys(nextFilters)) {
+        if (nextFilters[key] !== current.filters[key]) {
+          changed = true;
+          break;
+        }
+      }
+      if (!changed) return prev;
+      return {
+        ...prev,
+        [viewKey]: {
+          ...current,
+          filters: nextFilters,
+          incoming: { ...current.incoming, page: 1 },
+          outgoing: { ...current.outgoing, page: 1 },
+        },
+      };
+    });
+  }, []);
+
+  const updatePerPage = useCallback((viewKey, value) => {
+    setViewState((prev) => {
+      const current = prev[viewKey];
+      if (!current) return prev;
+      if (current.perPage === value) return prev;
+      return {
+        ...prev,
+        [viewKey]: {
+          ...current,
+          perPage: value,
+          incoming: { ...current.incoming, page: 1 },
+          outgoing: { ...current.outgoing, page: 1 },
+        },
+      };
+    });
+  }, []);
+
+  const triggerReload = useCallback((viewKey, direction) => {
+    setViewState((prev) => {
+      const current = prev[viewKey];
+      if (!current) return prev;
+      return {
+        ...prev,
+        [viewKey]: {
+          ...current,
+          [direction]: {
+            ...current[direction],
+            reloadKey: current[direction].reloadKey + 1,
+          },
+        },
+      };
+    });
+  }, []);
+
+  const setPageFor = useCallback((viewKey, direction, page) => {
+    setViewState((prev) => {
+      const current = prev[viewKey];
+      if (!current) return prev;
+      if (current[direction].page === page) return prev;
+      return {
+        ...prev,
+        [viewKey]: {
+          ...current,
+          [direction]: {
+            ...current[direction],
+            page,
+          },
+        },
+      };
+    });
+  }, []);
 
   const configCache = useRef({});
 
+  const activeViewConfig = VIEW_CONFIG[activeView] || VIEW_CONFIG.changes;
+  const activeViewState = viewState[activeView] || createViewState(activeViewConfig, {
+    today: todayStr,
+    initialStatus: initialStatus || 'pending',
+  });
+  const activeFilters = activeViewState.filters;
+  const currentStatus = activeFilters.status || 'pending';
+  const { requestedEmpid, tableName, requestType, dateFrom, dateTo, dateField } =
+    activeFilters;
+  const perPage = activeViewState.perPage;
+  const incomingState = activeViewState.incoming;
+  const outgoingState = activeViewState.outgoing;
+  const incomingRequests = incomingState.data;
+  const outgoingRequests = outgoingState.data;
   const requests =
     activeTab === 'incoming' ? incomingRequests : outgoingRequests;
   const loading =
-    activeTab === 'incoming' ? incomingLoading : outgoingLoading;
-  const error = activeTab === 'incoming' ? incomingError : outgoingError;
-  const currentPage = activeTab === 'incoming' ? incomingPage : outgoingPage;
-  const total = activeTab === 'incoming' ? incomingTotal : outgoingTotal;
+    activeTab === 'incoming' ? incomingState.loading : outgoingState.loading;
+  const error = activeTab === 'incoming' ? incomingState.error : outgoingState.error;
+  const currentPage =
+    activeTab === 'incoming' ? incomingState.page : outgoingState.page;
+  const total = activeTab === 'incoming' ? incomingState.total : outgoingState.total;
   const totalPages = Math.max(1, Math.ceil(total / perPage));
 
   const requesterOptions = useMemo(() => {
@@ -124,41 +325,56 @@ export default function RequestsPage() {
 
   const allFields = useMemo(() => {
     const set = new Set();
-    requests.forEach((r) => r.fields?.forEach((f) => set.add(f.name)));
+    requests.forEach((r) => {
+      if (Array.isArray(r.fields)) {
+        r.fields.forEach((f) => set.add(f.name));
+      }
+    });
     return Array.from(set);
   }, [requests]);
 
   const headerMap = useHeaderMappings(allFields);
-  useEffect(() => {
-    const today = formatTimestamp(new Date()).slice(0, 10);
-    setDateFrom(today);
-    setDateTo(today);
-  }, []);
+  const requestTypeOptions = useMemo(
+    () => getRequestTypeOptions(activeViewConfig),
+    [activeViewConfig],
+  );
+
   useEffect(() => {
     const tab = searchParams.get('tab');
     if (tab && tab !== activeTab) {
       setActiveTab(tab === 'incoming' ? 'incoming' : 'outgoing');
     }
-    const spStatus = searchParams.get('status');
-    if (spStatus && spStatus !== status) {
-      setStatus(spStatus);
+    const spView = searchParams.get('view');
+    const nextView =
+      spView && availableViewKeys.includes(spView) ? spView : activeView;
+    if (spView && spView !== activeView && availableViewKeys.includes(spView)) {
+      setActiveView(spView);
     }
-  }, [searchParams]);
+    const spStatus = searchParams.get('status');
+    if (spStatus && spStatus !== (viewState[nextView]?.filters.status ?? '')) {
+      updateFilters(nextView, { status: spStatus });
+    }
+  }, [
+    searchParams,
+    activeTab,
+    activeView,
+    availableViewKeys,
+    updateFilters,
+    viewState,
+  ]);
 
   useEffect(() => {
     const params = new URLSearchParams();
     params.set('tab', activeTab);
-    params.set('status', status);
+    if (currentStatus) params.set('status', currentStatus);
+    params.set('view', activeView);
     setSearchParams(params, { replace: true });
-  }, [activeTab, status, setSearchParams]);
-  useEffect(() => {
-    setIncomingPage(1);
-  }, [status, requestedEmpid, tableName, requestType, dateFrom, dateTo, dateField]);
-  useEffect(() => {
-    setOutgoingPage(1);
-  }, [status, tableName, requestType, dateFrom, dateTo, dateField]);
+  }, [activeTab, currentStatus, activeView, setSearchParams]);
   async function enrichRequests(data) {
-    const tables = Array.from(new Set(data.map((r) => r.table_name)));
+    const changeRequests = data.filter(
+      (req) => req.request_type === 'edit' || req.request_type === 'delete',
+    );
+    const tables = Array.from(new Set(changeRequests.map((r) => r.table_name)));
     await Promise.all(
       tables
         .filter((t) => !configCache.current[t])
@@ -177,66 +393,152 @@ export default function RequestsPage() {
     );
 
     return data.map((req) => {
-      const original = req.original || null;
-      const cfg = configCache.current[req.table_name] || { displayFields: [] };
-      const visible = cfg.displayFields?.length
-        ? cfg.displayFields
-        : Array.from(
-            new Set([
-              ...Object.keys(original || {}),
-              ...Object.keys(req.proposed_data || {}),
-            ]),
-          );
-
-      const fields = visible
-        .map((name) => {
-          const before = original ? original[name] : undefined;
-          const after = req.proposed_data ? req.proposed_data[name] : undefined;
-          const isComplex =
-            (before && typeof before === 'object') ||
-            (after && typeof after === 'object');
-          let changed = false;
-          if (isComplex) {
-            changed = !!diff(before, after);
-          } else {
-            changed = JSON.stringify(before) !== JSON.stringify(after);
-          }
-          return { name, before, after, changed, isComplex };
-        })
-        .filter((f) => {
-          const emptyBefore =
-            f.before === undefined || f.before === null || f.before === '';
-          const emptyAfter =
-            f.after === undefined || f.after === null || f.after === '';
-          return !(emptyBefore && emptyAfter);
-        });
-
-      return {
+      const base = {
         ...req,
-        original,
-        fields,
+        original: req.original || null,
         notes: '',
         response_status: null,
         error: null,
       };
+      if (req.request_type === 'edit' || req.request_type === 'delete') {
+        const cfg = configCache.current[req.table_name] || { displayFields: [] };
+        const visible = cfg.displayFields?.length
+          ? cfg.displayFields
+          : Array.from(
+              new Set([
+                ...Object.keys(base.original || {}),
+                ...Object.keys(req.proposed_data || {}),
+              ]),
+            );
+
+        const fields = visible
+          .map((name) => {
+            const before = base.original ? base.original[name] : undefined;
+            const after = req.proposed_data ? req.proposed_data[name] : undefined;
+            const isComplex =
+              (before && typeof before === 'object') ||
+              (after && typeof after === 'object');
+            let changed = false;
+            if (isComplex) {
+              changed = !!diff(before, after);
+            } else {
+              changed = JSON.stringify(before) !== JSON.stringify(after);
+            }
+            return { name, before, after, changed, isComplex };
+          })
+          .filter((f) => {
+            const emptyBefore =
+              f.before === undefined || f.before === null || f.before === '';
+            const emptyAfter =
+              f.after === undefined || f.after === null || f.after === '';
+            return !(emptyBefore && emptyAfter);
+          });
+
+        return {
+          ...base,
+          fields,
+        };
+      }
+
+      if (req.request_type === 'report_approval') {
+        const proposed =
+          req.proposed_data && typeof req.proposed_data === 'object'
+            ? req.proposed_data
+            : {};
+        const transactions = Array.isArray(proposed.transactions)
+          ? proposed.transactions
+              .map((tx) => {
+                if (!tx || typeof tx !== 'object') return null;
+                const table = tx.table || tx.tableName || tx.table_name;
+                const recordId =
+                  tx.recordId ?? tx.record_id ?? tx.id ?? tx.transactionId;
+                if (!table || recordId === undefined || recordId === null) {
+                  return null;
+                }
+                return { table, recordId: String(recordId) };
+              })
+              .filter(Boolean)
+          : [];
+        const parameters =
+          proposed.parameters && typeof proposed.parameters === 'object'
+            ? proposed.parameters
+            : {};
+        return {
+          ...base,
+          reportInfo: {
+            procedure: proposed.procedure || '',
+            parameters,
+            transactions,
+          },
+        };
+      }
+
+      if (req.request_type === 'temporary_insert') {
+        const proposed =
+          req.proposed_data && typeof req.proposed_data === 'object'
+            ? req.proposed_data
+            : {};
+        const entries = Object.entries(proposed)
+          .map(([name, value]) => ({ name, value }))
+          .sort((a, b) => a.name.localeCompare(b.name));
+        return {
+          ...base,
+          insertFields: entries,
+        };
+      }
+
+      return base;
     });
   }
 
   useEffect(() => {
-    if (activeTab !== 'incoming' || !seniorEmpId || !dateFrom || !dateTo)
+    if (activeTab !== 'incoming') return;
+    if (!dateFrom || !dateTo) return;
+    const viewKey = activeView;
+    const counts = categories?.[viewKey];
+    counts?.markSeen?.();
+    if (!seniorEmpId) {
+      setViewState((prev) => {
+        const current = prev[viewKey];
+        if (!current) return prev;
+        return {
+          ...prev,
+          [viewKey]: {
+            ...current,
+            incoming: {
+              ...current.incoming,
+              loading: false,
+              error: null,
+              data: [],
+              total: 0,
+            },
+          },
+        };
+      });
       return;
-    markSeen();
+    }
+    debugLog('Loading incoming requests', { view: viewKey });
+    setViewState((prev) => {
+      const current = prev[viewKey];
+      if (!current) return prev;
+      return {
+        ...prev,
+        [viewKey]: {
+          ...current,
+          incoming: { ...current.incoming, loading: true, error: null },
+        },
+      };
+    });
+    let cancelled = false;
+
     async function load() {
-      debugLog('Loading pending requests');
-      setIncomingLoading(true);
-      setIncomingError(null);
       try {
         const params = new URLSearchParams({
-          senior_empid: seniorEmpId,
-          page: incomingPage,
-          per_page: perPage,
+          senior_empid: String(seniorEmpId),
+          page: String(incomingState.page),
+          per_page: String(perPage),
         });
-        if (status) params.append('status', status);
+        if (currentStatus) params.append('status', currentStatus);
         if (requestedEmpid) params.append('requested_empid', requestedEmpid);
         if (tableName) params.append('table_name', tableName);
         if (requestType) params.append('request_type', requestType);
@@ -250,45 +552,92 @@ export default function RequestsPage() {
         if (!res.ok) throw new Error('Failed to load requests');
         const data = await res.json();
         const enriched = await enrichRequests(data.rows || []);
-        setIncomingRequests(enriched);
-        setIncomingTotal(data.total || 0);
+        if (cancelled) return;
+        setViewState((prev) => {
+          const current = prev[viewKey];
+          if (!current) return prev;
+          return {
+            ...prev,
+            [viewKey]: {
+              ...current,
+              incoming: {
+                ...current.incoming,
+                loading: false,
+                data: enriched,
+                total: data.total || 0,
+                error: null,
+              },
+            },
+          };
+        });
       } catch (err) {
         console.error(err);
-        setIncomingError('Failed to load requests');
-      } finally {
-        setIncomingLoading(false);
+        if (cancelled) return;
+        setViewState((prev) => {
+          const current = prev[viewKey];
+          if (!current) return prev;
+          return {
+            ...prev,
+            [viewKey]: {
+              ...current,
+              incoming: {
+                ...current.incoming,
+                loading: false,
+                error: 'Failed to load requests',
+              },
+            },
+          };
+        });
       }
     }
 
-      load();
-    }, [
-      activeTab,
-      markSeen,
-      seniorEmpId,
-      status,
-      requestedEmpid,
-      tableName,
-      requestType,
-      dateFrom,
-      dateTo,
-      dateField,
-      incomingReloadKey,
-      incomingPage,
-      perPage,
-    ]);
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    activeTab,
+    activeView,
+    categories,
+    seniorEmpId,
+    currentStatus,
+    requestedEmpid,
+    tableName,
+    requestType,
+    dateFrom,
+    dateTo,
+    dateField,
+    incomingState.page,
+    incomingState.reloadKey,
+    perPage,
+  ]);
 
   useEffect(() => {
-    if (activeTab !== 'outgoing' || !dateFrom || !dateTo) return;
-    markSeen();
+    if (activeTab !== 'outgoing') return;
+    if (!dateFrom || !dateTo) return;
+    const viewKey = activeView;
+    const counts = categories?.[viewKey];
+    counts?.markSeen?.();
+    setViewState((prev) => {
+      const current = prev[viewKey];
+      if (!current) return prev;
+      return {
+        ...prev,
+        [viewKey]: {
+          ...current,
+          outgoing: { ...current.outgoing, loading: true, error: null },
+        },
+      };
+    });
+    let cancelled = false;
+
     async function load() {
-      setOutgoingLoading(true);
-      setOutgoingError(null);
       try {
         const params = new URLSearchParams({
-          page: outgoingPage,
-          per_page: perPage,
+          page: String(outgoingState.page),
+          per_page: String(perPage),
         });
-        if (status) params.append('status', status);
+        if (currentStatus) params.append('status', currentStatus);
         if (tableName) params.append('table_name', tableName);
         if (requestType) params.append('request_type', requestType);
         if (dateFrom) params.append('date_from', dateFrom);
@@ -301,142 +650,595 @@ export default function RequestsPage() {
         if (!res.ok) throw new Error('Failed to load requests');
         const data = await res.json();
         const enriched = await enrichRequests(data.rows || []);
-        setOutgoingRequests(enriched);
-        setOutgoingTotal(data.total || 0);
+        if (cancelled) return;
+        setViewState((prev) => {
+          const current = prev[viewKey];
+          if (!current) return prev;
+          return {
+            ...prev,
+            [viewKey]: {
+              ...current,
+              outgoing: {
+                ...current.outgoing,
+                loading: false,
+                data: enriched,
+                total: data.total || 0,
+                error: null,
+              },
+            },
+          };
+        });
       } catch (err) {
         console.error(err);
-        setOutgoingError('Failed to load requests');
-      } finally {
-        setOutgoingLoading(false);
+        if (cancelled) return;
+        setViewState((prev) => {
+          const current = prev[viewKey];
+          if (!current) return prev;
+          return {
+            ...prev,
+            [viewKey]: {
+              ...current,
+              outgoing: {
+                ...current.outgoing,
+                loading: false,
+                error: 'Failed to load requests',
+              },
+            },
+          };
+        });
       }
     }
-      load();
-    }, [
-      activeTab,
-      markSeen,
-      user?.empid,
-      status,
-      tableName,
-      requestType,
-      dateFrom,
-      dateTo,
-      dateField,
-      outgoingReloadKey,
-      outgoingPage,
-      perPage,
-    ]);
 
-  const updateNotes = (id, value) => {
-    setIncomingRequests((reqs) =>
-      reqs.map((r) => (r.request_id === id ? { ...r, notes: value } : r)),
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    activeTab,
+    activeView,
+    categories,
+    currentStatus,
+    tableName,
+    requestType,
+    dateFrom,
+    dateTo,
+    dateField,
+    outgoingState.page,
+    outgoingState.reloadKey,
+    perPage,
+  ]);
+
+  const updateNotes = useCallback(
+    (id, value) => {
+      setViewState((prev) => {
+        const current = prev[activeView];
+        if (!current) return prev;
+        const updated = current.incoming.data.map((r) =>
+          r.request_id === id ? { ...r, notes: value, error: null } : r,
+        );
+        return {
+          ...prev,
+          [activeView]: {
+            ...current,
+            incoming: { ...current.incoming, data: updated },
+          },
+        };
+      });
+    },
+    [activeView],
+  );
+
+  const respond = useCallback(
+    async (id, respStatus) => {
+      const reqItem = incomingRequests.find((r) => r.request_id === id);
+      if (!reqItem?.notes?.trim()) {
+        setViewState((prev) => {
+          const current = prev[activeView];
+          if (!current) return prev;
+          const updated = current.incoming.data.map((r) =>
+            r.request_id === id
+              ? { ...r, error: 'Response notes required' }
+              : r,
+          );
+          return {
+            ...prev,
+            [activeView]: {
+              ...current,
+              incoming: { ...current.incoming, data: updated },
+            },
+          };
+        });
+        return;
+      }
+      try {
+        const res = await fetch(`${API_BASE}/pending_request/${id}/respond`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            status: respStatus,
+            response_notes: reqItem.notes,
+            response_empid: user.empid,
+            senior_empid: reqItem?.senior_empid || user.empid,
+          }),
+        });
+        if (!res.ok) {
+          if (res.status === 403) throw new Error('Forbidden');
+          throw new Error('Failed to respond');
+        }
+        setViewState((prev) => {
+          const current = prev[activeView];
+          if (!current) return prev;
+          const updated = current.incoming.data.map((r) =>
+            r.request_id === id
+              ? {
+                  ...r,
+                  response_status: respStatus,
+                  status: respStatus,
+                  error: null,
+                }
+              : r,
+          );
+          return {
+            ...prev,
+            [activeView]: {
+              ...current,
+              incoming: { ...current.incoming, data: updated },
+            },
+          };
+        });
+      } catch (err) {
+        setViewState((prev) => {
+          const current = prev[activeView];
+          if (!current) return prev;
+          const updated = current.incoming.data.map((r) =>
+            r.request_id === id ? { ...r, error: err.message } : r,
+          );
+          return {
+            ...prev,
+            [activeView]: {
+              ...current,
+              incoming: { ...current.incoming, data: updated },
+            },
+          };
+        });
+      }
+    },
+    [activeView, incomingRequests, user?.empid],
+  );
+  const statusOrder = ['pending', 'accepted', 'declined'];
+
+  const getViewCounts = useCallback(
+    (viewKey) => {
+      const category = categories?.[viewKey];
+      if (!category) return null;
+      return activeTab === 'incoming' ? category.incoming : category.outgoing;
+    },
+    [activeTab, categories],
+  );
+
+  const directionCounts = getViewCounts(activeView) || {};
+  const directionKey = activeTab === 'incoming' ? 'incoming' : 'outgoing';
+
+  const newPillStyle = {
+    background: '#dc2626',
+    color: '#fff',
+    borderRadius: '999px',
+    padding: '0 0.4rem',
+    fontSize: '0.7rem',
+    marginLeft: '0.4rem',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  };
+
+  const statusChipStyle = {
+    background: '#eff6ff',
+    borderRadius: '999px',
+    padding: '0.25rem 0.75rem',
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0.4rem',
+    border: '1px solid #bfdbfe',
+    fontSize: '0.85rem',
+  };
+
+  const formatDateValue = (value) => {
+    if (!value) return '';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return String(value);
+    return formatTimestamp(date);
+  };
+
+  const renderChangeDetails = (req) => {
+    const fields = Array.isArray(req.fields) ? req.fields : [];
+    if (!fields.length) {
+      return <p style={{ margin: 0 }}>No field changes detected.</p>;
+    }
+    const columns = fields.map((f) => f.name);
+    const fieldMap = {};
+    fields.forEach((f) => {
+      fieldMap[f.name] = f;
+    });
+    const columnAlign = {};
+    columns.forEach((name) => {
+      const field = fieldMap[name];
+      const sample =
+        field.before !== undefined && field.before !== null
+          ? field.before
+          : field.after;
+      columnAlign[name] = typeof sample === 'number' ? 'right' : 'left';
+    });
+
+    return (
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr>
+              <th
+                style={{
+                  border: '1px solid #d1d5db',
+                  padding: '0.35rem',
+                  whiteSpace: 'nowrap',
+                }}
+              />
+              {columns.map((name) => (
+                <th
+                  key={name}
+                  style={{
+                    border: '1px solid #d1d5db',
+                    padding: '0.35rem',
+                    textAlign: columnAlign[name],
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {headerMap[name] || translateToMn(name)}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th
+                style={{
+                  border: '1px solid #d1d5db',
+                  padding: '0.35rem',
+                  textAlign: 'left',
+                  verticalAlign: 'top',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                Original
+              </th>
+              {columns.map((name) => {
+                const field = fieldMap[name];
+                return (
+                  <td
+                    key={name}
+                    style={{
+                      border: '1px solid #d1d5db',
+                      padding: '0.35rem',
+                      backgroundColor: field.changed ? '#fee2e2' : undefined,
+                      textAlign: columnAlign[name],
+                      verticalAlign: 'top',
+                    }}
+                  >
+                    {renderValue(field.before)}
+                  </td>
+                );
+              })}
+            </tr>
+            {req.request_type !== 'delete' && (
+              <tr>
+                <th
+                  style={{
+                    border: '1px solid #d1d5db',
+                    padding: '0.35rem',
+                    textAlign: 'left',
+                    verticalAlign: 'top',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  Proposed
+                </th>
+                {columns.map((name) => {
+                  const field = fieldMap[name];
+                  return (
+                    <td
+                      key={name}
+                      style={{
+                        border: '1px solid #d1d5db',
+                        padding: '0.35rem',
+                        backgroundColor: field.changed ? '#dcfce7' : undefined,
+                        textAlign: columnAlign[name],
+                        verticalAlign: 'top',
+                      }}
+                    >
+                      {renderValue(field.after)}
+                    </td>
+                  );
+                })}
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
     );
   };
 
-  const respond = async (id, respStatus) => {
-    const reqItem = incomingRequests.find((r) => r.request_id === id);
-    if (!reqItem?.notes?.trim()) {
-      setIncomingRequests((reqs) =>
-        reqs.map((r) =>
-          r.request_id === id ? { ...r, error: 'Response notes required' } : r,
-        ),
-      );
-      return;
-    }
-    try {
-      const res = await fetch(`${API_BASE}/pending_request/${id}/respond`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          status: respStatus,
-          response_notes: reqItem.notes,
-          response_empid: user.empid,
-          senior_empid: reqItem?.senior_empid || user.empid,
-        }),
-      });
-      if (!res.ok) {
-        if (res.status === 403) throw new Error('Forbidden');
-        throw new Error('Failed to respond');
-      }
-      setIncomingRequests((reqs) =>
-        reqs.map((r) =>
-          r.request_id === id
-            ? {
-                ...r,
-                response_status: respStatus,
-                status: respStatus,
-                error: null,
-              }
-            : r,
-        ),
-      );
-    } catch (err) {
-      setIncomingRequests((reqs) =>
-        reqs.map((r) =>
-          r.request_id === id ? { ...r, error: err.message } : r,
-        ),
-      );
-    }
+  const renderReportApprovalDetails = (req) => {
+    const info = req.reportInfo || {};
+    const parameters = Object.entries(info.parameters || {});
+    const transactions = Array.isArray(info.transactions)
+      ? info.transactions
+      : [];
+
+    return (
+      <div style={{ display: 'grid', gap: '0.75rem' }}>
+        <div>
+          <strong>Procedure:</strong>{' '}
+          <code>{info.procedure || 'N/A'}</code>
+        </div>
+        <div>
+          <strong>Parameters</strong>
+          {parameters.length ? (
+            <div style={{ overflowX: 'auto', marginTop: '0.35rem' }}>
+              <table style={{ borderCollapse: 'collapse', minWidth: '250px' }}>
+                <tbody>
+                  {parameters.map(([name, value]) => (
+                    <tr key={name}>
+                      <th
+                        style={{
+                          textAlign: 'left',
+                          padding: '0.35rem',
+                          border: '1px solid #d1d5db',
+                          backgroundColor: '#f1f5f9',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {name}
+                      </th>
+                      <td
+                        style={{
+                          padding: '0.35rem',
+                          border: '1px solid #d1d5db',
+                        }}
+                      >
+                        {renderValue(value)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p style={{ margin: '0.35rem 0 0' }}>No parameters provided.</p>
+          )}
+        </div>
+        <div>
+          <strong>Transactions</strong>
+          {transactions.length ? (
+            <ul style={{ margin: '0.35rem 0 0 1.25rem' }}>
+              {transactions.map((tx, idx) => (
+                <li key={`${tx.table}-${tx.recordId}-${idx}`}>
+                  <code>{tx.table}</code>
+                  {tx.recordId ? ` #${tx.recordId}` : ''}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p style={{ margin: '0.35rem 0 0' }}>No linked transactions.</p>
+          )}
+        </div>
+      </div>
+    );
   };
+
+  const renderTemporaryInsertDetails = (req) => {
+    const fields = Array.isArray(req.insertFields) ? req.insertFields : [];
+    if (!fields.length) {
+      return <p style={{ margin: 0 }}>No temporary values supplied.</p>;
+    }
+
+    return (
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ borderCollapse: 'collapse', minWidth: '240px' }}>
+          <tbody>
+            {fields.map(({ name, value }) => (
+              <tr key={name}>
+                <th
+                  style={{
+                    textAlign: 'left',
+                    padding: '0.35rem',
+                    border: '1px solid #d1d5db',
+                    backgroundColor: '#f1f5f9',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {name}
+                </th>
+                <td
+                  style={{
+                    padding: '0.35rem',
+                    border: '1px solid #d1d5db',
+                    verticalAlign: 'top',
+                  }}
+                >
+                  {renderValue(value)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  };
+
+  const renderRequestDetails = (req) => {
+    if (req.request_type === 'report_approval') {
+      return renderReportApprovalDetails(req);
+    }
+    if (req.request_type === 'temporary_insert') {
+      return renderTemporaryInsertDetails(req);
+    }
+    return renderChangeDetails(req);
+  };
+
+  const renderStatusSummary = () => (
+    <div
+      style={{
+        display: 'flex',
+        gap: '0.5rem',
+        flexWrap: 'wrap',
+        marginBottom: '1rem',
+      }}
+    >
+      {statusOrder.map((status) => {
+        const entry = directionCounts?.[status] || {
+          count: 0,
+          hasNew: false,
+          newCount: 0,
+        };
+        return (
+          <span key={status} style={statusChipStyle}>
+            <span style={{ fontWeight: 600 }}>
+              {STATUS_LABELS[status] || status}:
+            </span>
+            <span>{entry.count}</span>
+            {entry.hasNew && entry.newCount > 0 ? (
+              <span style={newPillStyle}>+{entry.newCount}</span>
+            ) : null}
+          </span>
+        );
+      })}
+    </div>
+  );
+
   if (!user?.empid) {
     return <p>Login required</p>;
   }
 
   return (
-    <div>
-      <h2>Requests</h2>
+    <div style={{ padding: '0 0.5rem 2rem' }}>
+      <h2 style={{ marginBottom: '1rem' }}>Requests</h2>
       <div
         style={{
-          marginBottom: '1em',
+          marginBottom: '0.75rem',
           display: 'flex',
-          alignItems: 'center',
-          gap: '0.5em',
+          flexWrap: 'wrap',
+          gap: '0.5rem',
         }}
       >
+        {availableViewKeys.map((key) => {
+          const cfg = VIEW_CONFIG[key] || VIEW_CONFIG.changes;
+          const counts = getViewCounts(key) || {};
+          const pendingEntry = counts.pending || { count: 0, newCount: 0, hasNew: false };
+          return (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setActiveView(key)}
+              style={{
+                borderRadius: '999px',
+                border: activeView === key ? '2px solid #2563eb' : '1px solid #cbd5f5',
+                padding: '0.4rem 0.9rem',
+                background: activeView === key ? '#eff6ff' : '#fff',
+                cursor: 'pointer',
+                fontWeight: activeView === key ? 600 : 500,
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '0.4rem',
+              }}
+            >
+              <span>{cfg.label}</span>
+              <span style={{ color: '#4b5563', fontSize: '0.85rem' }}>
+                {pendingEntry.count} pending
+              </span>
+              {pendingEntry.hasNew && pendingEntry.newCount > 0 ? (
+                <span style={newPillStyle}>+{pendingEntry.newCount}</span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+      <div
+        style={{
+          marginBottom: '1rem',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.75rem',
+          flexWrap: 'wrap',
+        }}
+      >
+        <div style={{ display: 'inline-flex', gap: '0.5rem' }}>
+          <button
+            type="button"
+            onClick={() => setActiveTab('incoming')}
+            style={{
+              border: 'none',
+              background: 'none',
+              padding: '0.25rem 0.5rem',
+              borderBottom:
+                activeTab === 'incoming' ? '2px solid #2563eb' : '2px solid transparent',
+              fontWeight: activeTab === 'incoming' ? 600 : 500,
+              cursor: 'pointer',
+            }}
+          >
+            Incoming
+          </button>
+          <button
+            type="button"
+            onClick={() => setActiveTab('outgoing')}
+            style={{
+              border: 'none',
+              background: 'none',
+              padding: '0.25rem 0.5rem',
+              borderBottom:
+                activeTab === 'outgoing' ? '2px solid #2563eb' : '2px solid transparent',
+              fontWeight: activeTab === 'outgoing' ? 600 : 500,
+              cursor: 'pointer',
+            }}
+          >
+            Outgoing
+          </button>
+        </div>
         <button
-          onClick={() => setActiveTab('incoming')}
+          type="button"
+          onClick={() => triggerReload(activeView, directionKey)}
           style={{
-            marginRight: '0.5em',
-            fontWeight: activeTab === 'incoming' ? 'bold' : 'normal',
+            padding: '0.35rem 0.75rem',
+            borderRadius: '0.375rem',
+            border: '1px solid #cbd5f5',
+            background: '#fff',
+            cursor: 'pointer',
           }}
         >
-          {`Incoming requests (${incomingCounts[status]?.count ?? 0})`}
+          Refresh
         </button>
-        <button
-          onClick={() => setActiveTab('outgoing')}
-          style={{ fontWeight: activeTab === 'outgoing' ? 'bold' : 'normal' }}
-        >
-          {`Outgoing requests (${outgoingCounts[status]?.count ?? 0})`}
-        </button>
-        {activeTab === 'incoming' && (
-          <button onClick={() => setIncomingReloadKey((k) => k + 1)}>
-            Refresh
-          </button>
-        )}
-        {activeTab === 'outgoing' && (
-          <button onClick={() => setOutgoingReloadKey((k) => k + 1)}>
-            Refresh
-          </button>
-        )}
       </div>
+      {renderStatusSummary()}
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          if (activeTab === 'incoming') {
-            setIncomingReloadKey((k) => k + 1);
-          } else {
-            setOutgoingReloadKey((k) => k + 1);
-          }
+          triggerReload(activeView, directionKey);
         }}
-        style={{ marginBottom: '1em' }}
+        style={{
+          marginBottom: '1.25rem',
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '0.75rem',
+          alignItems: 'center',
+        }}
       >
-        {activeTab === 'incoming' && (
-          <label style={{ marginRight: '0.5em' }}>
+        {activeTab === 'incoming' && activeViewConfig.showRequesterFilter && (
+          <label style={{ fontSize: '0.9rem' }}>
             Requester:
             <select
               value={requestedEmpid}
-              onChange={(e) => setRequestedEmpid(e.target.value)}
-              style={{ marginLeft: '0.25em' }}
+              onChange={(e) =>
+                updateFilters(activeView, { requestedEmpid: e.target.value })
+              }
+              style={{ marginLeft: '0.35rem' }}
             >
               <option value="">Any</option>
               {requesterOptions.map((id) => (
@@ -447,39 +1249,52 @@ export default function RequestsPage() {
             </select>
           </label>
         )}
-        <label style={{ marginRight: '0.5em' }}>
-          Transaction Type:
+        {activeViewConfig.showTableFilter && (
+          <label style={{ fontSize: '0.9rem' }}>
+            Transaction Type:
+            <select
+              value={tableName}
+              onChange={(e) =>
+                updateFilters(activeView, { tableName: e.target.value })
+              }
+              style={{ marginLeft: '0.35rem' }}
+            >
+              <option value="">Any</option>
+              {tableOptions.map((tbl) => (
+                <option key={tbl} value={tbl}>
+                  {tbl}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+        <label style={{ fontSize: '0.9rem' }}>
+          Request Type:
           <select
-            value={tableName}
-            onChange={(e) => setTableName(e.target.value)}
-            style={{ marginLeft: '0.25em' }}
+            value={requestType}
+            onChange={(e) =>
+              updateFilters(activeView, { requestType: e.target.value })
+            }
+            style={{ marginLeft: '0.35rem' }}
+            disabled={
+              activeViewConfig.lockRequestType && requestTypeOptions.length === 1
+            }
           >
-            <option value="">Any</option>
-            {tableOptions.map((tbl) => (
-              <option key={tbl} value={tbl}>
-                {tbl}
+            {requestTypeOptions.map(({ value, label }) => (
+              <option key={value} value={value}>
+                {label}
               </option>
             ))}
           </select>
         </label>
-        <label style={{ marginRight: '0.5em' }}>
-          Request Type:
-          <select
-            value={requestType}
-            onChange={(e) => setRequestType(e.target.value)}
-            style={{ marginLeft: '0.25em' }}
-          >
-            <option value="">Any</option>
-            <option value="edit">Edit Request</option>
-            <option value="delete">Delete Request</option>
-          </select>
-        </label>
-        <label style={{ marginRight: '0.5em' }}>
+        <label style={{ fontSize: '0.9rem' }}>
           Status:
           <select
-            value={status}
-            onChange={(e) => setStatus(e.target.value)}
-            style={{ marginLeft: '0.25em' }}
+            value={activeFilters.status}
+            onChange={(e) =>
+              updateFilters(activeView, { status: e.target.value })
+            }
+            style={{ marginLeft: '0.35rem' }}
           >
             <option value="">Any</option>
             <option value="pending">Pending</option>
@@ -487,47 +1302,47 @@ export default function RequestsPage() {
             <option value="declined">Declined</option>
           </select>
         </label>
-        <label style={{ marginRight: '0.5em' }}>
+        <label style={{ fontSize: '0.9rem' }}>
           Date Field:
           <select
             value={dateField}
-            onChange={(e) => setDateField(e.target.value)}
-            style={{ marginLeft: '0.25em' }}
+            onChange={(e) =>
+              updateFilters(activeView, { dateField: e.target.value })
+            }
+            style={{ marginLeft: '0.35rem' }}
           >
             <option value="created">Created</option>
             <option value="responded">Responded</option>
           </select>
         </label>
-        <label style={{ marginRight: '0.5em' }}>
+        <label style={{ fontSize: '0.9rem' }}>
           Date:
           <DateRangePicker
             start={dateFrom}
             end={dateTo}
-            onChange={({ start, end }) => {
-              setDateFrom(start);
-              setDateTo(end);
-            }}
-            style={{ marginLeft: '0.25em' }}
+            onChange={({ start, end }) =>
+              updateFilters(activeView, { dateFrom: start, dateTo: end })
+            }
+            style={{ marginLeft: '0.35rem' }}
           />
         </label>
-        <button type="submit">Apply</button>
+        <button
+          type="submit"
+          style={{
+            padding: '0.35rem 0.85rem',
+            borderRadius: '0.375rem',
+            border: '1px solid #2563eb',
+            background: '#2563eb',
+            color: '#fff',
+            cursor: 'pointer',
+          }}
+        >
+          Apply
+        </button>
       </form>
       {loading && <p>Loading...</p>}
       {error && <p style={{ color: 'red' }}>{error}</p>}
       {requests.map((req) => {
-        const columns = req.fields.map((f) => f.name);
-        const fieldMap = {};
-        req.fields.forEach((f) => {
-          fieldMap[f.name] = f;
-        });
-        const columnAlign = {};
-        columns.forEach((c) => {
-          const sample =
-            fieldMap[c].before !== undefined && fieldMap[c].before !== null
-              ? fieldMap[c].before
-              : fieldMap[c].after;
-          columnAlign[c] = typeof sample === 'number' ? 'right' : 'left';
-        });
         const userEmp = String(user.empid).trim();
         const requestStatus = req.status || req.response_status;
         const requestStatusLower = requestStatus
@@ -549,153 +1364,139 @@ export default function RequestsPage() {
           isPending &&
           (!assignedSenior || assignedSenior === userEmp);
 
+        const createdAt = formatDateValue(req.created_at);
+        const resolvedAt = formatDateValue(req.response_date || req.updated_at);
+        const requestTypeLabel =
+          REQUEST_TYPE_LABELS[req.request_type] || req.request_type;
+
         return (
           <div
             key={req.request_id}
             style={{
-              border: '1px solid #ccc',
-              margin: '1em 0',
-              padding: '1em',
+              border: '1px solid #e5e7eb',
+              marginBottom: '1.25rem',
+              borderRadius: '0.5rem',
+              boxShadow: '0 1px 2px rgba(15, 23, 42, 0.05)',
               background:
                 requestStatus === 'accepted'
-                  ? '#e6ffed'
+                  ? '#f0fdf4'
                   : requestStatus === 'declined'
-                  ? '#ffe6e6'
-                  : 'transparent',
+                  ? '#fef2f2'
+                  : '#fff',
+              padding: '1rem 1.25rem',
             }}
           >
-            <h4>
-              {req.table_name} #{req.record_id} ({req.request_type})
-            </h4>
-            <div style={{ overflowX: 'auto' }}>
-              <table
-                style={{ width: '100%', borderCollapse: 'collapse' }}
-              >
-                <thead>
-                <tr>
-                  <th
-                    style={{
-                      border: '1px solid #ccc',
-                      padding: '0.25em',
-                      whiteSpace: 'nowrap',
-                      width: '1%',
-                    }}
-                  />
-                  {columns.map((c) => (
-                    <th
-                      key={c}
-                      style={{
-                        border: '1px solid #ccc',
-                        padding: '0.25em',
-                        textAlign: columnAlign[c],
-                        whiteSpace: 'nowrap',
-                      }}
-                    >
-                      {headerMap[c] || translateToMn(c)}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <th
-                    style={{
-                      border: '1px solid #ccc',
-                      padding: '0.25em',
-                      whiteSpace: 'nowrap',
-                      width: '1%',
-                      textAlign: 'left',
-                      verticalAlign: 'top',
-                    }}
-                  >
-                    Original
-                  </th>
-                  {columns.map((c) => (
-                    <td
-                      key={c}
-                      style={{
-                        border: '1px solid #ccc',
-                        padding: '0.25em',
-                        background: fieldMap[c].changed
-                          ? '#ffe6e6'
-                          : undefined,
-                        textAlign: columnAlign[c],
-                        whiteSpace: 'pre-wrap',
-                        wordBreak: 'break-word',
-                        verticalAlign: 'top',
-                      }}
-                    >
-                      {renderValue(fieldMap[c].before)}
-                    </td>
-                  ))}
-                </tr>
-                {req.request_type !== 'delete' && (
-                  <tr>
-                    <th
-                      style={{
-                        border: '1px solid #ccc',
-                        padding: '0.25em',
-                        whiteSpace: 'nowrap',
-                        width: '1%',
-                        textAlign: 'left',
-                        verticalAlign: 'top',
-                      }}
-                    >
-                      Proposed
-                    </th>
-                    {columns.map((c) => (
-                      <td
-                        key={c}
-                        style={{
-                          border: '1px solid #ccc',
-                          padding: '0.25em',
-                          background: fieldMap[c].changed
-                            ? '#e6ffe6'
-                            : undefined,
-                          textAlign: columnAlign[c],
-                          whiteSpace: 'pre-wrap',
-                          wordBreak: 'break-word',
-                          verticalAlign: 'top',
-                        }}
-                      >
-                        {renderValue(fieldMap[c].after)}
-                      </td>
-                    ))}
-                  </tr>
+            <div
+              style={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                justifyContent: 'space-between',
+                gap: '0.75rem',
+                marginBottom: '0.75rem',
+              }}
+            >
+              <div>
+                <div style={{ fontSize: '0.85rem', color: '#6b7280' }}>
+                  Request #{req.request_id}
+                </div>
+                <div style={{ fontSize: '1.05rem', fontWeight: 600 }}>
+                  {requestTypeLabel}
+                </div>
+              </div>
+              <div style={{ textAlign: 'right', fontSize: '0.9rem' }}>
+                <div>
+                  <strong>Status:</strong>{' '}
+                  {requestStatus ? requestStatus.toUpperCase() : 'PENDING'}
+                </div>
+                {createdAt && (
+                  <div>
+                    <strong>Submitted:</strong> {createdAt}
+                  </div>
                 )}
-              </tbody>
-              </table>
+                {resolvedAt && !isPending && (
+                  <div>
+                    <strong>Updated:</strong> {resolvedAt}
+                  </div>
+                )}
+              </div>
             </div>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+                gap: '0.75rem',
+                marginBottom: '1rem',
+                fontSize: '0.9rem',
+              }}
+            >
+              <div>
+                <strong>Requester:</strong> {req.emp_id}
+              </div>
+              <div>
+                <strong>Assigned Senior:</strong>{' '}
+                {assignedSenior || 'Unassigned'}
+              </div>
+              {req.table_name && (
+                <div>
+                  <strong>Table:</strong> {req.table_name}
+                </div>
+              )}
+              {req.record_id !== undefined && req.record_id !== null && (
+                <div>
+                  <strong>Record:</strong> {req.record_id}
+                </div>
+              )}
+            </div>
+            <div style={{ marginBottom: '1rem' }}>{renderRequestDetails(req)}</div>
             {!isPending ? (
-              <p>Request {requestStatus}</p>
+              <p style={{ margin: '0.5rem 0 0', fontWeight: 500 }}>
+                Request {requestStatus}
+              </p>
             ) : canRespond ? (
-              <>
+              <div style={{ display: 'grid', gap: '0.75rem' }}>
                 <textarea
                   placeholder="Response Notes"
                   value={req.notes}
                   onChange={(e) => updateNotes(req.request_id, e.target.value)}
-                  style={{ width: '100%', minHeight: '4em' }}
+                  style={{ width: '100%', minHeight: '4.5rem', resize: 'vertical' }}
                 />
-                <div style={{ marginTop: '0.5em' }}>
+                <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
                   <button
+                    type="button"
                     onClick={() => respond(req.request_id, 'accepted')}
                     disabled={!req.notes?.trim()}
+                    style={{
+                      padding: '0.4rem 0.9rem',
+                      borderRadius: '0.375rem',
+                      border: '1px solid #16a34a',
+                      background: '#16a34a',
+                      color: '#fff',
+                      cursor: req.notes?.trim() ? 'pointer' : 'not-allowed',
+                    }}
                   >
                     Accept
                   </button>
                   <button
+                    type="button"
                     onClick={() => respond(req.request_id, 'declined')}
-                    style={{ marginLeft: '0.5em' }}
                     disabled={!req.notes?.trim()}
+                    style={{
+                      padding: '0.4rem 0.9rem',
+                      borderRadius: '0.375rem',
+                      border: '1px solid #dc2626',
+                      background: '#dc2626',
+                      color: '#fff',
+                      cursor: req.notes?.trim() ? 'pointer' : 'not-allowed',
+                    }}
                   >
                     Decline
                   </button>
                 </div>
-              </>
+              </div>
             ) : isRequester ? (
-              <p>Awaiting senior response…</p>
+              <p style={{ margin: 0 }}>Awaiting senior response…</p>
             ) : null}
-            {req.error && <p style={{ color: 'red' }}>{req.error}</p>}
+            {req.error && <p style={{ color: 'red', marginTop: '0.5rem' }}>{req.error}</p>}
           </div>
         );
       })}
@@ -704,8 +1505,9 @@ export default function RequestsPage() {
           display: 'flex',
           justifyContent: 'flex-start',
           alignItems: 'center',
-          marginTop: '1em',
+          marginTop: '1.25rem',
           gap: '1rem',
+          flexWrap: 'wrap',
         }}
       >
         <div>
@@ -714,39 +1516,31 @@ export default function RequestsPage() {
             type="number"
             value={perPage}
             onChange={(e) => {
-              const val = Number(e.target.value) || 1;
-              setIncomingPage(1);
-              setOutgoingPage(1);
-              setPerPage(val);
+              const val = Math.max(1, Number(e.target.value) || 1);
+              updatePerPage(activeView, val);
             }}
             min="1"
-            style={{ marginLeft: '0.25rem', width: '4rem' }}
+            style={{ marginLeft: '0.35rem', width: '4rem' }}
           />
         </div>
-        <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.35rem' }}>
           <button
-            onClick={() =>
-              activeTab === 'incoming'
-                ? setIncomingPage(1)
-                : setOutgoingPage(1)
-            }
+            type="button"
+            onClick={() => setPageFor(activeView, directionKey, 1)}
             disabled={currentPage === 1 || loading}
-            style={{ marginRight: '0.25rem' }}
           >
             {'<<'}
           </button>
           <button
+            type="button"
             onClick={() =>
-              activeTab === 'incoming'
-                ? setIncomingPage((p) => Math.max(1, p - 1))
-                : setOutgoingPage((p) => Math.max(1, p - 1))
+              setPageFor(activeView, directionKey, Math.max(1, currentPage - 1))
             }
             disabled={currentPage === 1 || loading}
-            style={{ marginRight: '0.25rem' }}
           >
             {'<'}
           </button>
-          <span>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.35rem' }}>
             Page
             <input
               type="number"
@@ -755,35 +1549,331 @@ export default function RequestsPage() {
                 let val = Number(e.target.value) || 1;
                 if (val < 1) val = 1;
                 if (val > totalPages) val = totalPages;
-                activeTab === 'incoming'
-                  ? setIncomingPage(val)
-                  : setOutgoingPage(val);
+                setPageFor(activeView, directionKey, val);
               }}
-              style={{ width: '3rem', margin: '0 0.25rem', textAlign: 'center' }}
+              style={{ width: '3rem', textAlign: 'center' }}
               min="1"
               max={totalPages}
             />
-            {` of ${totalPages}`}
+            {`of ${totalPages}`}
           </span>
           <button
+            type="button"
             onClick={() =>
-              activeTab === 'incoming'
-                ? setIncomingPage((p) => Math.min(totalPages, p + 1))
-                : setOutgoingPage((p) => Math.min(totalPages, p + 1))
+              setPageFor(activeView, directionKey, Math.min(totalPages, currentPage + 1))
             }
             disabled={currentPage >= totalPages || loading}
-            style={{ marginLeft: '0.25rem' }}
           >
             {'>'}
           </button>
           <button
+            type="button"
+            onClick={() => setPageFor(activeView, directionKey, totalPages)}
+            disabled={currentPage >= totalPages || loading}
+          >
+            {'>>'}
+          </button>
+        </div>
+      </div>
+      {!loading && requests.length === 0 && <p>No pending requests.</p>}
+    </div>
+  );
+}
+            style={{ marginLeft: '0.35rem' }}
+            disabled={
+              activeViewConfig.lockRequestType && requestTypeOptions.length === 1
+            }
+          >
+            {requestTypeOptions.map(({ value, label }) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label style={{ fontSize: '0.9rem' }}>
+          Status:
+          <select
+            value={activeFilters.status}
+            onChange={(e) =>
+              updateFilters(activeView, { status: e.target.value })
+            }
+            style={{ marginLeft: '0.35rem' }}
+          >
+            <option value="">Any</option>
+            <option value="pending">Pending</option>
+            <option value="accepted">Accepted</option>
+            <option value="declined">Declined</option>
+          </select>
+        </label>
+        <label style={{ fontSize: '0.9rem' }}>
+          Date Field:
+          <select
+            value={dateField}
+            onChange={(e) =>
+              updateFilters(activeView, { dateField: e.target.value })
+            }
+            style={{ marginLeft: '0.35rem' }}
+          >
+            <option value="created">Created</option>
+            <option value="responded">Responded</option>
+          </select>
+        </label>
+        <label style={{ fontSize: '0.9rem' }}>
+          Date:
+          <DateRangePicker
+            start={dateFrom}
+            end={dateTo}
+            onChange={({ start, end }) =>
+              updateFilters(activeView, { dateFrom: start, dateTo: end })
+            }
+            style={{ marginLeft: '0.35rem' }}
+          />
+        </label>
+        <button
+          type="submit"
+          style={{
+            padding: '0.35rem 0.85rem',
+            borderRadius: '0.375rem',
+            border: '1px solid #2563eb',
+            background: '#2563eb',
+            color: '#fff',
+            cursor: 'pointer',
+          }}
+        >
+          Apply
+        </button>
+      </form>
+      {loading && <p>Loading...</p>}
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      {requests.map((req) => {
+        const userEmp = String(user.empid).trim();
+        const requestStatus = req.status || req.response_status;
+        const requestStatusLower = requestStatus
+          ? String(requestStatus).trim().toLowerCase()
+          : undefined;
+        const isRequester = String(req.emp_id).trim() === userEmp;
+
+        const seniorStr = String(req.senior_empid ?? '').trim();
+        const seniorNorm = seniorStr.toLowerCase();
+        const assignedSenior =
+          seniorStr && !['0', 'null', 'undefined'].includes(seniorNorm)
+            ? seniorStr
+            : null;
+
+        const isPending =
+          !requestStatusLower || requestStatusLower === 'pending';
+        const canRespond =
+          !isRequester &&
+          isPending &&
+          (!assignedSenior || assignedSenior === userEmp);
+
+        const createdAt = formatDateValue(req.created_at);
+        const resolvedAt = formatDateValue(req.response_date || req.updated_at);
+        const requestTypeLabel =
+          REQUEST_TYPE_LABELS[req.request_type] || req.request_type;
+
+        return (
+          <div
+            key={req.request_id}
+            style={{
+              border: '1px solid #e5e7eb',
+              marginBottom: '1.25rem',
+              borderRadius: '0.5rem',
+              boxShadow: '0 1px 2px rgba(15, 23, 42, 0.05)',
+              background:
+                requestStatus === 'accepted'
+                  ? '#f0fdf4'
+                  : requestStatus === 'declined'
+                  ? '#fef2f2'
+                  : '#fff',
+              padding: '1rem 1.25rem',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                justifyContent: 'space-between',
+                gap: '0.75rem',
+                marginBottom: '0.75rem',
+              }}
+            >
+              <div>
+                <div style={{ fontSize: '0.85rem', color: '#6b7280' }}>
+                  Request #{req.request_id}
+                </div>
+                <div style={{ fontSize: '1.05rem', fontWeight: 600 }}>
+                  {requestTypeLabel}
+                </div>
+              </div>
+              <div style={{ textAlign: 'right', fontSize: '0.9rem' }}>
+                <div>
+                  <strong>Status:</strong>{' '}
+                  {requestStatus ? requestStatus.toUpperCase() : 'PENDING'}
+                </div>
+                {createdAt && (
+                  <div>
+                    <strong>Submitted:</strong> {createdAt}
+                  </div>
+                )}
+                {resolvedAt && !isPending && (
+                  <div>
+                    <strong>Updated:</strong> {resolvedAt}
+                  </div>
+                )}
+              </div>
+            </div>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+                gap: '0.75rem',
+                marginBottom: '1rem',
+                fontSize: '0.9rem',
+              }}
+            >
+              <div>
+                <strong>Requester:</strong> {req.emp_id}
+              </div>
+              <div>
+                <strong>Assigned Senior:</strong>{' '}
+                {assignedSenior || 'Unassigned'}
+              </div>
+              {req.table_name && (
+                <div>
+                  <strong>Table:</strong> {req.table_name}
+                </div>
+              )}
+              {req.record_id !== undefined && req.record_id !== null && (
+                <div>
+                  <strong>Record:</strong> {req.record_id}
+                </div>
+              )}
+            </div>
+            <div style={{ marginBottom: '1rem' }}>{renderRequestDetails(req)}</div>
+            {!isPending ? (
+              <p style={{ margin: '0.5rem 0 0', fontWeight: 500 }}>
+                Request {requestStatus}
+              </p>
+            ) : canRespond ? (
+              <div style={{ display: 'grid', gap: '0.75rem' }}>
+                <textarea
+                  placeholder="Response Notes"
+                  value={req.notes}
+                  onChange={(e) => updateNotes(req.request_id, e.target.value)}
+                  style={{ width: '100%', minHeight: '4.5rem', resize: 'vertical' }}
+                />
+                <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+                  <button
+                    type="button"
+                    onClick={() => respond(req.request_id, 'accepted')}
+                    disabled={!req.notes?.trim()}
+                    style={{
+                      padding: '0.4rem 0.9rem',
+                      borderRadius: '0.375rem',
+                      border: '1px solid #16a34a',
+                      background: '#16a34a',
+                      color: '#fff',
+                      cursor: req.notes?.trim() ? 'pointer' : 'not-allowed',
+                    }}
+                  >
+                    Accept
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => respond(req.request_id, 'declined')}
+                    disabled={!req.notes?.trim()}
+                    style={{
+                      padding: '0.4rem 0.9rem',
+                      borderRadius: '0.375rem',
+                      border: '1px solid #dc2626',
+                      background: '#dc2626',
+                      color: '#fff',
+                      cursor: req.notes?.trim() ? 'pointer' : 'not-allowed',
+                    }}
+                  >
+                    Decline
+                  </button>
+                </div>
+              </div>
+            ) : isRequester ? (
+              <p style={{ margin: 0 }}>Awaiting senior response…</p>
+            ) : null}
+            {req.error && <p style={{ color: 'red', marginTop: '0.5rem' }}>{req.error}</p>}
+          </div>
+        );
+      })}
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'flex-start',
+          alignItems: 'center',
+          marginTop: '1.25rem',
+          gap: '1rem',
+          flexWrap: 'wrap',
+        }}
+      >
+        <div>
+          Rows per page:
+          <input
+            type="number"
+            value={perPage}
+            onChange={(e) => {
+              const val = Math.max(1, Number(e.target.value) || 1);
+              updatePerPage(activeView, val);
+            }}
+            min="1"
+            style={{ marginLeft: '0.35rem', width: '4rem' }}
+          />
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.35rem' }}>
+          <button
+            type="button"
+            onClick={() => setPageFor(activeView, directionKey, 1)}
+            disabled={currentPage === 1 || loading}
+          >
+            {'<<'}
+          </button>
+          <button
+            type="button"
             onClick={() =>
-              activeTab === 'incoming'
-                ? setIncomingPage(totalPages)
-                : setOutgoingPage(totalPages)
+              setPageFor(activeView, directionKey, Math.max(1, currentPage - 1))
+            }
+            disabled={currentPage === 1 || loading}
+          >
+            {'<'}
+          </button>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.35rem' }}>
+            Page
+            <input
+              type="number"
+              value={currentPage}
+              onChange={(e) => {
+                let val = Number(e.target.value) || 1;
+                if (val < 1) val = 1;
+                if (val > totalPages) val = totalPages;
+                setPageFor(activeView, directionKey, val);
+              }}
+              style={{ width: '3rem', textAlign: 'center' }}
+              min="1"
+              max={totalPages}
+            />
+            {`of ${totalPages}`}
+          </span>
+          <button
+            type="button"
+            onClick={() =>
+              setPageFor(activeView, directionKey, Math.min(totalPages, currentPage + 1))
             }
             disabled={currentPage >= totalPages || loading}
-            style={{ marginLeft: '0.25rem' }}
+          >
+            {'>'}
+          </button>
+          <button
+            type="button"
+            onClick={() => setPageFor(activeView, directionKey, totalPages)}
+            disabled={currentPage >= totalPages || loading}
           >
             {'>>'}
           </button>

--- a/tests/hooks/requestNotifications.test.js
+++ b/tests/hooks/requestNotifications.test.js
@@ -152,6 +152,74 @@ if (!haveReact) {
     unmount3();
   });
 
+  test('request notification counts honor request type filter', async (t) => {
+    const store = {};
+    global.localStorage = {
+      getItem: (k) => (k in store ? store[k] : null),
+      setItem: (k, v) => {
+        store[k] = String(v);
+      },
+      removeItem: (k) => {
+        delete store[k];
+      },
+      clear: () => {
+        for (const k in store) delete store[k];
+      },
+    };
+    localStorage.clear();
+
+    const seenTypes = [];
+    global.fetch = async (url) => {
+      const u = new URL(url, 'http://example.com');
+      if (
+        u.pathname === '/api/pending_request' ||
+        u.pathname === '/api/pending_request/outgoing'
+      ) {
+        seenTypes.push(u.searchParams.get('request_type'));
+        return { ok: true, json: async () => ({ rows: [], total: 0 }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    };
+
+    const { default: useRequestNotificationCounts } = await t.mock.import(
+      '../../src/erp.mgt.mn/hooks/useRequestNotificationCounts.js',
+      {
+        '../utils/socket.js': {
+          connectSocket: () => ({ on: () => {}, off: () => {} }),
+          disconnectSocket: () => {},
+        },
+        '../hooks/useGeneralConfig.js': {
+          default: () => ({ general: { requestPollingEnabled: false } }),
+        },
+      },
+    );
+
+    const { value, unmount } = renderHook(() =>
+      useRequestNotificationCounts(5, undefined, 'u1', 'report_approval'),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    assert.ok(seenTypes.every((type) => type === 'report_approval'));
+    assert.equal(
+      localStorage.getItem('u1-report_approval-incoming-pending-seen'),
+      '0',
+    );
+
+    act(() => {
+      value.markSeen();
+    });
+    assert.equal(
+      localStorage.getItem('u1-report_approval-outgoing-accepted-seen'),
+      '0',
+    );
+    unmount();
+  });
+
   test('stale counts cleared when server reports zero', async (t) => {
     const store = {};
     global.localStorage = {
@@ -167,8 +235,8 @@ if (!haveReact) {
       },
     };
     localStorage.clear();
-    localStorage.setItem('u1-incoming-pending-seen', '5');
-    localStorage.setItem('u1-outgoing-accepted-seen', '3');
+    localStorage.setItem('u1-all-incoming-pending-seen', '5');
+    localStorage.setItem('u1-all-outgoing-accepted-seen', '3');
 
     global.fetch = async (url) => {
       const u = new URL(url, 'http://example.com');
@@ -208,8 +276,8 @@ if (!haveReact) {
     assert.equal(value.incoming.pending.newCount, 0);
     assert.equal(value.outgoing.accepted.hasNew, false);
     assert.equal(value.outgoing.accepted.newCount, 0);
-    assert.equal(localStorage.getItem('u1-incoming-pending-seen'), '0');
-    assert.equal(localStorage.getItem('u1-outgoing-accepted-seen'), '0');
+    assert.equal(localStorage.getItem('u1-all-incoming-pending-seen'), '0');
+    assert.equal(localStorage.getItem('u1-all-outgoing-accepted-seen'), '0');
 
     unmount();
   });


### PR DESCRIPTION
## Summary
- expand the Requests page with category-aware tabs, per-view filters, and tailored rendering for report approvals and temporary transactions
- surface per-category notification data through the pending request context and update the ERP layout to aggregate counts
- refresh the pending request widget and header menu to display category counts and new-item badges

## Testing
- npm test *(fails: database seeding tests expect soft-delete support in test fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68e01f0b15548331a18d6c72de04ae51