### PR TITLE
feat: auto-size manual parameter inputs

### DIFF
--- a/src/erp.mgt.mn/components/AutoSizingTextInput.jsx
+++ b/src/erp.mgt.mn/components/AutoSizingTextInput.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import computeAutoSizingInputWidth from './computeAutoSizingInputWidth.js';
+
+const AutoSizingTextInput = React.forwardRef(function AutoSizingTextInput(
+  props,
+  ref,
+) {
+  const {
+    value = '',
+    placeholder = '',
+    minChars = 0,
+    charWidth = 1,
+    style,
+    ...rest
+  } = props;
+
+  const widthCh = computeAutoSizingInputWidth({
+    value,
+    placeholder,
+    minChars,
+    charWidth,
+  });
+
+  const mergedStyle = {
+    ...style,
+    width: `${widthCh}ch`,
+  };
+
+  return (
+    <input
+      {...rest}
+      ref={ref}
+      value={value}
+      placeholder={placeholder}
+      style={mergedStyle}
+    />
+  );
+});
+
+export default AutoSizingTextInput;

--- a/src/erp.mgt.mn/components/computeAutoSizingInputWidth.js
+++ b/src/erp.mgt.mn/components/computeAutoSizingInputWidth.js
@@ -1,0 +1,33 @@
+export function normalizeText(value) {
+  if (value === null || value === undefined) return '';
+  return String(value);
+}
+
+export function toPositiveNumber(value, fallback = 0) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+export default function computeAutoSizingInputWidth({
+  value = '',
+  placeholder = '',
+  minChars = 0,
+  charWidth = 1,
+} = {}) {
+  const normalizedValue = normalizeText(value);
+  const normalizedPlaceholder = normalizeText(placeholder);
+  const normalizedMinChars = Math.max(0, toPositiveNumber(minChars, 0));
+  const normalizedCharWidth = Math.max(1, toPositiveNumber(charWidth, 1));
+
+  const longest = Math.max(
+    normalizedMinChars,
+    normalizedValue.length,
+    normalizedPlaceholder.length,
+  );
+
+  return (longest + 1) * normalizedCharWidth;
+}

--- a/src/erp.mgt.mn/pages/FinanceTransactions.jsx
+++ b/src/erp.mgt.mn/pages/FinanceTransactions.jsx
@@ -18,6 +18,7 @@ import useHeaderMappings from '../hooks/useHeaderMappings.js';
 import CustomDatePicker from '../components/CustomDatePicker.jsx';
 import useButtonPerms from '../hooks/useButtonPerms.js';
 import normalizeDateInput from '../utils/normalizeDateInput.js';
+import AutoSizingTextInput from '../components/AutoSizingTextInput.jsx';
 
 const DATE_PARAM_ALLOWLIST = new Set([
   'startdt',
@@ -715,7 +716,7 @@ useEffect(() => {
                       const key = name || String(i);
                       const val = manualParams[key] || '';
                       return (
-                        <input
+                        <AutoSizingTextInput
                           key={key}
                           type="text"
                           placeholder={name}

--- a/src/erp.mgt.mn/pages/Reports.jsx
+++ b/src/erp.mgt.mn/pages/Reports.jsx
@@ -18,6 +18,7 @@ import CustomDatePicker from '../components/CustomDatePicker.jsx';
 import useButtonPerms from '../hooks/useButtonPerms.js';
 import normalizeDateInput from '../utils/normalizeDateInput.js';
 import Modal from '../components/Modal.jsx';
+import AutoSizingTextInput from '../components/AutoSizingTextInput.jsx';
 
 const DATE_PARAM_ALLOWLIST = new Set([
   'startdt',
@@ -1628,7 +1629,7 @@ export default function Reports() {
               const val = manualParams[p] || '';
               const inputRef = manualInputRefs.current[p];
               return (
-                <input
+                <AutoSizingTextInput
                   key={p}
                   type="text"
                   placeholder={p}

--- a/tests/components/autoSizingTextInput.test.js
+++ b/tests/components/autoSizingTextInput.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import computeAutoSizingInputWidth, {
+  normalizeText,
+  toPositiveNumber,
+} from '../../src/erp.mgt.mn/components/computeAutoSizingInputWidth.js';
+
+test('normalizeText converts falsy values to empty strings', () => {
+  assert.equal(normalizeText(null), '');
+  assert.equal(normalizeText(undefined), '');
+  assert.equal(normalizeText(123), '123');
+  assert.equal(normalizeText('abc'), 'abc');
+});
+
+test('toPositiveNumber coerces values safely', () => {
+  assert.equal(toPositiveNumber(5), 5);
+  assert.equal(toPositiveNumber('8'), 8);
+  assert.equal(toPositiveNumber('not-a-number', 2), 2);
+  assert.equal(toPositiveNumber(null, 3), 3);
+});
+
+test('computeAutoSizingInputWidth respects placeholder length', () => {
+  const placeholder = 'enter-your-very-long-parameter-name';
+  const width = computeAutoSizingInputWidth({ placeholder });
+  assert.equal(width, placeholder.length + 1);
+});
+
+test('computeAutoSizingInputWidth respects current value length', () => {
+  const value = 'value-that-is-even-longer-than-placeholder';
+  const width = computeAutoSizingInputWidth({ value });
+  assert.equal(width, value.length + 1);
+});
+
+test('computeAutoSizingInputWidth respects minChars and charWidth', () => {
+  const width = computeAutoSizingInputWidth({ minChars: 10, charWidth: 2 });
+  assert.equal(width, (10 + 1) * 2);
+});


### PR DESCRIPTION
## Summary
- add an auto-sizing text input component for manual parameter fields
- replace manual parameter inputs in Reports and FinanceTransactions with the new component
- cover the auto-sizing helper logic with focused unit tests

## Testing
- npm test -- tests/components/autoSizingTextInput.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e19826cf208331906ba8080640724f