### PR TITLE
Add multi-lock candidate test coverage and SQL fixture instructions

### DIFF
--- a/docs/report-builder.md
+++ b/docs/report-builder.md
@@ -7,3 +7,57 @@ presses are caught and displayed, preventing the window from going blank.
 
 When extending the builder, throw descriptive errors rather than letting
 failures fall through silently so the boundary can surface them to the user.
+
+## Testing report lock candidates
+
+Use the following stored procedure to simulate a report that publishes
+multiple lock candidates via both result sets and the modern session variables.
+The procedure seeds locks for two report rows and a related approval request so
+that the API can exercise the metadata merge logic.
+
+```sql
+DELIMITER $$
+CREATE PROCEDURE `sp_multiple_lock_test`()
+BEGIN
+  SET @__report_lock_candidates = JSON_ARRAY(
+    JSON_OBJECT('table', 'reports', 'record_id', 7, 'label', 'Report 7'),
+    JSON_OBJECT('table', 'reports', 'record_id', 10, 'label', 'Report 10')
+  );
+
+  SELECT JSON_ARRAY(
+           JSON_OBJECT(
+             'lock_table', 'reports',
+             'lock_record_id', 7,
+             'label', 'Report 7'
+           ),
+           JSON_OBJECT(
+             'lock_table', 'reports',
+             'lock_record_ids', JSON_ARRAY(8, 9),
+             'description', 'Queued reports'
+           )
+         ) AS strict_candidates,
+         JSON_ARRAY(
+           JSON_OBJECT(
+             'approvals', JSON_ARRAY(
+               JSON_OBJECT(
+                 'table', 'requests',
+                 'record_id', 'req-1',
+                 'label', 'Approval 1'
+               )
+             )
+           )
+         ) AS secondary_candidates;
+END $$
+DELIMITER ;
+```
+
+After loading the procedure, run the dedicated test to verify the multiple-lock
+handling branch:
+
+```bash
+node --test tests/db/procedureLockCandidates.test.js
+```
+
+The new assertions confirm that the data access layer queries the
+`report_transaction_locks` table for each table bucket, merges metadata from the
+priority statuses, and surfaces the final lock context back to the caller.

--- a/tests/db/procedureLockCandidates.test.js
+++ b/tests/db/procedureLockCandidates.test.js
@@ -230,3 +230,193 @@ test('getProcedureLockCandidates splits repeated table strings into distinct can
     restoreQuery();
   }
 });
+
+test('getProcedureLockCandidates attaches metadata for multiple lock candidates', async () => {
+  const queryLog = [];
+  let released = false;
+
+  const mockConn = {
+    async query(sql, params) {
+      queryLog.push([sql, params]);
+      if (/^SET @/.test(sql)) {
+        return [[], []];
+      }
+      if (sql.startsWith('CALL ')) {
+        return [
+          [
+            [
+              {
+                lock_table: 'reports',
+                lock_record_id: 7,
+                label: 'Report 7',
+              },
+              {
+                lock_table: 'reports',
+                lock_record_ids: [8, '9'],
+                description: 'Queued reports',
+              },
+            ],
+            [
+              {
+                approvals: [
+                  {
+                    table: 'requests',
+                    record_id: 'req-1',
+                    label: 'Approval 1',
+                  },
+                ],
+              },
+            ],
+          ],
+          [],
+        ];
+      }
+      if (sql === STRICT_SESSION_VAR_QUERY) {
+        return [
+          [
+            {
+              strict: JSON.stringify([
+                {
+                  table: 'reports',
+                  record_id: '10',
+                  label: 'Report 10',
+                },
+              ]),
+              secondary: null,
+              legacy: null,
+            },
+          ],
+          [],
+        ];
+      }
+      if (sql.includes('FROM report_transaction_locks')) {
+        const tableName = params?.[0];
+        if (tableName === 'reports') {
+          return [
+            [
+              {
+                table_name: 'reports',
+                record_id: '7',
+                status: 'locked',
+                finalized_by: 'Analyst A',
+                finalized_at: '2024-02-01T00:00:00.000Z',
+              },
+              {
+                table_name: 'reports',
+                record_id: '8',
+                status: 'pending',
+                status_changed_by: 'Analyst B',
+                status_changed_at: '2024-02-02T00:00:00.000Z',
+              },
+            ],
+            [],
+          ];
+        }
+        if (tableName === 'requests') {
+          return [
+            [
+              {
+                table_name: 'requests',
+                record_id: 'req-1',
+                status: 'locked',
+                status_changed_by: 'Manager M',
+                status_changed_at: '2024-02-03T00:00:00.000Z',
+              },
+            ],
+            [],
+          ];
+        }
+        return [[], []];
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    },
+    release() {
+      released = true;
+    },
+  };
+
+  const originalGetConnection = db.pool.getConnection;
+  const originalQuery = db.pool.query;
+  const restoreGetConnection = () => {
+    if (originalGetConnection === undefined) {
+      delete db.pool.getConnection;
+    } else {
+      db.pool.getConnection = originalGetConnection;
+    }
+  };
+  const restoreQuery = () => {
+    db.pool.query = originalQuery;
+  };
+
+  db.pool.getConnection = async () => mockConn;
+  db.pool.query = async () => {
+    const err = new Error('no such table');
+    err.code = 'ER_NO_SUCH_TABLE';
+    throw err;
+  };
+
+  try {
+    const candidates = await db.getProcedureLockCandidates(
+      'sp_multiple_lock_test',
+      [],
+      [],
+      { companyId: 23 },
+    );
+
+    const keys = candidates.map((c) => c.key).sort();
+    assert.deepEqual(keys, [
+      'reports#10',
+      'reports#7',
+      'reports#8',
+      'reports#9',
+      'requests#req-1',
+    ]);
+
+    const report7 = candidates.find((c) => c.key === 'reports#7');
+    assert.equal(report7?.locked, true);
+    assert.equal(report7?.lockStatus, 'locked');
+    assert.equal(report7?.lockedBy, 'Analyst A');
+    assert.equal(report7?.lockedAt, '2024-02-01T00:00:00.000Z');
+
+    const report8 = candidates.find((c) => c.key === 'reports#8');
+    assert.equal(report8?.locked, true);
+    assert.equal(report8?.lockStatus, 'pending');
+    assert.equal(report8?.lockedBy, 'Analyst B');
+    assert.equal(report8?.lockedAt, '2024-02-02T00:00:00.000Z');
+
+    const report9 = candidates.find((c) => c.key === 'reports#9');
+    assert.equal(report9?.locked, false);
+    assert.equal(report9?.lockStatus, null);
+    assert.equal(report9?.lockedBy, null);
+
+    const request = candidates.find((c) => c.key === 'requests#req-1');
+    assert.equal(request?.locked, true);
+    assert.equal(request?.lockStatus, 'locked');
+    assert.equal(request?.lockedBy, 'Manager M');
+    assert.equal(request?.lockedAt, '2024-02-03T00:00:00.000Z');
+
+    assert.ok(released, 'connection should be released');
+
+    const lockQueries = queryLog.filter(([sql]) =>
+      sql.includes('FROM report_transaction_locks'),
+    );
+    assert.equal(lockQueries.length, 2);
+
+    const [reportsParams, requestsParams] = lockQueries.map(([, params]) => params);
+    assert.equal(reportsParams[0], 'reports');
+    assert.equal(reportsParams[1], 23);
+    assert.deepEqual(
+      new Set(reportsParams.slice(2, reportsParams.length - 2)),
+      new Set(['7', '8', '9', '10']),
+    );
+    assert.deepEqual(reportsParams.slice(-2), ['locked', 'pending']);
+
+    assert.equal(requestsParams[0], 'requests');
+    assert.equal(requestsParams[1], 23);
+    assert.deepEqual(requestsParams.slice(2, requestsParams.length - 2), ['req-1']);
+    assert.deepEqual(requestsParams.slice(-2), ['locked', 'pending']);
+  } finally {
+    restoreGetConnection();
+    restoreQuery();
+  }
+});


### PR DESCRIPTION
## Summary
- document a reusable `sp_multiple_lock_test` stored procedure for exercising report lock candidates
- extend the procedure lock candidates test suite with coverage for multiple bucket metadata resolution

## Testing
- node --test tests/db/procedureLockCandidates.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e48a7f2db083319a2c9f229785da6f