### PR TITLE
Handle multi-value procedure lock candidate strings

### DIFF
--- a/tests/db/procedureLockCandidates.test.js
+++ b/tests/db/procedureLockCandidates.test.js
@@ -161,3 +161,72 @@ test('getProcedureLockCandidates preserves table context for JSON strings', asyn
     restoreQuery();
   }
 });
+
+test('getProcedureLockCandidates splits repeated table strings into distinct candidates', async () => {
+  const queryLog = [];
+  let released = false;
+
+  const mockConn = {
+    async query(sql, params) {
+      queryLog.push([sql, params]);
+      if (/^SET @/.test(sql)) {
+        return [[], []];
+      }
+      if (sql.startsWith('CALL ')) {
+        return [
+          [
+            [
+              'transactions_sales#41, transactions_sales#42',
+              'transactions_sales#41 transactions_sales#42',
+            ],
+          ],
+          [],
+        ];
+      }
+      if (sql === STRICT_SESSION_VAR_QUERY) {
+        return [[{ strict: null, secondary: null, legacy: null }], []];
+      }
+      if (sql.includes('FROM report_transaction_locks')) {
+        return [[], []];
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    },
+    release() {
+      released = true;
+    },
+  };
+
+  const originalGetConnection = db.pool.getConnection;
+  const originalQuery = db.pool.query;
+  const restoreGetConnection = () => {
+    if (originalGetConnection === undefined) {
+      delete db.pool.getConnection;
+    } else {
+      db.pool.getConnection = originalGetConnection;
+    }
+  };
+  const restoreQuery = () => {
+    db.pool.query = originalQuery;
+  };
+
+  db.pool.getConnection = async () => mockConn;
+  db.pool.query = async () => {
+    const err = new Error('no such table');
+    err.code = 'ER_NO_SUCH_TABLE';
+    throw err;
+  };
+
+  try {
+    const candidates = await db.getProcedureLockCandidates('sp_multi_string_report');
+    const keys = candidates.map((c) => `${c.tableName}#${c.recordId}`).sort();
+    assert.deepEqual(keys, ['transactions_sales#41', 'transactions_sales#42']);
+    assert.ok(released, 'connection should be released');
+    assert.ok(
+      queryLog.some(([sql]) => sql.startsWith('CALL sp_multi_string_report')),
+      'stored procedure should be invoked',
+    );
+  } finally {
+    restoreGetConnection();
+    restoreQuery();
+  }
+});


### PR DESCRIPTION
## Summary
- split the record id portion in parseCandidateString so repeated table prefixes produce distinct candidates
- add database procedure lock candidate tests covering repeated table strings

## Testing
- npm test -- tests/db *(fails in existing seedTenantTables and usersTrigger suites due to missing fixtures, new coverage passes)*

------
https://chatgpt.com/codex/tasks/task_e_68e197b05e5483318f7f056b8f5991ba