### PR TITLE
feat: allow string record ids in approval flow

### DIFF
--- a/db/mgtmn_erp_db.sql
+++ b/db/mgtmn_erp_db.sql
@@ -1177,7 +1177,7 @@ CREATE TABLE `payments` (
 CREATE TABLE `pending_request` (
   `request_id` bigint NOT NULL,
   `table_name` varchar(100) NOT NULL,
-  `record_id` bigint NOT NULL,
+  `record_id` varchar(191) NOT NULL,
   `emp_id` varchar(10) NOT NULL,
   `senior_empid` varchar(10) NOT NULL,
   `request_type` enum('edit','delete') NOT NULL,
@@ -4073,7 +4073,7 @@ CREATE TABLE `user_activity_log` (
   `log_id` bigint NOT NULL,
   `emp_id` varchar(10) NOT NULL,
   `table_name` varchar(100) NOT NULL,
-  `record_id` bigint NOT NULL,
+  `record_id` varchar(191) NOT NULL,
   `action` enum('create','update','delete','request_edit','request_delete','approve','decline') NOT NULL,
   `details` json DEFAULT NULL,
   `request_id` bigint DEFAULT NULL,
@@ -4861,7 +4861,8 @@ ALTER TABLE `users`
 -- Indexes for table `user_activity_log`
 --
 ALTER TABLE `user_activity_log`
-  ADD PRIMARY KEY (`log_id`);
+  ADD PRIMARY KEY (`log_id`),
+  ADD CONSTRAINT `fk_activity_request` FOREIGN KEY (`request_id`) REFERENCES `pending_request` (`request_id`);
 
 --
 -- Indexes for table `user_levels`

--- a/db/migrations/2025-10-16_pending_request_record_id_varchar.sql
+++ b/db/migrations/2025-10-16_pending_request_record_id_varchar.sql
@@ -1,0 +1,34 @@
+-- Update record_id columns to support string identifiers
+
+-- Ensure the user activity FK is dropped before altering columns when present
+SET @drop_fk_activity_request = (
+  SELECT IF(
+    COUNT(*) > 0,
+    'ALTER TABLE `user_activity_log` DROP FOREIGN KEY `fk_activity_request`;',
+    'SELECT 1'
+  )
+  FROM information_schema.REFERENTIAL_CONSTRAINTS
+  WHERE CONSTRAINT_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'user_activity_log'
+    AND CONSTRAINT_NAME = 'fk_activity_request'
+);
+PREPARE stmt FROM @drop_fk_activity_request;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+ALTER TABLE pending_request
+  DROP INDEX idx_pending_unique;
+
+-- 2. Alter record_id column types
+ALTER TABLE pending_request
+  MODIFY record_id varchar(191) NOT NULL;
+
+ALTER TABLE user_activity_log
+  MODIFY record_id varchar(191) NOT NULL;
+
+ALTER TABLE pending_request
+  ADD UNIQUE KEY idx_pending_unique (table_name, record_id, emp_id, request_type, is_pending);
+
+ALTER TABLE user_activity_log
+  ADD CONSTRAINT fk_activity_request FOREIGN KEY (request_id)
+    REFERENCES pending_request (request_id);

--- a/db/migrations/README.md
+++ b/db/migrations/README.md
@@ -5,6 +5,7 @@ Legacy migrations have been moved to the `archive/` directory. New migrations sh
 ## Current migrations
 
 - `2025-10-05_employment_plan_senior.sql`: Adds `employment_senior_plan_empid` to `tbl_employment`, indexes it, and seeds the column from `employment_senior_empid` for existing records.
+- `2025-10-16_pending_request_record_id_varchar.sql`: Converts `pending_request.record_id` and `user_activity_log.record_id` to `VARCHAR(191)` and re-applies related indexes/constraints.
 
 No migrations are pending. The baseline schema now mirrors the production snapshot in `db/mgtmn_erp_db.sql` (generated 2025-10-03) so fresh databases already contain the identifier columns and audit metadata that earlier scripts added.
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1177,7 +1177,7 @@ CREATE TABLE `payments` (
 CREATE TABLE `pending_request` (
   `request_id` bigint NOT NULL,
   `table_name` varchar(100) NOT NULL,
-  `record_id` bigint NOT NULL,
+  `record_id` varchar(191) NOT NULL,
   `emp_id` varchar(10) NOT NULL,
   `senior_empid` varchar(10) NOT NULL,
   `request_type` enum('edit','delete') NOT NULL,
@@ -4073,7 +4073,7 @@ CREATE TABLE `user_activity_log` (
   `log_id` bigint NOT NULL,
   `emp_id` varchar(10) NOT NULL,
   `table_name` varchar(100) NOT NULL,
-  `record_id` bigint NOT NULL,
+  `record_id` varchar(191) NOT NULL,
   `action` enum('create','update','delete','request_edit','request_delete','approve','decline') NOT NULL,
   `details` json DEFAULT NULL,
   `request_id` bigint DEFAULT NULL,
@@ -4861,7 +4861,8 @@ ALTER TABLE `users`
 -- Indexes for table `user_activity_log`
 --
 ALTER TABLE `user_activity_log`
-  ADD PRIMARY KEY (`log_id`);
+  ADD PRIMARY KEY (`log_id`),
+  ADD CONSTRAINT `fk_activity_request` FOREIGN KEY (`request_id`) REFERENCES `pending_request` (`request_id`);
 
 --
 -- Indexes for table `user_levels`


### PR DESCRIPTION
## Summary
- add a migration that converts pending_request.record_id and user_activity_log.record_id to VARCHAR(191) while recreating the pending request unique index and fk_activity_request constraint
- refresh db/schema.sql and db/mgtmn_erp_db.sql so the baseline schema matches the new column definitions and foreign key
- document the new migration in the migrations README for visibility

## Testing
- not run (database change only)


------
https://chatgpt.com/codex/tasks/task_e_68e17b9450c08331a6fe93b87edb8c80