### PR TITLE
Stabilize temporary notifications memoization

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -2771,20 +2771,61 @@ export default function ERPLayout() {
     };
   }, [reportNotifications, editNotifications, deleteNotifications]);
 
+  const {
+    counts: temporaryCounts,
+    hasNew: temporaryHasNew,
+    markScopeSeen: rawTemporaryMarkScopeSeen,
+    markAllSeen: rawTemporaryMarkAllSeen,
+    fetchScopeEntries: rawTemporaryFetchScopeEntries,
+  } = temporaryNotifications || {};
+
+  const markTemporaryScopeSeen = useCallback(
+    (...args) => rawTemporaryMarkScopeSeen?.(...args),
+    [rawTemporaryMarkScopeSeen],
+  );
+
+  const markTemporaryAllSeen = useCallback(
+    () => rawTemporaryMarkAllSeen?.(),
+    [rawTemporaryMarkAllSeen],
+  );
+
+  const fetchTemporaryScopeEntries = useCallback(
+    (...args) => rawTemporaryFetchScopeEntries?.(...args),
+    [rawTemporaryFetchScopeEntries],
+  );
+
+  const temporaryCreatedCount = Number(temporaryCounts?.created?.count) || 0;
+  const temporaryCreatedNewCount = Number(temporaryCounts?.created?.newCount) || 0;
+  const temporaryReviewCount = Number(temporaryCounts?.review?.count) || 0;
+  const temporaryReviewNewCount = Number(temporaryCounts?.review?.newCount) || 0;
+
+  const temporaryValue = useMemo(
+    () => ({
+      counts: temporaryCounts,
+      hasNew: temporaryHasNew,
+      markScopeSeen: markTemporaryScopeSeen,
+      markAllSeen: markTemporaryAllSeen,
+      fetchScopeEntries: fetchTemporaryScopeEntries,
+    }),
+    [
+      temporaryCreatedCount,
+      temporaryCreatedNewCount,
+      temporaryReviewCount,
+      temporaryReviewNewCount,
+      temporaryHasNew,
+      markTemporaryScopeSeen,
+      markTemporaryAllSeen,
+      fetchTemporaryScopeEntries,
+    ],
+  );
+
   const pendingRequestValue = useMemo(
     () => ({
       ...pendingRequestSummary.contextValue,
-      temporary: {
-        counts: temporaryNotifications.counts,
-        hasNew: temporaryNotifications.hasNew,
-        markScopeSeen: temporaryNotifications.markScopeSeen,
-        markAllSeen: temporaryNotifications.markAllSeen,
-        fetchScopeEntries: temporaryNotifications.fetchScopeEntries,
-      },
-      anyHasNew:
-        pendingRequestSummary.requestHasNew || temporaryNotifications.hasNew,
+      temporary: temporaryValue,
+      anyHasNew: pendingRequestSummary.requestHasNew || temporaryHasNew,
     }),
-    [pendingRequestSummary, temporaryNotifications],
+    [pendingRequestSummary, temporaryHasNew, temporaryValue],
   );
 
   useEffect(() => {

--- a/src/erp.mgt.mn/pages/Notifications.jsx
+++ b/src/erp.mgt.mn/pages/Notifications.jsx
@@ -179,18 +179,16 @@ export default function NotificationsPage() {
     workflows?.changeRequests?.outgoing?.pending?.count,
   ]);
 
+  const temporaryReviewCount = Number(temporary?.counts?.review?.count) || 0;
+  const temporaryCreatedCount = Number(temporary?.counts?.created?.count) || 0;
+  const temporaryFetchScopeEntries = temporary?.fetchScopeEntries;
+
   useEffect(() => {
-    if (!temporary) return;
+    if (typeof temporaryFetchScopeEntries !== 'function') return undefined;
     let cancelled = false;
     setTemporaryState((prev) => ({ ...prev, loading: true, error: '' }));
-    const reviewPromise =
-      typeof temporary.fetchScopeEntries === 'function'
-        ? temporary.fetchScopeEntries('review', SECTION_LIMIT)
-        : Promise.resolve([]);
-    const createdPromise =
-      typeof temporary.fetchScopeEntries === 'function'
-        ? temporary.fetchScopeEntries('created', SECTION_LIMIT)
-        : Promise.resolve([]);
+    const reviewPromise = temporaryFetchScopeEntries('review', SECTION_LIMIT);
+    const createdPromise = temporaryFetchScopeEntries('created', SECTION_LIMIT);
     Promise.all([reviewPromise, createdPromise])
       .then(([review, created]) => {
         if (!cancelled) {
@@ -216,10 +214,9 @@ export default function NotificationsPage() {
     };
   }, [
     t,
-    temporary?.counts?.review?.count,
-    temporary?.counts?.created?.count,
-    temporary?.fetchScopeEntries,
-    temporary,
+    temporaryReviewCount,
+    temporaryCreatedCount,
+    temporaryFetchScopeEntries,
   ]);
 
   const reportPending = useMemo(() => {
@@ -261,7 +258,7 @@ export default function NotificationsPage() {
     (scope) => {
       temporary?.markScopeSeen?.(scope);
     },
-    [temporary],
+    [temporary?.markScopeSeen],
   );
 
   const openRequest = useCallback(


### PR DESCRIPTION
## Summary
- memoize the temporary notifications handlers and payload in ERP layout so the context value stays stable
- adjust the notifications page temporary effect to depend on stable primitives and use the memoized handlers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e14b5dfcec8331894bdf38379a7a5c