### PR TITLE
Fix report bucket details toggle behavior

### DIFF
--- a/src/erp.mgt.mn/pages/Reports.jsx
+++ b/src/erp.mgt.mn/pages/Reports.jsx
@@ -1294,7 +1294,7 @@ export default function Reports() {
         <details
           key={`${listType}-${bucket.tableName}`}
           style={{ margin: '0.25rem 0' }}
-          open={shouldDefaultOpen}
+          defaultOpen={shouldDefaultOpen}
         >
           <summary style={{ cursor: 'pointer', fontWeight: 'bold' }}>
             {summary}


### PR DESCRIPTION
## Summary
- allow report bucket detail sections to rely on `defaultOpen` so browsers can toggle them
- retain the default-open experience when only one transactions or excluded bucket exists

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e191496d6c83318e6b576984f11aa1