### PR TITLE
Optimize pending request date filtering

### DIFF
--- a/api-server/services/pendingRequest.js
+++ b/api-server/services/pendingRequest.js
@@ -411,6 +411,19 @@ export async function createRequest({
   }
 }
 
+function normalizeDateInput(value, type = 'start') {
+  if (!value) return null;
+  let trimmed = String(value).trim();
+  if (!trimmed) return null;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    return type === 'start' ? `${trimmed} 00:00:00` : trimmed;
+  }
+  if (trimmed.includes('T')) {
+    trimmed = trimmed.replace('T', ' ').replace(/Z$/, '');
+  }
+  return trimmed;
+}
+
 export async function listRequests(filters) {
   const {
     status,
@@ -457,17 +470,21 @@ export async function listRequests(filters) {
   const dateColumn =
     date_field === 'responded' ? 'responded_at' : 'created_at';
   if (date_from || date_to) {
-    if (date_from && date_to) {
-      conditions.push(`DATE(${dateColumn}) BETWEEN ? AND ?`);
-      params.push(date_from, date_to);
+    const normalizedFrom = normalizeDateInput(date_from, 'start');
+    const normalizedTo = normalizeDateInput(date_to, 'end');
+    if (date_from && date_to && normalizedFrom && normalizedTo) {
+      conditions.push(`${dateColumn} >= ?`);
+      params.push(normalizedFrom);
+      conditions.push(`${dateColumn} < DATE_ADD(?, INTERVAL 1 DAY)`);
+      params.push(normalizedTo);
     } else {
-      if (date_from) {
+      if (normalizedFrom) {
         conditions.push(`${dateColumn} >= ?`);
-        params.push(date_from);
+        params.push(normalizedFrom);
       }
-      if (date_to) {
+      if (normalizedTo) {
         conditions.push(`${dateColumn} < DATE_ADD(?, INTERVAL 1 DAY)`);
-        params.push(date_to);
+        params.push(normalizedTo);
       }
     }
   }

--- a/tests/api/pendingRequest.test.js
+++ b/tests/api/pendingRequest.test.js
@@ -250,11 +250,12 @@ await test('listRequests filters by date range', async () => {
   };
   await service.listRequests({ date_from: '2024-01-01', date_to: '2024-01-31' });
   db.pool.query = origQuery;
-  assert.ok(queries[1].sql.includes('DATE(created_at) BETWEEN ? AND ?'));
+  assert.ok(queries[1].sql.includes('created_at >= ?'));
+  assert.ok(queries[1].sql.includes('created_at < DATE_ADD(?, INTERVAL 1 DAY)'));
   assert.ok(queries[1].sql.includes('LIMIT ? OFFSET ?'));
   assert.deepEqual(
     queries[1].params,
-    ['2024-01-01', '2024-01-31', 2, 0],
+    ['2024-01-01 00:00:00', '2024-01-31', 2, 0],
   );
 });
 
@@ -270,10 +271,11 @@ await test('listRequests returns requests from entire day when date range is sin
   db.pool.query = origQuery;
   assert.equal(result.rows.length, 1);
   assert.equal(result.rows[0].request_id, 1);
-  assert.ok(queries[1].sql.includes('DATE(created_at) BETWEEN ? AND ?'));
+  assert.ok(queries[1].sql.includes('created_at >= ?'));
+  assert.ok(queries[1].sql.includes('created_at < DATE_ADD(?, INTERVAL 1 DAY)'));
   assert.deepEqual(
     queries[1].params,
-    ['2024-06-06', '2024-06-06', 2, 0],
+    ['2024-06-06 00:00:00', '2024-06-06', 2, 0],
   );
 });
 


### PR DESCRIPTION
## Summary
- avoid wrapping pending request timestamps in DATE() so MySQL can use indexes and avoid sort buffer exhaustion
- normalize incoming date filters before building SQL conditions to keep inclusive day ranges
- adjust pending request service tests to reflect the new range filtering behavior

## Testing
- npm test -- tests/api/pendingRequest.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e4eea8249c83318687c0b573b2bc44