### PR TITLE
Gate notification seen events behind explicit user actions

### DIFF
--- a/src/erp.mgt.mn/pages/DashboardPage.jsx
+++ b/src/erp.mgt.mn/pages/DashboardPage.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect, useRef } from 'react';
+import React, { useContext, useState } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
 import PendingRequestWidget from '../components/PendingRequestWidget.jsx';
 import OutgoingRequestWidget from '../components/OutgoingRequestWidget.jsx';
@@ -13,17 +13,16 @@ export default function DashboardPage() {
   const [active, setActive] = useState('general');
   useTour('dashboard');
 
-  const prevTab = useRef('general');
-  useEffect(() => {
-    if (prevTab.current === 'audition' && active !== 'audition') {
+  const handleMarkAuditionRead = () => {
+    if (typeof markSeen === 'function') {
       markSeen();
     }
-    prevTab.current = active;
-  }, [active, markSeen]);
+  };
 
-  useEffect(() => () => {
-    if (prevTab.current === 'audition') markSeen();
-  }, [markSeen]);
+  const auditionNewCount =
+    (Number(outgoing?.accepted?.newCount) || 0) +
+    (Number(outgoing?.declined?.newCount) || 0);
+  const auditionHasNew = Boolean(hasNew || auditionNewCount);
 
   const dotBadgeStyle = {
     background: 'red',
@@ -82,8 +81,8 @@ export default function DashboardPage() {
         {tabButton(
           'audition',
           t('audition', 'Audition'),
-          outgoing.accepted.newCount + outgoing.declined.newCount,
-          hasNew,
+          auditionNewCount,
+          auditionHasNew,
         )}
         {tabButton('plans', t('plans', 'Plans'))}
       </div>
@@ -124,12 +123,31 @@ export default function DashboardPage() {
       )}
 
       {active === 'audition' && (
-        <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
-          <div style={{ ...cardStyle, flex: '1 1 300px' }}>
-            <PendingRequestWidget />
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <button
+              type="button"
+              onClick={handleMarkAuditionRead}
+              disabled={!auditionHasNew}
+              style={{
+                padding: '0.4rem 0.8rem',
+                borderRadius: '4px',
+                border: '1px solid #2563eb',
+                background: auditionHasNew ? '#2563eb' : '#e5e7eb',
+                color: auditionHasNew ? '#ffffff' : '#6b7280',
+                cursor: auditionHasNew ? 'pointer' : 'not-allowed',
+              }}
+            >
+              {t('mark_audition_read', 'Mark audition items read')}
+            </button>
           </div>
-          <div style={{ ...cardStyle, flex: '1 1 300px' }}>
-            <OutgoingRequestWidget />
+          <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+            <div style={{ ...cardStyle, flex: '1 1 300px' }}>
+              <PendingRequestWidget />
+            </div>
+            <div style={{ ...cardStyle, flex: '1 1 300px' }}>
+              <OutgoingRequestWidget />
+            </div>
           </div>
         </div>
       )}

--- a/src/erp.mgt.mn/pages/Notifications.jsx
+++ b/src/erp.mgt.mn/pages/Notifications.jsx
@@ -258,12 +258,6 @@ export default function NotificationsPage() {
     workflows?.changeRequests?.outgoing?.declined?.count,
   ]);
 
-  useEffect(() => {
-    if (typeof markWorkflowSeen !== 'function') return;
-    markWorkflowSeen('reportApproval', 'outgoing', ['accepted', 'declined']);
-    markWorkflowSeen('changeRequests', 'outgoing', ['accepted', 'declined']);
-  }, [markWorkflowSeen]);
-
   const temporaryReviewCount = Number(temporary?.counts?.review?.count) || 0;
   const temporaryCreatedCount = Number(temporary?.counts?.created?.count) || 0;
   const temporaryFetchScopeEntries = temporary?.fetchScopeEntries;


### PR DESCRIPTION
## Summary
- stop automatically marking accepted and declined workflow notifications as seen on page load
- add a manual "Mark audition items read" control on the dashboard so badges persist until acknowledged

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e19022159c83319a1abd7066475961