### PR TITLE
Fix supportsTemporary initialization order

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -346,6 +346,15 @@ const TableManager = forwardRef(function TableManager({
     return () => window.removeEventListener('click', hideMenu);
   }, []);
 
+  const supportsTemporary = useMemo(() => {
+    if (!formConfig) return false;
+    const flag =
+      formConfig.supportsTemporarySubmission ??
+      formConfig.allowTemporarySubmission ??
+      false;
+    return Boolean(flag);
+  }, [formConfig]);
+
   const refreshTemporarySummary = useCallback(async () => {
     if (!supportsTemporary) {
       setTemporarySummary(null);
@@ -524,15 +533,6 @@ const TableManager = forwardRef(function TableManager({
     const defaultFields = ['created_by', 'employee_id', 'emp_id', 'empid', 'user_id'];
     return defaultFields.filter(f => validCols.has(f));
   }, [formConfig, validCols]);
-
-  const supportsTemporary = useMemo(() => {
-    if (!formConfig) return false;
-    const flag =
-      formConfig.supportsTemporarySubmission ??
-      formConfig.allowTemporarySubmission ??
-      false;
-    return Boolean(flag);
-  }, [formConfig]);
 
   function computeAutoInc(meta) {
     const auto = meta


### PR DESCRIPTION
## Summary
- move the `supportsTemporary` memo earlier so callbacks cannot reference it before initialization

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e13a28dce08331b94e52a527871cc5