### PR TITLE
Improve Mongolian translation validation heuristics

### DIFF
--- a/src/erp.mgt.mn/utils/translateWithAI.js
+++ b/src/erp.mgt.mn/utils/translateWithAI.js
@@ -1,6 +1,143 @@
+import { evaluateTranslationCandidate } from '../../../utils/translationValidation.js';
+
 const localeCache = {};
 const aiCache = {};
 let aiDisabled = false;
+
+const LANGUAGE_LABELS = {
+  mn: 'Mongolian (Cyrillic)',
+  en: 'English',
+  ru: 'Russian',
+  ja: 'Japanese',
+  ko: 'Korean',
+  zh: 'Chinese',
+  de: 'German',
+  fr: 'French',
+  es: 'Spanish',
+};
+
+const RETRY_HINTS = {
+  contains_latin_script:
+    'Remove Latin characters and write the translation using Mongolian Cyrillic script only.',
+  contains_tibetan_script:
+    'Avoid Tibetan letters; use only standard Mongolian Cyrillic.',
+  no_cyrillic_content:
+    'Use Mongolian Cyrillic letters for the translation.',
+  insufficient_cyrillic_ratio:
+    'Increase the proportion of Mongolian Cyrillic letters.',
+  limited_cyrillic_content:
+    'Provide fuller Mongolian words instead of short fragments.',
+  insufficient_character_variety:
+    'Use varied Mongolian words rather than repeating the same characters.',
+  insufficient_word_length:
+    'Write meaningful Mongolian words that are a few letters long.',
+  missing_mongolian_vowel:
+    'Include natural Mongolian vowels to form real words.',
+  appears_english: 'Translate the text instead of leaving it in English.',
+  possibly_english:
+    'Ensure the translation is in the target language, not English.',
+  no_language_signal:
+    'Provide meaningful words in the target language, not punctuation or symbols.',
+  identical_to_base: 'Do not repeat the source text; translate it.',
+  too_short_for_context:
+    'Give a translation that matches the level of detail in the source sentence.',
+};
+
+function getLanguageLabel(lang) {
+  if (!lang) return 'the requested language';
+  const lower = String(lang).toLowerCase();
+  return LANGUAGE_LABELS[lower] || lower;
+}
+
+function sanitizeSnippet(value, maxLength = 400) {
+  if (!value) return '';
+  const str = typeof value === 'string' ? value : String(value ?? '');
+  return str.replace(/\s+/g, ' ').trim().slice(0, maxLength);
+}
+
+function buildPrompt(text, lang, options = {}) {
+  const textStr = typeof text === 'string' ? text : String(text ?? '');
+  const label = getLanguageLabel(lang);
+  const parts = [
+    `You are a professional translator. Translate the following text into ${label}.`,
+    'Return only the translated text without commentary.',
+    'Preserve any placeholders such as {{variable}}, %s, {0}, or HTML tags exactly as in the source.',
+  ];
+
+  if (String(lang).toLowerCase() === 'mn') {
+    parts.push(
+      'Write fluent, natural Mongolian using Cyrillic script only. The result must be meaningful business terminology, not transliteration or gibberish.',
+    );
+  }
+
+  const feedback = sanitizeSnippet(options.feedback, 360);
+  if (feedback) {
+    parts.push(`Address these quality issues: ${feedback}`);
+  }
+
+  if (options.attempt && options.attempt > 1) {
+    parts.push('Provide a different phrasing from earlier attempts while keeping the same meaning.');
+  }
+
+  const previous = Array.isArray(options.previousCandidates)
+    ? options.previousCandidates
+        .map((candidate) => sanitizeSnippet(candidate, 120))
+        .filter(Boolean)
+    : [];
+  if (previous.length) {
+    const recent = previous.slice(-3).map((candidate) => `"${candidate}"`).join('; ');
+    if (recent) {
+      parts.push(`Do not repeat these rejected outputs: ${recent}.`);
+    }
+  }
+
+  parts.push(`Text to translate:\n"""${textStr}"""`);
+  return parts.join('\n\n');
+}
+
+function formatReason(reason) {
+  if (!reason) return '';
+  if (reason.startsWith('missing_placeholders')) {
+    const [, payload] = reason.split(':');
+    if (payload) {
+      const placeholders = payload
+        .split(',')
+        .map((item) => item.trim())
+        .filter(Boolean)
+        .join(', ');
+      if (placeholders) {
+        return `Ensure these placeholders appear exactly: ${placeholders}.`;
+      }
+    }
+    return 'Preserve all placeholders exactly as in the source text.';
+  }
+  if (RETRY_HINTS[reason]) return RETRY_HINTS[reason];
+  if (reason.includes('_')) {
+    return reason.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+  return reason;
+}
+
+function buildFeedbackFromHeuristics(heuristics) {
+  if (!heuristics) return '';
+  const hints = [];
+  if (Array.isArray(heuristics.reasons)) {
+    for (const reason of heuristics.reasons) {
+      const formatted = formatReason(reason);
+      if (formatted) hints.push(formatted);
+    }
+  }
+  const missingPlaceholders = heuristics.placeholders?.missing;
+  if (Array.isArray(missingPlaceholders) && missingPlaceholders.length) {
+    hints.push(
+      `Include these placeholders: ${missingPlaceholders
+        .map((ph) => ph.trim())
+        .filter(Boolean)
+        .join(', ')}.`,
+    );
+  }
+  return sanitizeSnippet(hints.join(' '), 360);
+}
 
 async function loadLocale(lang) {
   if (!localeCache[lang]) {
@@ -29,13 +166,14 @@ function saveCache(lang) {
   localStorage.setItem(`ai-translations-${lang}`, JSON.stringify(aiCache[lang]));
 }
 
-async function requestAI(text, lang) {
+async function requestAI(text, lang, options = {}) {
   if (aiDisabled) return text;
   try {
+    const prompt = buildPrompt(text, lang, options);
     const res = await fetch('/api/openai', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ prompt: `Translate the following text to ${lang}: ${text}` }),
+      body: JSON.stringify({ prompt }),
       skipErrorToast: true,
       skipLoader: true,
     });
@@ -58,8 +196,56 @@ export default async function translateWithAI(lang, key, fallback) {
   const cache = getCache(lang);
   if (cache[key]) return cache[key];
   const text = fallback ?? key;
-  const translated = await requestAI(text, lang);
-  cache[key] = translated;
-  saveCache(lang);
-  return translated;
+  const normalizedText = typeof text === 'string' ? text : String(text ?? '');
+  const maxAttempts = String(lang).toLowerCase() === 'mn' ? 5 : 3;
+  const previousCandidates = [];
+  let heuristics = null;
+  let finalTranslation = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const feedback = buildFeedbackFromHeuristics(heuristics);
+    const candidate = await requestAI(normalizedText, lang, {
+      attempt,
+      feedback,
+      previousCandidates,
+    });
+    if (!candidate || !candidate.trim()) {
+      heuristics = {
+        status: 'fail',
+        reasons: ['empty_translation'],
+        placeholders: { missing: [], extra: [] },
+      };
+      continue;
+    }
+
+    const candidateText = candidate.trim();
+    const evaluation = evaluateTranslationCandidate({
+      candidate: candidateText,
+      base: normalizedText,
+      lang,
+    });
+
+    if (evaluation.status === 'pass') {
+      finalTranslation = candidateText;
+      heuristics = evaluation;
+      break;
+    }
+
+    heuristics = evaluation;
+    if (!previousCandidates.includes(candidateText)) {
+      previousCandidates.push(candidateText);
+    }
+
+    if (evaluation.status === 'fail' && !evaluation.reasons.length) {
+      break;
+    }
+  }
+
+  if (finalTranslation) {
+    cache[key] = finalTranslation;
+    saveCache(lang);
+    return finalTranslation;
+  }
+
+  return normalizedText;
 }

--- a/src/erp.mgt.mn/utils/translateWithCache.js
+++ b/src/erp.mgt.mn/utils/translateWithCache.js
@@ -257,7 +257,7 @@ const RETRY_REASON_HINTS = {
   limited_cyrillic_content:
     'Add more substantial Mongolian words written in Cyrillic.',
   insufficient_character_variety:
-    'Use a variety of Mongolian letters to form meaningful words, not repeated single characters.',
+    'Use natural Mongolian words instead of repeating the same few characters.',
   insufficient_word_length:
     'Include meaningful Mongolian words that are at least a few letters long.',
   missing_mongolian_vowel:

--- a/tests/utils/translationValidation.mn.test.js
+++ b/tests/utils/translationValidation.mn.test.js
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { evaluateTranslationCandidate } from '../../utils/translationValidation.js';
+
+test('flags Mongolian translations that still include Latin script', () => {
+  const result = evaluateTranslationCandidate({
+    candidate: 'Орлого report',
+    base: 'Revenue report',
+    lang: 'mn',
+  });
+  assert.equal(result.status, 'fail');
+  assert.ok(result.reasons.includes('contains_latin_script'));
+});
+
+test('rejects Mongolian outputs without vowels', () => {
+  const result = evaluateTranslationCandidate({
+    candidate: 'Брхт',
+    base: 'Detailed balance',
+    lang: 'mn',
+  });
+  assert.equal(result.status, 'fail');
+  assert.ok(result.reasons.includes('missing_mongolian_vowel'));
+});
+
+test('rejects Mongolian outputs with repeated characters only', () => {
+  const result = evaluateTranslationCandidate({
+    candidate: 'аааааа',
+    base: 'Inventory summary',
+    lang: 'mn',
+  });
+  assert.equal(result.status, 'fail');
+  assert.ok(result.reasons.includes('insufficient_character_variety'));
+});
+
+test('requires substantive Mongolian words for longer phrases', () => {
+  const result = evaluateTranslationCandidate({
+    candidate: 'Өн',
+    base: 'Consolidated financial statement',
+    lang: 'mn',
+  });
+  assert.equal(result.status, 'fail');
+  assert.ok(result.reasons.includes('insufficient_word_length'));
+});
+
+test('accepts meaningful Mongolian Cyrillic translations', () => {
+  const result = evaluateTranslationCandidate({
+    candidate: 'Борлуулалтын орлогын тайлан',
+    base: 'Sales revenue report',
+    lang: 'mn',
+  });
+  assert.equal(result.status, 'pass');
+});


### PR DESCRIPTION
## Summary
- harden Mongolian translation heuristics to reject Latin script output, missing vowels, and meaningless short words
- update the AI translation helper to retry with contextual feedback until a validated Mongolian result is produced
- align retry hints and add regression tests covering the new Mongolian quality checks

## Testing
- node --test tests/utils/translationValidation.mn.test.js
- npm test *(fails: pre-existing seedTenantTables and users trigger assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d2696d18833187de2c21ec544838