### PR TITLE
Filter inactive report procedures from permitted list

### DIFF
--- a/api-server/utils/reportProcedures.js
+++ b/api-server/utils/reportProcedures.js
@@ -1,7 +1,7 @@
 import { listTransactionNames } from '../services/transactionFormConfig.js';
 import { listAllowedReports } from '../services/reportAccessConfig.js';
 import { getProcTriggers } from '../services/procTriggers.js';
-import { getEmploymentSession } from '../../db/index.js';
+import { getEmploymentSession, listReportProcedures } from '../../db/index.js';
 
 async function getUserContext(user, companyId) {
   const session = await getEmploymentSession(user.empid, companyId);
@@ -54,6 +54,8 @@ export async function listPermittedProcedures(
     ...Object.keys(allowedCfg),
   ]);
 
+  const liveProcedures = new Set(await listReportProcedures(prefix));
+
   const userCtx = await getUserContext(user, companyId);
   const bId = Number(branchId ?? userCtx.branchId);
   const dId = Number(departmentId ?? userCtx.departmentId);
@@ -62,6 +64,7 @@ export async function listPermittedProcedures(
 
   const list = [];
   for (const proc of allProcs) {
+    if (!liveProcedures.has(proc)) continue;
     if (prefix && !proc.toLowerCase().includes(prefix.toLowerCase())) continue;
     const access = allowedCfg[proc];
     if (access) {


### PR DESCRIPTION
## Summary
- query the database for existing report procedures and only return live entries from the merged list
- extend the API test to stub the procedure lookup and confirm deleted procedures are filtered out

## Testing
- npm test -- tests/api/reportProcedures.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e12294b9348331a55e4ae43f506f82