### PR TITLE
Add dynrep transactions test fixtures and lock coverage

### DIFF
--- a/db/migrations/2025-11-02_report_transactions_test_fixture.sql
+++ b/db/migrations/2025-11-02_report_transactions_test_fixture.sql
@@ -1,0 +1,195 @@
+-- Seed data and stored procedure used by report builder tests
+CREATE TABLE IF NOT EXISTS transactions_test (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  company_id INT NOT NULL,
+  request_id BIGINT NOT NULL,
+  customer_name VARCHAR(191) NOT NULL,
+  status ENUM('draft', 'pending', 'approved') NOT NULL DEFAULT 'pending',
+  total_amount DECIMAL(18,2) NOT NULL DEFAULT 0,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  KEY idx_transactions_test_company (company_id),
+  KEY idx_transactions_test_request (request_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+INSERT INTO transactions_test (
+  id,
+  company_id,
+  request_id,
+  customer_name,
+  status,
+  total_amount,
+  created_at,
+  updated_at
+) VALUES
+  (1, 1, 9001, 'Acme Manufacturing', 'pending', 125000.00, '2024-09-15 10:30:00', '2024-09-15 11:00:00'),
+  (2, 1, 9002, 'Beta Logistics', 'approved', 86500.00, '2024-09-16 09:20:00', '2024-09-16 10:05:00'),
+  (3, 2, 9100, 'Central Retail', 'draft', 152500.00, '2024-09-17 08:45:00', '2024-09-17 08:45:00')
+ON DUPLICATE KEY UPDATE
+  company_id = VALUES(company_id),
+  request_id = VALUES(request_id),
+  customer_name = VALUES(customer_name),
+  status = VALUES(status),
+  total_amount = VALUES(total_amount),
+  created_at = VALUES(created_at),
+  updated_at = VALUES(updated_at);
+
+CREATE TABLE IF NOT EXISTS transactions_test_detail (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  transaction_id BIGINT UNSIGNED NOT NULL,
+  line_no INT NOT NULL,
+  sku VARCHAR(64) NULL,
+  quantity DECIMAL(18,2) NOT NULL DEFAULT 0,
+  line_total DECIMAL(18,2) NOT NULL DEFAULT 0,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  KEY idx_transactions_detail_transaction (transaction_id),
+  CONSTRAINT fk_transactions_test_detail_transaction FOREIGN KEY (transaction_id)
+    REFERENCES transactions_test (id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+INSERT INTO transactions_test_detail (
+  id,
+  transaction_id,
+  line_no,
+  sku,
+  quantity,
+  line_total,
+  created_at,
+  updated_at
+) VALUES
+  (1001, 1, 1, 'SKU-001', 2, 50000.00, '2024-09-15 10:31:00', '2024-09-15 10:31:00'),
+  (1002, 1, 2, 'SKU-002', 3, 75000.00, '2024-09-15 10:32:00', '2024-09-15 10:32:00'),
+  (1003, 2, 1, 'SKU-003', 5, 86500.00, '2024-09-16 09:21:00', '2024-09-16 09:21:00')
+ON DUPLICATE KEY UPDATE
+  transaction_id = VALUES(transaction_id),
+  line_no = VALUES(line_no),
+  sku = VALUES(sku),
+  quantity = VALUES(quantity),
+  line_total = VALUES(line_total),
+  created_at = VALUES(created_at),
+  updated_at = VALUES(updated_at);
+
+DROP PROCEDURE IF EXISTS dynrep_1_sp_transactions_test_report;
+DELIMITER $$
+CREATE PROCEDURE dynrep_1_sp_transactions_test_report(
+  IN p_company_id INT
+)
+BEGIN
+  DECLARE v_company_id INT DEFAULT NULL;
+
+  IF p_company_id IS NOT NULL AND p_company_id <> 0 THEN
+    SET v_company_id = p_company_id;
+  END IF;
+
+  SET @__report_lock_candidates = JSON_ARRAY();
+  SET @_report_lock_candidates = JSON_ARRAY();
+  SET @report_lock_candidates = JSON_ARRAY();
+
+  WITH base AS (
+    SELECT
+      t.id,
+      t.company_id,
+      t.request_id,
+      t.customer_name,
+      t.status,
+      t.total_amount,
+      COALESCE((
+        SELECT JSON_ARRAYAGG(
+          JSON_OBJECT(
+            'lock_table', 'transactions_test_detail',
+            'lock_record_id', d.id,
+            'label', CONCAT('Detail ', d.line_no, ' (', IFNULL(d.sku, 'N/A'), ')'),
+            'context', JSON_OBJECT(
+              'line_no', d.line_no,
+              'sku', d.sku,
+              'quantity', d.quantity,
+              'line_total', d.line_total
+            )
+          )
+        )
+        FROM transactions_test_detail d
+        WHERE d.transaction_id = t.id
+      ), JSON_ARRAY()) AS detail_records
+    FROM transactions_test t
+    WHERE v_company_id IS NULL OR t.company_id = v_company_id
+  )
+  SELECT
+    b.id AS transaction_id,
+    b.company_id,
+    b.request_id,
+    b.customer_name,
+    b.status,
+    b.total_amount,
+    JSON_OBJECT(
+      'transactions_test',
+      JSON_ARRAY(
+        JSON_OBJECT(
+          'lock_table', 'transactions_test',
+          'lock_record_id', b.id,
+          'label', CONCAT('Transaction ', b.id),
+          'context', JSON_OBJECT(
+            'company_id', b.company_id,
+            'request_id', b.request_id,
+            'customer', b.customer_name
+          )
+        )
+      ),
+      'transactions_test_detail',
+      JSON_OBJECT(
+        'lock_table', 'transactions_test_detail',
+        'lock_record_ids',
+        IF(
+          JSON_LENGTH(b.detail_records) IS NULL OR JSON_LENGTH(b.detail_records) = 0,
+          JSON_ARRAY(),
+          JSON_EXTRACT(b.detail_records, '$[*].lock_record_id')
+        ),
+        'records', b.detail_records,
+        'label', CONCAT('Transaction ', b.id, ' details')
+      )
+    ) AS lock_bundle
+  FROM base b
+  ORDER BY b.id;
+
+  SELECT COALESCE(JSON_ARRAYAGG(candidate), JSON_ARRAY())
+    INTO @__report_lock_candidates
+  FROM (
+    SELECT JSON_OBJECT(
+      'table', 'transactions_test',
+      'record_id', CAST(t.id AS CHAR),
+      'label', CONCAT('Transaction ', t.id),
+      'context', JSON_OBJECT(
+        'company_id', t.company_id,
+        'request_id', t.request_id,
+        'customer', t.customer_name
+      )
+    ) AS candidate
+    FROM transactions_test t
+    WHERE v_company_id IS NULL OR t.company_id = v_company_id
+
+    UNION ALL
+
+    SELECT JSON_OBJECT(
+      'table', 'transactions_test_detail',
+      'record_id', CAST(d.id AS CHAR),
+      'label', CONCAT('Detail ', d.line_no, ' of Txn ', d.transaction_id),
+      'context', JSON_OBJECT(
+        'transaction_id', d.transaction_id,
+        'sku', d.sku,
+        'line_no', d.line_no,
+        'quantity', d.quantity
+      )
+    )
+    FROM transactions_test_detail d
+    JOIN transactions_test t ON t.id = d.transaction_id
+    WHERE v_company_id IS NULL OR t.company_id = v_company_id
+  ) AS derived;
+
+  SET @_report_lock_candidates = @__report_lock_candidates;
+  SET @report_lock_candidates = @__report_lock_candidates;
+END $$
+DELIMITER ;

--- a/db/migrations/README.md
+++ b/db/migrations/README.md
@@ -6,6 +6,7 @@ Legacy migrations have been moved to the `archive/` directory. New migrations sh
 
 - `2025-10-05_employment_plan_senior.sql`: Adds `employment_senior_plan_empid` to `tbl_employment`, indexes it, and seeds the column from `employment_senior_empid` for existing records.
 - `2025-10-16_pending_request_record_id_varchar.sql`: Converts `pending_request.record_id` and `user_activity_log.record_id` to `VARCHAR(191)` and re-applies related indexes/constraints.
+- `2025-11-02_report_transactions_test_fixture.sql`: Seeds the `transactions_test` and `transactions_test_detail` tables and adds the `dynrep_1_sp_transactions_test_report` stored procedure with expanded lock candidate metadata used by report tests.
 
 No migrations are pending. The baseline schema now mirrors the production snapshot in `db/mgtmn_erp_db.sql` (generated 2025-10-03) so fresh databases already contain the identifier columns and audit metadata that earlier scripts added.
 

--- a/docs/report-builder.md
+++ b/docs/report-builder.md
@@ -7,3 +7,19 @@ presses are caught and displayed, preventing the window from going blank.
 
 When extending the builder, throw descriptive errors rather than letting
 failures fall through silently so the boundary can surface them to the user.
+
+## Sample transactions dataset
+
+The database migrations now seed a lightweight `transactions_test` table along
+with a related `transactions_test_detail` table. Three sample transactions are
+inserted so the report builder can showcase aggregate totals and the locking
+workflow without having to bootstrap additional fixtures. Each detail row is
+linked back to its parent transaction and includes quantities, SKU metadata and
+line totals.
+
+On top of the tables, the `dynrep_1_sp_transactions_test_report` stored
+procedure demonstrates how dynamic reports can surface multiple lock candidates
+at once. The procedure groups detail rows into a JSON payload that exposes both
+record-level hints and session variables for the locking subsystem. This makes
+it easy to exercise scenarios where a single report row needs to reserve records
+from more than one table before the report can be approved.

--- a/tests/db/procedureLockCandidates.test.js
+++ b/tests/db/procedureLockCandidates.test.js
@@ -230,3 +230,188 @@ test('getProcedureLockCandidates splits repeated table strings into distinct can
     restoreQuery();
   }
 });
+
+test('getProcedureLockCandidates parses dynrep lock bundle JSON with multiple tables', async () => {
+  const queryLog = [];
+  let released = false;
+
+  const lockBundleRows = [
+    [
+      {
+        transaction_id: 1,
+        lock_bundle: JSON.stringify({
+          transactions_test: [
+            {
+              lock_table: 'transactions_test',
+              lock_record_id: 1,
+              label: 'Transaction 1',
+              context: { company_id: 1, request_id: 9001 },
+            },
+          ],
+          transactions_test_detail: {
+            lock_table: 'transactions_test_detail',
+            lock_record_ids: [1001, 1002],
+            records: [
+              {
+                lock_table: 'transactions_test_detail',
+                lock_record_id: 1001,
+                label: 'Detail 1 (SKU-001)',
+                context: { sku: 'SKU-001', line_no: 1 },
+              },
+              {
+                lock_table: 'transactions_test_detail',
+                lock_record_id: 1002,
+                label: 'Detail 2 (SKU-002)',
+                context: { sku: 'SKU-002', line_no: 2 },
+              },
+            ],
+            label: 'Transaction 1 details',
+          },
+        }),
+      },
+      {
+        transaction_id: 2,
+        lock_bundle: JSON.stringify({
+          transactions_test: [
+            {
+              lock_table: 'transactions_test',
+              lock_record_id: 2,
+              label: 'Transaction 2',
+              context: { company_id: 1, request_id: 9002 },
+            },
+          ],
+          transactions_test_detail: {
+            lock_table: 'transactions_test_detail',
+            lock_record_ids: [1003],
+            records: [
+              {
+                lock_table: 'transactions_test_detail',
+                lock_record_id: 1003,
+                label: 'Detail 1 (SKU-003)',
+                context: { sku: 'SKU-003', line_no: 1 },
+              },
+            ],
+            label: 'Transaction 2 details',
+          },
+        }),
+      },
+    ],
+  ];
+
+  const strictCandidates = JSON.stringify([
+    { table: 'transactions_test', record_id: 1, label: 'Transaction 1' },
+    { table: 'transactions_test', record_id: 2, label: 'Transaction 2' },
+    { table: 'transactions_test_detail', record_id: 1001, label: 'Detail 1' },
+    { table: 'transactions_test_detail', record_id: 1002, label: 'Detail 2' },
+    { table: 'transactions_test_detail', record_id: 1003, label: 'Detail 3' },
+  ]);
+
+  const mockConn = {
+    async query(sql, params) {
+      queryLog.push([sql, params]);
+      if (/^SET @/.test(sql)) {
+        return [[], []];
+      }
+      if (sql.startsWith('CALL ')) {
+        return [lockBundleRows, []];
+      }
+      if (sql === STRICT_SESSION_VAR_QUERY) {
+        return [[{ strict: strictCandidates, secondary: null, legacy: null }], []];
+      }
+      if (sql.includes('FROM report_transaction_locks')) {
+        const tableName = params?.[0];
+        if (tableName === 'transactions_test') {
+          return [
+            [
+              {
+                table_name: 'transactions_test',
+                record_id: '1',
+                status: 'locked',
+                status_changed_by: 'alice',
+                status_changed_at: '2024-10-01T00:00:00.000Z',
+              },
+            ],
+            [],
+          ];
+        }
+        if (tableName === 'transactions_test_detail') {
+          return [
+            [
+              {
+                table_name: 'transactions_test_detail',
+                record_id: '1002',
+                status: 'pending',
+                status_changed_by: 'bob',
+                status_changed_at: '2024-10-02T00:00:00.000Z',
+              },
+            ],
+            [],
+          ];
+        }
+        return [[], []];
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    },
+    release() {
+      released = true;
+    },
+  };
+
+  const originalGetConnection = db.pool.getConnection;
+  const originalQuery = db.pool.query;
+
+  const restoreGetConnection = () => {
+    if (originalGetConnection === undefined) {
+      delete db.pool.getConnection;
+    } else {
+      db.pool.getConnection = originalGetConnection;
+    }
+  };
+  const restoreQuery = () => {
+    db.pool.query = originalQuery;
+  };
+
+  db.pool.getConnection = async () => mockConn;
+  db.pool.query = async () => {
+    const err = new Error('no such table');
+    err.code = 'ER_NO_SUCH_TABLE';
+    throw err;
+  };
+
+  try {
+    const candidates = await db.getProcedureLockCandidates(
+      'dynrep_1_sp_transactions_test_report',
+      [1],
+      [],
+      { companyId: 1 },
+    );
+
+    const keys = candidates.map((c) => `${c.tableName}#${c.recordId}`).sort();
+    assert.deepEqual(keys, [
+      'transactions_test#1',
+      'transactions_test#2',
+      'transactions_test_detail#1001',
+      'transactions_test_detail#1002',
+      'transactions_test_detail#1003',
+    ]);
+
+    const lockedTxn = candidates.find((c) => c.tableName === 'transactions_test' && c.recordId === '1');
+    assert.ok(lockedTxn?.locked, 'transaction 1 should be marked locked');
+    assert.equal(lockedTxn?.lockStatus, 'locked');
+    assert.equal(lockedTxn?.lockedBy, 'alice');
+
+    const pendingDetail = candidates.find((c) => c.tableName === 'transactions_test_detail' && c.recordId === '1002');
+    assert.equal(pendingDetail?.lockStatus, 'pending');
+    assert.equal(pendingDetail?.lockedBy, 'bob');
+    assert.match(pendingDetail?.label || '', /Detail 2/);
+
+    assert.ok(released, 'connection should be released');
+    assert.ok(
+      queryLog.some(([sql]) => sql.startsWith('CALL dynrep_1_sp_transactions_test_report')),
+      'stored procedure should be invoked',
+    );
+  } finally {
+    restoreGetConnection();
+    restoreQuery();
+  }
+});


### PR DESCRIPTION
## Summary
- seed `transactions_test` and `transactions_test_detail` tables with sample rows for report testing
- add the `dynrep_1_sp_transactions_test_report` stored procedure to emit multi-table lock candidates
- extend lock-candidate tests and documentation to cover the new dataset

## Testing
- npm test -- tests/db/procedureLockCandidates.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e48e8c1ec48331b0e1b555f7482a5d