### PR TITLE
Reduce pending request load and skip empty notification fetches

### DIFF
--- a/api-server/services/pendingRequest.js
+++ b/api-server/services/pendingRequest.js
@@ -486,10 +486,40 @@ export async function listRequests(filters) {
   const limit = Number(per_page) > 0 ? Number(per_page) : 2;
   const offset = (Number(page) > 0 ? Number(page) - 1 : 0) * limit;
 
-  const [rows] = await pool.query(
-    `SELECT *, DATE_FORMAT(created_at, '%Y-%m-%d %H:%i:%s') AS created_at_fmt, DATE_FORMAT(responded_at, '%Y-%m-%d %H:%i:%s') AS responded_at_fmt FROM pending_request ${where} ORDER BY ${dateColumn} DESC LIMIT ? OFFSET ?`,
+  const [orderedIds] = await pool.query(
+    `SELECT request_id,
+            ${dateColumn} AS sort_value
+       FROM pending_request
+       ${where}
+      ORDER BY ${dateColumn} DESC, request_id DESC
+      LIMIT ? OFFSET ?`,
     [...params, limit, offset],
   );
+
+  if (!orderedIds.length) {
+    return { rows: [], total };
+  }
+
+  const idOrder = orderedIds
+    .map((row) => row.request_id)
+    .filter((id) => id !== null && id !== undefined);
+
+  if (!idOrder.length) {
+    return { rows: [], total };
+  }
+
+  const placeholders = idOrder.map(() => '?').join(', ');
+  const [rowsRaw] = await pool.query(
+    `SELECT pr.*, DATE_FORMAT(pr.created_at, '%Y-%m-%d %H:%i:%s') AS created_at_fmt, DATE_FORMAT(pr.responded_at, '%Y-%m-%d %H:%i:%s') AS responded_at_fmt
+       FROM pending_request pr
+      WHERE pr.request_id IN (${placeholders})`,
+    idOrder,
+  );
+
+  const rowsById = new Map(rowsRaw.map((row) => [row.request_id, row]));
+  const rows = idOrder
+    .map((id) => rowsById.get(id))
+    .filter((row) => row);
 
   const approvalRequestIds = rows
     .filter((row) => row.request_type === 'report_approval')

--- a/src/erp.mgt.mn/pages/Notifications.jsx
+++ b/src/erp.mgt.mn/pages/Notifications.jsx
@@ -172,6 +172,26 @@ export default function NotificationsPage() {
 
   useEffect(() => {
     let cancelled = false;
+    const incomingPending = workflows?.reportApproval?.incoming?.pending?.count || 0;
+    const outgoingPending = workflows?.reportApproval?.outgoing?.pending?.count || 0;
+    const outgoingAccepted = workflows?.reportApproval?.outgoing?.accepted?.count || 0;
+    const outgoingDeclined = workflows?.reportApproval?.outgoing?.declined?.count || 0;
+    const totalCount =
+      incomingPending + outgoingPending + outgoingAccepted + outgoingDeclined;
+
+    if (totalCount === 0) {
+      setReportState({
+        incoming: [],
+        outgoing: [],
+        responses: createEmptyResponses(),
+        loading: false,
+        error: '',
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+
     setReportState((prev) => ({
       ...prev,
       loading: true,
@@ -216,6 +236,26 @@ export default function NotificationsPage() {
 
   useEffect(() => {
     let cancelled = false;
+    const incomingPending = workflows?.changeRequests?.incoming?.pending?.count || 0;
+    const outgoingPending = workflows?.changeRequests?.outgoing?.pending?.count || 0;
+    const outgoingAccepted = workflows?.changeRequests?.outgoing?.accepted?.count || 0;
+    const outgoingDeclined = workflows?.changeRequests?.outgoing?.declined?.count || 0;
+    const totalCount =
+      incomingPending + outgoingPending + outgoingAccepted + outgoingDeclined;
+
+    if (totalCount === 0) {
+      setChangeState({
+        incoming: [],
+        outgoing: [],
+        responses: createEmptyResponses(),
+        loading: false,
+        error: '',
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+
     setChangeState((prev) => ({
       ...prev,
       loading: true,


### PR DESCRIPTION
## Summary
- Avoid sorting large pending_request rows directly by first fetching ordered request IDs, then loading the selected rows
- Skip notifications tab fetches when workflow counts are zero to prevent unnecessary API calls and errors

## Testing
- npm test *(fails: existing failures in pendingRequest, seedTenantTables, addRow, and related suites)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b859280c8331a001c5707eaaa1d8