### PR TITLE
Preserve lock candidate context for JSON strings

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -5877,14 +5877,14 @@ export async function getProcedureLockCandidates(
     return [value];
   };
 
-  const parseCandidateString = (raw) => {
+  const parseCandidateString = (raw, extras = {}) => {
     if (typeof raw !== 'string') return;
     const trimmed = raw.trim();
     if (!trimmed) return;
     try {
       const parsed = JSON.parse(trimmed);
       if (parsed !== null) {
-        collectCandidateValue(parsed);
+        collectCandidateValue(parsed, extras);
         return;
       }
     } catch {}
@@ -5895,7 +5895,7 @@ export async function getProcedureLockCandidates(
         const tablePart = trimmed.slice(0, idx).trim();
         const idPart = trimmed.slice(idx + 1).trim();
         if (tablePart && idPart) {
-          upsertCandidate(tablePart, idPart);
+          upsertCandidate(tablePart, idPart, extras);
           return;
         }
       }
@@ -5968,7 +5968,7 @@ export async function getProcedureLockCandidates(
   const collectCandidateValue = (value, extras = {}) => {
     if (value === undefined || value === null) return;
     if (typeof value === 'string') {
-      parseCandidateString(value);
+      parseCandidateString(value, extras);
       return;
     }
     if (Array.isArray(value)) {

--- a/tests/db/procedureLockCandidates.test.js
+++ b/tests/db/procedureLockCandidates.test.js
@@ -91,3 +91,73 @@ test('getProcedureLockCandidates ignores primitive columns and keeps structured 
     restoreQuery();
   }
 });
+
+test('getProcedureLockCandidates preserves table context for JSON strings', async () => {
+  const queryLog = [];
+  let released = false;
+
+  const mockConn = {
+    async query(sql, params) {
+      queryLog.push([sql, params]);
+      if (/^SET @/.test(sql)) {
+        return [[], []];
+      }
+      if (sql.startsWith('CALL ')) {
+        return [
+          [
+            [
+              {
+                sales_orders: ' [41,42] ',
+              },
+            ],
+          ],
+          [],
+        ];
+      }
+      if (sql === STRICT_SESSION_VAR_QUERY) {
+        return [[{ strict: null, secondary: null, legacy: null }], []];
+      }
+      if (sql.includes('FROM report_transaction_locks')) {
+        return [[], []];
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    },
+    release() {
+      released = true;
+    },
+  };
+
+  const originalGetConnection = db.pool.getConnection;
+  const originalQuery = db.pool.query;
+  const restoreGetConnection = () => {
+    if (originalGetConnection === undefined) {
+      delete db.pool.getConnection;
+    } else {
+      db.pool.getConnection = originalGetConnection;
+    }
+  };
+  const restoreQuery = () => {
+    db.pool.query = originalQuery;
+  };
+
+  db.pool.getConnection = async () => mockConn;
+  db.pool.query = async () => {
+    const err = new Error('no such table');
+    err.code = 'ER_NO_SUCH_TABLE';
+    throw err;
+  };
+
+  try {
+    const candidates = await db.getProcedureLockCandidates('sp_json_report');
+    const keys = candidates.map((c) => `${c.tableName}#${c.recordId}`).sort();
+    assert.deepEqual(keys, ['sales_orders#41', 'sales_orders#42']);
+    assert.ok(released, 'connection should be released');
+    assert.ok(
+      queryLog.some(([sql]) => sql.startsWith('CALL sp_json_report')),
+      'stored procedure should be invoked',
+    );
+  } finally {
+    restoreGetConnection();
+    restoreQuery();
+  }
+});


### PR DESCRIPTION
## Summary
- ensure JSON-derived lock candidates retain their table metadata when parsed from strings
- add a regression test covering table-keyed JSON strings returned from stored procedures

## Testing
- npm test -- tests/db/procedureLockCandidates.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e156df92148331a52d74c642672461