### PR TITLE
Ensure temporary submission flag surfaces in form configs

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -28,6 +28,12 @@ function arrify(val) {
 }
 
 function parseEntry(raw = {}) {
+  const temporaryFlag = Boolean(
+    raw.supportsTemporarySubmission ??
+      raw.allowTemporarySubmission ??
+      raw.supportsTemporary ??
+      false,
+  );
   return {
     visibleFields: Array.isArray(raw.visibleFields)
       ? raw.visibleFields.map(String)
@@ -89,13 +95,8 @@ function parseEntry(raw = {}) {
       : [],
     moduleLabel: typeof raw.moduleLabel === 'string' ? raw.moduleLabel : '',
     procedures: arrify(raw.procedures || raw.procedure),
-    supportsTemporarySubmission:
-      Boolean(
-        raw.supportsTemporarySubmission ??
-          raw.allowTemporarySubmission ??
-          raw.supportsTemporary ??
-          false,
-      ),
+    supportsTemporarySubmission: temporaryFlag,
+    allowTemporarySubmission: temporaryFlag,
   };
 }
 


### PR DESCRIPTION
## Summary
- derive a shared temporary flag when parsing transaction form entries
- expose the flag via both supportsTemporarySubmission and allowTemporarySubmission to keep dynamic forms aware of temporary support

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e03a749d84833192283265fcf89fad