### PR TITLE
Improve report approval modal loading state

### DIFF
--- a/src/erp.mgt.mn/pages/Reports.jsx
+++ b/src/erp.mgt.mn/pages/Reports.jsx
@@ -1356,9 +1356,8 @@ export default function Reports() {
   }
 
   const openApprovalModal = useCallback(() => {
-    setApprovalData({ incoming: [], outgoing: [] });
     setApprovalError('');
-    setApprovalLoading(false);
+    setApprovalLoading(true);
     setApprovalModalOpen(true);
     setApprovalRefreshKey((k) => k + 1);
   }, []);
@@ -1503,7 +1502,6 @@ export default function Reports() {
     async function loadApprovals() {
       setApprovalLoading(true);
       setApprovalError('');
-      setApprovalData({ incoming: [], outgoing: [] });
       let outgoingRows = [];
       let incomingRows = [];
       let errorMsg = '';
@@ -1544,7 +1542,9 @@ export default function Reports() {
         }
       }
       if (!cancelled) {
-        setApprovalData({ incoming: incomingRows, outgoing: outgoingRows });
+        if (!errorMsg) {
+          setApprovalData({ incoming: incomingRows, outgoing: outgoingRows });
+        }
         setApprovalError(errorMsg);
         setApprovalLoading(false);
       }


### PR DESCRIPTION
## Summary
- start the report approvals modal in a loading state so existing data remains visible until the fetch returns
- update the approvals fetch logic to only replace the cached data on success and retain previous data when requests fail

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e197cf3b4c83318498577626787ca5