### PR TITLE
Add diagnostic edit flow failure toast

### DIFF
--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -1588,8 +1588,14 @@ const TableManager = forwardRef(function TableManager({
     }
 
     let payload = null;
+    let lastResponseInfo = null;
     try {
       const res = await fetch(url, { credentials: 'include' });
+      lastResponseInfo = {
+        status: res?.status,
+        statusText: res?.statusText,
+        url,
+      };
       if (!res.ok) {
         if (txnToastEnabled) {
           addToast(
@@ -1624,6 +1630,19 @@ const TableManager = forwardRef(function TableManager({
         );
       }
     } catch (err) {
+      if (txnToastEnabled) {
+        addToast(
+          `Transaction toast: Edit flow failed ${formatTxnToastPayload({
+            error: {
+              message: err?.message ?? String(err),
+              stack: err?.stack,
+              name: err?.name,
+            },
+            response: lastResponseInfo,
+          })}`,
+          'error',
+        );
+      }
       addToast(t('failed_load_record', 'Failed to load record details'), 'error');
       return;
     }


### PR DESCRIPTION
## Summary
- add transaction toast diagnostics when edit flow fails to surface error and response info

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e17defd42c8331a1b6e335d6a750d2