### PR TITLE
Add polling hook for build updates and header refresh prompt

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -16,6 +16,7 @@ import { useIsLoading } from "../context/LoadingContext.jsx";
 import Spinner from "./Spinner.jsx";
 import useHeaderMappings from "../hooks/useHeaderMappings.js";
 import useRequestNotificationCounts from "../hooks/useRequestNotificationCounts.js";
+import useBuildUpdateNotice from "../hooks/useBuildUpdateNotice.js";
 import { PendingRequestContext } from "../context/PendingRequestContext.jsx";
 import Joyride, { STATUS, ACTIONS, EVENTS } from "react-joyride";
 import ErrorBoundary from "../components/ErrorBoundary.jsx";
@@ -517,6 +518,7 @@ export default function ERPLayout() {
   const { user, setUser, session, userSettings, updateUserSettings } = useContext(AuthContext);
   const generalConfig = useGeneralConfig();
   const { t } = useContext(LangContext);
+  const { hasUpdateAvailable } = useBuildUpdateNotice();
   const renderCount = useRef(0);
   useEffect(() => {
   renderCount.current++;
@@ -2733,6 +2735,7 @@ export default function ERPLayout() {
             onToggleSidebar={() => setSidebarOpen((o) => !o)}
             onOpen={handleOpen}
             onResetGuide={resetGuide}
+            hasUpdateAvailable={hasUpdateAvailable}
           />
           <div style={styles.body(isMobile)}>
             {isMobile && sidebarOpen && (
@@ -2756,9 +2759,28 @@ export default function ERPLayout() {
 }
 
 /** Top header bar **/
-function Header({ user, onLogout, onHome, isMobile, onToggleSidebar, onOpen, onResetGuide }) {
+export function Header({
+  user,
+  onLogout,
+  onHome,
+  isMobile,
+  onToggleSidebar,
+  onOpen,
+  onResetGuide,
+  hasUpdateAvailable = false,
+}) {
   const { session } = useContext(AuthContext);
   const { lang, setLang, t } = useContext(LangContext);
+  const handleRefresh = () => {
+    if (typeof window === 'undefined' || !window?.location) return;
+    try {
+      window.location.reload(true);
+    } catch (err) {
+      if (typeof window.location.reload === 'function') {
+        window.location.reload();
+      }
+    }
+  };
 
   return (
     <header className="sticky-header" style={styles.header(isMobile)}>
@@ -2786,6 +2808,11 @@ function Header({ user, onLogout, onHome, isMobile, onToggleSidebar, onOpen, onR
         <button style={styles.iconBtn}>🗗 {t("windows")}</button>
         <button style={styles.iconBtn}>❔ {t("help")}</button>
       </nav>
+      {hasUpdateAvailable && (
+        <button type="button" style={styles.updateButton} onClick={handleRefresh}>
+          🔄 {t('refresh_to_update', 'Refresh to update')}
+        </button>
+      )}
       <HeaderMenu onOpen={onOpen} />
       {session && (
         <span style={styles.locationInfo}>
@@ -3303,6 +3330,18 @@ const styles = {
     overflowX: "auto",
     whiteSpace: "nowrap",
     flexGrow: 1,
+  },
+  updateButton: {
+    backgroundColor: "#f97316",
+    color: "#111827",
+    border: "none",
+    borderRadius: "4px",
+    padding: "0.35rem 0.75rem",
+    fontWeight: "bold",
+    cursor: "pointer",
+    marginRight: "0.75rem",
+    flexShrink: 0,
+    boxShadow: "0 0 0 2px rgba(249, 115, 22, 0.3)",
   },
   iconBtn: {
     background: "transparent",

--- a/src/erp.mgt.mn/hooks/useBuildUpdateNotice.js
+++ b/src/erp.mgt.mn/hooks/useBuildUpdateNotice.js
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useState } from 'react';
+
+const MODULE_SELECTOR = 'script[type="module"][src]';
+const MODULE_SRC_REGEX = /<script[^>]*type=["']module["'][^>]*src=["']([^"']+)["'][^>]*>/i;
+
+function getCurrentModuleUrl() {
+  if (typeof document === 'undefined') return null;
+  try {
+    if (typeof document.querySelector === 'function') {
+      const script = document.querySelector(MODULE_SELECTOR);
+      if (script && typeof script.getAttribute === 'function') {
+        return script.getAttribute('src');
+      }
+    }
+  } catch (err) {
+    console.warn('useBuildUpdateNotice: failed to read current module URL', err);
+  }
+  return null;
+}
+
+function extractModuleUrlFromHtml(html) {
+  if (!html || typeof html !== 'string') return null;
+  const match = MODULE_SRC_REGEX.exec(html);
+  return match ? match[1] : null;
+}
+
+export default function useBuildUpdateNotice({ intervalMs = 30000 } = {}) {
+  const [currentBundleUrl, setCurrentBundleUrl] = useState(() => getCurrentModuleUrl());
+  const [latestBundleUrl, setLatestBundleUrl] = useState(null);
+  const [hasUpdateAvailable, setHasUpdateAvailable] = useState(false);
+  const bundleUrlRef = useRef(currentBundleUrl);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof fetch !== 'function') {
+      return undefined;
+    }
+
+    bundleUrlRef.current = getCurrentModuleUrl();
+    setCurrentBundleUrl(bundleUrlRef.current);
+
+    let cancelled = false;
+    let intervalId = null;
+
+    async function pollForUpdates() {
+      try {
+        const response = await fetch('/index.html', { cache: 'no-store' });
+        if (!response?.ok) return;
+        const html = await response.text();
+        const moduleUrl = extractModuleUrlFromHtml(html);
+        if (!moduleUrl) return;
+
+        setLatestBundleUrl(moduleUrl);
+
+        const previousUrl = bundleUrlRef.current;
+        if (!previousUrl) {
+          bundleUrlRef.current = moduleUrl;
+          if (!cancelled) {
+            setCurrentBundleUrl(moduleUrl);
+          }
+          return;
+        }
+
+        if (moduleUrl !== previousUrl) {
+          if (!cancelled) {
+            setHasUpdateAvailable(true);
+          }
+        }
+      } catch (err) {
+        console.warn('useBuildUpdateNotice: polling failed', err);
+      }
+    }
+
+    pollForUpdates();
+    intervalId = window.setInterval(pollForUpdates, intervalMs);
+
+    return () => {
+      cancelled = true;
+      if (intervalId !== null) {
+        window.clearInterval(intervalId);
+      }
+    };
+  }, [intervalMs]);
+
+  return { hasUpdateAvailable, currentBundleUrl, latestBundleUrl };
+}

--- a/tests/components/headerUpdateNotice.test.js
+++ b/tests/components/headerUpdateNotice.test.js
@@ -1,0 +1,117 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+function createMockReact() {
+  const ReactMock = {
+    Fragment: Symbol('Fragment'),
+  };
+
+  ReactMock.createElement = (type, props, ...children) => ({
+    type,
+    props: props || {},
+    children,
+  });
+
+  ReactMock.createContext = (defaultValue) => {
+    const context = {
+      _currentValue: defaultValue,
+      Provider: ({ value, children }) => {
+        context._currentValue = value;
+        return children;
+      },
+    };
+    return context;
+  };
+
+  ReactMock.useContext = (context) => context._currentValue;
+  ReactMock.useState = (initial) => [typeof initial === 'function' ? initial() : initial, () => {}];
+  ReactMock.useEffect = () => {};
+  ReactMock.useMemo = (factory) => factory();
+  ReactMock.useCallback = (fn) => fn;
+  ReactMock.useRef = (initial) => ({ current: initial });
+
+  return ReactMock;
+}
+
+function collectStrings(node, acc = []) {
+  if (node === null || node === undefined) return acc;
+  if (typeof node === 'string') {
+    acc.push(node);
+    return acc;
+  }
+  if (Array.isArray(node)) {
+    node.forEach((child) => collectStrings(child, acc));
+    return acc;
+  }
+  if (typeof node === 'object') {
+    if (Array.isArray(node.children)) {
+      node.children.forEach((child) => collectStrings(child, acc));
+    }
+    if (node.props && node.props.children !== undefined) {
+      collectStrings(node.props.children, acc);
+    }
+  }
+  return acc;
+}
+
+if (typeof mock?.import !== 'function') {
+  test('Header renders refresh notice when update flag becomes true', { skip: true }, () => {});
+} else {
+  test('Header renders refresh notice when update flag becomes true', async () => {
+    const mockReact = createMockReact();
+    const TestAuthContext = mockReact.createContext({ session: null });
+    const TestLangContext = mockReact.createContext({
+      lang: 'en',
+      setLang: () => {},
+      t: (key, fallback) => fallback ?? key,
+    });
+
+    const { Header } = await mock.import(
+      '../../src/erp.mgt.mn/components/ERPLayout.jsx',
+      {
+        react: {
+          default: mockReact,
+          ...mockReact,
+        },
+        '../context/AuthContext.jsx': { AuthContext: TestAuthContext },
+        '../context/I18nContext.jsx': { default: TestLangContext },
+        './HeaderMenu.jsx': {
+          default: () => mockReact.createElement('div', {}, 'header-menu'),
+        },
+        './UserMenu.jsx': {
+          default: () => mockReact.createElement('div', {}, 'user-menu'),
+        },
+      },
+    );
+
+    const originalWindow = global.window;
+    global.window = { location: { reload: () => {} } };
+
+    const baseProps = {
+      user: { name: 'User' },
+      onLogout: () => {},
+      onHome: () => {},
+      isMobile: false,
+      onToggleSidebar: () => {},
+      onOpen: () => {},
+      onResetGuide: () => {},
+    };
+
+    TestAuthContext._currentValue = { session: { company_name: 'Acme Co.' } };
+    TestLangContext._currentValue = {
+      lang: 'en',
+      setLang: () => {},
+      t: (key, fallback) => fallback ?? key,
+    };
+
+    const withoutUpdateTree = Header({ ...baseProps, hasUpdateAvailable: false });
+    const withoutUpdateText = collectStrings(withoutUpdateTree).join(' ');
+    assert.ok(!withoutUpdateText.includes('Refresh to update'));
+
+    const withUpdateTree = Header({ ...baseProps, hasUpdateAvailable: true });
+    const withUpdateText = collectStrings(withUpdateTree).join(' ');
+    assert.ok(withUpdateText.includes('Refresh to update'));
+
+    global.window = originalWindow;
+  });
+}


### PR DESCRIPTION
## Summary
- add a reusable `useBuildUpdateNotice` hook that polls `index.html` for changed module bundle URLs
- surface the build update flag through `ERPLayout` and show a refresh button in the header when updates are available
- add a header component test that verifies the refresh notice appears once the update flag is true

## Testing
- npm test *(fails: existing suite has unrelated seedTenantTables and company controller regressions)*
- node --test tests/components/headerUpdateNotice.test.js *(skipped: environment lacks mock.import support)*

------
https://chatgpt.com/codex/tasks/task_e_68e125f0312c8331ad41a04bcf1da49f