### PR TITLE
Enrich report lock candidates with snapshots

### DIFF
--- a/api-server/routes/procedures.js
+++ b/api-server/routes/procedures.js
@@ -67,6 +67,7 @@ router.post('/locks', requireAuth, async (req, res, next) => {
       name,
       Array.isArray(params) ? params : [],
       Array.isArray(aliases) ? aliases : [],
+      { companyId },
     );
     res.json({ lockCandidates });
   } catch (err) {


### PR DESCRIPTION
## Summary
- enrich the procedure lock candidate lookup with report lock metadata and row snapshots
- expose company context to the lock candidate route so existing locks are surfaced to the UI
- group report lock candidates by table in the approval workflow, show row snapshots, and prevent selection of already locked records

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e142cb661c8331bc47bb627c9544ae