### PR TITLE
Harden POS configuration access checks

### DIFF
--- a/api-server/routes/pos_txn_config.js
+++ b/api-server/routes/pos_txn_config.js
@@ -7,14 +7,46 @@ import {
   deleteConfig,
   filterPosConfigsByAccess,
   hasPosTransactionAccess,
+  hasPosConfigReadAccess,
+  pickScopeValue,
 } from '../services/posTransactionConfig.js';
+import { getEmploymentSession, getUserLevelActions } from '../../db/index.js';
 
 const router = express.Router();
 
 router.get('/', requireAuth, async (req, res, next) => {
   try {
     const companyId = Number(req.query.companyId ?? req.user.companyId);
-    const { name, branchId, departmentId } = req.query;
+    const { name } = req.query;
+
+    const session =
+      req.session && Number(req.session?.company_id) === companyId
+        ? req.session
+        : await getEmploymentSession(req.user.empid, companyId);
+    const actions = await getUserLevelActions(req.user.userLevel, companyId);
+
+    if (!hasPosConfigReadAccess(session, actions)) {
+      res.status(403).json({ message: 'Access denied' });
+      return;
+    }
+
+    const sessionBranch =
+      session?.branch_id ??
+      session?.branchId ??
+      req.session?.branch_id ??
+      req.session?.branchId;
+    const sessionDepartment =
+      session?.department_id ??
+      session?.departmentId ??
+      req.session?.department_id ??
+      req.session?.departmentId;
+
+    const branchId = pickScopeValue(req.query.branchId, sessionBranch);
+    const departmentId = pickScopeValue(
+      req.query.departmentId,
+      sessionDepartment,
+    );
+
     if (name) {
       const { config, isDefault } = await getConfig(name, companyId);
       if (!config) {

--- a/api-server/services/posTransactionConfig.js
+++ b/api-server/services/posTransactionConfig.js
@@ -54,13 +54,70 @@ function normalizeStoredAccessList(list) {
   return normalized;
 }
 
+export function pickScopeValue(requestValue, sessionValue) {
+  if (requestValue !== undefined && requestValue !== null) {
+    if (typeof requestValue === 'string') {
+      if (requestValue.trim() !== '') return requestValue;
+    } else {
+      return requestValue;
+    }
+  }
+  if (sessionValue !== undefined && sessionValue !== null) {
+    return sessionValue;
+  }
+  return undefined;
+}
+
+export function hasPosConfigReadAccess(session = {}, actions = {}) {
+  const sessionPerms = session?.permissions || {};
+  if (sessionPerms.system_settings) return true;
+
+  const actionPermissions = actions?.permissions || {};
+  if (actionPermissions.system_settings) return true;
+
+  const apiPermissions = actions?.api || {};
+  if (apiPermissions['/api/pos_txn_config']) return true;
+
+  if (actions.pos_transaction_management) return true;
+  if (actions.pos_transactions) return true;
+
+  return false;
+}
+
 export function hasPosTransactionAccess(config, branchId, departmentId) {
   if (!config || typeof config !== 'object') return true;
+
+  const branchValue = normalizeAccessValue(branchId);
+  const departmentValue = normalizeAccessValue(departmentId);
+
   const allowedBranches = normalizeAccessList(config.allowedBranches);
   const allowedDepartments = normalizeAccessList(config.allowedDepartments);
+
+  const generalAllowed =
+    matchesScope(allowedBranches, branchValue) &&
+    matchesScope(allowedDepartments, departmentValue);
+
+  if (generalAllowed) return true;
+
+  const temporaryEnabled = Boolean(
+    config.supportsTemporarySubmission ??
+      config.allowTemporarySubmission ??
+      config.supportsTemporary ??
+      false,
+  );
+
+  if (!temporaryEnabled) return false;
+
+  const temporaryBranches = normalizeAccessList(
+    config.temporaryAllowedBranches,
+  );
+  const temporaryDepartments = normalizeAccessList(
+    config.temporaryAllowedDepartments,
+  );
+
   return (
-    matchesScope(allowedBranches, branchId) &&
-    matchesScope(allowedDepartments, departmentId)
+    matchesScope(temporaryBranches, branchValue) &&
+    matchesScope(temporaryDepartments, departmentValue)
   );
 }
 
@@ -97,6 +154,24 @@ export async function setConfig(name, config = {}, companyId = 0) {
     ...config,
     allowedBranches: normalizeStoredAccessList(config.allowedBranches),
     allowedDepartments: normalizeStoredAccessList(config.allowedDepartments),
+    temporaryAllowedBranches: normalizeStoredAccessList(
+      config.temporaryAllowedBranches,
+    ),
+    temporaryAllowedDepartments: normalizeStoredAccessList(
+      config.temporaryAllowedDepartments,
+    ),
+    supportsTemporarySubmission: Boolean(
+      config.supportsTemporarySubmission ??
+        config.allowTemporarySubmission ??
+        config.supportsTemporary ??
+        false,
+    ),
+    allowTemporarySubmission: Boolean(
+      config.supportsTemporarySubmission ??
+        config.allowTemporarySubmission ??
+        config.supportsTemporary ??
+        false,
+    ),
     procedures: Array.isArray(config.procedures)
       ? config.procedures
           .map((proc) => (typeof proc === 'string' ? proc.trim() : ''))

--- a/tests/services/posTransactionConfig.test.js
+++ b/tests/services/posTransactionConfig.test.js
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict';
 import {
   hasPosTransactionAccess,
   filterPosConfigsByAccess,
+  hasPosConfigReadAccess,
+  pickScopeValue,
 } from '../../api-server/services/posTransactionConfig.js';
 
 test('hasPosTransactionAccess allows when no restrictions are set', () => {
@@ -23,13 +25,69 @@ test('hasPosTransactionAccess enforces branch and department restrictions', () =
   assert.equal(hasPosTransactionAccess(config, undefined, undefined), true);
 });
 
+test('hasPosTransactionAccess honors temporary permissions', () => {
+  const config = {
+    allowedBranches: [1],
+    allowedDepartments: ['10'],
+    temporaryAllowedBranches: ['2'],
+    temporaryAllowedDepartments: ['20'],
+    supportsTemporarySubmission: true,
+  };
+  assert.equal(hasPosTransactionAccess(config, 1, '10'), true);
+  assert.equal(hasPosTransactionAccess(config, '2', '20'), true);
+  assert.equal(hasPosTransactionAccess(config, '2', '10'), false);
+  assert.equal(hasPosTransactionAccess(config, '3', '20'), false);
+});
+
 test('filterPosConfigsByAccess returns only permitted configurations', () => {
   const configs = {
     Alpha: { allowedBranches: [1], allowedDepartments: [] },
     Beta: { allowedBranches: [], allowedDepartments: ['20'] },
     Gamma: { allowedBranches: [3], allowedDepartments: ['30'] },
+    Temp: {
+      allowedBranches: [9],
+      allowedDepartments: ['90'],
+      temporaryAllowedBranches: ['1'],
+      temporaryAllowedDepartments: ['20'],
+      supportsTemporarySubmission: true,
+    },
   };
   const filtered = filterPosConfigsByAccess(configs, 1, 20);
-  assert.deepEqual(Object.keys(filtered).sort(), ['Alpha', 'Beta']);
+  assert.deepEqual(Object.keys(filtered).sort(), ['Alpha', 'Beta', 'Temp']);
   assert.ok(!filtered.Gamma);
+});
+
+test('pickScopeValue prefers request value when provided', () => {
+  assert.equal(pickScopeValue('5', 3), '5');
+  assert.equal(pickScopeValue(7, 3), 7);
+  assert.equal(pickScopeValue('  ', 3), 3);
+  assert.equal(pickScopeValue(undefined, 4), 4);
+  assert.equal(pickScopeValue(null, 4), 4);
+  assert.equal(pickScopeValue(undefined, null), undefined);
+});
+
+test('hasPosConfigReadAccess grants access for permitted permissions', () => {
+  assert.equal(hasPosConfigReadAccess({ permissions: { system_settings: true } }, {}), true);
+  assert.equal(
+    hasPosConfigReadAccess({}, { permissions: { system_settings: true } }),
+    true,
+  );
+  assert.equal(
+    hasPosConfigReadAccess({}, { api: { '/api/pos_txn_config': true } }),
+    true,
+  );
+  assert.equal(hasPosConfigReadAccess({}, { pos_transaction_management: true }), true);
+  assert.equal(hasPosConfigReadAccess({}, { pos_transactions: true }), true);
+});
+
+test('hasPosConfigReadAccess denies when no permissions granted', () => {
+  assert.equal(hasPosConfigReadAccess({}, {}), false);
+  assert.equal(
+    hasPosConfigReadAccess({ permissions: { system_settings: false } }, {}),
+    false,
+  );
+  assert.equal(
+    hasPosConfigReadAccess({}, { permissions: { system_settings: false } }),
+    false,
+  );
 });


### PR DESCRIPTION
## Summary
- gate POS transaction config requests on API/module permissions and session scope
- add reusable helpers (with tests) for resolving request scope and permission checks
- align frontend POS access logic with backend temporary access handling

## Testing
- node --test tests/services/posTransactionConfig.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e633df00308331bd5b751f9257bc53