### PR TITLE
Scope temporary transaction workflow by branch and department

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -28,6 +28,12 @@ function arrify(val) {
 }
 
 function parseEntry(raw = {}) {
+  const temporaryFlag = Boolean(
+    raw.supportsTemporarySubmission ??
+      raw.allowTemporarySubmission ??
+      raw.supportsTemporary ??
+      false,
+  );
   return {
     visibleFields: Array.isArray(raw.visibleFields)
       ? raw.visibleFields.map(String)
@@ -87,15 +93,20 @@ function parseEntry(raw = {}) {
     allowedDepartments: Array.isArray(raw.allowedDepartments)
       ? raw.allowedDepartments.map((v) => Number(v)).filter((v) => !Number.isNaN(v))
       : [],
+    temporaryAllowedBranches: Array.isArray(raw.temporaryAllowedBranches)
+      ? raw.temporaryAllowedBranches
+          .map((v) => Number(v))
+          .filter((v) => !Number.isNaN(v))
+      : [],
+    temporaryAllowedDepartments: Array.isArray(raw.temporaryAllowedDepartments)
+      ? raw.temporaryAllowedDepartments
+          .map((v) => Number(v))
+          .filter((v) => !Number.isNaN(v))
+      : [],
     moduleLabel: typeof raw.moduleLabel === 'string' ? raw.moduleLabel : '',
     procedures: arrify(raw.procedures || raw.procedure),
-    supportsTemporarySubmission:
-      Boolean(
-        raw.supportsTemporarySubmission ??
-          raw.allowTemporarySubmission ??
-          raw.supportsTemporary ??
-          false,
-      ),
+    supportsTemporarySubmission: temporaryFlag,
+    allowTemporarySubmission: temporaryFlag,
   };
 }
 
@@ -186,6 +197,8 @@ export async function setFormConfig(
     companyIdFields = [],
     allowedBranches = [],
     allowedDepartments = [],
+    temporaryAllowedBranches = [],
+    temporaryAllowedDepartments = [],
     moduleKey: parentModuleKey = '',
     moduleLabel,
     userIdField,
@@ -226,6 +239,12 @@ export async function setFormConfig(
   const ad = Array.isArray(allowedDepartments)
     ? allowedDepartments.map((v) => Number(v)).filter((v) => !Number.isNaN(v))
     : [];
+  const tab = Array.isArray(temporaryAllowedBranches)
+    ? temporaryAllowedBranches.map((v) => Number(v)).filter((v) => !Number.isNaN(v))
+    : [];
+  const tad = Array.isArray(temporaryAllowedDepartments)
+    ? temporaryAllowedDepartments.map((v) => Number(v)).filter((v) => !Number.isNaN(v))
+    : [];
   const { cfg } = await readConfig(companyId);
   if (!cfg[table]) cfg[table] = {};
   cfg[table][name] = {
@@ -260,8 +279,13 @@ export async function setFormConfig(
     moduleLabel: moduleLabel || undefined,
     allowedBranches: ab,
     allowedDepartments: ad,
+    temporaryAllowedBranches: tab,
+    temporaryAllowedDepartments: tad,
     procedures: arrify(procedures),
     allowTemporarySubmission: Boolean(
+      supportsTemporarySubmission ?? allowTemporarySubmission ?? false,
+    ),
+    supportsTemporarySubmission: Boolean(
       supportsTemporarySubmission ?? allowTemporarySubmission ?? false,
     ),
   };

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -403,8 +403,43 @@ const TableManager = forwardRef(function TableManager({
       formConfig.supportsTemporarySubmission ??
       formConfig.allowTemporarySubmission ??
       false;
-    return Boolean(flag);
-  }, [formConfig]);
+    if (!flag) return false;
+
+    const branchRules = Array.isArray(formConfig.temporaryAllowedBranches)
+      ? formConfig.temporaryAllowedBranches
+      : [];
+    const deptRules = Array.isArray(formConfig.temporaryAllowedDepartments)
+      ? formConfig.temporaryAllowedDepartments
+      : [];
+
+    const resolveId = (value) => {
+      if (value == null) return null;
+      if (typeof value === 'object') {
+        if (value.id != null) return value.id;
+        if (value.branch_id != null) return value.branch_id;
+        if (value.department_id != null) return value.department_id;
+        if (value.value != null) return value.value;
+      }
+      return value;
+    };
+
+    const branchId = resolveId(branch);
+    const departmentId = resolveId(department);
+
+    if (branchRules.length > 0) {
+      if (branchId == null) return false;
+      const allowed = branchRules.map((v) => String(v));
+      if (!allowed.includes(String(branchId))) return false;
+    }
+
+    if (deptRules.length > 0) {
+      if (departmentId == null) return false;
+      const allowed = deptRules.map((v) => String(v));
+      if (!allowed.includes(String(departmentId))) return false;
+    }
+
+    return true;
+  }, [branch, department, formConfig]);
 
   const refreshTemporarySummary = useCallback(async () => {
     if (!supportsTemporary) {

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -9,6 +9,74 @@ import { useToast } from '../context/ToastContext.jsx';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { Navigate } from 'react-router-dom';
 
+function normalizeFormConfig(info = {}) {
+  const toArray = (value) => (Array.isArray(value) ? [...value] : []);
+  const toObject = (value) =>
+    value && typeof value === 'object' && !Array.isArray(value) ? { ...value } : {};
+  const toString = (value) => (typeof value === 'string' ? value : '');
+  const temporaryFlag = Boolean(
+    info.supportsTemporarySubmission ??
+      info.allowTemporarySubmission ??
+      info.supportsTemporary ??
+      false,
+  );
+
+  const allowedBranches = toArray(info.allowedBranches).map((v) => String(v));
+  const allowedDepartments = toArray(info.allowedDepartments).map((v) => String(v));
+  let temporaryAllowedBranches = toArray(info.temporaryAllowedBranches).map((v) =>
+    String(v),
+  );
+  let temporaryAllowedDepartments = toArray(info.temporaryAllowedDepartments).map((v) =>
+    String(v),
+  );
+
+  if (temporaryFlag) {
+    if (temporaryAllowedBranches.length === 0 && allowedBranches.length > 0) {
+      temporaryAllowedBranches = [...allowedBranches];
+    }
+    if (temporaryAllowedDepartments.length === 0 && allowedDepartments.length > 0) {
+      temporaryAllowedDepartments = [...allowedDepartments];
+    }
+  }
+
+  return {
+    visibleFields: toArray(info.visibleFields),
+    requiredFields: toArray(info.requiredFields),
+    defaultValues: toObject(info.defaultValues),
+    editableDefaultFields: toArray(info.editableDefaultFields),
+    editableFields:
+      info.editableFields === undefined ? [] : toArray(info.editableFields),
+    userIdFields: toArray(info.userIdFields),
+    branchIdFields: toArray(info.branchIdFields),
+    departmentIdFields: toArray(info.departmentIdFields),
+    companyIdFields: toArray(info.companyIdFields),
+    dateField: toArray(info.dateField),
+    emailField: toArray(info.emailField),
+    imagenameField: toArray(info.imagenameField),
+    imageIdField: toString(info.imageIdField),
+    imageFolder: toString(info.imageFolder),
+    printEmpField: toArray(info.printEmpField),
+    printCustField: toArray(info.printCustField),
+    totalCurrencyFields: toArray(info.totalCurrencyFields),
+    totalAmountFields: toArray(info.totalAmountFields),
+    signatureFields: toArray(info.signatureFields),
+    headerFields: toArray(info.headerFields),
+    mainFields: toArray(info.mainFields),
+    footerFields: toArray(info.footerFields),
+    viewSource: toObject(info.viewSource),
+    transactionTypeField: toString(info.transactionTypeField),
+    transactionTypeValue: toString(info.transactionTypeValue),
+    detectFields: toArray(info.detectFields),
+    allowedBranches,
+    allowedDepartments,
+    temporaryAllowedBranches,
+    temporaryAllowedDepartments,
+    procedures: toArray(info.procedures),
+    supportsTemporarySubmission: temporaryFlag,
+    allowTemporarySubmission: temporaryFlag,
+  };
+}
+
 export default function FormsManagement() {
   const { t } = useContext(I18nContext);
   const { addToast } = useToast();
@@ -45,37 +113,7 @@ export default function FormsManagement() {
     debugLog('Component mounted: FormsManagement');
   }, []);
 
-  const [config, setConfig] = useState({
-    visibleFields: [],
-    requiredFields: [],
-    defaultValues: {},
-    editableDefaultFields: [],
-    editableFields: [],
-    userIdFields: [],
-    branchIdFields: [],
-    departmentIdFields: [],
-    companyIdFields: [],
-    dateField: [],
-    emailField: [],
-    imagenameField: [],
-    imageIdField: '',
-    imageFolder: '',
-    printEmpField: [],
-    printCustField: [],
-    totalCurrencyFields: [],
-    totalAmountFields: [],
-    signatureFields: [],
-    headerFields: [],
-    mainFields: [],
-    footerFields: [],
-    viewSource: {},
-    transactionTypeField: '',
-    transactionTypeValue: '',
-    detectFields: [],
-    allowedBranches: [],
-    allowedDepartments: [],
-    procedures: [],
-  });
+  const [config, setConfig] = useState(() => normalizeFormConfig());
 
   useEffect(() => {
     fetch('/api/transaction_forms', { credentials: 'include' })
@@ -145,37 +183,7 @@ export default function FormsManagement() {
     setName(cfg.name);
     setModuleKey(cfg.moduleKey || '');
     const info = cfg.config || {};
-    setConfig({
-      visibleFields: info.visibleFields || [],
-      requiredFields: info.requiredFields || [],
-      defaultValues: info.defaultValues || {},
-      editableDefaultFields: info.editableDefaultFields || [],
-      editableFields: info.editableFields || [],
-      userIdFields: info.userIdFields || [],
-      branchIdFields: info.branchIdFields || [],
-      departmentIdFields: info.departmentIdFields || [],
-      companyIdFields: info.companyIdFields || [],
-      dateField: info.dateField || [],
-      emailField: info.emailField || [],
-      imagenameField: info.imagenameField || [],
-      imageIdField: info.imageIdField || '',
-      imageFolder: info.imageFolder || '',
-      printEmpField: info.printEmpField || [],
-      printCustField: info.printCustField || [],
-      totalCurrencyFields: info.totalCurrencyFields || [],
-      totalAmountFields: info.totalAmountFields || [],
-      signatureFields: info.signatureFields || [],
-      headerFields: info.headerFields || [],
-      mainFields: info.mainFields || [],
-      footerFields: info.footerFields || [],
-      viewSource: info.viewSource || {},
-      transactionTypeField: info.transactionTypeField || '',
-      transactionTypeValue: info.transactionTypeValue || '',
-      detectFields: info.detectFields || [],
-      allowedBranches: (info.allowedBranches || []).map(String),
-      allowedDepartments: (info.allowedDepartments || []).map(String),
-      procedures: info.procedures || [],
-    });
+    setConfig(normalizeFormConfig(info));
     setNames([cfg.name]);
     fetch(`/api/tables/${encodeURIComponent(cfg.table)}/columns`, {
       credentials: 'include',
@@ -272,107 +280,17 @@ export default function FormsManagement() {
         setNames(Object.keys(filtered));
         if (filtered[name]) {
           setModuleKey(filtered[name].moduleKey || '');
-          setConfig({
-            visibleFields: filtered[name].visibleFields || [],
-            requiredFields: filtered[name].requiredFields || [],
-            defaultValues: filtered[name].defaultValues || {},
-            editableDefaultFields: filtered[name].editableDefaultFields || [],
-            editableFields: filtered[name].editableFields || [],
-            userIdFields: filtered[name].userIdFields || [],
-            branchIdFields: filtered[name].branchIdFields || [],
-            departmentIdFields: filtered[name].departmentIdFields || [],
-            companyIdFields: filtered[name].companyIdFields || [],
-            dateField: filtered[name].dateField || [],
-            emailField: filtered[name].emailField || [],
-            imagenameField: filtered[name].imagenameField || [],
-            imageIdField: filtered[name].imageIdField || '',
-            imageFolder: filtered[name].imageFolder || '',
-            printEmpField: filtered[name].printEmpField || [],
-            printCustField: filtered[name].printCustField || [],
-            totalCurrencyFields: filtered[name].totalCurrencyFields || [],
-            totalAmountFields: filtered[name].totalAmountFields || [],
-            signatureFields: filtered[name].signatureFields || [],
-            headerFields: filtered[name].headerFields || [],
-            mainFields: filtered[name].mainFields || [],
-            footerFields: filtered[name].footerFields || [],
-            viewSource: filtered[name].viewSource || {},
-            transactionTypeField: filtered[name].transactionTypeField || '',
-            transactionTypeValue: filtered[name].transactionTypeValue || '',
-            detectFields: filtered[name].detectFields || [],
-            allowedBranches: (filtered[name].allowedBranches || []).map(String),
-            allowedDepartments: (filtered[name].allowedDepartments || []).map(String),
-            procedures: filtered[name].procedures || [],
-          });
+          setConfig(normalizeFormConfig(filtered[name]));
         } else {
           setName('');
-          setConfig({
-            visibleFields: [],
-            requiredFields: [],
-            defaultValues: {},
-            editableDefaultFields: [],
-            editableFields: [],
-            userIdFields: [],
-            branchIdFields: [],
-            departmentIdFields: [],
-            companyIdFields: [],
-            dateField: [],
-            emailField: [],
-            imagenameField: [],
-            imageIdField: '',
-            imageFolder: '',
-            printEmpField: [],
-            printCustField: [],
-            totalCurrencyFields: [],
-            totalAmountFields: [],
-            signatureFields: [],
-            headerFields: [],
-            mainFields: [],
-            footerFields: [],
-            viewSource: {},
-            transactionTypeField: '',
-            transactionTypeValue: '',
-            detectFields: [],
-            allowedBranches: [],
-            allowedDepartments: [],
-            procedures: [],
-          });
+          setConfig(normalizeFormConfig());
         }
       })
       .catch(() => {
         setIsDefault(true);
         setNames([]);
         setName('');
-        setConfig({
-          visibleFields: [],
-          requiredFields: [],
-          defaultValues: {},
-          editableDefaultFields: [],
-          editableFields: [],
-          userIdFields: [],
-          branchIdFields: [],
-          departmentIdFields: [],
-          companyIdFields: [],
-          dateField: [],
-          emailField: [],
-          imagenameField: [],
-          imageIdField: '',
-          imageFolder: '',
-          printEmpField: [],
-          printCustField: [],
-          totalCurrencyFields: [],
-          totalAmountFields: [],
-          signatureFields: [],
-          headerFields: [],
-          mainFields: [],
-          footerFields: [],
-          viewSource: {},
-          transactionTypeField: '',
-          transactionTypeValue: '',
-          detectFields: [],
-          allowedBranches: [],
-          allowedDepartments: [],
-          procedures: [],
-        });
+        setConfig(normalizeFormConfig());
         setModuleKey('');
       });
   }, [table, moduleKey]);
@@ -384,71 +302,11 @@ export default function FormsManagement() {
       .then((cfg) => {
         setIsDefault(!!cfg.isDefault);
         setModuleKey(cfg.moduleKey || '');
-        setConfig({
-          visibleFields: cfg.visibleFields || [],
-          requiredFields: cfg.requiredFields || [],
-          defaultValues: cfg.defaultValues || {},
-          editableDefaultFields: cfg.editableDefaultFields || [],
-          editableFields: cfg.editableFields || [],
-          userIdFields: cfg.userIdFields || [],
-          branchIdFields: cfg.branchIdFields || [],
-          departmentIdFields: cfg.departmentIdFields || [],
-          companyIdFields: cfg.companyIdFields || [],
-          dateField: cfg.dateField || [],
-          emailField: cfg.emailField || [],
-          imagenameField: cfg.imagenameField || [],
-          imageIdField: cfg.imageIdField || '',
-          imageFolder: cfg.imageFolder || '',
-          printEmpField: cfg.printEmpField || [],
-          printCustField: cfg.printCustField || [],
-          totalCurrencyFields: cfg.totalCurrencyFields || [],
-          totalAmountFields: cfg.totalAmountFields || [],
-          signatureFields: cfg.signatureFields || [],
-          headerFields: cfg.headerFields || [],
-          mainFields: cfg.mainFields || [],
-          footerFields: cfg.footerFields || [],
-          viewSource: cfg.viewSource || {},
-          transactionTypeField: cfg.transactionTypeField || '',
-          transactionTypeValue: cfg.transactionTypeValue || '',
-          detectFields: cfg.detectFields || [],
-          allowedBranches: (cfg.allowedBranches || []).map(String),
-          allowedDepartments: (cfg.allowedDepartments || []).map(String),
-          procedures: cfg.procedures || [],
-        });
+        setConfig(normalizeFormConfig(cfg));
       })
       .catch(() => {
         setIsDefault(true);
-        setConfig({
-          visibleFields: [],
-          requiredFields: [],
-          defaultValues: {},
-          editableDefaultFields: [],
-          editableFields: [],
-          userIdFields: [],
-          branchIdFields: [],
-          departmentIdFields: [],
-          companyIdFields: [],
-          dateField: [],
-          emailField: [],
-          imagenameField: [],
-          imageIdField: '',
-          imageFolder: '',
-          printEmpField: [],
-          printCustField: [],
-          totalCurrencyFields: [],
-          totalAmountFields: [],
-          signatureFields: [],
-          headerFields: [],
-          mainFields: [],
-          footerFields: [],
-          viewSource: {},
-          transactionTypeField: '',
-          transactionTypeValue: '',
-          detectFields: [],
-          allowedBranches: [],
-          allowedDepartments: [],
-          procedures: [],
-        });
+        setConfig(normalizeFormConfig());
         setModuleKey('');
       });
   }, [table, name, names]);
@@ -509,11 +367,30 @@ export default function FormsManagement() {
       ...config,
       moduleKey,
       allowedBranches: config.allowedBranches.map((b) => Number(b)).filter((b) => !Number.isNaN(b)),
-      allowedDepartments: config.allowedDepartments.map((d) => Number(d)).filter((d) => !Number.isNaN(d)),
+      allowedDepartments: config.allowedDepartments
+        .map((d) => Number(d))
+        .filter((d) => !Number.isNaN(d)),
+      temporaryAllowedBranches: config.temporaryAllowedBranches
+        .map((b) => Number(b))
+        .filter((b) => !Number.isNaN(b)),
+      temporaryAllowedDepartments: config.temporaryAllowedDepartments
+        .map((d) => Number(d))
+        .filter((d) => !Number.isNaN(d)),
       transactionTypeValue: config.transactionTypeValue
         ? String(config.transactionTypeValue)
         : '',
     };
+    const temporaryFlag = Boolean(
+      config.supportsTemporarySubmission ??
+        config.allowTemporarySubmission ??
+        false,
+    );
+    cfg.allowTemporarySubmission = temporaryFlag;
+    cfg.supportsTemporarySubmission = temporaryFlag;
+    if (!temporaryFlag) {
+      cfg.temporaryAllowedBranches = [];
+      cfg.temporaryAllowedDepartments = [];
+    }
     if (cfg.transactionTypeField && cfg.transactionTypeValue) {
       cfg.defaultValues = {
         ...cfg.defaultValues,
@@ -601,37 +478,7 @@ export default function FormsManagement() {
       list.filter((c) => !(c.table === table && c.name === name)),
     );
     setName('');
-    setConfig({
-      visibleFields: [],
-      requiredFields: [],
-      defaultValues: {},
-      editableDefaultFields: [],
-      editableFields: [],
-      userIdFields: [],
-      branchIdFields: [],
-      departmentIdFields: [],
-      companyIdFields: [],
-      dateField: [],
-      emailField: [],
-      imagenameField: [],
-      imageIdField: '',
-      imageFolder: '',
-      printEmpField: [],
-      printCustField: [],
-      totalCurrencyFields: [],
-      totalAmountFields: [],
-      signatureFields: [],
-      headerFields: [],
-      mainFields: [],
-      footerFields: [],
-      viewSource: {},
-      transactionTypeField: '',
-      transactionTypeValue: '',
-      detectFields: [],
-      allowedBranches: [],
-      allowedDepartments: [],
-      procedures: [],
-    });
+    setConfig(normalizeFormConfig());
     setModuleKey('');
     setSelectedConfig('');
   }
@@ -690,70 +537,10 @@ export default function FormsManagement() {
         const formNames = Object.keys(filtered);
         setNames(formNames);
         if (filtered[name]) {
-          setConfig({
-            visibleFields: filtered[name].visibleFields || [],
-            requiredFields: filtered[name].requiredFields || [],
-            defaultValues: filtered[name].defaultValues || {},
-            editableDefaultFields: filtered[name].editableDefaultFields || [],
-            editableFields: filtered[name].editableFields || [],
-            userIdFields: filtered[name].userIdFields || [],
-            branchIdFields: filtered[name].branchIdFields || [],
-            departmentIdFields: filtered[name].departmentIdFields || [],
-            companyIdFields: filtered[name].companyIdFields || [],
-            dateField: filtered[name].dateField || [],
-            emailField: filtered[name].emailField || [],
-            imagenameField: filtered[name].imagenameField || [],
-            imageIdField: filtered[name].imageIdField || '',
-            imageFolder: filtered[name].imageFolder || '',
-            printEmpField: filtered[name].printEmpField || [],
-            printCustField: filtered[name].printCustField || [],
-            totalCurrencyFields: filtered[name].totalCurrencyFields || [],
-            totalAmountFields: filtered[name].totalAmountFields || [],
-            signatureFields: filtered[name].signatureFields || [],
-            headerFields: filtered[name].headerFields || [],
-            mainFields: filtered[name].mainFields || [],
-            footerFields: filtered[name].footerFields || [],
-            viewSource: filtered[name].viewSource || {},
-            transactionTypeField: filtered[name].transactionTypeField || '',
-            transactionTypeValue: filtered[name].transactionTypeValue || '',
-            detectFields: filtered[name].detectFields || [],
-            allowedBranches: (filtered[name].allowedBranches || []).map(String),
-            allowedDepartments: (filtered[name].allowedDepartments || []).map(String),
-            procedures: filtered[name].procedures || [],
-          });
+          setConfig(normalizeFormConfig(filtered[name]));
         } else {
           setName('');
-          setConfig({
-            visibleFields: [],
-            requiredFields: [],
-            defaultValues: {},
-            editableDefaultFields: [],
-            editableFields: [],
-            userIdFields: [],
-            branchIdFields: [],
-            departmentIdFields: [],
-            companyIdFields: [],
-            dateField: [],
-            emailField: [],
-            imagenameField: [],
-            imageIdField: '',
-            imageFolder: '',
-            printEmpField: [],
-            printCustField: [],
-            totalCurrencyFields: [],
-            totalAmountFields: [],
-            signatureFields: [],
-            headerFields: [],
-            mainFields: [],
-            footerFields: [],
-            viewSource: {},
-            transactionTypeField: '',
-            transactionTypeValue: '',
-            detectFields: [],
-            allowedBranches: [],
-            allowedDepartments: [],
-            procedures: [],
-          });
+          setConfig(normalizeFormConfig());
         }
       }
       addToast('Imported', 'success');
@@ -888,6 +675,51 @@ export default function FormsManagement() {
                 }
               />
             </label>
+
+            <label style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+              <input
+                type="checkbox"
+                checked={Boolean(config.allowTemporarySubmission)}
+                onChange={(e) => {
+                  const checked = e.target.checked;
+                  setConfig((c) => {
+                    const next = {
+                      ...c,
+                      allowTemporarySubmission: checked,
+                      supportsTemporarySubmission: checked,
+                    };
+                    if (checked) {
+                      if (
+                        (!c.temporaryAllowedBranches || c.temporaryAllowedBranches.length === 0) &&
+                        c.allowedBranches?.length
+                      ) {
+                        next.temporaryAllowedBranches = [...c.allowedBranches];
+                      }
+                      if (
+                        (!c.temporaryAllowedDepartments ||
+                          c.temporaryAllowedDepartments.length === 0) &&
+                        c.allowedDepartments?.length
+                      ) {
+                        next.temporaryAllowedDepartments = [...c.allowedDepartments];
+                      }
+                    }
+                    return next;
+                  });
+                }}
+              />
+              <span>
+                {t(
+                  'allow_temporary_submission',
+                  'Allow temporary transaction submissions',
+                )}
+              </span>
+            </label>
+            <small style={{ color: '#666', marginLeft: '1.5rem', display: 'block' }}>
+              {t(
+                'allow_temporary_submission_hint',
+                'When enabled, users can save drafts that require senior confirmation before posting.',
+              )}
+            </small>
 
             {name && <button onClick={handleDelete}>Delete</button>}
           </div>
@@ -1186,6 +1018,94 @@ export default function FormsManagement() {
                 None
               </button>
             </label>
+            {config.allowTemporarySubmission && (
+              <>
+                <label style={{ marginLeft: '1rem' }}>
+                  Temporary allowed branches:{' '}
+                  <select
+                    multiple
+                    size={8}
+                    value={config.temporaryAllowedBranches}
+                    onChange={(e) =>
+                      setConfig((c) => ({
+                        ...c,
+                        temporaryAllowedBranches: Array.from(
+                          e.target.selectedOptions,
+                          (o) => o.value,
+                        ),
+                      }))
+                    }
+                  >
+                    {branchOptions.map((b) => (
+                      <option key={b.value} value={b.value}>
+                        {b.label}
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setConfig((c) => ({
+                        ...c,
+                        temporaryAllowedBranches: branchOptions.map((b) => b.value),
+                      }))
+                    }
+                  >
+                    All
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setConfig((c) => ({ ...c, temporaryAllowedBranches: [] }))
+                    }
+                  >
+                    None
+                  </button>
+                </label>
+                <label style={{ marginLeft: '1rem' }}>
+                  Temporary allowed departments:{' '}
+                  <select
+                    multiple
+                    size={8}
+                    value={config.temporaryAllowedDepartments}
+                    onChange={(e) =>
+                      setConfig((c) => ({
+                        ...c,
+                        temporaryAllowedDepartments: Array.from(
+                          e.target.selectedOptions,
+                          (o) => o.value,
+                        ),
+                      }))
+                    }
+                  >
+                    {deptOptions.map((d) => (
+                      <option key={d.value} value={d.value}>
+                        {d.label}
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setConfig((c) => ({
+                        ...c,
+                        temporaryAllowedDepartments: deptOptions.map((d) => d.value),
+                      }))
+                    }
+                  >
+                    All
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setConfig((c) => ({ ...c, temporaryAllowedDepartments: [] }))
+                    }
+                  >
+                    None
+                  </button>
+                </label>
+              </>
+            )}
             {procedureOptions.length > 0 && (
               <label style={{ marginLeft: '1rem' }}>
                 Procedures:{' '}


### PR DESCRIPTION
## Summary
- persist temporary-submission branch and department allow-lists in transaction form configs and surface them via the API
- expose matching selectors in Forms Management, defaulting to the standard allow lists when enabling temporary submissions
- gate the TableManager temporary workflow on the configured branch/department allow lists so only permitted users see the controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e03a749d84833192283265fcf89fad