### PR TITLE
Fix tab synchronization effect to avoid redundant navigation

### DIFF
--- a/src/erp.mgt.mn/components/ERPLayout.jsx
+++ b/src/erp.mgt.mn/components/ERPLayout.jsx
@@ -3452,8 +3452,8 @@ function MainWindow({ title }) {
     if (!activeKey || activeKey === location.pathname) return;
     if (typeof activeKey !== 'string') return;
     if (!activeKey.startsWith('/')) return;
-    navigate(activeKey);
-  }, [activeKey, location.pathname, navigate, tabKeys, tabs]);
+    switchTab(location.pathname);
+  }, [activeKey, location.pathname, switchTab, tabKeys]);
 
   function handleSwitch(key) {
     switchTab(key);


### PR DESCRIPTION
## Summary
- update the tab synchronization effect to switch the active tab instead of navigating when the current path is already open
- prevent unnecessary effect executions when the active key already matches the current pathname

## Testing
- npm run dev *(fails: vite not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68e16ac107c88331b5037e9187b25797