### PR TITLE
Stabilize request notification filter handling

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -2709,23 +2709,36 @@ export default function ERPLayout() {
     session && user?.empid && !hasSupervisor ? user.empid : null;
   const seniorPlanEmpId = hasSupervisor ? session?.senior_plan_empid : null;
 
+  const reportFilters = useMemo(
+    () => ({ request_type: 'report_approval' }),
+    [],
+  );
+  const editFilters = useMemo(
+    () => ({ request_type: 'edit' }),
+    [],
+  );
+  const deleteFilters = useMemo(
+    () => ({ request_type: 'delete' }),
+    [],
+  );
+
   const reportNotifications = useRequestNotificationCounts(
     seniorEmpId,
-    { request_type: 'report_approval' },
+    reportFilters,
     user?.empid,
     seniorPlanEmpId,
     { storageNamespace: 'report_approval' },
   );
   const editNotifications = useRequestNotificationCounts(
     seniorEmpId,
-    { request_type: 'edit' },
+    editFilters,
     user?.empid,
     seniorPlanEmpId,
     { storageNamespace: 'request_edit' },
   );
   const deleteNotifications = useRequestNotificationCounts(
     seniorEmpId,
-    { request_type: 'delete' },
+    deleteFilters,
     user?.empid,
     seniorPlanEmpId,
     { storageNamespace: 'request_delete' },

--- a/src/erp.mgt.mn/hooks/useRequestNotificationCounts.js
+++ b/src/erp.mgt.mn/hooks/useRequestNotificationCounts.js
@@ -125,7 +125,7 @@ export default function useRequestNotificationCounts(
     [markStatusesAsSeen],
   );
 
-  const memoFilters = useMemo(() => filters || {}, [filters]);
+  const memoFilters = useMemo(() => (filters ? { ...filters } : {}), [filterKey]);
   const supervisorIds = useMemo(() => {
     const ids = [];
     if (seniorEmpId) ids.push(String(seniorEmpId).trim());
@@ -295,7 +295,7 @@ export default function useRequestNotificationCounts(
       }
       stopPolling();
     };
-  }, [supervisorIds, memoFilters, pollingEnabled, intervalSeconds, storageKey]);
+  }, [supervisorIds, filterKey, pollingEnabled, intervalSeconds, storageKey]);
 
   const hasNew =
     STATUSES.some((s) => incoming[s].hasNew) ||


### PR DESCRIPTION
## Summary
- memoize the request type filter objects in ERPLayout so hooks receive stable references
- derive memoized request filters in useRequestNotificationCounts from a deterministic key and gate effect reruns on the key

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e15029dfac83318ddba758c2faf4d4