### PR TITLE
Fix lock candidate snapshot rendering for report approvals

### DIFF
--- a/src/erp.mgt.mn/components/ReportSnapshotViewer.jsx
+++ b/src/erp.mgt.mn/components/ReportSnapshotViewer.jsx
@@ -41,14 +41,58 @@ export default function ReportSnapshotViewer({
   const [error, setError] = useState('');
   const [artifact, setArtifact] = useState(snapshot?.artifact || null);
   const totalRow = useMemo(() => {
-    if (
-      snapshot &&
-      typeof snapshot === 'object' &&
-      !Array.isArray(snapshot.totalRow) &&
-      snapshot.totalRow &&
-      typeof snapshot.totalRow === 'object'
-    ) {
-      return snapshot.totalRow;
+    if (!snapshot || typeof snapshot !== 'object') return null;
+    const collectColumns = () => {
+      const set = new Set();
+      const addColumns = (cols) => {
+        if (!Array.isArray(cols)) return;
+        cols.forEach((col) => {
+          if (typeof col !== 'string') return;
+          const trimmed = col.trim();
+          if (!trimmed) return;
+          set.add(trimmed);
+        });
+      };
+      addColumns(snapshot.columns);
+      addColumns(snapshot.columnNames);
+      addColumns(snapshot.headers);
+      return Array.from(set);
+    };
+    const columns = collectColumns();
+    const normalizeRow = (row) => {
+      if (!row) return null;
+      if (Array.isArray(row)) {
+        const mappedColumns = columns.length
+          ? columns
+          : row.map((_, idx) => `column_${idx + 1}`);
+        if (!mappedColumns.length) return null;
+        return Object.fromEntries(
+          mappedColumns.map((col, idx) => [col, row[idx]]),
+        );
+      }
+      if (typeof row === 'object') {
+        return row;
+      }
+      return null;
+    };
+    const candidateKeys = [
+      'totalRow',
+      'total_row',
+      'total',
+      'footer',
+      'summaryRow',
+      'summary_row',
+      'totals',
+      'grandTotal',
+      'grand_total',
+    ];
+    for (const key of candidateKeys) {
+      const value = snapshot[key];
+      if (!value) continue;
+      const normalized = normalizeRow(value);
+      if (normalized && Object.keys(normalized).length) {
+        return normalized;
+      }
     }
     return null;
   }, [snapshot]);
@@ -113,17 +157,35 @@ export default function ReportSnapshotViewer({
   }, [artifact?.id, page, perPage]);
 
   const columns = useMemo(() => {
-    if (Array.isArray(snapshot?.columns) && snapshot.columns.length) {
-      return snapshot.columns;
-    }
+    const set = new Set();
+    const addColumns = (cols) => {
+      if (!Array.isArray(cols)) return;
+      cols.forEach((col) => {
+        if (typeof col !== 'string') return;
+        const trimmed = col.trim();
+        if (!trimmed) return;
+        set.add(trimmed);
+      });
+    };
+    addColumns(snapshot?.columns);
+    addColumns(snapshot?.columnNames);
+    addColumns(snapshot?.headers);
     if (pageRows.length > 0) {
-      return Object.keys(pageRows[0]);
+      Object.keys(pageRows[0]).forEach((col) => {
+        if (typeof col === 'string' && col.trim()) {
+          set.add(col.trim());
+        }
+      });
     }
     if (totalRow) {
-      return Object.keys(totalRow);
+      Object.keys(totalRow).forEach((col) => {
+        if (typeof col === 'string' && col.trim()) {
+          set.add(col.trim());
+        }
+      });
     }
-    return [];
-  }, [snapshot?.columns, pageRows, totalRow]);
+    return Array.from(set);
+  }, [snapshot?.columns, snapshot?.columnNames, snapshot?.headers, pageRows, totalRow]);
 
   const fieldTypeMap = snapshot?.fieldTypeMap || {};
 

--- a/src/erp.mgt.mn/pages/Requests.jsx
+++ b/src/erp.mgt.mn/pages/Requests.jsx
@@ -342,14 +342,164 @@ function normalizeApprovalTransaction(tx) {
     tx.lock_reason ||
     tx.lockReason ||
     '';
-  const snapshot =
-    tx.snapshot && typeof tx.snapshot === 'object' ? tx.snapshot : null;
-  const snapshotColumns = Array.isArray(tx.snapshotColumns)
-    ? tx.snapshotColumns.filter(Boolean)
-    : Array.isArray(tx.columns)
-    ? tx.columns.filter(Boolean)
+  const snapshotContainer =
+    tx.snapshot && typeof tx.snapshot === 'object' && !Array.isArray(tx.snapshot)
+      ? tx.snapshot
+      : null;
+  const columnSet = new Set();
+  const addColumns = (cols) => {
+    if (!Array.isArray(cols)) return;
+    cols.forEach((col) => {
+      if (typeof col !== 'string') return;
+      const trimmed = col.trim();
+      if (!trimmed) return;
+      columnSet.add(trimmed);
+    });
+  };
+  addColumns(tx.snapshotColumns);
+  addColumns(tx.columns);
+  if (snapshotContainer) {
+    addColumns(snapshotContainer.columns);
+    addColumns(snapshotContainer.snapshotColumns);
+    addColumns(snapshotContainer.headers);
+    addColumns(snapshotContainer.columnNames);
+  }
+
+  const snapshotFieldTypeMap = (() => {
+    const candidates = [
+      tx.snapshotFieldTypeMap,
+      tx.fieldTypeMap,
+      snapshotContainer?.fieldTypeMap,
+      snapshotContainer?.snapshotFieldTypeMap,
+      snapshotContainer?.field_type_map,
+      snapshotContainer?.snapshot_field_type_map,
+    ];
+    for (const candidate of candidates) {
+      if (
+        candidate &&
+        typeof candidate === 'object' &&
+        !Array.isArray(candidate) &&
+        Object.keys(candidate).length
+      ) {
+        return candidate;
+      }
+    }
+    return {};
+  })();
+
+  const convertRow = (row) => {
+    if (!row) return null;
+    if (Array.isArray(row)) {
+      const orderedColumns = columnSet.size
+        ? Array.from(columnSet)
+        : row.map((_, idx) => `column_${idx + 1}`);
+      if (!orderedColumns.length) return null;
+      const obj = {};
+      orderedColumns.forEach((col, idx) => {
+        if (typeof col !== 'string' || !col) return;
+        if (Object.prototype.hasOwnProperty.call(obj, col)) return;
+        obj[col] = row[idx];
+      });
+      return obj;
+    }
+    if (typeof row === 'object' && !Array.isArray(row)) {
+      return row;
+    }
+    return null;
+  };
+
+  const extractSnapshotFromContainer = (container) => {
+    if (!container || typeof container !== 'object') return null;
+    if (Array.isArray(container.rows)) {
+      for (const row of container.rows) {
+        const normalized = convertRow(row);
+        if (normalized && Object.keys(normalized).length) {
+          return normalized;
+        }
+      }
+    }
+    const nestedKeys = [
+      'row',
+      'record',
+      'snapshotRow',
+      'snapshot_row',
+      'current',
+      'previous',
+      'data',
+      'values',
+      'item',
+      'entry',
+    ];
+    for (const key of nestedKeys) {
+      const normalized = convertRow(container[key]);
+      if (normalized && Object.keys(normalized).length) {
+        return normalized;
+      }
+    }
+    const primitiveEntries = Object.entries(container).filter(([key, value]) => {
+      if (typeof key !== 'string') return false;
+      const trimmed = key.trim();
+      if (!trimmed) return false;
+      const normalizedKey = trimmed.toLowerCase();
+      if (
+        [
+          'rows',
+          'columns',
+          'snapshotcolumns',
+          'headers',
+          'columnnames',
+          'fieldtypemap',
+          'snapshotfieldtypemap',
+          'field_type_map',
+          'snapshot_field_type_map',
+          'rowcount',
+          'count',
+          'totalrow',
+          'total_row',
+          'total',
+          'footer',
+          'summaryrow',
+          'summary_row',
+          'artifact',
+          'artifact_id',
+          'version',
+          'params',
+          'parameters',
+          'procedure',
+        ].includes(normalizedKey)
+      ) {
+        return false;
+      }
+      if (value && typeof value === 'object') return false;
+      return true;
+    });
+    if (primitiveEntries.length) {
+      return Object.fromEntries(primitiveEntries);
+    }
+    return null;
+  };
+
+  let snapshot = extractSnapshotFromContainer(snapshotContainer);
+  if (!snapshot && tx.row && typeof tx.row === 'object' && !Array.isArray(tx.row)) {
+    snapshot = tx.row;
+  }
+  if (!snapshot && tx.current && typeof tx.current === 'object' && !Array.isArray(tx.current)) {
+    snapshot = tx.current;
+  }
+
+  if (snapshot && typeof snapshot === 'object') {
+    Object.keys(snapshot).forEach((col) => {
+      if (typeof col === 'string' && col.trim()) {
+        columnSet.add(col.trim());
+      }
+    });
+  }
+
+  const snapshotColumns = columnSet.size
+    ? Array.from(columnSet)
+    : snapshot && typeof snapshot === 'object'
+    ? Object.keys(snapshot)
     : [];
-  const snapshotFieldTypeMap = tx.snapshotFieldTypeMap || tx.fieldTypeMap || {};
   const lockStatus = tx.lockStatus || tx.status || '';
   const lockedBy = tx.lockedBy || tx.locked_by || '';
   const lockedAt = tx.lockedAt || tx.locked_at || '';


### PR DESCRIPTION
## Summary
- normalize approval transaction snapshots to extract usable row data, derived columns, and field type metadata for lock candidate tables
- update the report snapshot viewer to recognize additional total row metadata and merge columns from rows and totals so summaries display

## Testing
- npm test *(fails: pending request/service and seed tenant table fixtures in test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e5cc7d2fdc8331951691745e587cce