### PR TITLE
fix: prevent duplicate React import and optionalize tour parser

### DIFF
--- a/src/erp.mgt.mn/pages/Reports.jsx
+++ b/src/erp.mgt.mn/pages/Reports.jsx
@@ -1,6 +1,12 @@
 // src/erp.mgt.mn/pages/Reports.jsx
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { useToast } from '../context/ToastContext.jsx';
 import formatTimestamp from '../utils/formatTimestamp.js';


### PR DESCRIPTION
## Summary
- collapse duplicate React imports in the Reports page to avoid redeclaration build errors
- allow the tour extraction script to fall back to regex parsing when Babel packages are unavailable

## Testing
- node scripts/extractTourOrder.js
- npm run build:erp *(fails: vite binary not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e12e0dbf288331b806bed6fb289155