### PR TITLE
Fix snapshot normalization for array payloads

### DIFF
--- a/src/erp.mgt.mn/pages/Reports.jsx
+++ b/src/erp.mgt.mn/pages/Reports.jsx
@@ -19,6 +19,10 @@ import useButtonPerms from '../hooks/useButtonPerms.js';
 import normalizeDateInput from '../utils/normalizeDateInput.js';
 import Modal from '../components/Modal.jsx';
 import AutoSizingTextInput from '../components/AutoSizingTextInput.jsx';
+import {
+  normalizeSnapshotRecord,
+  resolveSnapshotSource,
+} from '../utils/normalizeSnapshot.js';
 
 const DATE_PARAM_ALLOWLIST = new Set([
   'startdt',
@@ -287,7 +291,47 @@ export default function Reports() {
             }
             const recordId = String(rawId);
             const key = candidate.key ?? `${tableName}#${recordId}`;
-            const next = { ...candidate, tableName, recordId, key };
+            const rawSnapshot =
+              resolveSnapshotSource(candidate) ||
+              (candidate.snapshot &&
+              typeof candidate.snapshot === 'object' &&
+              !Array.isArray(candidate.snapshot)
+                ? candidate.snapshot
+                : null);
+            const {
+              row: normalizedSnapshot,
+              columns: derivedColumns,
+              fieldTypeMap,
+            } = normalizeSnapshotRecord(rawSnapshot || {});
+            let snapshotColumns = Array.isArray(candidate.snapshotColumns)
+              ? candidate.snapshotColumns
+              : Array.isArray(candidate.snapshot_columns)
+              ? candidate.snapshot_columns
+              : Array.isArray(candidate.columns)
+              ? candidate.columns
+              : [];
+            snapshotColumns = snapshotColumns
+              .map((col) => (col === null || col === undefined ? '' : String(col)))
+              .filter(Boolean);
+            if (!snapshotColumns.length) {
+              snapshotColumns = derivedColumns;
+            }
+            const snapshotFieldTypeMap =
+              candidate.snapshotFieldTypeMap ||
+              candidate.snapshot_field_type_map ||
+              candidate.fieldTypeMap ||
+              candidate.field_type_map ||
+              fieldTypeMap ||
+              {};
+            const next = {
+              ...candidate,
+              tableName,
+              recordId,
+              key,
+              snapshot: normalizedSnapshot,
+              snapshotColumns,
+              snapshotFieldTypeMap,
+            };
             if (candidate.table === undefined) next.table = tableName;
             return next;
           })
@@ -1015,50 +1059,45 @@ export default function Reports() {
             }
             const recordId = String(rawId);
             const key = `${tableName}#${recordId}`;
+            const rawSnapshot =
+              resolveSnapshotSource(lock) ||
+              (lock.snapshot &&
+              typeof lock.snapshot === 'object' &&
+              !Array.isArray(lock.snapshot)
+                ? lock.snapshot
+                : null);
+            const {
+              row: normalizedSnapshot,
+              columns: derivedColumns,
+              fieldTypeMap,
+            } = normalizeSnapshotRecord(rawSnapshot || {});
             let snapshotColumns = Array.isArray(lock.snapshotColumns)
-              ? lock.snapshotColumns.filter(Boolean)
+              ? lock.snapshotColumns
+              : Array.isArray(lock.snapshot_columns)
+              ? lock.snapshot_columns
               : Array.isArray(lock.columns)
-              ? lock.columns.filter(Boolean)
+              ? lock.columns
               : [];
-            let fieldTypeMap =
-              lock.snapshotFieldTypeMap || lock.fieldTypeMap || {};
-            let snapshot = null;
-            if (lock.snapshot && typeof lock.snapshot === 'object') {
-              if (Array.isArray(lock.snapshot.rows)) {
-                const row = lock.snapshot.rows[0];
-                if (row && typeof row === 'object') {
-                  snapshot = row;
-                  if (!snapshotColumns.length) {
-                    if (
-                      Array.isArray(lock.snapshot.columns) &&
-                      lock.snapshot.columns.length
-                    ) {
-                      snapshotColumns = lock.snapshot.columns.filter(Boolean);
-                    } else {
-                      snapshotColumns = Object.keys(row);
-                    }
-                  }
-                  if (!fieldTypeMap || Object.keys(fieldTypeMap).length === 0) {
-                    fieldTypeMap = lock.snapshot.fieldTypeMap || {};
-                  }
-                }
-              } else {
-                snapshot = lock.snapshot;
-              }
-            } else if (
-              lock.row &&
-              typeof lock.row === 'object' &&
-              !Array.isArray(lock.row)
-            ) {
-              snapshot = lock.row;
+            snapshotColumns = snapshotColumns
+              .map((col) => (col === null || col === undefined ? '' : String(col)))
+              .filter(Boolean);
+            if (!snapshotColumns.length) {
+              snapshotColumns = derivedColumns;
             }
+            const snapshotFieldTypeMap =
+              lock.snapshotFieldTypeMap ||
+              lock.snapshot_field_type_map ||
+              lock.fieldTypeMap ||
+              lock.field_type_map ||
+              fieldTypeMap ||
+              {};
             return {
               key,
               tableName,
               recordId,
-              snapshot,
+              snapshot: normalizedSnapshot,
               snapshotColumns,
-              snapshotFieldTypeMap: fieldTypeMap || {},
+              snapshotFieldTypeMap,
             };
           })
           .filter(Boolean);
@@ -1361,15 +1400,38 @@ export default function Reports() {
         tx.lock_reason ||
         tx.lockReason ||
         '';
-      const snapshot =
-        tx.snapshot && typeof tx.snapshot === 'object' ? tx.snapshot : null;
-      const snapshotColumns = Array.isArray(tx.snapshotColumns)
-        ? tx.snapshotColumns.filter(Boolean)
+      const rawSnapshot =
+        resolveSnapshotSource(tx) ||
+        (tx.snapshot &&
+        typeof tx.snapshot === 'object' &&
+        !Array.isArray(tx.snapshot)
+          ? tx.snapshot
+          : null);
+      const {
+        row: snapshot,
+        columns: derivedColumns,
+        fieldTypeMap,
+      } = normalizeSnapshotRecord(rawSnapshot || {});
+      let snapshotColumns = Array.isArray(tx.snapshotColumns)
+        ? tx.snapshotColumns
+        : Array.isArray(tx.snapshot_columns)
+        ? tx.snapshot_columns
         : Array.isArray(tx.columns)
-        ? tx.columns.filter(Boolean)
+        ? tx.columns
         : [];
+      snapshotColumns = snapshotColumns
+        .map((col) => (col === null || col === undefined ? '' : String(col)))
+        .filter(Boolean);
+      if (!snapshotColumns.length) {
+        snapshotColumns = derivedColumns;
+      }
       const snapshotFieldTypeMap =
-        tx.snapshotFieldTypeMap || tx.fieldTypeMap || {};
+        tx.snapshotFieldTypeMap ||
+        tx.snapshot_field_type_map ||
+        tx.fieldTypeMap ||
+        tx.field_type_map ||
+        fieldTypeMap ||
+        {};
       return {
         key,
         tableName,
@@ -1790,19 +1852,133 @@ export default function Reports() {
       addToast('Unable to capture report snapshot', 'error');
       return;
     }
+    const serializeCandidateForRequest = (candidate, overrides = {}) => {
+      if (!candidate || typeof candidate !== 'object') return null;
+      const tableName = candidate.tableName || getCandidateTable(candidate);
+      if (!tableName) return null;
+      const rawId =
+        candidate.recordId ??
+        candidate.record_id ??
+        candidate.lock_record_id ??
+        candidate.id;
+      if (rawId === undefined || rawId === null || rawId === '') {
+        return null;
+      }
+      const payload = {
+        table: tableName,
+        recordId: String(rawId),
+      };
+
+      const labelCandidate =
+        candidate.label || candidate.description || candidate.note || '';
+      const normalizedLabel = String(labelCandidate || '').trim();
+      if (normalizedLabel) {
+        payload.label = normalizedLabel;
+      }
+
+      const reasonCandidate =
+        candidate.reason ||
+        candidate.justification ||
+        candidate.explanation ||
+        candidate.exclude_reason ||
+        candidate.lock_reason ||
+        candidate.lockReason ||
+        '';
+      const normalizedReason = String(reasonCandidate || '').trim();
+      if (normalizedReason) {
+        payload.reason = normalizedReason;
+      }
+
+      const lockStatusCandidate =
+        candidate.lockStatus || candidate.status || candidate.lock_status || '';
+      const normalizedStatus = String(lockStatusCandidate || '').trim();
+      if (normalizedStatus) {
+        payload.lockStatus = normalizedStatus;
+      }
+
+      const lockedByCandidate =
+        candidate.lockedBy || candidate.locked_by || candidate.locked_by_emp;
+      const normalizedLockedBy = String(lockedByCandidate || '').trim();
+      if (normalizedLockedBy) {
+        payload.lockedBy = normalizedLockedBy;
+      }
+
+      const lockedAtCandidate =
+        candidate.lockedAt || candidate.locked_at || candidate.locked_date;
+      const normalizedLockedAt = String(lockedAtCandidate || '').trim();
+      if (normalizedLockedAt) {
+        payload.lockedAt = normalizedLockedAt;
+      }
+
+      if (candidate.locked || candidate.is_locked || candidate.isLocked) {
+        payload.locked = true;
+      }
+
+      const rawSnapshot =
+        resolveSnapshotSource(candidate) ||
+        (candidate.snapshot &&
+        typeof candidate.snapshot === 'object' &&
+        !Array.isArray(candidate.snapshot)
+          ? candidate.snapshot
+          : null);
+      const {
+        row: normalizedSnapshot,
+        columns: derivedColumns,
+        fieldTypeMap,
+      } = normalizeSnapshotRecord(rawSnapshot || {});
+      if (normalizedSnapshot) {
+        payload.snapshot = normalizedSnapshot;
+        let snapshotColumns = [];
+        if (Array.isArray(candidate.snapshotColumns)) {
+          snapshotColumns = candidate.snapshotColumns;
+        } else if (Array.isArray(candidate.snapshot_columns)) {
+          snapshotColumns = candidate.snapshot_columns;
+        } else if (Array.isArray(candidate.columns)) {
+          snapshotColumns = candidate.columns;
+        }
+        snapshotColumns = snapshotColumns
+          .map((col) => (col === null || col === undefined ? '' : String(col)))
+          .filter(Boolean);
+        if (!snapshotColumns.length && Array.isArray(derivedColumns)) {
+          snapshotColumns = derivedColumns;
+        }
+        if (snapshotColumns.length) {
+          payload.snapshotColumns = snapshotColumns;
+        }
+        const snapshotFieldTypeMap =
+          candidate.snapshotFieldTypeMap ||
+          candidate.snapshot_field_type_map ||
+          candidate.fieldTypeMap ||
+          candidate.field_type_map ||
+          fieldTypeMap ||
+          {};
+        if (
+          snapshotFieldTypeMap &&
+          typeof snapshotFieldTypeMap === 'object' &&
+          Object.keys(snapshotFieldTypeMap).length
+        ) {
+          payload.snapshotFieldTypeMap = snapshotFieldTypeMap;
+        }
+      }
+
+      return {
+        ...payload,
+        ...Object.fromEntries(
+          Object.entries(overrides || {}).filter(
+            ([, value]) => value !== undefined && value !== null,
+          ),
+        ),
+      };
+    };
+
     const excludedTransactions = lockCandidates
       .filter((candidate) => !candidate?.locked)
       .filter((candidate) => !lockSelections[getCandidateKey(candidate)])
       .map((candidate) => {
         const key = getCandidateKey(candidate);
         const info = lockExclusions[key];
-        const tableName = candidate.tableName || getCandidateTable(candidate);
-        if (!tableName) return null;
-        return {
-          table: tableName,
-          recordId: String(candidate.recordId),
-          reason: info?.reason?.trim() || '',
-        };
+        const reason = (info?.reason || '').trim();
+        return serializeCandidateForRequest(candidate, { reason });
       })
       .filter(Boolean);
     if (excludedTransactions.some((tx) => !tx.reason)) {
@@ -1814,14 +1990,7 @@ export default function Reports() {
       parameters: snapshot?.params || result.params,
       transactions: lockCandidates
         .filter((candidate) => lockSelections[getCandidateKey(candidate)])
-        .map((candidate) => {
-          const tableName = candidate.tableName || getCandidateTable(candidate);
-          if (!tableName) return null;
-          return {
-            table: tableName,
-            recordId: String(candidate.recordId),
-          };
-        })
+        .map((candidate) => serializeCandidateForRequest(candidate))
         .filter(Boolean),
       excludedTransactions,
       snapshot: {

--- a/src/erp.mgt.mn/utils/normalizeSnapshot.js
+++ b/src/erp.mgt.mn/utils/normalizeSnapshot.js
@@ -1,0 +1,351 @@
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeColumnList(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => (entry === null || entry === undefined ? '' : String(entry)))
+    .filter(Boolean);
+}
+
+const DATASET_META_KEYS = new Set([
+  'rows',
+  'snapshotRows',
+  'snapshot_rows',
+  'data',
+  'items',
+  'records',
+  'row',
+  'record',
+  'rowCount',
+  'row_count',
+  'rowcount',
+  'totalRows',
+  'total_rows',
+  'columns',
+  'snapshotColumns',
+  'snapshot_columns',
+  'columnNames',
+  'column_names',
+  'fieldTypeMap',
+  'field_type_map',
+  'snapshotFieldTypeMap',
+  'snapshot_field_type_map',
+  'artifact',
+  'snapshotArtifact',
+  'snapshot_artifact',
+  'archive',
+  'snapshotArchive',
+  'snapshot_archive',
+  'totalRow',
+  'total_row',
+  'totals',
+  'summary',
+  'summaryRow',
+  'summary_row',
+  'params',
+  'parameters',
+  'executed_at',
+]);
+
+const ROW_ARRAY_KEYS = [
+  'rows',
+  'snapshotRows',
+  'snapshot_rows',
+  'data',
+  'items',
+  'records',
+  'values',
+  'result',
+];
+
+const SNAPSHOT_SOURCE_KEYS = [
+  'snapshot',
+  'snapshotData',
+  'snapshot_data',
+  'snapshotRow',
+  'snapshot_row',
+  'snapshotRecord',
+  'snapshot_record',
+  'snapshotDetails',
+  'snapshot_details',
+  'row',
+  'record',
+  'data',
+];
+
+function parseJsonRow(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (isPlainObject(parsed) || Array.isArray(parsed)) {
+      return parsed;
+    }
+  } catch {}
+  return null;
+}
+
+function normalizeRowEntry(row, columnHints = []) {
+  if (!row) return null;
+  if (isPlainObject(row)) {
+    const entries = Object.entries(row).filter(
+      ([key]) => typeof key === 'string' && key.trim(),
+    );
+    if (entries.length) {
+      return Object.fromEntries(entries);
+    }
+    return null;
+  }
+  if (Array.isArray(row)) {
+    const columns = columnHints.length
+      ? columnHints
+      : row.map((_, idx) => `column_${idx + 1}`);
+    const normalized = Object.fromEntries(
+      columns
+        .map((col, idx) => [col, row[idx]])
+        .filter(([key]) => Boolean(key)),
+    );
+    return Object.keys(normalized).length ? normalized : null;
+  }
+  if (typeof row === 'string') {
+    const parsed = parseJsonRow(row);
+    if (parsed) {
+      return normalizeRowEntry(parsed, columnHints);
+    }
+  }
+  if (typeof row === 'object') {
+    const entries = Object.entries(row).filter(
+      ([key]) => typeof key === 'string' && key.trim(),
+    );
+    if (entries.length) {
+      return Object.fromEntries(entries);
+    }
+  }
+  return null;
+}
+
+function extractColumnHints(snapshotLike) {
+  const candidates = [
+    snapshotLike?.columns,
+    snapshotLike?.snapshotColumns,
+    snapshotLike?.snapshot_columns,
+    snapshotLike?.columnNames,
+    snapshotLike?.column_names,
+  ];
+  for (const candidate of candidates) {
+    const normalized = normalizeColumnList(candidate);
+    if (normalized.length) {
+      return normalized;
+    }
+  }
+  return [];
+}
+
+function collectRows(snapshotLike, columnHints = []) {
+  for (const key of ROW_ARRAY_KEYS) {
+    const candidate = snapshotLike?.[key];
+    if (Array.isArray(candidate) && candidate.length) {
+      const normalized = candidate
+        .map((row) => normalizeRowEntry(row, columnHints))
+        .filter(Boolean);
+      if (normalized.length) {
+        return normalized;
+      }
+    }
+  }
+  const directRow = normalizeRowEntry(snapshotLike?.row, columnHints);
+  if (directRow) return [directRow];
+  const directRecord = normalizeRowEntry(snapshotLike?.record, columnHints);
+  if (directRecord) return [directRecord];
+  return [];
+}
+
+function deriveRowCount(snapshotLike, rowsLength) {
+  const candidates = [
+    snapshotLike?.rowCount,
+    snapshotLike?.row_count,
+    snapshotLike?.rowcount,
+    snapshotLike?.totalRows,
+    snapshotLike?.total_rows,
+  ];
+  for (const candidate of candidates) {
+    const num = Number(candidate);
+    if (Number.isFinite(num) && num >= 0) {
+      return num;
+    }
+  }
+  return rowsLength;
+}
+
+function deriveFieldTypeMap(snapshotLike) {
+  const candidates = [
+    snapshotLike?.snapshotFieldTypeMap,
+    snapshotLike?.snapshot_field_type_map,
+    snapshotLike?.fieldTypeMap,
+    snapshotLike?.field_type_map,
+  ];
+  for (const candidate of candidates) {
+    if (isPlainObject(candidate)) {
+      return candidate;
+    }
+  }
+  return {};
+}
+
+function deriveArtifact(snapshotLike) {
+  const candidates = [
+    snapshotLike?.artifact,
+    snapshotLike?.snapshotArtifact,
+    snapshotLike?.snapshot_artifact,
+    snapshotLike?.archive,
+    snapshotLike?.snapshotArchive,
+    snapshotLike?.snapshot_archive,
+  ];
+  for (const candidate of candidates) {
+    if (candidate) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function deriveColumns(snapshotLike, rows, columnHints = []) {
+  if (columnHints.length) {
+    return columnHints;
+  }
+  if (Array.isArray(rows) && rows.length) {
+    const set = new Set();
+    rows.forEach((row) => {
+      if (!isPlainObject(row)) return;
+      Object.keys(row).forEach((key) => {
+        if (key) set.add(key);
+      });
+    });
+    return Array.from(set);
+  }
+  return [];
+}
+
+function deriveRows(snapshotLike, columnHints = []) {
+  const collected = collectRows(snapshotLike, columnHints);
+  if (collected.length) {
+    return collected;
+  }
+  if (!isPlainObject(snapshotLike)) {
+    return [];
+  }
+  const entries = Object.entries(snapshotLike).filter(
+    ([key]) => !DATASET_META_KEYS.has(key),
+  );
+  if (entries.length) {
+    return [Object.fromEntries(entries)];
+  }
+  const parsed = normalizeRowEntry(snapshotLike, columnHints);
+  if (parsed && parsed !== snapshotLike && isPlainObject(parsed)) {
+    return [parsed];
+  }
+  return [];
+}
+
+function deriveTotalRow(snapshotLike, rows, columns = [], columnHints = []) {
+  const candidates = [
+    snapshotLike?.totalRow,
+    snapshotLike?.total_row,
+    snapshotLike?.totals,
+    snapshotLike?.summary,
+    snapshotLike?.summaryRow,
+    snapshotLike?.summary_row,
+  ];
+  for (const candidate of candidates) {
+    if (isPlainObject(candidate)) {
+      return candidate;
+    }
+    if (Array.isArray(candidate) && candidate.length) {
+      const columnSource = columnHints.length
+        ? columnHints
+        : columns.length
+        ? columns
+        : Array.isArray(rows) && rows.length && isPlainObject(rows[0])
+        ? Object.keys(rows[0])
+        : candidate.map((_, idx) => `column_${idx + 1}`);
+      const normalized = Object.fromEntries(
+        columnSource
+          .map((col, idx) => [col, candidate[idx]])
+          .filter(([key]) => Boolean(key)),
+      );
+      if (Object.keys(normalized).length) {
+        return normalized;
+      }
+    }
+    if (typeof candidate === 'string') {
+      const parsed = parseJsonRow(candidate);
+      if (parsed) {
+        const normalized = normalizeRowEntry(parsed, columnHints);
+        if (normalized) {
+          return normalized;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+export function normalizeSnapshotDataset(snapshotLike) {
+  if (!isPlainObject(snapshotLike)) {
+    return {
+      rows: [],
+      columns: [],
+      rowCount: 0,
+      fieldTypeMap: {},
+      artifact: null,
+      totalRow: null,
+    };
+  }
+
+  const columnHints = extractColumnHints(snapshotLike);
+  const rows = deriveRows(snapshotLike, columnHints);
+  const columns = deriveColumns(snapshotLike, rows, columnHints);
+  const rowCount = deriveRowCount(snapshotLike, rows.length);
+  const fieldTypeMap = deriveFieldTypeMap(snapshotLike);
+  const artifact = deriveArtifact(snapshotLike);
+  const totalRow = deriveTotalRow(snapshotLike, rows, columns, columnHints);
+
+  return {
+    rows,
+    columns,
+    rowCount,
+    fieldTypeMap,
+    artifact,
+    totalRow,
+  };
+}
+
+export function normalizeSnapshotRecord(snapshotLike) {
+  if (!isPlainObject(snapshotLike)) {
+    return { row: null, columns: [], fieldTypeMap: {} };
+  }
+  const dataset = normalizeSnapshotDataset(snapshotLike);
+  return {
+    row: dataset.rows.length ? dataset.rows[0] : null,
+    columns: dataset.columns,
+    fieldTypeMap: dataset.fieldTypeMap,
+  };
+}
+
+export function resolveSnapshotSource(source) {
+  if (!isPlainObject(source)) {
+    return null;
+  }
+  for (const key of SNAPSHOT_SOURCE_KEYS) {
+    const candidate = source[key];
+    if (isPlainObject(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+export default normalizeSnapshotDataset;


### PR DESCRIPTION
## Summary
- normalize snapshot rows sourced from arrays or JSON strings using the provided column hints so lock candidates retain field values
- reuse extracted column names when mapping summary/total rows to prevent blank snapshot columns in request tables

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5d9b4414483319e15f1b8e515a8e5