### PR TITLE
Improve tour fallback selector derivation

### DIFF
--- a/src/erp.mgt.mn/utils/findVisibleTourStep.js
+++ b/src/erp.mgt.mn/utils/findVisibleTourStep.js
@@ -52,6 +52,190 @@ function isElementVisible(element) {
   return false;
 }
 
+const CSS_ESCAPE =
+  typeof globalThis !== "undefined" &&
+  globalThis.CSS &&
+  typeof globalThis.CSS.escape === "function"
+    ? globalThis.CSS.escape
+    : null;
+
+function escapeCssIdentifier(value) {
+  if (typeof value !== "string") return "";
+  if (CSS_ESCAPE) return CSS_ESCAPE(value);
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/(["'#.:;?+<>=~*^$\[\]\(\)\s])/g, "\\$1");
+}
+
+function escapeAttributeValue(value) {
+  if (typeof value !== "string") return "";
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function listElementAttributeNames(element) {
+  if (!element || typeof element !== "object") return [];
+  if (typeof element.getAttributeNames === "function") {
+    try {
+      const names = element.getAttributeNames();
+      return Array.isArray(names) ? names : [];
+    } catch (err) {
+      return [];
+    }
+  }
+
+  const attributes = element.attributes;
+  if (!attributes || typeof attributes !== "object") return [];
+  const result = [];
+  for (let idx = 0; idx < attributes.length; idx += 1) {
+    const attr = attributes[idx];
+    if (!attr || typeof attr.name !== "string") continue;
+    result.push(attr.name);
+  }
+  return result;
+}
+
+const PREFERRED_DATA_ATTRIBUTES = [
+  "data-testid",
+  "data-test",
+  "data-tour",
+  "data-tour-target",
+  "data-qa",
+  "data-automation-id",
+  "data-id",
+];
+
+function deriveElementSegment(element) {
+  if (!element || typeof element !== "object") return "";
+
+  const tagName =
+    typeof element.tagName === "string" && element.tagName
+      ? element.tagName.toLowerCase()
+      : "";
+
+  const id = typeof element.id === "string" ? element.id.trim() : "";
+  if (id) {
+    return `#${escapeCssIdentifier(id)}`;
+  }
+
+  const attributeNames = listElementAttributeNames(element);
+  if (attributeNames.length) {
+    let chosenAttr = "";
+    let chosenValue = "";
+
+    const preferredAttr = PREFERRED_DATA_ATTRIBUTES.find((name) =>
+      attributeNames.includes(name),
+    );
+    if (preferredAttr) {
+      const preferredValue = element.getAttribute
+        ? element.getAttribute(preferredAttr)
+        : null;
+      if (typeof preferredValue === "string" && preferredValue.trim()) {
+        chosenAttr = preferredAttr;
+        chosenValue = preferredValue.trim();
+      }
+    }
+
+    if (!chosenAttr) {
+      for (let idx = 0; idx < attributeNames.length; idx += 1) {
+        const name = attributeNames[idx];
+        if (typeof name !== "string" || !name.startsWith("data-")) continue;
+        const value = element.getAttribute ? element.getAttribute(name) : null;
+        if (typeof value !== "string") continue;
+        const trimmed = value.trim();
+        if (!trimmed) continue;
+        chosenAttr = name;
+        chosenValue = trimmed;
+        break;
+      }
+    }
+
+    if (chosenAttr && chosenValue) {
+      const attrSelector = `[${chosenAttr}="${escapeAttributeValue(chosenValue)}"]`;
+      if (tagName) {
+        return `${tagName}${attrSelector}`;
+      }
+      return attrSelector;
+    }
+  }
+
+  const classList =
+    element.classList && typeof element.classList === "object"
+      ? Array.from(element.classList)
+          .map((value) => (typeof value === "string" ? value.trim() : ""))
+          .filter(Boolean)
+      : [];
+  if (classList.length) {
+    const limited = classList.slice(0, 3).map((cls) => `.${escapeCssIdentifier(cls)}`);
+    const classSelector = limited.join("");
+    if (classSelector) {
+      if (tagName) {
+        return `${tagName}${classSelector}`;
+      }
+      return classSelector;
+    }
+  }
+
+  if (tagName) {
+    const parent = element.parentElement;
+    if (parent && parent.children) {
+      const siblings = Array.from(parent.children).filter(
+        (child) => child && child.tagName === element.tagName,
+      );
+      const index = siblings.indexOf(element);
+      if (index >= 0) {
+        return `${tagName}:nth-of-type(${index + 1})`;
+      }
+    }
+    return tagName;
+  }
+
+  return "";
+}
+
+function deriveElementSelector(element) {
+  if (!element || typeof element !== "object") return "";
+
+  const segments = [];
+  let current = element;
+  const visited = new Set();
+  let depth = 0;
+  const MAX_DEPTH = 6;
+
+  while (current && depth < MAX_DEPTH) {
+    if (visited.has(current)) {
+      break;
+    }
+    visited.add(current);
+
+    const segment = deriveElementSegment(current);
+    if (!segment) break;
+    segments.unshift(segment);
+    if (segment.startsWith("#")) {
+      break;
+    }
+    current = current.parentElement;
+    depth += 1;
+  }
+
+  return segments.join(" > ");
+}
+
+function createFallbackResult(selector, options = {}) {
+  const trimmed = typeof selector === "string" ? selector.trim() : "";
+  const highlightCandidates = normalizeSelectorList(options.highlightSelectors);
+  const highlightSet = new Set();
+  if (trimmed) {
+    highlightSet.add(trimmed);
+  }
+  highlightCandidates.forEach((value) => highlightSet.add(value));
+
+  return {
+    selector: trimmed,
+    highlightSelectors: Array.from(highlightSet),
+    derivedFrom: typeof options.derivedFrom === "string" ? options.derivedFrom : "",
+  };
+}
+
 function findExistingSelector(selectors, querySelector) {
   for (let idx = 0; idx < selectors.length; idx += 1) {
     const selector = selectors[idx];
@@ -101,7 +285,9 @@ export function findVisibleFallbackSelector(
 
   const resolvedSelector = findExistingSelector(selectorPool, querySelector);
   if (resolvedSelector) {
-    return resolvedSelector;
+    return createFallbackResult(resolvedSelector, {
+      derivedFrom: "highlight",
+    });
   }
 
   const baseSelector =
@@ -118,14 +304,77 @@ export function findVisibleFallbackSelector(
     try {
       const element = querySelector(parentSelector);
       if (isElementVisible(element)) {
-        return parentSelector;
+        return createFallbackResult(parentSelector, {
+          derivedFrom: "selector-ancestor",
+        });
       }
     } catch (err) {
       // Ignore invalid selectors and continue searching upward.
     }
   }
 
-  return "";
+  if (baseSelector) {
+    let baseElement = null;
+    try {
+      baseElement = querySelector(baseSelector);
+    } catch (err) {
+      baseElement = null;
+    }
+
+    let currentElement = baseElement;
+    const visited = new Set();
+    let depth = 0;
+    const MAX_DEPTH = 10;
+    while (currentElement && depth < MAX_DEPTH) {
+      if (visited.has(currentElement)) break;
+      visited.add(currentElement);
+
+      if (isElementVisible(currentElement)) {
+        const derivedSelector = deriveElementSelector(currentElement);
+        if (derivedSelector) {
+          return createFallbackResult(derivedSelector, {
+            derivedFrom:
+              currentElement === baseElement ? "target" : "dom-ancestor",
+          });
+        }
+      }
+
+      currentElement = currentElement.parentElement || null;
+      depth += 1;
+    }
+
+    const ownerDocument =
+      baseElement && typeof baseElement === "object"
+        ? baseElement.ownerDocument
+        : typeof document !== "undefined"
+          ? document
+          : null;
+    if (ownerDocument && ownerDocument.body) {
+      const bodyElement = ownerDocument.body;
+      if (isElementVisible(bodyElement)) {
+        const bodySelector = deriveElementSelector(bodyElement) || "body";
+        if (bodySelector) {
+          return createFallbackResult(bodySelector, {
+            derivedFrom: "document-body",
+          });
+        }
+      }
+    }
+  }
+
+  if (baseSelector) {
+    return createFallbackResult(baseSelector, {
+      derivedFrom: "base",
+    });
+  }
+
+  if (selectorPool.length) {
+    return createFallbackResult(selectorPool[0], {
+      derivedFrom: "selectors",
+    });
+  }
+
+  return createFallbackResult("", { derivedFrom: "none" });
 }
 
 export function findLastVisibleTourStepIndex(

--- a/tests/findLastVisibleTourStepIndex.test.js
+++ b/tests/findLastVisibleTourStepIndex.test.js
@@ -67,7 +67,9 @@ test("findVisibleFallbackSelector returns first visible highlight selector", () 
 
   const result = findVisibleFallbackSelector(step, query);
 
-  assert.equal(result, "#fallback");
+  assert.equal(result.selector, "#fallback");
+  assert.deepEqual(result.highlightSelectors, ["#fallback"]);
+  assert.equal(result.derivedFrom, "highlight");
 });
 
 test("findVisibleFallbackSelector skips hidden targets and pauses on visible parent", () => {
@@ -99,5 +101,38 @@ test("findVisibleFallbackSelector skips hidden targets and pauses on visible par
 
   const result = findVisibleFallbackSelector(step, query);
 
-  assert.equal(result, "#alpha");
+  assert.equal(result.selector, "#alpha");
+  assert.equal(result.derivedFrom, "selector-ancestor");
+  assert.deepEqual(result.highlightSelectors, ["#alpha"]);
+});
+
+test("findVisibleFallbackSelector walks DOM ancestry for hidden target", () => {
+  const target = {
+    offsetParent: null,
+    offsetWidth: 0,
+    offsetHeight: 0,
+    getBoundingClientRect: () => ({ width: 0, height: 0 }),
+    parentElement: null,
+  };
+  const ancestor = {
+    offsetParent: {},
+    offsetWidth: 200,
+    offsetHeight: 40,
+    getBoundingClientRect: () => ({ width: 200, height: 40 }),
+    tagName: "SECTION",
+    classList: [],
+    parentElement: null,
+  };
+  target.parentElement = ancestor;
+  const step = { target: "#alpha" };
+  const elements = {
+    "#alpha": target,
+  };
+  const query = (selector) => elements[selector] || null;
+
+  const result = findVisibleFallbackSelector(step, query);
+
+  assert.equal(result.selector, "section");
+  assert.equal(result.derivedFrom, "dom-ancestor");
+  assert.deepEqual(result.highlightSelectors, ["section"]);
 });


### PR DESCRIPTION
## Summary
- extend `findVisibleFallbackSelector` to derive selectors from visible DOM ancestors using reusable element selector helpers
- update ERPLayout tour handling to consume richer fallback metadata and preserve highlight arrays for pause steps
- expand unit coverage for fallback selector behavior, including DOM ancestor traversal cases

## Testing
- npm test -- tests/findLastVisibleTourStepIndex.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e4713665c48331a9b4fa9f27854a54