### PR TITLE
Fix tour extractor build dependency issue

### DIFF
--- a/scripts/extractTourOrder.js
+++ b/scripts/extractTourOrder.js
@@ -1,9 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import parser from '@babel/parser';
-import _traverse from '@babel/traverse';
-const traverse = _traverse.default ?? _traverse; // works for ESM or CJS
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -25,23 +22,18 @@ function sanitizeKey(sel) {
   return sel.replace(/^[#.]/, '').replace(/[^\w]/g, '_');
 }
 
+const ATTRIBUTE_REGEX = /(id|data-tour|data-tour-id)\s*=\s*(["'])(.*?)\2/gs;
+
 function parseSelectors(code) {
-  const ast = parser.parse(code, {
-    sourceType: 'module',
-    plugins: ['jsx'],
-  });
   const selectors = [];
-  traverse(ast, {
-    JSXAttribute({ node }) {
-      const { name, value } = node;
-      if (!value || value.type !== 'StringLiteral') return;
-      if (name.name === 'id') {
-        selectors.push(`#${value.value}`);
-      } else if (name.name === 'data-tour' || name.name === 'data-tour-id') {
-        selectors.push(`[${name.name}="${value.value}"]`);
-      }
-    },
-  });
+  for (const match of code.matchAll(ATTRIBUTE_REGEX)) {
+    const [, name, , value] = match;
+    if (name === 'id') {
+      selectors.push(`#${value}`);
+    } else {
+      selectors.push(`[${name}="${value}"]`);
+    }
+  }
   return selectors;
 }
 


### PR DESCRIPTION
## Summary
- simplify the tour extraction script to use a lightweight regex-based attribute scan
- eliminate the hard dependency on @babel/parser/@babel/traverse during builds

## Testing
- node scripts/extractTourOrder.js
- npm run build:erp *(fails: vite: not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e029ae5a008331b4a2104933d11a4f