### PR TITLE
Expand pending_request request_type enum

### DIFF
--- a/db/mgtmn_erp_db.sql
+++ b/db/mgtmn_erp_db.sql
@@ -1180,7 +1180,7 @@ CREATE TABLE `pending_request` (
   `record_id` varchar(191) NOT NULL,
   `emp_id` varchar(10) NOT NULL,
   `senior_empid` varchar(10) NOT NULL,
-  `request_type` enum('edit','delete') NOT NULL,
+  `request_type` enum('edit','delete','report_approval') NOT NULL,
   `request_reason` text NOT NULL,
   `proposed_data` json DEFAULT NULL,
   `original_data` json DEFAULT NULL,

--- a/db/migrations/2025-10-17_pending_request_request_type_enum.sql
+++ b/db/migrations/2025-10-17_pending_request_request_type_enum.sql
@@ -1,0 +1,5 @@
+-- Expand pending_request.request_type enum to support report approvals.
+-- Existing values remain valid; the ALTER simply appends the new enum member.
+
+ALTER TABLE `pending_request`
+  MODIFY `request_type` ENUM('edit','delete','report_approval') NOT NULL;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1180,7 +1180,7 @@ CREATE TABLE `pending_request` (
   `record_id` varchar(191) NOT NULL,
   `emp_id` varchar(10) NOT NULL,
   `senior_empid` varchar(10) NOT NULL,
-  `request_type` enum('edit','delete') NOT NULL,
+  `request_type` enum('edit','delete','report_approval') NOT NULL,
   `request_reason` text NOT NULL,
   `proposed_data` json DEFAULT NULL,
   `original_data` json DEFAULT NULL,


### PR DESCRIPTION
## Summary
- add a migration that expands pending_request.request_type to include the report_approval option
- update the schema snapshots so the new enum member is reflected in checked-in DDL

## Testing
- `npm test -- tests/api/pendingRequest.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68e1800e97748331bc758ee07065f192