### PR TITLE
Align POS transaction visibility with access scopes

### DIFF
--- a/api-server/routes/pos_txn_config.js
+++ b/api-server/routes/pos_txn_config.js
@@ -5,20 +5,58 @@ import {
   getConfig,
   setConfig,
   deleteConfig,
+  filterPosConfigsByAccess,
+  hasPosTransactionAccess,
 } from '../services/posTransactionConfig.js';
+import {
+  resolveScopedCompanyId,
+  pickFirstScopeValue,
+} from '../utils/requestScopes.js';
 
 const router = express.Router();
 
 router.get('/', requireAuth, async (req, res, next) => {
   try {
-    const companyId = Number(req.query.companyId ?? req.user.companyId);
-    const name = req.query.name;
+    const companyId = resolveScopedCompanyId(
+      req.query.companyId,
+      req.user.companyId,
+    );
+    const { name } = req.query;
+    const branchId = pickFirstScopeValue(
+      req.query.branchId,
+      req.query.branch_id,
+      req.query.branch,
+      req.user?.branchId,
+      req.user?.branch_id,
+      req.user?.branch,
+    );
+    const departmentId = pickFirstScopeValue(
+      req.query.departmentId,
+      req.query.department_id,
+      req.query.department,
+      req.user?.departmentId,
+      req.user?.department_id,
+      req.user?.department,
+    );
     if (name) {
       const { config, isDefault } = await getConfig(name, companyId);
-      res.json(config ? { ...config, isDefault } : { isDefault });
+      if (!config) {
+        res.status(404).json({ message: 'POS config not found', isDefault });
+        return;
+      }
+      if (!hasPosTransactionAccess(config, branchId, departmentId)) {
+        res.status(403).json({ message: 'Access denied', isDefault });
+        return;
+      }
+      res.json({ ...config, isDefault });
     } else {
       const { config, isDefault } = await getAllConfigs(companyId);
-      res.json({ ...config, isDefault });
+      const filtered = filterPosConfigsByAccess(
+        config,
+        branchId,
+        departmentId,
+      );
+      res.json({ ...filtered, isDefault });
     }
   } catch (err) {
     next(err);

--- a/api-server/routes/pos_txn_layout.js
+++ b/api-server/routes/pos_txn_layout.js
@@ -1,19 +1,71 @@
 import express from 'express';
 import { requireAuth } from '../middlewares/auth.js';
 import { getLayout, getAllLayouts, setLayout } from '../services/posTransactionLayout.js';
+import {
+  getConfig,
+  getAllConfigs,
+  filterPosConfigsByAccess,
+  hasPosTransactionAccess,
+} from '../services/posTransactionConfig.js';
+import { resolveScopedCompanyId, pickFirstScopeValue } from '../utils/requestScopes.js';
 
 const router = express.Router();
 
 router.get('/', requireAuth, async (req, res, next) => {
   try {
-    const companyId = Number(req.query.companyId ?? req.user.companyId);
+    const companyId = resolveScopedCompanyId(
+      req.query.companyId,
+      req.user.companyId,
+    );
     const name = req.query.name;
+    const branchId = pickFirstScopeValue(
+      req.query.branchId,
+      req.query.branch_id,
+      req.query.branch,
+      req.user?.branchId,
+      req.user?.branch_id,
+      req.user?.branch,
+    );
+    const departmentId = pickFirstScopeValue(
+      req.query.departmentId,
+      req.query.department_id,
+      req.query.department,
+      req.user?.departmentId,
+      req.user?.department_id,
+      req.user?.department,
+    );
     if (name) {
+      const { config: posConfig } = await getConfig(name, companyId);
+      if (!posConfig) {
+        res.status(404).json({ message: 'POS config not found' });
+        return;
+      }
+      if (!hasPosTransactionAccess(posConfig, branchId, departmentId)) {
+        res.status(403).json({ message: 'Access denied' });
+        return;
+      }
       const cfg = await getLayout(name, companyId);
       res.json(cfg || {});
     } else {
+      const { config: configMap } = await getAllConfigs(companyId);
+      const allowedNames = filterPosConfigsByAccess(
+        configMap,
+        branchId,
+        departmentId,
+      );
+      const allowedSet = new Set(Object.keys(allowedNames));
       const all = await getAllLayouts(companyId);
-      res.json(all);
+      if (!all || typeof all !== 'object') {
+        res.json({});
+        return;
+      }
+      const filteredLayouts = {};
+      Object.entries(all).forEach(([layoutName, layoutValue]) => {
+        if (allowedSet.has(layoutName)) {
+          filteredLayouts[layoutName] = layoutValue;
+        }
+      });
+      res.json(filteredLayouts);
     }
   } catch (err) {
     next(err);
@@ -22,7 +74,10 @@ router.get('/', requireAuth, async (req, res, next) => {
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {
-    const companyId = Number(req.query.companyId ?? req.user.companyId);
+    const companyId = resolveScopedCompanyId(
+      req.query.companyId,
+      req.user.companyId,
+    );
     const { name, layout } = req.body;
     if (!name) return res.status(400).json({ message: 'name is required' });
     await setLayout(name, layout || {}, companyId);

--- a/api-server/routes/pos_txn_pending.js
+++ b/api-server/routes/pos_txn_pending.js
@@ -1,12 +1,21 @@
 import express from 'express';
 import { requireAuth } from '../middlewares/auth.js';
-import { listPending, getPending, savePending, deletePending } from '../services/posTransactionPending.js';
+import {
+  listPending,
+  getPending,
+  savePending,
+  deletePending,
+} from '../services/posTransactionPending.js';
+import { resolveScopedCompanyId } from '../utils/requestScopes.js';
 
 const router = express.Router();
 
 router.get('/', requireAuth, async (req, res, next) => {
   try {
-    const companyId = Number(req.query.companyId ?? req.user.companyId);
+    const companyId = resolveScopedCompanyId(
+      req.query.companyId,
+      req.user.companyId,
+    );
     const { id, name } = req.query;
     if (id) {
       const rec = await getPending(id, companyId);
@@ -25,7 +34,10 @@ router.get('/', requireAuth, async (req, res, next) => {
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {
-    const companyId = Number(req.query.companyId ?? req.user.companyId);
+    const companyId = resolveScopedCompanyId(
+      req.query.companyId,
+      req.user.companyId,
+    );
     const { id, name, data, masterId, session } = req.body;
     if (!name) return res.status(400).json({ message: 'name is required' });
     const info = { ...(session || {}), employeeId: req.user.empid };
@@ -43,7 +55,10 @@ router.post('/', requireAuth, async (req, res, next) => {
 
 router.delete('/', requireAuth, async (req, res, next) => {
   try {
-    const companyId = Number(req.query.companyId ?? req.user.companyId);
+    const companyId = resolveScopedCompanyId(
+      req.query.companyId,
+      req.user.companyId,
+    );
     const { id } = req.query;
     if (!id) return res.status(400).json({ message: 'id is required' });
     await deletePending(id, companyId);

--- a/api-server/routes/pos_txn_post.js
+++ b/api-server/routes/pos_txn_post.js
@@ -1,15 +1,37 @@
 import express from 'express';
 import { requireAuth } from '../middlewares/auth.js';
 import { postPosTransaction } from '../services/postPosTransaction.js';
+import { resolveScopedCompanyId, pickFirstScopeValue } from '../utils/requestScopes.js';
 
 const router = express.Router();
 
 router.post('/', requireAuth, async (req, res, next) => {
   try {
-    const companyId = Number(req.query.companyId ?? req.user.companyId);
+    const companyId = resolveScopedCompanyId(
+      req.query.companyId,
+      req.user.companyId,
+    );
     const { name, data, session } = req.body;
     if (!data) return res.status(400).json({ message: 'invalid data' });
     const info = { ...(session || {}), userId: req.user.id };
+    const resolvedBranchId = pickFirstScopeValue(
+      session?.branchId,
+      session?.branch_id,
+      session?.branch,
+      req.user?.branchId,
+      req.user?.branch_id,
+      req.user?.branch,
+    );
+    const resolvedDepartmentId = pickFirstScopeValue(
+      session?.departmentId,
+      session?.department_id,
+      session?.department,
+      req.user?.departmentId,
+      req.user?.department_id,
+      req.user?.department,
+    );
+    if (resolvedBranchId !== null) info.branchId = resolvedBranchId;
+    if (resolvedDepartmentId !== null) info.departmentId = resolvedDepartmentId;
     const id = await postPosTransaction(name, data, info, companyId);
     res.json({ id });
   } catch (err) {

--- a/api-server/services/posTransactionConfig.js
+++ b/api-server/services/posTransactionConfig.js
@@ -2,18 +2,100 @@ import fs from 'fs/promises';
 import path from 'path';
 import { tenantConfigPath, getConfigPath } from '../utils/configPaths.js';
 
-  async function readConfig(companyId = 0) {
-    const { path: filePath, isDefault } = await getConfigPath(
-      'posTransactionConfig.json',
-      companyId,
-    );
-    try {
-      const data = await fs.readFile(filePath, 'utf8');
-      return { cfg: JSON.parse(data), isDefault };
-    } catch {
-      return { cfg: {}, isDefault: true };
-    }
+async function readConfig(companyId = 0) {
+  const { path: filePath, isDefault } = await getConfigPath(
+    'posTransactionConfig.json',
+    companyId,
+  );
+  try {
+    const data = await fs.readFile(filePath, 'utf8');
+    return { cfg: JSON.parse(data), isDefault };
+  } catch {
+    return { cfg: {}, isDefault: true };
   }
+}
+
+function normalizeAccessValue(value) {
+  if (value === undefined || value === null) return null;
+  const str = String(value).trim();
+  return str === '' ? null : str;
+}
+
+function normalizeAccessList(list) {
+  if (!Array.isArray(list) || list.length === 0) return [];
+  const normalized = [];
+  list.forEach((item) => {
+    const val = normalizeAccessValue(item);
+    if (val !== null) normalized.push(val);
+  });
+  return normalized;
+}
+
+function matchesScope(list, value) {
+  if (!Array.isArray(list) || list.length === 0) return true;
+  const normalizedValue = normalizeAccessValue(value);
+  if (normalizedValue === null) return true;
+  return list.includes(normalizedValue);
+}
+
+function normalizeStoredAccessList(list) {
+  if (!Array.isArray(list) || list.length === 0) return [];
+  const normalized = [];
+  list.forEach((item) => {
+    if (item === undefined || item === null) return;
+    const num = Number(item);
+    if (Number.isFinite(num)) {
+      normalized.push(num);
+      return;
+    }
+    const str = String(item).trim();
+    if (str) normalized.push(str);
+  });
+  return normalized;
+}
+
+export function hasPosTransactionAccess(config, branchId, departmentId) {
+  if (!config || typeof config !== 'object') return true;
+  const branchValue = normalizeAccessValue(branchId);
+  const departmentValue = normalizeAccessValue(departmentId);
+
+  const allowedBranches = normalizeAccessList(config.allowedBranches);
+  const allowedDepartments = normalizeAccessList(config.allowedDepartments);
+
+  const generalAllowed =
+    matchesScope(allowedBranches, branchValue) &&
+    matchesScope(allowedDepartments, departmentValue);
+
+  if (generalAllowed) return true;
+
+  const temporaryEnabled = Boolean(
+    config.supportsTemporarySubmission ??
+      config.allowTemporarySubmission ??
+      config.supportsTemporary ??
+      false,
+  );
+
+  if (!temporaryEnabled) return false;
+
+  const tempBranches = normalizeAccessList(config.temporaryAllowedBranches);
+  const tempDepartments = normalizeAccessList(config.temporaryAllowedDepartments);
+
+  return (
+    matchesScope(tempBranches, branchValue) &&
+    matchesScope(tempDepartments, departmentValue)
+  );
+}
+
+export function filterPosConfigsByAccess(configMap = {}, branchId, departmentId) {
+  const filtered = {};
+  Object.entries(configMap || {}).forEach(([name, info]) => {
+    if (!info || typeof info !== 'object') return;
+    if (hasPosTransactionAccess(info, branchId, departmentId)) {
+      filtered[name] = info;
+    }
+  });
+  return filtered;
+}
 
 async function writeConfig(cfg, companyId = 0) {
   const filePath = tenantConfigPath('posTransactionConfig.json', companyId);
@@ -33,7 +115,23 @@ export async function getAllConfigs(companyId = 0) {
 
 export async function setConfig(name, config = {}, companyId = 0) {
   const { cfg } = await readConfig(companyId);
-  cfg[name] = config;
+  const normalizedConfig = {
+    ...config,
+    allowedBranches: normalizeStoredAccessList(config.allowedBranches),
+    allowedDepartments: normalizeStoredAccessList(config.allowedDepartments),
+    temporaryAllowedBranches: normalizeStoredAccessList(
+      config.temporaryAllowedBranches,
+    ),
+    temporaryAllowedDepartments: normalizeStoredAccessList(
+      config.temporaryAllowedDepartments,
+    ),
+    procedures: Array.isArray(config.procedures)
+      ? config.procedures
+          .map((proc) => (typeof proc === 'string' ? proc.trim() : ''))
+          .filter((proc) => proc)
+      : [],
+  };
+  cfg[name] = normalizedConfig;
   await writeConfig(cfg, companyId);
   return cfg[name];
 }

--- a/api-server/utils/requestScopes.js
+++ b/api-server/utils/requestScopes.js
@@ -1,0 +1,30 @@
+export function resolveScopedCompanyId(requestedCompanyId, userCompanyId) {
+  const normalizedUserCompany = Number.isFinite(Number(userCompanyId))
+    ? Number(userCompanyId)
+    : 0;
+  if (
+    normalizedUserCompany === 0 &&
+    requestedCompanyId !== undefined &&
+    requestedCompanyId !== null
+  ) {
+    const parsed = Number(requestedCompanyId);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return normalizedUserCompany;
+}
+
+export function pickFirstScopeValue(...values) {
+  for (const value of values) {
+    if (value === undefined || value === null) continue;
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed !== '') return trimmed;
+      continue;
+    }
+    const str = String(value).trim();
+    if (str !== '') return str;
+  }
+  return null;
+}

--- a/config/0/posTransactionConfig.json
+++ b/config/0/posTransactionConfig.json
@@ -60,6 +60,9 @@
         "position": "hidden"
       }
     ],
+    "allowedBranches": [],
+    "allowedDepartments": [],
+    "procedures": [],
     "calcFields": [
       {
         "name": "Map1",
@@ -605,6 +608,9 @@
         "position": "hidden"
       }
     ],
+    "allowedBranches": [],
+    "allowedDepartments": [],
+    "procedures": [],
     "calcFields": [
       {
         "name": "Map1",

--- a/src/erp.mgt.mn/pages/PosTransactions.jsx
+++ b/src/erp.mgt.mn/pages/PosTransactions.jsx
@@ -18,6 +18,7 @@ import { debugLog } from '../utils/debug.js';
 import { syncCalcFields } from '../utils/syncCalcFields.js';
 import { fetchTriggersForTables } from '../utils/fetchTriggersForTables.js';
 import { valuesEqual } from '../utils/generatedColumns.js';
+import { hasPosTransactionAccess } from '../utils/posTransactionAccess.js';
 import {
   isPlainRecord,
   assignArrayMetadata,
@@ -452,9 +453,22 @@ async function putRow(addToast, table, id, row) {
 
 export default function PosTransactionsPage() {
   const { addToast } = useToast();
-  const { user, company, branch } = useContext(AuthContext);
+  const { user, company, branch, department } = useContext(AuthContext);
   const generalConfig = useGeneralConfig();
-  const [configs, setConfigs] = useState({});
+  const [rawConfigs, setRawConfigs] = useState({});
+  const configs = useMemo(() => {
+    if (!rawConfigs || typeof rawConfigs !== 'object') return {};
+    const entries = Object.entries(rawConfigs).filter(([key]) => key !== 'isDefault');
+    if (entries.length === 0) return {};
+    const filtered = {};
+    entries.forEach(([cfgName, cfgValue]) => {
+      if (!cfgValue || typeof cfgValue !== 'object') return;
+      if (hasPosTransactionAccess(cfgValue, branch, department)) {
+        filtered[cfgName] = cfgValue;
+      }
+    });
+    return filtered;
+  }, [rawConfigs, branch, department]);
   const [name, setName] = useState('');
   const [config, setConfig] = useState(null);
   const [formConfigs, setFormConfigs] = useState({});
@@ -893,11 +907,23 @@ export default function PosTransactionsPage() {
   }
 
   useEffect(() => {
-    fetch('/api/pos_txn_config', { credentials: 'include' })
+    const params = new URLSearchParams();
+    if (branch !== undefined && branch !== null && String(branch).trim() !== '') {
+      params.set('branchId', branch);
+    }
+    if (
+      department !== undefined &&
+      department !== null &&
+      String(department).trim() !== ''
+    ) {
+      params.set('departmentId', department);
+    }
+    const qs = params.toString();
+    fetch(`/api/pos_txn_config${qs ? `?${qs}` : ''}`, { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : {}))
-      .then((data) => setConfigs(data))
-      .catch(() => setConfigs({}));
-  }, []);
+      .then((data) => setRawConfigs(data))
+      .catch(() => setRawConfigs({}));
+  }, [branch, department]);
 
   const initRef = useRef('');
 
@@ -909,9 +935,27 @@ export default function PosTransactionsPage() {
       setCurrentSessionId(null);
       return;
     }
+    if (!configs[name]) {
+      setConfig(null);
+      setLayout({});
+      setSessionFields(null);
+      setCurrentSessionId(null);
+      return;
+    }
     setSessionFields(null);
     setCurrentSessionId(null);
-    fetch(`/api/pos_txn_config?name=${encodeURIComponent(name)}`, { credentials: 'include' })
+    const params = new URLSearchParams({ name });
+    if (branch !== undefined && branch !== null && String(branch).trim() !== '') {
+      params.set('branchId', branch);
+    }
+    if (
+      department !== undefined &&
+      department !== null &&
+      String(department).trim() !== ''
+    ) {
+      params.set('departmentId', department);
+    }
+    fetch(`/api/pos_txn_config?${params.toString()}`, { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : null))
       .then((cfg) => {
         if (cfg && Array.isArray(cfg.tables) && cfg.tables.length > 0 && !cfg.masterTable) {
@@ -926,11 +970,22 @@ export default function PosTransactionsPage() {
         setRelationData({});
       })
       .catch(() => { setConfig(null); });
-    fetch(`/api/pos_txn_layout?name=${encodeURIComponent(name)}`, { credentials: 'include' })
-      .then(res => res.ok ? res.json() : {})
-      .then(data => setLayout(data || {}))
+    const layoutParams = new URLSearchParams({ name });
+    if (branch !== undefined && branch !== null && String(branch).trim() !== '') {
+      layoutParams.set('branchId', branch);
+    }
+    if (
+      department !== undefined &&
+      department !== null &&
+      String(department).trim() !== ''
+    ) {
+      layoutParams.set('departmentId', department);
+    }
+    fetch(`/api/pos_txn_layout?${layoutParams.toString()}`, { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : {}))
+      .then((data) => setLayout(data || {}))
       .catch(() => setLayout({}));
-  }, [name]);
+  }, [name, configs, branch, department]);
 
   const { formList, visibleTables } = React.useMemo(() => {
     if (!config) return { formList: [], visibleTables: new Set() };
@@ -1586,6 +1641,7 @@ export default function PosTransactionsPage() {
       employeeId: user?.empid,
       companyId: company,
       branchId: branch,
+      departmentId: department,
       date: formatTimestamp(new Date()),
     };
     try {
@@ -1730,6 +1786,7 @@ export default function PosTransactionsPage() {
       employeeId: user?.empid,
       companyId: company,
       branchId: branch,
+      departmentId: department,
       date: formatTimestamp(new Date()),
     };
     try {

--- a/src/erp.mgt.mn/utils/posTransactionAccess.js
+++ b/src/erp.mgt.mn/utils/posTransactionAccess.js
@@ -1,0 +1,21 @@
+import {
+  normalizeAccessValue,
+  hasTransactionFormAccess,
+} from './transactionFormAccess.js';
+
+export { normalizeAccessValue };
+
+export function hasPosTransactionAccess(info, branchId, departmentId) {
+  return hasTransactionFormAccess(info, branchId, departmentId);
+}
+
+export function filterPosConfigsByAccess(configMap = {}, branchId, departmentId) {
+  const filtered = {};
+  Object.entries(configMap || {}).forEach(([name, cfg]) => {
+    if (!cfg || typeof cfg !== 'object') return;
+    if (hasPosTransactionAccess(cfg, branchId, departmentId)) {
+      filtered[name] = cfg;
+    }
+  });
+  return filtered;
+}

--- a/tests/services/posTransactionConfig.test.js
+++ b/tests/services/posTransactionConfig.test.js
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  hasPosTransactionAccess,
+  filterPosConfigsByAccess,
+} from '../../api-server/services/posTransactionConfig.js';
+
+test('hasPosTransactionAccess allows when no restrictions are set', () => {
+  assert.equal(hasPosTransactionAccess({}, 1, 2), true);
+  assert.equal(
+    hasPosTransactionAccess({ allowedBranches: [], allowedDepartments: [] }, '5', '7'),
+    true,
+  );
+});
+
+test('hasPosTransactionAccess enforces branch and department restrictions', () => {
+  const config = { allowedBranches: [1, '2'], allowedDepartments: ['10'] };
+  assert.equal(hasPosTransactionAccess(config, 1, 10), true);
+  assert.equal(hasPosTransactionAccess(config, '2', '10'), true);
+  assert.equal(hasPosTransactionAccess(config, 3, 10), false);
+  assert.equal(hasPosTransactionAccess(config, 1, '11'), false);
+  assert.equal(hasPosTransactionAccess(config, null, '10'), true);
+  assert.equal(hasPosTransactionAccess(config, undefined, undefined), true);
+});
+
+test('temporary access flags mirror dynamic transaction logic', () => {
+  const config = {
+    allowedBranches: ['1'],
+    allowedDepartments: ['2'],
+    supportsTemporarySubmission: true,
+    temporaryAllowedBranches: ['3'],
+    temporaryAllowedDepartments: ['4'],
+  };
+
+  assert.equal(hasPosTransactionAccess(config, '1', '2'), true);
+  assert.equal(hasPosTransactionAccess(config, '3', '4'), true);
+  assert.equal(hasPosTransactionAccess(config, '3', '5'), false);
+});
+
+test('filterPosConfigsByAccess returns only permitted configurations', () => {
+  const configs = {
+    Alpha: { allowedBranches: [1], allowedDepartments: [] },
+    Beta: { allowedBranches: [], allowedDepartments: ['20'] },
+    Gamma: { allowedBranches: [3], allowedDepartments: ['30'] },
+  };
+  const filtered = filterPosConfigsByAccess(configs, 1, 20);
+  assert.deepEqual(Object.keys(filtered).sort(), ['Alpha', 'Beta']);
+  assert.ok(!filtered.Gamma);
+});

--- a/tests/utils/requestScopes.test.js
+++ b/tests/utils/requestScopes.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  resolveScopedCompanyId,
+  pickFirstScopeValue,
+} from '../../api-server/utils/requestScopes.js';
+
+test('resolveScopedCompanyId keeps user company when not super admin', () => {
+  assert.equal(resolveScopedCompanyId(0, 12), 12);
+  assert.equal(resolveScopedCompanyId(undefined, 5), 5);
+  assert.equal(resolveScopedCompanyId('77', '9'), 9);
+});
+
+test('resolveScopedCompanyId allows overrides for company 0', () => {
+  assert.equal(resolveScopedCompanyId('77', 0), 77);
+  assert.equal(resolveScopedCompanyId(55, '0'), 55);
+  assert.equal(resolveScopedCompanyId('not-a-number', 0), 0);
+});
+
+test('pickFirstScopeValue prefers first non-empty string', () => {
+  assert.equal(pickFirstScopeValue(undefined, null, '  '), null);
+  assert.equal(pickFirstScopeValue(' 42 ', null), '42');
+  assert.equal(pickFirstScopeValue(null, 0), '0');
+  assert.equal(pickFirstScopeValue('', '  value  ', 'next'), 'value');
+});


### PR DESCRIPTION
## Summary
- derive branch and department scopes for POS configuration and layout routes from both the request and authenticated user so unauthorized users cannot load restricted layouts
- gate layout responses behind the same access check and filter bulk layout listings to only include permitted configurations
- include resolved scope metadata in POS post requests and forward scope parameters when loading layouts from the client

## Testing
- npm test -- tests/services/posTransactionConfig.test.js tests/utils/requestScopes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cff8d456a883318dc1adcfcc46985a