### PR TITLE
Document txn toast toggle in general configuration docs

### DIFF
--- a/docs/general-configuration.md
+++ b/docs/general-configuration.md
@@ -22,7 +22,8 @@
   "general": {
     "aiApiEnabled": false,
     "requestPollingEnabled": false,
-    "requestPollingIntervalSeconds": 30
+    "requestPollingIntervalSeconds": 30,
+    "txnToastEnabled": false
   },
   "images": {
     "basePath": "uploads"
@@ -45,7 +46,9 @@ permission can launch the tour builder to create or edit guides. Other options
 include `requestPollingEnabled`, which determines whether the client
 falls back to periodic API polling when a Socket.IO connection cannot be
 established, and `requestPollingIntervalSeconds`, which sets the polling
-cadence (default 30&nbsp;seconds).
+cadence (default 30&nbsp;seconds). Enable `txnToastEnabled` when you need the
+app to surface debug toasts for transaction fetch/edit flows; it defaults to
+`false` so the extra notifications stay hidden in production.
 
 The **Images** tab exposes `basePath`, `cleanupDays` and an `ignoreOnSearch` list.
 `basePath` sets the root directory for uploaded transaction images. The default


### PR DESCRIPTION
## Summary
- document the `txnToastEnabled` flag in the general configuration guide
- note that the toggle surfaces transaction debug toasts and defaults to false
- update the sample JSON to include the new key with its default value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1571585d88331b5d60ae610ae7eb7