### PR TITLE
Handle request date filters via URL

### DIFF
--- a/src/erp.mgt.mn/components/DateRangePicker.jsx
+++ b/src/erp.mgt.mn/components/DateRangePicker.jsx
@@ -7,6 +7,62 @@ import normalizeDateInput from '../utils/normalizeDateInput.js';
  * Reusable date range picker with common presets.
  * Calls `onChange` with an object `{ start, end }` using YYYY-MM-DD strings.
  */
+const PRESET_KEYS = [
+  'today',
+  'yesterday',
+  'last7',
+  'month',
+  'q1',
+  'q2',
+  'q3',
+  'q4',
+  'year',
+];
+
+function getPresetRange(preset, customStart, customEnd) {
+  const fmt = (d) => formatTimestamp(d).slice(0, 10);
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = now.getMonth();
+  switch (preset) {
+    case 'custom':
+      return { start: customStart, end: customEnd };
+    case 'today': {
+      const value = fmt(now);
+      return { start: value, end: value };
+    }
+    case 'yesterday': {
+      const d = new Date(now);
+      d.setDate(now.getDate() - 1);
+      const value = fmt(d);
+      return { start: value, end: value };
+    }
+    case 'last7': {
+      const endDate = fmt(now);
+      const startDate = new Date(now);
+      startDate.setDate(now.getDate() - 6);
+      return { start: fmt(startDate), end: endDate };
+    }
+    case 'month': {
+      const startDate = new Date(y, m, 1);
+      const endDate = new Date(y, m + 1, 0);
+      return { start: fmt(startDate), end: fmt(endDate) };
+    }
+    case 'q1':
+      return { start: fmt(new Date(y, 0, 1)), end: fmt(new Date(y, 3, 0)) };
+    case 'q2':
+      return { start: fmt(new Date(y, 3, 1)), end: fmt(new Date(y, 6, 0)) };
+    case 'q3':
+      return { start: fmt(new Date(y, 6, 1)), end: fmt(new Date(y, 9, 0)) };
+    case 'q4':
+      return { start: fmt(new Date(y, 9, 1)), end: fmt(new Date(y, 12, 0)) };
+    case 'year':
+      return { start: fmt(new Date(y, 0, 1)), end: fmt(new Date(y, 12, 0)) };
+    default:
+      return { start: customStart, end: customEnd };
+  }
+}
+
 export default function DateRangePicker({ start, end, onChange, style }) {
   const [preset, setPreset] = useState('today');
   const [customStart, setCustomStart] = useState(() =>
@@ -17,68 +73,41 @@ export default function DateRangePicker({ start, end, onChange, style }) {
   );
 
   useEffect(() => {
-    const fmt = (d) => formatTimestamp(d).slice(0, 10);
-    let s;
-    let e;
-    if (preset === 'custom') {
-      s = customStart;
-      e = customEnd;
-    } else {
-      const now = new Date();
-      const y = now.getFullYear();
-      const m = now.getMonth();
-      switch (preset) {
-        case 'today':
-          s = e = fmt(now);
-          break;
-        case 'yesterday': {
-          const d = new Date(now);
-          d.setDate(now.getDate() - 1);
-          s = e = fmt(d);
-          break;
-        }
-        case 'last7': {
-          const endDate = fmt(now);
-          const startDate = new Date(now);
-          startDate.setDate(now.getDate() - 6);
-          s = fmt(startDate);
-          e = endDate;
-          break;
-        }
-        case 'month': {
-          const startDate = new Date(y, m, 1);
-          const endDate = new Date(y, m + 1, 0);
-          s = fmt(startDate);
-          e = fmt(endDate);
-          break;
-        }
-        case 'q1':
-          s = fmt(new Date(y, 0, 1));
-          e = fmt(new Date(y, 3, 0));
-          break;
-        case 'q2':
-          s = fmt(new Date(y, 3, 1));
-          e = fmt(new Date(y, 6, 0));
-          break;
-        case 'q3':
-          s = fmt(new Date(y, 6, 1));
-          e = fmt(new Date(y, 9, 0));
-          break;
-        case 'q4':
-          s = fmt(new Date(y, 9, 1));
-          e = fmt(new Date(y, 12, 0));
-          break;
-        case 'year':
-          s = fmt(new Date(y, 0, 1));
-          e = fmt(new Date(y, 12, 0));
-          break;
-        default:
-          s = customStart;
-          e = customEnd;
-      }
-    }
+    const { start: s, end: e } = getPresetRange(preset, customStart, customEnd);
     onChange({ start: s, end: e });
-  }, [preset, customStart, customEnd]);
+  }, [preset, customStart, customEnd, onChange]);
+
+  useEffect(() => {
+    const normalizedStart = normalizeDateInput(start || '', 'YYYY-MM-DD');
+    const normalizedEnd = normalizeDateInput(end || '', 'YYYY-MM-DD');
+
+    if (normalizedStart !== customStart) {
+      setCustomStart(normalizedStart);
+    }
+    if (normalizedEnd !== customEnd) {
+      setCustomEnd(normalizedEnd);
+    }
+
+    const matchedPreset = PRESET_KEYS.find((key) => {
+      const range = getPresetRange(key, normalizedStart, normalizedEnd);
+      return range.start === normalizedStart && range.end === normalizedEnd;
+    });
+
+    if (matchedPreset) {
+      if (matchedPreset !== preset) {
+        setPreset(matchedPreset);
+      }
+      return;
+    }
+
+    if (normalizedStart || normalizedEnd) {
+      if (preset !== 'custom') {
+        setPreset('custom');
+      }
+    } else if (preset !== 'today') {
+      setPreset('today');
+    }
+  }, [start, end, customStart, customEnd, preset]);
 
   return (
     <span style={style}>

--- a/src/erp.mgt.mn/pages/Notifications.jsx
+++ b/src/erp.mgt.mn/pages/Notifications.jsx
@@ -356,6 +356,23 @@ export default function NotificationsPage() {
       if (normalizedStatus) params.set('status', normalizedStatus);
       if (req?.request_type) params.set('requestType', req.request_type);
       if (req?.table_name) params.set('table_name', req.table_name);
+      const createdAt = req?.created_at || req?.createdAt;
+      let createdDate = '';
+      if (createdAt) {
+        const parsed = new Date(createdAt);
+        if (!Number.isNaN(parsed.getTime())) {
+          createdDate = formatTimestamp(parsed).slice(0, 10);
+        } else if (typeof createdAt === 'string') {
+          const match = createdAt.match(/^(\d{4}-\d{2}-\d{2})/);
+          if (match) {
+            createdDate = match[1];
+          }
+        }
+      }
+      if (createdDate) {
+        params.set('date_from', createdDate);
+        params.set('date_to', createdDate);
+      }
       params.set('requestId', req?.request_id);
       navigate(`/requests?${params.toString()}`);
     },


### PR DESCRIPTION
## Summary
- respect existing date range query parameters when loading the requests page and avoid overwriting them with "today" defaults
- keep the URL in sync with the selected date range and update the date picker so custom ranges render accurately
- include the request creation date in notification links so deep links surface older requests immediately

## Testing
- npm run test *(fails: upstream tenant seeding and trigger tests already failing)*

------
https://chatgpt.com/codex/tasks/task_e_68e197e20c6c8331850086430266a1b2