### PR TITLE
Ensure RowFormModal sees hidden form columns

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -2661,6 +2661,21 @@ const TableManager = forwardRef(function TableManager({
     return set;
   }, [auditFieldSet]);
   let columns = ordered.filter((c) => !hiddenColumnSet.has(c.toLowerCase()));
+  const formColumnOrder = useMemo(() => {
+    const seen = new Set();
+    const merged = [];
+    ordered.forEach((col) => {
+      if (seen.has(col)) return;
+      seen.add(col);
+      merged.push(col);
+    });
+    allColumns.forEach((col) => {
+      if (seen.has(col)) return;
+      seen.add(col);
+      merged.push(col);
+    });
+    return merged;
+  }, [ordered, allColumns]);
   const provided = Array.isArray(formConfig?.editableFields)
     ? formConfig.editableFields
     : [];
@@ -2733,7 +2748,7 @@ const TableManager = forwardRef(function TableManager({
   if (columnMeta.length === 0 && autoCols.size === 0 && allColumns.includes('id')) {
     autoCols.add('id');
   }
-  let formColumns = ordered.filter((c) => {
+  let formColumns = formColumnOrder.filter((c) => {
     if (autoCols.has(c)) return false;
     const lower = c.toLowerCase();
     if (auditFieldSet.has(lower) && !(editSet?.has(lower))) return false;


### PR DESCRIPTION
## Summary
- expand the form column order so hidden-but-valid fields are available to the form
- keep grid columns filtered by the hidden set while passing the expanded list to the row modal

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e16fc299a88331b2b1b07749c6cc0c