### PR TITLE
Prevent temporary-only transaction posting

### DIFF
--- a/api-server/services/transactionFormConfig.js
+++ b/api-server/services/transactionFormConfig.js
@@ -28,6 +28,12 @@ function arrify(val) {
 }
 
 function parseEntry(raw = {}) {
+  const temporaryFlag = Boolean(
+    raw.supportsTemporarySubmission ??
+      raw.allowTemporarySubmission ??
+      raw.supportsTemporary ??
+      false,
+  );
   return {
     visibleFields: Array.isArray(raw.visibleFields)
       ? raw.visibleFields.map(String)
@@ -87,15 +93,20 @@ function parseEntry(raw = {}) {
     allowedDepartments: Array.isArray(raw.allowedDepartments)
       ? raw.allowedDepartments.map((v) => Number(v)).filter((v) => !Number.isNaN(v))
       : [],
+    temporaryAllowedBranches: Array.isArray(raw.temporaryAllowedBranches)
+      ? raw.temporaryAllowedBranches
+          .map((v) => Number(v))
+          .filter((v) => !Number.isNaN(v))
+      : [],
+    temporaryAllowedDepartments: Array.isArray(raw.temporaryAllowedDepartments)
+      ? raw.temporaryAllowedDepartments
+          .map((v) => Number(v))
+          .filter((v) => !Number.isNaN(v))
+      : [],
     moduleLabel: typeof raw.moduleLabel === 'string' ? raw.moduleLabel : '',
     procedures: arrify(raw.procedures || raw.procedure),
-    supportsTemporarySubmission:
-      Boolean(
-        raw.supportsTemporarySubmission ??
-          raw.allowTemporarySubmission ??
-          raw.supportsTemporary ??
-          false,
-      ),
+    supportsTemporarySubmission: temporaryFlag,
+    allowTemporarySubmission: temporaryFlag,
   };
 }
 
@@ -157,11 +168,53 @@ export async function listTransactionNames(
     for (const [name, info] of Object.entries(names)) {
       const parsed = parseEntry(info);
       const modKey = parsed.moduleKey;
-      const allowed = parsed.allowedBranches;
-      const deptAllowed = parsed.allowedDepartments;
       if (moduleKey && moduleKey !== modKey) continue;
-      if (bId != null && allowed.length > 0 && !allowed.includes(bId)) continue;
-      if (dId != null && deptAllowed.length > 0 && !deptAllowed.includes(dId)) continue;
+
+      const allowedBranches = Array.isArray(parsed.allowedBranches)
+        ? parsed.allowedBranches
+        : [];
+      const allowedDepartments = Array.isArray(parsed.allowedDepartments)
+        ? parsed.allowedDepartments
+        : [];
+      const tempBranches = Array.isArray(parsed.temporaryAllowedBranches)
+        ? parsed.temporaryAllowedBranches
+        : [];
+      const tempDepartments = Array.isArray(parsed.temporaryAllowedDepartments)
+        ? parsed.temporaryAllowedDepartments
+        : [];
+
+      const branchAllowed =
+        allowedBranches.length === 0 ||
+        bId == null ||
+        allowedBranches.includes(bId);
+      const departmentAllowed =
+        allowedDepartments.length === 0 ||
+        dId == null ||
+        allowedDepartments.includes(dId);
+
+      let permitted = branchAllowed && departmentAllowed;
+
+      if (!permitted) {
+        const tempEnabled = Boolean(
+          parsed.supportsTemporarySubmission ||
+            parsed.allowTemporarySubmission ||
+            parsed.supportsTemporary,
+        );
+        if (tempEnabled) {
+          const tempBranchAllowed =
+            tempBranches.length === 0 ||
+            bId == null ||
+            tempBranches.includes(bId);
+          const tempDepartmentAllowed =
+            tempDepartments.length === 0 ||
+            dId == null ||
+            tempDepartments.includes(dId);
+          permitted = tempBranchAllowed && tempDepartmentAllowed;
+        }
+      }
+
+      if (!permitted) continue;
+
       result[name] = { table: tbl, ...parsed };
     }
   }
@@ -186,6 +239,8 @@ export async function setFormConfig(
     companyIdFields = [],
     allowedBranches = [],
     allowedDepartments = [],
+    temporaryAllowedBranches = [],
+    temporaryAllowedDepartments = [],
     moduleKey: parentModuleKey = '',
     moduleLabel,
     userIdField,
@@ -226,6 +281,12 @@ export async function setFormConfig(
   const ad = Array.isArray(allowedDepartments)
     ? allowedDepartments.map((v) => Number(v)).filter((v) => !Number.isNaN(v))
     : [];
+  const tab = Array.isArray(temporaryAllowedBranches)
+    ? temporaryAllowedBranches.map((v) => Number(v)).filter((v) => !Number.isNaN(v))
+    : [];
+  const tad = Array.isArray(temporaryAllowedDepartments)
+    ? temporaryAllowedDepartments.map((v) => Number(v)).filter((v) => !Number.isNaN(v))
+    : [];
   const { cfg } = await readConfig(companyId);
   if (!cfg[table]) cfg[table] = {};
   cfg[table][name] = {
@@ -260,8 +321,13 @@ export async function setFormConfig(
     moduleLabel: moduleLabel || undefined,
     allowedBranches: ab,
     allowedDepartments: ad,
+    temporaryAllowedBranches: tab,
+    temporaryAllowedDepartments: tad,
     procedures: arrify(procedures),
     allowTemporarySubmission: Boolean(
+      supportsTemporarySubmission ?? allowTemporarySubmission ?? false,
+    ),
+    supportsTemporarySubmission: Boolean(
       supportsTemporarySubmission ?? allowTemporarySubmission ?? false,
     ),
   };

--- a/api-server/services/transactionTemporaries.js
+++ b/api-server/services/transactionTemporaries.js
@@ -70,7 +70,7 @@ async function ensureTemporaryTable(conn = pool) {
 
 async function insertNotification(
   conn,
-  { companyId, recipientEmpId, message, createdBy, relatedId, type = 'transaction_temporary' },
+  { companyId, recipientEmpId, message, createdBy, relatedId, type = 'request' },
 ) {
   const recipient = normalizeEmpId(recipientEmpId);
   if (!recipient) return;
@@ -138,10 +138,11 @@ export async function createTemporarySubmission({
         emp_id: normalizedCreator,
         table_name: tableName,
         record_id: temporaryId,
-        action: 'temporary_save',
+        action: 'create',
         details: {
           formName: formName ?? null,
           configName: configName ?? null,
+          temporarySubmission: true,
         },
         company_id: companyId ?? null,
       },

--- a/src/erp.mgt.mn/components/RowFormModal.jsx
+++ b/src/erp.mgt.mn/components/RowFormModal.jsx
@@ -69,6 +69,7 @@ const RowFormModal = function RowFormModal({
   onSaveTemporary = null,
   allowTemporarySave = false,
   isAdding = false,
+  canPost = true,
 }) {
   const mounted = useRef(false);
   const renderCount = useRef(0);
@@ -904,8 +905,10 @@ const RowFormModal = function RowFormModal({
       return;
     }
     if (!next) {
-      submitForm();
-      if (onNextForm) onNextForm();
+      if (canPost) {
+        submitForm();
+        if (onNextForm) onNextForm();
+      }
     }
   }
 
@@ -1435,12 +1438,89 @@ const RowFormModal = function RowFormModal({
   async function handleTemporarySave() {
     if (!allowTemporarySave || !onSaveTemporary) return;
     if (useGrid && tableRef.current) {
-      alert(
-        t(
-          'temporary_save_grid_not_supported',
-          'Saving as temporary is not available for grid-based forms yet.',
-        ),
-      );
+      if (tableRef.current.hasInvalid && tableRef.current.hasInvalid()) {
+        alert('Тэмдэглэсэн талбаруудыг засна уу.');
+        return;
+      }
+      const rows = tableRef.current.getRows();
+      const cleanedRows = [];
+      const rawRows = [];
+      let hasMissing = false;
+      let hasInvalid = false;
+      rows.forEach((r) => {
+        const hasValue = Object.values(r).some((v) => {
+          if (v === null || v === undefined || v === '') return false;
+          if (typeof v === 'object' && 'value' in v) return v.value !== '';
+          return true;
+        });
+        if (!hasValue) return;
+        const normalized = {};
+        Object.entries(r).forEach(([k, v]) => {
+          const raw = typeof v === 'object' && v !== null && 'value' in v ? v.value : v;
+          let val = normalizeDateInput(raw, placeholders[k]);
+          if (totalAmountSet.has(k) || totalCurrencySet.has(k)) {
+            val = normalizeNumberInput(val);
+          }
+          normalized[k] = val;
+        });
+        requiredFields.forEach((f) => {
+          if (
+            normalized[f] === '' ||
+            normalized[f] === null ||
+            normalized[f] === undefined
+          )
+            hasMissing = true;
+          if (
+            (totalAmountSet.has(f) || totalCurrencySet.has(f)) &&
+            normalized[f] !== '' &&
+            !/code/i.test(f) &&
+            isNaN(Number(normalizeNumberInput(normalized[f])))
+          )
+            hasInvalid = true;
+          const ph = placeholders[f];
+          if (ph && !isValidDate(normalized[f], ph)) hasInvalid = true;
+        });
+        cleanedRows.push(normalized);
+        rawRows.push(r);
+      });
+      if (hasMissing) {
+        alert('Шаардлагатай талбаруудыг бөглөнө үү.');
+        return;
+      }
+      if (hasInvalid) {
+        alert('Буруу утгуудыг засна уу.');
+        return;
+      }
+      if (cleanedRows.length === 0) {
+        return;
+      }
+      const mergedExtra = { ...extraVals };
+      if (mergedExtra.seedRecords && mergedExtra.seedTables) {
+        const set = new Set(mergedExtra.seedTables);
+        const filtered = {};
+        Object.entries(mergedExtra.seedRecords).forEach(([tbl, recs]) => {
+          if (set.has(tbl)) filtered[tbl] = recs;
+        });
+        mergedExtra.seedRecords = filtered;
+      }
+      const normalizedExtra = {};
+      Object.entries(mergedExtra).forEach(([k, v]) => {
+        let val = normalizeDateInput(v, placeholders[k]);
+        if (totalAmountSet.has(k) || totalCurrencySet.has(k)) {
+          val = normalizeNumberInput(val);
+        }
+        normalizedExtra[k] = val;
+      });
+      try {
+        await Promise.resolve(
+          onSaveTemporary({
+            values: { ...normalizedExtra, rows: cleanedRows },
+            rawRows,
+          }),
+        );
+      } catch (err) {
+        console.error('Temporary save failed', err);
+      }
       return;
     }
     const merged = { ...extraVals, ...formVals };
@@ -1468,6 +1548,15 @@ const RowFormModal = function RowFormModal({
   }
 
   async function submitForm() {
+    if (!canPost) {
+      alert(
+        t(
+          'temporary_post_not_allowed',
+          'You do not have permission to post this transaction.',
+        ),
+      );
+      return;
+    }
     if (submitLocked) return;
     setSubmitLocked(true);
     if (useGrid && tableRef.current) {
@@ -2290,13 +2379,23 @@ const RowFormModal = function RowFormModal({
           >
             {t('cancel', 'Cancel')}
           </button>
-          <button
-            type="submit"
-            className="px-3 py-1 bg-blue-600 text-white rounded"
-          >
-            {t('post', 'Post')}
-          </button>
+          {canPost && (
+            <button
+              type="submit"
+              className="px-3 py-1 bg-blue-600 text-white rounded"
+            >
+              {t('post', 'Post')}
+            </button>
+          )}
         </div>
+        {!canPost && allowTemporarySave && (
+          <div className="mt-2 text-sm text-gray-600">
+            {t(
+              'temporary_post_hint',
+              'This form only allows temporary submissions for your branch/department.',
+            )}
+          </div>
+        )}
         <div className="text-sm text-gray-600">
           Press <strong>Enter</strong> to move to next field. The field will be automatically selected. Use arrow keys to navigate selections.
         </div>

--- a/src/erp.mgt.mn/components/TableManager.jsx
+++ b/src/erp.mgt.mn/components/TableManager.jsx
@@ -28,6 +28,7 @@ import { API_BASE } from '../utils/apiBase.js';
 import { useTranslation } from 'react-i18next';
 import TooltipWrapper from './TooltipWrapper.jsx';
 import normalizeDateInput from '../utils/normalizeDateInput.js';
+import { evaluateTransactionFormAccess } from '../utils/transactionFormAccess.js';
 import {
   applyGeneratedColumnEvaluators,
   createGeneratedColumnEvaluator,
@@ -397,14 +398,13 @@ const TableManager = forwardRef(function TableManager({
     return () => window.removeEventListener('click', hideMenu);
   }, []);
 
-  const supportsTemporary = useMemo(() => {
-    if (!formConfig) return false;
-    const flag =
-      formConfig.supportsTemporarySubmission ??
-      formConfig.allowTemporarySubmission ??
-      false;
-    return Boolean(flag);
-  }, [formConfig]);
+  const accessInfo = useMemo(
+    () => evaluateTransactionFormAccess(formConfig, branch, department),
+    [branch, department, formConfig],
+  );
+
+  const supportsTemporary = accessInfo.temporary;
+  const canPostTransactions = accessInfo.general;
 
   const refreshTemporarySummary = useCallback(async () => {
     if (!supportsTemporary) {
@@ -2044,6 +2044,16 @@ const TableManager = forwardRef(function TableManager({
   }
 
   async function handleSubmit(values) {
+    if (!canPostTransactions) {
+      addToast(
+        t(
+          'temporary_post_not_allowed',
+          'You do not have permission to post this transaction.',
+        ),
+        'error',
+      );
+      return false;
+    }
     const columns = new Set(allColumns);
     const merged = { ...(editing || {}) };
     Object.entries(values).forEach(([k, v]) => {
@@ -2256,6 +2266,14 @@ const TableManager = forwardRef(function TableManager({
     if (!supportsTemporary) return false;
     if (!submission || typeof submission !== 'object') return false;
     const normalizedValues = submission.values || submission;
+    const rawOverride = submission.rawValues && typeof submission.rawValues === 'object'
+      ? submission.rawValues
+      : null;
+    const gridRows = Array.isArray(submission.normalizedRows)
+      ? submission.normalizedRows
+      : Array.isArray(normalizedValues?.rows)
+      ? normalizedValues.rows
+      : null;
     const merged = { ...(editing || {}) };
     Object.entries(normalizedValues).forEach(([k, v]) => {
       merged[k] = v;
@@ -2291,16 +2309,31 @@ const TableManager = forwardRef(function TableManager({
       }
     });
 
+    const payload = {
+      values: normalizedValues,
+      submittedAt: new Date().toISOString(),
+    };
+    if (gridRows) {
+      payload.gridRows = gridRows;
+      const currentValues =
+        payload.values && typeof payload.values === 'object' && !Array.isArray(payload.values)
+          ? payload.values
+          : {};
+      if (!Array.isArray(currentValues.rows)) {
+        payload.values = { ...currentValues, rows: gridRows };
+      }
+      payload.rowCount = gridRows.length;
+    }
+    if (submission.rawRows) {
+      payload.rawRows = submission.rawRows;
+    }
     const body = {
       table,
       formName: formName || formConfig?.moduleLabel || null,
       configName: formName || null,
       moduleKey: formConfig?.moduleKey || null,
-      payload: {
-        values: normalizedValues,
-        submittedAt: new Date().toISOString(),
-      },
-      rawValues: merged,
+      payload,
+      rawValues: rawOverride || merged,
       cleanedValues: cleaned,
       tenant: {
         company_id: company ?? null,
@@ -2316,7 +2349,24 @@ const TableManager = forwardRef(function TableManager({
         credentials: 'include',
         body: JSON.stringify(body),
       });
-      if (!res.ok) throw new Error('Failed');
+      if (!res.ok) {
+        let errorMessage = t('temporary_save_failed', 'Failed to save temporary draft');
+        try {
+          const data = await res.json();
+          if (data?.message) {
+            errorMessage = `${errorMessage}: ${data.message}`;
+          }
+        } catch {
+          try {
+            const text = await res.text();
+            if (text) {
+              errorMessage = `${errorMessage}: ${text}`;
+            }
+          } catch {}
+        }
+        addToast(errorMessage, 'error');
+        return false;
+      }
       addToast(t('temporary_saved', 'Saved as temporary draft'), 'success');
       setShowForm(false);
       setEditing(null);
@@ -4020,6 +4070,7 @@ const TableManager = forwardRef(function TableManager({
         scope="forms"
         allowTemporarySave={supportsTemporary}
         isAdding={isAdding}
+        canPost={canPostTransactions}
       />
       <CascadeDeleteModal
         visible={showCascade}

--- a/src/erp.mgt.mn/pages/FormsManagement.jsx
+++ b/src/erp.mgt.mn/pages/FormsManagement.jsx
@@ -9,6 +9,74 @@ import { useToast } from '../context/ToastContext.jsx';
 import { AuthContext } from '../context/AuthContext.jsx';
 import { Navigate } from 'react-router-dom';
 
+function normalizeFormConfig(info = {}) {
+  const toArray = (value) => (Array.isArray(value) ? [...value] : []);
+  const toObject = (value) =>
+    value && typeof value === 'object' && !Array.isArray(value) ? { ...value } : {};
+  const toString = (value) => (typeof value === 'string' ? value : '');
+  const temporaryFlag = Boolean(
+    info.supportsTemporarySubmission ??
+      info.allowTemporarySubmission ??
+      info.supportsTemporary ??
+      false,
+  );
+
+  const allowedBranches = toArray(info.allowedBranches).map((v) => String(v));
+  const allowedDepartments = toArray(info.allowedDepartments).map((v) => String(v));
+  let temporaryAllowedBranches = toArray(info.temporaryAllowedBranches).map((v) =>
+    String(v),
+  );
+  let temporaryAllowedDepartments = toArray(info.temporaryAllowedDepartments).map((v) =>
+    String(v),
+  );
+
+  if (temporaryFlag) {
+    if (temporaryAllowedBranches.length === 0 && allowedBranches.length > 0) {
+      temporaryAllowedBranches = [...allowedBranches];
+    }
+    if (temporaryAllowedDepartments.length === 0 && allowedDepartments.length > 0) {
+      temporaryAllowedDepartments = [...allowedDepartments];
+    }
+  }
+
+  return {
+    visibleFields: toArray(info.visibleFields),
+    requiredFields: toArray(info.requiredFields),
+    defaultValues: toObject(info.defaultValues),
+    editableDefaultFields: toArray(info.editableDefaultFields),
+    editableFields:
+      info.editableFields === undefined ? [] : toArray(info.editableFields),
+    userIdFields: toArray(info.userIdFields),
+    branchIdFields: toArray(info.branchIdFields),
+    departmentIdFields: toArray(info.departmentIdFields),
+    companyIdFields: toArray(info.companyIdFields),
+    dateField: toArray(info.dateField),
+    emailField: toArray(info.emailField),
+    imagenameField: toArray(info.imagenameField),
+    imageIdField: toString(info.imageIdField),
+    imageFolder: toString(info.imageFolder),
+    printEmpField: toArray(info.printEmpField),
+    printCustField: toArray(info.printCustField),
+    totalCurrencyFields: toArray(info.totalCurrencyFields),
+    totalAmountFields: toArray(info.totalAmountFields),
+    signatureFields: toArray(info.signatureFields),
+    headerFields: toArray(info.headerFields),
+    mainFields: toArray(info.mainFields),
+    footerFields: toArray(info.footerFields),
+    viewSource: toObject(info.viewSource),
+    transactionTypeField: toString(info.transactionTypeField),
+    transactionTypeValue: toString(info.transactionTypeValue),
+    detectFields: toArray(info.detectFields),
+    allowedBranches,
+    allowedDepartments,
+    temporaryAllowedBranches,
+    temporaryAllowedDepartments,
+    procedures: toArray(info.procedures),
+    supportsTemporarySubmission: temporaryFlag,
+    allowTemporarySubmission: temporaryFlag,
+  };
+}
+
 export default function FormsManagement() {
   const { t } = useContext(I18nContext);
   const { addToast } = useToast();
@@ -45,37 +113,7 @@ export default function FormsManagement() {
     debugLog('Component mounted: FormsManagement');
   }, []);
 
-  const [config, setConfig] = useState({
-    visibleFields: [],
-    requiredFields: [],
-    defaultValues: {},
-    editableDefaultFields: [],
-    editableFields: [],
-    userIdFields: [],
-    branchIdFields: [],
-    departmentIdFields: [],
-    companyIdFields: [],
-    dateField: [],
-    emailField: [],
-    imagenameField: [],
-    imageIdField: '',
-    imageFolder: '',
-    printEmpField: [],
-    printCustField: [],
-    totalCurrencyFields: [],
-    totalAmountFields: [],
-    signatureFields: [],
-    headerFields: [],
-    mainFields: [],
-    footerFields: [],
-    viewSource: {},
-    transactionTypeField: '',
-    transactionTypeValue: '',
-    detectFields: [],
-    allowedBranches: [],
-    allowedDepartments: [],
-    procedures: [],
-  });
+  const [config, setConfig] = useState(() => normalizeFormConfig());
 
   useEffect(() => {
     fetch('/api/transaction_forms', { credentials: 'include' })
@@ -145,37 +183,7 @@ export default function FormsManagement() {
     setName(cfg.name);
     setModuleKey(cfg.moduleKey || '');
     const info = cfg.config || {};
-    setConfig({
-      visibleFields: info.visibleFields || [],
-      requiredFields: info.requiredFields || [],
-      defaultValues: info.defaultValues || {},
-      editableDefaultFields: info.editableDefaultFields || [],
-      editableFields: info.editableFields || [],
-      userIdFields: info.userIdFields || [],
-      branchIdFields: info.branchIdFields || [],
-      departmentIdFields: info.departmentIdFields || [],
-      companyIdFields: info.companyIdFields || [],
-      dateField: info.dateField || [],
-      emailField: info.emailField || [],
-      imagenameField: info.imagenameField || [],
-      imageIdField: info.imageIdField || '',
-      imageFolder: info.imageFolder || '',
-      printEmpField: info.printEmpField || [],
-      printCustField: info.printCustField || [],
-      totalCurrencyFields: info.totalCurrencyFields || [],
-      totalAmountFields: info.totalAmountFields || [],
-      signatureFields: info.signatureFields || [],
-      headerFields: info.headerFields || [],
-      mainFields: info.mainFields || [],
-      footerFields: info.footerFields || [],
-      viewSource: info.viewSource || {},
-      transactionTypeField: info.transactionTypeField || '',
-      transactionTypeValue: info.transactionTypeValue || '',
-      detectFields: info.detectFields || [],
-      allowedBranches: (info.allowedBranches || []).map(String),
-      allowedDepartments: (info.allowedDepartments || []).map(String),
-      procedures: info.procedures || [],
-    });
+    setConfig(normalizeFormConfig(info));
     setNames([cfg.name]);
     fetch(`/api/tables/${encodeURIComponent(cfg.table)}/columns`, {
       credentials: 'include',
@@ -272,107 +280,17 @@ export default function FormsManagement() {
         setNames(Object.keys(filtered));
         if (filtered[name]) {
           setModuleKey(filtered[name].moduleKey || '');
-          setConfig({
-            visibleFields: filtered[name].visibleFields || [],
-            requiredFields: filtered[name].requiredFields || [],
-            defaultValues: filtered[name].defaultValues || {},
-            editableDefaultFields: filtered[name].editableDefaultFields || [],
-            editableFields: filtered[name].editableFields || [],
-            userIdFields: filtered[name].userIdFields || [],
-            branchIdFields: filtered[name].branchIdFields || [],
-            departmentIdFields: filtered[name].departmentIdFields || [],
-            companyIdFields: filtered[name].companyIdFields || [],
-            dateField: filtered[name].dateField || [],
-            emailField: filtered[name].emailField || [],
-            imagenameField: filtered[name].imagenameField || [],
-            imageIdField: filtered[name].imageIdField || '',
-            imageFolder: filtered[name].imageFolder || '',
-            printEmpField: filtered[name].printEmpField || [],
-            printCustField: filtered[name].printCustField || [],
-            totalCurrencyFields: filtered[name].totalCurrencyFields || [],
-            totalAmountFields: filtered[name].totalAmountFields || [],
-            signatureFields: filtered[name].signatureFields || [],
-            headerFields: filtered[name].headerFields || [],
-            mainFields: filtered[name].mainFields || [],
-            footerFields: filtered[name].footerFields || [],
-            viewSource: filtered[name].viewSource || {},
-            transactionTypeField: filtered[name].transactionTypeField || '',
-            transactionTypeValue: filtered[name].transactionTypeValue || '',
-            detectFields: filtered[name].detectFields || [],
-            allowedBranches: (filtered[name].allowedBranches || []).map(String),
-            allowedDepartments: (filtered[name].allowedDepartments || []).map(String),
-            procedures: filtered[name].procedures || [],
-          });
+          setConfig(normalizeFormConfig(filtered[name]));
         } else {
           setName('');
-          setConfig({
-            visibleFields: [],
-            requiredFields: [],
-            defaultValues: {},
-            editableDefaultFields: [],
-            editableFields: [],
-            userIdFields: [],
-            branchIdFields: [],
-            departmentIdFields: [],
-            companyIdFields: [],
-            dateField: [],
-            emailField: [],
-            imagenameField: [],
-            imageIdField: '',
-            imageFolder: '',
-            printEmpField: [],
-            printCustField: [],
-            totalCurrencyFields: [],
-            totalAmountFields: [],
-            signatureFields: [],
-            headerFields: [],
-            mainFields: [],
-            footerFields: [],
-            viewSource: {},
-            transactionTypeField: '',
-            transactionTypeValue: '',
-            detectFields: [],
-            allowedBranches: [],
-            allowedDepartments: [],
-            procedures: [],
-          });
+          setConfig(normalizeFormConfig());
         }
       })
       .catch(() => {
         setIsDefault(true);
         setNames([]);
         setName('');
-        setConfig({
-          visibleFields: [],
-          requiredFields: [],
-          defaultValues: {},
-          editableDefaultFields: [],
-          editableFields: [],
-          userIdFields: [],
-          branchIdFields: [],
-          departmentIdFields: [],
-          companyIdFields: [],
-          dateField: [],
-          emailField: [],
-          imagenameField: [],
-          imageIdField: '',
-          imageFolder: '',
-          printEmpField: [],
-          printCustField: [],
-          totalCurrencyFields: [],
-          totalAmountFields: [],
-          signatureFields: [],
-          headerFields: [],
-          mainFields: [],
-          footerFields: [],
-          viewSource: {},
-          transactionTypeField: '',
-          transactionTypeValue: '',
-          detectFields: [],
-          allowedBranches: [],
-          allowedDepartments: [],
-          procedures: [],
-        });
+        setConfig(normalizeFormConfig());
         setModuleKey('');
       });
   }, [table, moduleKey]);
@@ -384,71 +302,11 @@ export default function FormsManagement() {
       .then((cfg) => {
         setIsDefault(!!cfg.isDefault);
         setModuleKey(cfg.moduleKey || '');
-        setConfig({
-          visibleFields: cfg.visibleFields || [],
-          requiredFields: cfg.requiredFields || [],
-          defaultValues: cfg.defaultValues || {},
-          editableDefaultFields: cfg.editableDefaultFields || [],
-          editableFields: cfg.editableFields || [],
-          userIdFields: cfg.userIdFields || [],
-          branchIdFields: cfg.branchIdFields || [],
-          departmentIdFields: cfg.departmentIdFields || [],
-          companyIdFields: cfg.companyIdFields || [],
-          dateField: cfg.dateField || [],
-          emailField: cfg.emailField || [],
-          imagenameField: cfg.imagenameField || [],
-          imageIdField: cfg.imageIdField || '',
-          imageFolder: cfg.imageFolder || '',
-          printEmpField: cfg.printEmpField || [],
-          printCustField: cfg.printCustField || [],
-          totalCurrencyFields: cfg.totalCurrencyFields || [],
-          totalAmountFields: cfg.totalAmountFields || [],
-          signatureFields: cfg.signatureFields || [],
-          headerFields: cfg.headerFields || [],
-          mainFields: cfg.mainFields || [],
-          footerFields: cfg.footerFields || [],
-          viewSource: cfg.viewSource || {},
-          transactionTypeField: cfg.transactionTypeField || '',
-          transactionTypeValue: cfg.transactionTypeValue || '',
-          detectFields: cfg.detectFields || [],
-          allowedBranches: (cfg.allowedBranches || []).map(String),
-          allowedDepartments: (cfg.allowedDepartments || []).map(String),
-          procedures: cfg.procedures || [],
-        });
+        setConfig(normalizeFormConfig(cfg));
       })
       .catch(() => {
         setIsDefault(true);
-        setConfig({
-          visibleFields: [],
-          requiredFields: [],
-          defaultValues: {},
-          editableDefaultFields: [],
-          editableFields: [],
-          userIdFields: [],
-          branchIdFields: [],
-          departmentIdFields: [],
-          companyIdFields: [],
-          dateField: [],
-          emailField: [],
-          imagenameField: [],
-          imageIdField: '',
-          imageFolder: '',
-          printEmpField: [],
-          printCustField: [],
-          totalCurrencyFields: [],
-          totalAmountFields: [],
-          signatureFields: [],
-          headerFields: [],
-          mainFields: [],
-          footerFields: [],
-          viewSource: {},
-          transactionTypeField: '',
-          transactionTypeValue: '',
-          detectFields: [],
-          allowedBranches: [],
-          allowedDepartments: [],
-          procedures: [],
-        });
+        setConfig(normalizeFormConfig());
         setModuleKey('');
       });
   }, [table, name, names]);
@@ -509,11 +367,30 @@ export default function FormsManagement() {
       ...config,
       moduleKey,
       allowedBranches: config.allowedBranches.map((b) => Number(b)).filter((b) => !Number.isNaN(b)),
-      allowedDepartments: config.allowedDepartments.map((d) => Number(d)).filter((d) => !Number.isNaN(d)),
+      allowedDepartments: config.allowedDepartments
+        .map((d) => Number(d))
+        .filter((d) => !Number.isNaN(d)),
+      temporaryAllowedBranches: config.temporaryAllowedBranches
+        .map((b) => Number(b))
+        .filter((b) => !Number.isNaN(b)),
+      temporaryAllowedDepartments: config.temporaryAllowedDepartments
+        .map((d) => Number(d))
+        .filter((d) => !Number.isNaN(d)),
       transactionTypeValue: config.transactionTypeValue
         ? String(config.transactionTypeValue)
         : '',
     };
+    const temporaryFlag = Boolean(
+      config.supportsTemporarySubmission ??
+        config.allowTemporarySubmission ??
+        false,
+    );
+    cfg.allowTemporarySubmission = temporaryFlag;
+    cfg.supportsTemporarySubmission = temporaryFlag;
+    if (!temporaryFlag) {
+      cfg.temporaryAllowedBranches = [];
+      cfg.temporaryAllowedDepartments = [];
+    }
     if (cfg.transactionTypeField && cfg.transactionTypeValue) {
       cfg.defaultValues = {
         ...cfg.defaultValues,
@@ -601,37 +478,7 @@ export default function FormsManagement() {
       list.filter((c) => !(c.table === table && c.name === name)),
     );
     setName('');
-    setConfig({
-      visibleFields: [],
-      requiredFields: [],
-      defaultValues: {},
-      editableDefaultFields: [],
-      editableFields: [],
-      userIdFields: [],
-      branchIdFields: [],
-      departmentIdFields: [],
-      companyIdFields: [],
-      dateField: [],
-      emailField: [],
-      imagenameField: [],
-      imageIdField: '',
-      imageFolder: '',
-      printEmpField: [],
-      printCustField: [],
-      totalCurrencyFields: [],
-      totalAmountFields: [],
-      signatureFields: [],
-      headerFields: [],
-      mainFields: [],
-      footerFields: [],
-      viewSource: {},
-      transactionTypeField: '',
-      transactionTypeValue: '',
-      detectFields: [],
-      allowedBranches: [],
-      allowedDepartments: [],
-      procedures: [],
-    });
+    setConfig(normalizeFormConfig());
     setModuleKey('');
     setSelectedConfig('');
   }
@@ -690,70 +537,10 @@ export default function FormsManagement() {
         const formNames = Object.keys(filtered);
         setNames(formNames);
         if (filtered[name]) {
-          setConfig({
-            visibleFields: filtered[name].visibleFields || [],
-            requiredFields: filtered[name].requiredFields || [],
-            defaultValues: filtered[name].defaultValues || {},
-            editableDefaultFields: filtered[name].editableDefaultFields || [],
-            editableFields: filtered[name].editableFields || [],
-            userIdFields: filtered[name].userIdFields || [],
-            branchIdFields: filtered[name].branchIdFields || [],
-            departmentIdFields: filtered[name].departmentIdFields || [],
-            companyIdFields: filtered[name].companyIdFields || [],
-            dateField: filtered[name].dateField || [],
-            emailField: filtered[name].emailField || [],
-            imagenameField: filtered[name].imagenameField || [],
-            imageIdField: filtered[name].imageIdField || '',
-            imageFolder: filtered[name].imageFolder || '',
-            printEmpField: filtered[name].printEmpField || [],
-            printCustField: filtered[name].printCustField || [],
-            totalCurrencyFields: filtered[name].totalCurrencyFields || [],
-            totalAmountFields: filtered[name].totalAmountFields || [],
-            signatureFields: filtered[name].signatureFields || [],
-            headerFields: filtered[name].headerFields || [],
-            mainFields: filtered[name].mainFields || [],
-            footerFields: filtered[name].footerFields || [],
-            viewSource: filtered[name].viewSource || {},
-            transactionTypeField: filtered[name].transactionTypeField || '',
-            transactionTypeValue: filtered[name].transactionTypeValue || '',
-            detectFields: filtered[name].detectFields || [],
-            allowedBranches: (filtered[name].allowedBranches || []).map(String),
-            allowedDepartments: (filtered[name].allowedDepartments || []).map(String),
-            procedures: filtered[name].procedures || [],
-          });
+          setConfig(normalizeFormConfig(filtered[name]));
         } else {
           setName('');
-          setConfig({
-            visibleFields: [],
-            requiredFields: [],
-            defaultValues: {},
-            editableDefaultFields: [],
-            editableFields: [],
-            userIdFields: [],
-            branchIdFields: [],
-            departmentIdFields: [],
-            companyIdFields: [],
-            dateField: [],
-            emailField: [],
-            imagenameField: [],
-            imageIdField: '',
-            imageFolder: '',
-            printEmpField: [],
-            printCustField: [],
-            totalCurrencyFields: [],
-            totalAmountFields: [],
-            signatureFields: [],
-            headerFields: [],
-            mainFields: [],
-            footerFields: [],
-            viewSource: {},
-            transactionTypeField: '',
-            transactionTypeValue: '',
-            detectFields: [],
-            allowedBranches: [],
-            allowedDepartments: [],
-            procedures: [],
-          });
+          setConfig(normalizeFormConfig());
         }
       }
       addToast('Imported', 'success');
@@ -888,6 +675,51 @@ export default function FormsManagement() {
                 }
               />
             </label>
+
+            <label style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+              <input
+                type="checkbox"
+                checked={Boolean(config.allowTemporarySubmission)}
+                onChange={(e) => {
+                  const checked = e.target.checked;
+                  setConfig((c) => {
+                    const next = {
+                      ...c,
+                      allowTemporarySubmission: checked,
+                      supportsTemporarySubmission: checked,
+                    };
+                    if (checked) {
+                      if (
+                        (!c.temporaryAllowedBranches || c.temporaryAllowedBranches.length === 0) &&
+                        c.allowedBranches?.length
+                      ) {
+                        next.temporaryAllowedBranches = [...c.allowedBranches];
+                      }
+                      if (
+                        (!c.temporaryAllowedDepartments ||
+                          c.temporaryAllowedDepartments.length === 0) &&
+                        c.allowedDepartments?.length
+                      ) {
+                        next.temporaryAllowedDepartments = [...c.allowedDepartments];
+                      }
+                    }
+                    return next;
+                  });
+                }}
+              />
+              <span>
+                {t(
+                  'allow_temporary_submission',
+                  'Allow temporary transaction submissions',
+                )}
+              </span>
+            </label>
+            <small style={{ color: '#666', marginLeft: '1.5rem', display: 'block' }}>
+              {t(
+                'allow_temporary_submission_hint',
+                'When enabled, users can save drafts that require senior confirmation before posting.',
+              )}
+            </small>
 
             {name && <button onClick={handleDelete}>Delete</button>}
           </div>
@@ -1186,6 +1018,94 @@ export default function FormsManagement() {
                 None
               </button>
             </label>
+            {config.allowTemporarySubmission && (
+              <>
+                <label style={{ marginLeft: '1rem' }}>
+                  Temporary allowed branches:{' '}
+                  <select
+                    multiple
+                    size={8}
+                    value={config.temporaryAllowedBranches}
+                    onChange={(e) =>
+                      setConfig((c) => ({
+                        ...c,
+                        temporaryAllowedBranches: Array.from(
+                          e.target.selectedOptions,
+                          (o) => o.value,
+                        ),
+                      }))
+                    }
+                  >
+                    {branchOptions.map((b) => (
+                      <option key={b.value} value={b.value}>
+                        {b.label}
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setConfig((c) => ({
+                        ...c,
+                        temporaryAllowedBranches: branchOptions.map((b) => b.value),
+                      }))
+                    }
+                  >
+                    All
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setConfig((c) => ({ ...c, temporaryAllowedBranches: [] }))
+                    }
+                  >
+                    None
+                  </button>
+                </label>
+                <label style={{ marginLeft: '1rem' }}>
+                  Temporary allowed departments:{' '}
+                  <select
+                    multiple
+                    size={8}
+                    value={config.temporaryAllowedDepartments}
+                    onChange={(e) =>
+                      setConfig((c) => ({
+                        ...c,
+                        temporaryAllowedDepartments: Array.from(
+                          e.target.selectedOptions,
+                          (o) => o.value,
+                        ),
+                      }))
+                    }
+                  >
+                    {deptOptions.map((d) => (
+                      <option key={d.value} value={d.value}>
+                        {d.label}
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setConfig((c) => ({
+                        ...c,
+                        temporaryAllowedDepartments: deptOptions.map((d) => d.value),
+                      }))
+                    }
+                  >
+                    All
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setConfig((c) => ({ ...c, temporaryAllowedDepartments: [] }))
+                    }
+                  >
+                    None
+                  </button>
+                </label>
+              </>
+            )}
             {procedureOptions.length > 0 && (
               <label style={{ marginLeft: '1rem' }}>
                 Procedures:{' '}

--- a/src/erp.mgt.mn/utils/transactionFormAccess.js
+++ b/src/erp.mgt.mn/utils/transactionFormAccess.js
@@ -1,0 +1,81 @@
+export function normalizeAccessValue(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'object') {
+    if (value.id !== undefined && value.id !== null) {
+      return normalizeAccessValue(value.id);
+    }
+    if (value.branch_id !== undefined && value.branch_id !== null) {
+      return normalizeAccessValue(value.branch_id);
+    }
+    if (value.department_id !== undefined && value.department_id !== null) {
+      return normalizeAccessValue(value.department_id);
+    }
+    if (value.value !== undefined && value.value !== null) {
+      return normalizeAccessValue(value.value);
+    }
+  }
+  const str = String(value).trim();
+  return str === '' ? null : str;
+}
+
+function normalizeAccessList(list) {
+  if (!Array.isArray(list) || list.length === 0) return [];
+  const normalized = [];
+  list.forEach((item) => {
+    const val = normalizeAccessValue(item);
+    if (val !== null) normalized.push(val);
+  });
+  return normalized;
+}
+
+function matchesScope(list, value) {
+  if (!Array.isArray(list) || list.length === 0) return true;
+  if (value === null) return true;
+  return list.includes(value);
+}
+
+export function evaluateTransactionFormAccess(info, branchId, departmentId) {
+  if (!info || typeof info !== 'object') {
+    return {
+      allowed: true,
+      general: true,
+      temporary: false,
+      temporaryEnabled: false,
+    };
+  }
+  const branchValue = normalizeAccessValue(branchId);
+  const departmentValue = normalizeAccessValue(departmentId);
+
+  const allowedBranches = normalizeAccessList(info.allowedBranches);
+  const allowedDepartments = normalizeAccessList(info.allowedDepartments);
+
+  const generalAllowed =
+    matchesScope(allowedBranches, branchValue) &&
+    matchesScope(allowedDepartments, departmentValue);
+
+  const temporaryEnabled = Boolean(
+    info.supportsTemporarySubmission ??
+      info.allowTemporarySubmission ??
+      info.supportsTemporary ??
+      false,
+  );
+
+  const temporaryBranches = normalizeAccessList(info.temporaryAllowedBranches);
+  const temporaryDepartments = normalizeAccessList(info.temporaryAllowedDepartments);
+
+  const temporaryAllowed = temporaryEnabled
+    ? matchesScope(temporaryBranches, branchValue) &&
+      matchesScope(temporaryDepartments, departmentValue)
+    : false;
+
+  return {
+    allowed: generalAllowed || temporaryAllowed,
+    general: generalAllowed,
+    temporary: temporaryAllowed,
+    temporaryEnabled,
+  };
+}
+
+export function hasTransactionFormAccess(info, branchId, departmentId) {
+  return evaluateTransactionFormAccess(info, branchId, departmentId).allowed;
+}


### PR DESCRIPTION
## Summary
- differentiate general and temporary access when loading transaction forms so we can detect users who only have temporary permissions
- hide the Post action, block submit attempts, and show guidance for temporary-only users while still allowing Save as Temporary
- reuse the standard notification type for temporary submissions to avoid enum truncation errors when saving drafts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e03a749d84833192283265fcf89fad