### PR TITLE
Stabilize request workflow callbacks

### DIFF
--- a/src/erp.mgt.mn/pages/Requests.jsx
+++ b/src/erp.mgt.mn/pages/Requests.jsx
@@ -388,9 +388,15 @@ export default function RequestsPage() {
   }
 
   useEffect(() => {
+    if (!dateFrom || !dateTo) return;
+    if (activeTab === 'incoming' || activeTab === 'outgoing') {
+      markSeen();
+    }
+  }, [activeTab, dateFrom, dateTo, markSeen]);
+
+  useEffect(() => {
     if (activeTab !== 'incoming' || !seniorEmpId || !dateFrom || !dateTo)
       return;
-    markSeen();
     async function load() {
       debugLog('Loading pending requests');
       setIncomingLoading(true);
@@ -428,7 +434,6 @@ export default function RequestsPage() {
       load();
     }, [
       activeTab,
-      markSeen,
       seniorEmpId,
       status,
       requestedEmpid,
@@ -444,7 +449,6 @@ export default function RequestsPage() {
 
   useEffect(() => {
     if (activeTab !== 'outgoing' || !dateFrom || !dateTo) return;
-    markSeen();
     async function load() {
       setOutgoingLoading(true);
       setOutgoingError(null);
@@ -478,7 +482,6 @@ export default function RequestsPage() {
       load();
     }, [
       activeTab,
-      markSeen,
       user?.empid,
       status,
       tableName,


### PR DESCRIPTION
## Summary
- add a `useWorkflowEntry` helper that memoizes workflow counts and wraps mark callbacks in `useCallback`
- reuse the stabilized workflow objects when building pending request context and aggregate marks
- trigger `markSeen` from a guarded effect in the Requests page so fetch effects no longer re-run from callback churn

## Testing
- npm test *(fails: multiple pre-existing seedTenantTables and controller tests rely on unavailable database fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68e14c678efc83319915a28decc0d270