### PR TITLE
Add default transaction toast toggle

### DIFF
--- a/config/0/generalConfig.json
+++ b/config/0/generalConfig.json
@@ -21,6 +21,7 @@
     "viewToastEnabled": false,
     "reportRowToastEnabled": false,
     "imageToastEnabled": false,
+    "txnToastEnabled": false,
     "debugLoggingEnabled": false,
     "editLabelsEnabled": true,
     "showTourButtons": true,


### PR DESCRIPTION
## Summary
- add a default false flag for transaction toast notifications in the general config

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1555e5c00833186fa0a657833e5d1